### PR TITLE
AUT-1855: Enable Key Rotation

### DIFF
--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -196,6 +196,7 @@ resource "aws_kms_key" "lambda_env_vars_encryption_key" {
   deletion_window_in_days  = 30
   key_usage                = "ENCRYPT_DECRYPT"
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
 
   tags = local.default_tags
 }


### PR DESCRIPTION
## What?

Enabled key rotation for lambda_env_vars_encryption_key in kms.tf

## Why?

Lack of key rotation primarily impacts the confidentiality and integrity of the tested AWS
environment. This is due to the possibility that aged customer managed keys are compromised,
due to the lack of rotation it could be possible that the compromised key is still functional.
Should these keys provide administrative access, data encrypted by said keys could be exposed
outside of their current, protected environment, exposing sensitive information to malicious
actors.
