### PR TITLE
AUT-1774: Add timestamp and extend di-persistent-session-id cookie

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -31,6 +31,7 @@ import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
+import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.DocAppJwksExtension;
@@ -171,7 +172,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHttpCookieFromMultiValueResponseHeaders(
                         response.getMultiValueHeaders(), "di-persistent-session-id");
         assertThat(persistentCookie.isPresent(), equalTo(true));
-        assertThat(persistentCookie.get().getValue(), equalTo("persistent-id-value"));
+        assertThat(persistentCookie.get().getValue(), containsString("persistent-id-value--"));
+        assertTrue(
+                CookieHelper.isValidCookieWithDoubleDashedTimestamp(
+                        persistentCookie.get().getValue()));
 
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
@@ -205,7 +209,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHttpCookieFromMultiValueResponseHeaders(
                         response.getMultiValueHeaders(), "di-persistent-session-id");
         assertThat(persistentCookie.isPresent(), equalTo(true));
-        assertThat(persistentCookie.get().getValue(), equalTo("persistent-id-value"));
+        assertThat(persistentCookie.get().getValue(), containsString("persistent-id-value--"));
+        assertTrue(
+                CookieHelper.isValidCookieWithDoubleDashedTimestamp(
+                        persistentCookie.get().getValue()));
         var languageCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "lng");
         assertThat(languageCookie.isPresent(), equalTo(true));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -643,7 +643,7 @@ public class AuthorisationHandler
         cookies.add(
                 CookieHelper.buildCookieString(
                         CookieHelper.PERSISTENT_COOKIE_NAME,
-                        persistentSessionId,
+                        CookieHelper.appendTimestampToCookieValue(persistentSessionId),
                         configurationService.getPersistentCookieMaxAge(),
                         configurationService.getSessionCookieAttributes(),
                         configurationService.getDomainName()));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -61,6 +61,7 @@ import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.helpers.DocAppSubjectIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -85,6 +86,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -142,6 +144,7 @@ class AuthorisationHandlerTest {
             "gs=a-session-id.client-session-id; Max-Age=3600; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;";
     private static final String EXPECTED_PERSISTENT_COOKIE_STRING =
             "di-persistent-session-id=a-persistent-session-id; Max-Age=34190000; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;";
+    private static final String EXPECTED_PERSISTENT_COOKIE_VALUE = "a-persistent-session-id";
     private static final String EXPECTED_LANGUAGE_COOKIE_STRING =
             "lng=en; Max-Age=31536000; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;";
     private static final URI LOGIN_URL = URI.create("https://example.com");
@@ -240,10 +243,11 @@ class AuthorisationHandlerTest {
                     response.getMultiValueHeaders()
                             .get(ResponseHeaders.SET_COOKIE)
                             .contains(EXPECTED_SESSION_COOKIE_STRING));
-            assertTrue(
-                    response.getMultiValueHeaders()
-                            .get(ResponseHeaders.SET_COOKIE)
-                            .contains(EXPECTED_PERSISTENT_COOKIE_STRING));
+            var diPersistentCookieString =
+                    response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
+            var sessionId =
+                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
+            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
@@ -329,10 +333,11 @@ class AuthorisationHandlerTest {
                     response.getMultiValueHeaders()
                             .get(ResponseHeaders.SET_COOKIE)
                             .contains(EXPECTED_SESSION_COOKIE_STRING));
-            assertTrue(
-                    response.getMultiValueHeaders()
-                            .get(ResponseHeaders.SET_COOKIE)
-                            .contains(EXPECTED_PERSISTENT_COOKIE_STRING));
+            var diPersistentCookieString =
+                    response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
+            var sessionId =
+                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
+            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
             if (uiLocales.contains("en")) {
                 assertTrue(
                         response.getMultiValueHeaders()
@@ -383,10 +388,11 @@ class AuthorisationHandlerTest {
                     response.getMultiValueHeaders()
                             .get(ResponseHeaders.SET_COOKIE)
                             .contains(EXPECTED_SESSION_COOKIE_STRING));
-            assertTrue(
-                    response.getMultiValueHeaders()
-                            .get(ResponseHeaders.SET_COOKIE)
-                            .contains(EXPECTED_PERSISTENT_COOKIE_STRING));
+            var diPersistentCookieString =
+                    response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
+            var sessionId =
+                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
+            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
 
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -457,10 +463,12 @@ class AuthorisationHandlerTest {
                     response.getMultiValueHeaders()
                             .get(ResponseHeaders.SET_COOKIE)
                             .contains(EXPECTED_SESSION_COOKIE_STRING));
-            assertTrue(
-                    response.getMultiValueHeaders()
-                            .get(ResponseHeaders.SET_COOKIE)
-                            .contains(EXPECTED_PERSISTENT_COOKIE_STRING));
+
+            var diPersistentCookieString =
+                    response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
+            var sessionId =
+                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
+            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
 
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -501,10 +509,12 @@ class AuthorisationHandlerTest {
                     response.getMultiValueHeaders()
                             .get(ResponseHeaders.SET_COOKIE)
                             .contains(EXPECTED_SESSION_COOKIE_STRING));
-            assertTrue(
-                    response.getMultiValueHeaders()
-                            .get(ResponseHeaders.SET_COOKIE)
-                            .contains(EXPECTED_PERSISTENT_COOKIE_STRING));
+
+            var diPersistentCookieString =
+                    response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
+            var sessionId =
+                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
+            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
 
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -849,10 +859,11 @@ class AuthorisationHandlerTest {
                     response.getMultiValueHeaders()
                             .get(ResponseHeaders.SET_COOKIE)
                             .contains(EXPECTED_SESSION_COOKIE_STRING));
-            assertTrue(
-                    response.getMultiValueHeaders()
-                            .get(ResponseHeaders.SET_COOKIE)
-                            .contains(EXPECTED_PERSISTENT_COOKIE_STRING));
+            var diPersistentCookieString =
+                    response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
+            var sessionId =
+                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
+            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
             verify(sessionService).save(session);
 
             verify(requestObjectAuthorizeValidator).validate(any());
@@ -901,10 +912,11 @@ class AuthorisationHandlerTest {
                     response.getMultiValueHeaders()
                             .get(ResponseHeaders.SET_COOKIE)
                             .contains(EXPECTED_SESSION_COOKIE_STRING));
-            assertTrue(
-                    response.getMultiValueHeaders()
-                            .get(ResponseHeaders.SET_COOKIE)
-                            .contains(EXPECTED_PERSISTENT_COOKIE_STRING));
+            var diPersistentCookieString =
+                    response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
+            var sessionId =
+                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
+            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
             verify(sessionService).save(session);
 
             inOrder.verify(auditService)
@@ -984,7 +996,8 @@ class AuthorisationHandlerTest {
             assertTrue(
                     response.getMultiValueHeaders()
                             .get(ResponseHeaders.SET_COOKIE)
-                            .contains(EXPECTED_PERSISTENT_COOKIE_STRING));
+                            .get(1)
+                            .contains("a-persistent-session-id--"));
         }
 
         @Test
@@ -1281,6 +1294,18 @@ class AuthorisationHandlerTest {
                             any(),
                             any(),
                             any());
+        }
+    }
+
+    public static String extractSessionId(String input, String sessionIdPrefix) {
+        String sessionIdPattern = sessionIdPrefix + "--[0-9]+";
+        var pattern = Pattern.compile(sessionIdPattern);
+        var matcher = pattern.matcher(input);
+
+        if (matcher.find()) {
+            return matcher.group();
+        } else {
+            return "";
         }
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
@@ -180,7 +180,7 @@ class OrchestrationAuthorizationServiceTest {
                 orchestrationAuthorizationService.getExistingOrCreateNewPersistentSessionId(
                         requestCookieHeader);
 
-        assertThat(persistentSessionId, equalTo("some-persistent-id"));
+        assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(persistentSessionId));
     }
 
     @ParameterizedTest

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
@@ -160,4 +160,13 @@ public class CookieHelper {
                 "%s=%s; Max-Age=%d; Domain=%s; %s",
                 cookieName, cookieValue, maxAge, domain, attributes);
     }
