### PR TITLE
ATO-107: Remove required annotation from claims in AuthCodeRequest

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
@@ -20,7 +20,6 @@ public class AuthCodeRequest {
 
     @SerializedName("claims")
     @Expose
-    @Required
     private List<String> claims;
 
     @SerializedName("rp-sector-uri")

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -67,6 +67,17 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
     }
 
     @Test
+    void shouldReturn200StatusAndReturnMatchingAuthCodeForAuthCodeRequestWithNoClaims()
+            throws Json.JsonException {
+        setUpDynamo();
+        var authRequest =
+                new AuthCodeRequest(
+                        TEST_REDIRECT_URI, TEST_STATE, null, TEST_SECTOR_IDENTIFIER, false);
+        var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
+        assertThat(response, hasStatus(200));
+    }
+
+    @Test
     void shouldReturn400StatusForInvalidRedirectUri() throws Json.JsonException {
         setUpDynamo();
         var authRequest =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -107,17 +107,6 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
     }
 
-    @Test
-    void shouldReturn400StatusForInvalidRequestedScopeClaims() throws Json.JsonException {
-        setUpDynamo();
-        var authRequest =
-                new AuthCodeRequest(
-                        TEST_REDIRECT_URI, TEST_STATE, null, TEST_SECTOR_IDENTIFIER, false);
-        var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
-        assertThat(response, hasStatus(400));
-        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
-    }
-
     private Map<String, String> getHeaders() throws Json.JsonException {
         Map<String, String> headers = new HashMap<>();
         var sessionId = redis.createSession();


### PR DESCRIPTION
## What?

Removing 'required' annotation from claims in AuthCodeRequest

## Why?

These claims can be empty, if no scopes are requested. This causes the login flow to error after the user enters an auth code, since it validate the AuthCodeRequest object and expects claims to be required. This code is only currently used in sandpit, as it is behind the auth/orch split flag. Other instances claims do not have the required flag.

