### PR TITLE
AUT-1652: Create API and Lambda infra for AuthenticationCallbackHandler Lambda

### DIFF
--- a/ci/terraform/auth-external-api/outputs.tf
+++ b/ci/terraform/auth-external-api/outputs.tf
@@ -1,0 +1,7 @@
+output "di_auth_ext_api_id" {
+  value = aws_api_gateway_rest_api.di_auth_ext_api.id
+}
+
+output "vpce_id" {
+  value = data.aws_vpc_endpoint.auth_api_vpc_endpoint.id
+}

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -9,6 +9,7 @@ module "oidc_api_authentication_callback_role" {
     aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
     aws_iam_policy.dynamo_authentication_callback_userinfo_write_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.authentication_backend_uri_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -313,11 +313,6 @@ class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHandlerInte
         }
 
         @Override
-        public String getAuthenticationUserInfoEndpoint() {
-            return "/userinfo";
-        }
-
-        @Override
         public String getTxmaAuditQueueUrl() {
             return txmaAuditQueue.getQueueUrl();
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -222,11 +222,10 @@ public class AuthenticationCallbackHandler
             }
 
             try {
-                String userInfoPath = configurationService.getAuthenticationUserInfoEndpoint();
                 URI userInfoURI =
                         buildURI(
                                 configurationService.getAuthenticationBackendURI().toString(),
-                                userInfoPath);
+                                "userinfo");
 
                 HTTPRequest authorizationRequest = new HTTPRequest(POST, userInfoURI);
                 authorizationRequest.setAuthorization(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -79,7 +79,6 @@ class AuthenticationCallbackHandlerTest {
     private final ClientService clientService = mock(ClientService.class);
     private static final String TEST_FRONTEND_BASE_URL = "test.orchestration.frontend.url";
     private static final String TEST_AUTH_BACKEND_BASE_URL = "https://test.auth.backend.url";
-    private static final String TEST_AUTH_USERINFO_PATH = "/test-userinfo";
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String PERSISTENT_SESSION_ID = "a-persistent-session-id";
     private static final String SESSION_ID = "a-session-id";
@@ -113,8 +112,6 @@ class AuthenticationCallbackHandlerTest {
         when(configurationService.getLoginURI()).thenReturn(URI.create(TEST_FRONTEND_BASE_URL));
         when(configurationService.getAuthenticationBackendURI())
                 .thenReturn(URI.create(TEST_AUTH_BACKEND_BASE_URL));
-        when(configurationService.getAuthenticationUserInfoEndpoint())
-                .thenReturn(TEST_AUTH_USERINFO_PATH);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
                         CLIENT_SESSION_ID, TEST_EMAIL_ADDRESS, clientSession))
                 .thenReturn(AUTH_CODE_RP_TO_ORCH);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -180,11 +180,14 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public URI getAuthenticationBackendURI() {
-        return URI.create(System.getenv().getOrDefault("AUTHENTICATION_BACKEND_URI", ""));
-    }
-
-    public String getAuthenticationUserInfoEndpoint() {
-        return System.getenv("AUTHENTICATION_USER_INFO_ENDPOINT");
+        var paramName = format("{0}-authentication-backend-uri\"", getEnvironment());
+        try {
+            var request = GetParameterRequest.builder().name(paramName).build();
+            return URI.create(getSsmClient().getParameter(request).parameter().value());
+        } catch (ParameterNotFoundException e) {
+            LOG.error("No parameter exists with name: {}", paramName);
+            throw new RuntimeException(e);
+        }
     }
 
     public String getContactUsLinkRoute() {


### PR DESCRIPTION
## What?
The Orchestration callback Lambda will call the Authentication `token` and `userinfo` endpoints which will live on the new Authentication private external API. 


Orchestration will need to call the private API similar to this https://{rest-api-id}-{vpce-id}.execute-api.{region}.amazonaws.com/{stage}

## Why?

The private external API can only be called by traffic residing through the Authentication VPC endpoint (This will change when Orchestration moves into it’s own AWS account and VPC)

## Related PRs
https://github.com/alphagov/di-authentication-api/pull/3327