+
+    public static String appendTimestampToCookieValue(String cookieValue) {
+        return cookieValue + "--" + NowHelper.now().getTime();
+    }
+
+    public static boolean isValidCookieWithDoubleDashedTimestamp(String cookieValue) {
+        String sessionIdPattern = ".*--\\d+";
+        return cookieValue.matches(sessionIdPattern);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
@@ -3,6 +3,8 @@ package uk.gov.di.authentication.shared.helpers;
 import java.util.Map;
 import java.util.Objects;
 
+import static uk.gov.di.authentication.shared.helpers.CookieHelper.appendTimestampToCookieValue;
+
 public class PersistentIdHelper {
 
     public static final String PERSISTENT_ID_HEADER_NAME = "di-persistent-session-id";
@@ -25,8 +27,18 @@ public class PersistentIdHelper {
     }
 
     public static String getExistingOrCreateNewPersistentSessionId(Map<String, String> headers) {
-        return CookieHelper.parsePersistentCookie(headers)
-                .flatMap(InputSanitiser::sanitiseBase64)
-                .orElse(IdGenerator.generate());
+        var parsedCookie = CookieHelper.parsePersistentCookie(headers);
+        if (parsedCookie.isPresent()) {
+            String existingCookieValue =
+                    InputSanitiser.sanitiseBase64(parsedCookie.get()).orElse("");
+
+            if (existingCookieValue.contains("--")) {
+                return existingCookieValue;
+            } else {
+                return appendTimestampToCookieValue(existingCookieValue);
+            }
+        } else {
+            return appendTimestampToCookieValue(IdGenerator.generate());
+        }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -498,7 +498,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public int getPersistentCookieMaxAge() {
         return Integer.parseInt(
-                System.getenv().getOrDefault("PERSISTENT_COOKIE_MAX_AGE", "34190000"));
+                System.getenv().getOrDefault("PERSISTENT_COOKIE_MAX_AGE", "47340000"));
     }
 
     public int getLanguageCookieMaxAge() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PersistentIdHelperTest {
 
@@ -67,8 +68,7 @@ class PersistentIdHelperTest {
         Map<String, String> inputHeaders = Map.of(CookieHelper.REQUEST_COOKIE_HEADER, cookieString);
         String persistentId =
                 PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(inputHeaders);
-
-        assertThat(persistentId, equalTo("a-persistent-id"));
+        assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(persistentId));
     }
 
     @Test
@@ -80,6 +80,6 @@ class PersistentIdHelperTest {
                 PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(inputHeaders);
 
         assertThat(persistentId, not(equalTo("a-persistent-id")));
-        assertThat(Base64.getUrlDecoder().decode(persistentId).length, equalTo(20));
+        assertThat(Base64.getUrlDecoder().decode(persistentId.split("--")[0]).length, equalTo(20));
     }
 }


### PR DESCRIPTION
## What?

- Increase the max age of the `di-persistent-session-id` to 18 months rolling max-age
- For new cookies, append the timestamp to the end of the cookie value by using a double dash --
- For existing cookies, check whether it has a timestamp suffixed onto the cookie value, if not update the value by appending the timestamp

## Why?

So that the max-age for `di-persistent-session-id` is 18 months rather than 13

