### PR TITLE
AUT-1362: Do not warm up KmsConnectionService in all cases

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -97,7 +97,7 @@ public class DocAppCallbackHandler
     }
 
     public DocAppCallbackHandler(ConfigurationService configurationService) {
-        var kmsConnectionService = new KmsConnectionService(configurationService);
+        var kmsConnectionService = new KmsConnectionService(configurationService, false);
         this.configurationService = configurationService;
         this.authorisationService =
                 new DocAppAuthorisationService(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -95,7 +95,7 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
                 new IPVAuthorisationService(
                         configurationService,
                         new RedisConnectionService(configurationService),
-                        new KmsConnectionService(configurationService));
+                        new KmsConnectionService(configurationService, false));
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -118,7 +118,7 @@ public class IPVCallbackHandler
     }
 
     public IPVCallbackHandler(ConfigurationService configurationService) {
-        var kmsConnectionService = new KmsConnectionService(configurationService);
+        var kmsConnectionService = new KmsConnectionService(configurationService, false);
         this.configurationService = configurationService;
         this.ipvAuthorisationService =
                 new IPVAuthorisationService(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
@@ -25,8 +25,19 @@ public class KmsConnectionService {
                 configurationService.getTokenSigningKeyAlias());
     }
 
-    public KmsConnectionService(
-            Optional<String> localstackEndpointUri, String awsRegion, String tokenSigningKeyId) {
+    public KmsConnectionService(ConfigurationService configurationService, boolean warmUp) {
+        this(
+                configurationService.getLocalstackEndpointUri(),
+                configurationService.getAwsRegion(),
+                configurationService.getTokenSigningKeyAlias(),
+                false);
+    }
+
+    private KmsConnectionService(
+            Optional<String> localstackEndpointUri,
+            String awsRegion,
+            String tokenSigningKeyId,
+            boolean warmUp) {
         if (localstackEndpointUri.isPresent()) {
             LOG.info("Localstack endpoint URI is present: " + localstackEndpointUri.get());
             this.kmsClient =
@@ -42,7 +53,14 @@ public class KmsConnectionService {
                             .credentialsProvider(DefaultCredentialsProvider.create())
                             .build();
         }
-        warmUp(tokenSigningKeyId);
+        if (warmUp) {
+            warmUp(tokenSigningKeyId);
+        }
+    }
+
+    public KmsConnectionService(
+            Optional<String> localstackEndpointUri, String awsRegion, String tokenSigningKeyId) {
+        this(localstackEndpointUri, awsRegion, tokenSigningKeyId, false);
     }
 
     public GetPublicKeyResponse getPublicKey(GetPublicKeyRequest getPublicKeyRequest) {


### PR DESCRIPTION

## What?

Do not warm up KmsConnectionService in all cases.

Add an option to the constructore to omit warm up.

## Why?

The required keys for warm up to succeed are not available in the IPVAuthorisationHandler, IPVCallbackHandler and the DocAppCallbackHander, so calling warmup was generating error messages.

Removes 'Unable to retrieve Public Key whilst warming up' errors from the logs.
