### PR TITLE
WIP - Simplify the management of MFA methods

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AbstractMfaMethod.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AbstractMfaMethod.java
@@ -1,0 +1,34 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.frontendapi.exceptions.JourneyTypeNotSupportedException;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.List;
+
+public abstract class AbstractMfaMethod {
+
+    protected final ConfigurationService configurationService;
+    protected final JourneyType journeyType;
+    protected final Logger LOG = LogManager.getLogger(this.getClass());
+
+    public AbstractMfaMethod(ConfigurationService configurationService, JourneyType journeyType) {
+        this.configurationService = configurationService;
+        this.journeyType = journeyType;
+    }
+
+    public abstract MFAMethodType getMfaMethodType();
+
+    protected void validateJourneyTypes(List<JourneyType> supportedJourneyTypes) {
+        if (!supportedJourneyTypes.contains(journeyType)) {
+            LOG.error(
+                    "JourneyType: {} not supported for MFA Method: {}",
+                    journeyType.getValue(),
+                    getMfaMethodType());
+            throw new JourneyTypeNotSupportedException(getMfaMethodType());
+        }
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthenticatorApp.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthenticatorApp.java
@@ -1,0 +1,33 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.List;
+
+public class AuthenticatorApp extends AbstractMfaMethod implements MfaAttemptsStore {
+
+    private static final List<JourneyType> SUPPORTED_JOURNEY_TYPES =
+            List.of(JourneyType.REGISTRATION, JourneyType.SIGN_IN, JourneyType.ACCOUNT_RECOVERY);
+
+    public AuthenticatorApp(ConfigurationService configurationService, JourneyType journeyType) {
+        super(configurationService, journeyType);
+        validateJourneyTypes(SUPPORTED_JOURNEY_TYPES);
+    }
+
+    @Override
+    public long getMaxOtpInvalidAttempts() {
+        return configurationService.getCodeMaxRetries();
+    }
+
+    @Override
+    public boolean shouldBlockWhenMaxAttemptsReached() {
+        return true;
+    }
+
+    @Override
+    public MFAMethodType getMfaMethodType() {
+        return MFAMethodType.EMAIL;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/Email.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/Email.java
@@ -1,0 +1,47 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.List;
+
+public class Email extends AbstractMfaMethod implements MfaAttemptsStore, MfaRequestStore {
+
+    private static final List<JourneyType> SUPPORTED_JOURNEY_TYPES =
+            List.of(JourneyType.REGISTRATION, JourneyType.ACCOUNT_RECOVERY);
+
+    public Email(ConfigurationService configurationService, JourneyType journeyType) {
+        super(configurationService, journeyType);
+        validateJourneyTypes(SUPPORTED_JOURNEY_TYPES);
+    }
+
+    @Override
+    public long getOtpExpiryTime() {
+        if (journeyType.equals(JourneyType.REGISTRATION)) {
+            return configurationService.getEmailAccountCreationOtpCodeExpiry();
+        } else {
+            return configurationService.getDefaultOtpCodeExpiry();
+        }
+    }
+
+    @Override
+    public long getMaxOtpRequests() {
+        return configurationService.getCodeMaxRetries();
+    }
+
+    @Override
+    public long getMaxOtpInvalidAttempts() {
+        return configurationService.getCodeMaxRetries();
+    }
+
+    @Override
+    public boolean shouldBlockWhenMaxAttemptsReached() {
+        return !journeyType.equals(JourneyType.REGISTRATION);
+    }
+
+    @Override
+    public MFAMethodType getMfaMethodType() {
+        return MFAMethodType.EMAIL;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/MfaAttemptsStore.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/MfaAttemptsStore.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+public interface MfaAttemptsStore {
+
+    long getMaxOtpInvalidAttempts();
+
+    boolean shouldBlockWhenMaxAttemptsReached();
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/MfaRequestStore.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/MfaRequestStore.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+public interface MfaRequestStore {
+
+    long getOtpExpiryTime();
+
+    long getMaxOtpRequests();
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SMS.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SMS.java
@@ -1,0 +1,43 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.List;
+
+public class SMS extends AbstractMfaMethod implements MfaAttemptsStore, MfaRequestStore {
+
+    private static final List<JourneyType> SUPPORTED_JOURNEY_TYPES =
+            List.of(JourneyType.REGISTRATION, JourneyType.SIGN_IN, JourneyType.ACCOUNT_RECOVERY);
+
+    public SMS(ConfigurationService configurationService, JourneyType journeyType) {
+        super(configurationService, journeyType);
+        validateJourneyTypes(SUPPORTED_JOURNEY_TYPES);
+    }
+
+    @Override
+    public long getOtpExpiryTime() {
+        return configurationService.getDefaultOtpCodeExpiry();
+    }
+
+    @Override
+    public long getMaxOtpRequests() {
+        return configurationService.getCodeMaxRetries();
+    }
+
+    @Override
+    public long getMaxOtpInvalidAttempts() {
+        return configurationService.getCodeMaxRetries();
+    }
+
+    @Override
+    public boolean shouldBlockWhenMaxAttemptsReached() {
+        return true;
+    }
+
+    @Override
+    public MFAMethodType getMfaMethodType() {
+        return MFAMethodType.SMS;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/exceptions/JourneyTypeNotSupportedException.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/exceptions/JourneyTypeNotSupportedException.java
@@ -1,0 +1,16 @@
+package uk.gov.di.authentication.frontendapi.exceptions;
+
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
+
+import static java.lang.String.format;
+
+public class JourneyTypeNotSupportedException extends RuntimeException {
+
+    public JourneyTypeNotSupportedException(MFAMethodType mfaMethodType) {
+        super(format("JourneyType not supported for MFAMethodType: %s", mfaMethodType.getValue()));
+    }
+
+    public JourneyTypeNotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethodType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethodType.java
@@ -2,7 +2,8 @@ package uk.gov.di.authentication.shared.entity;
 
 public enum MFAMethodType {
     AUTH_APP("AUTH_APP"),
-    SMS("SMS");
+    SMS("SMS"),
+    EMAIL("EMAIL");
 
     private String value;
 


### PR DESCRIPTION
## What?

- Simplify the management of MFA methods so we can easily manage the rules which apply to each MfaMethod and the corresponding journey it's associated with
- Not all MFA methods use Notify to make requests. For example Authenticator apps. Auth apps don't care about some of the rules that apply to SMS and EMAIL such as the time to store an OTP code or how many request attempts a user is permitted to. Instead of having a single abstract class, break it down to 2 interfaces. The first one which will hold the methods which apply to MfaAttempts and the other which apply to MfaRequests. This way Auth apps can only care about MfaAttempt rule without having to worry about MfaRequest rules.
- Create a common AbstractMfaMethod class. Each MfaMethod requires the JourneyType and ConfigurationService to identify the rules the apply to a certain MFA method.


## Why?

- We have multiple MFA types configured in Authentication. Currently that is EMAIL, AUTH_APP and SMS. We have different rules for each MFA method depending on the journey. We don't have a place to easily identify what the rules are for each type. This is an attempt at trying to fix this.

