### PR TITLE
AUT-1908: Update urls in the emails and SMS

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
@@ -75,9 +75,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             emailPersonalisation.put("validation-code", notifyRequest.getCode());
                             emailPersonalisation.put(
                                     "email-address", notifyRequest.getDestination());
-                            emailPersonalisation.put(
-                                    "contact-us-link",
-                                    buildContactUsUrl("confirmEmailAddressEmail"));
+                            emailPersonalisation.put("contact-us-link", buildContactUsUrl());
                             LOG.info("Sending VERIFY_EMAIL email using Notify");
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
@@ -101,9 +99,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             Map<String, Object> emailUpdatePersonalisation = new HashMap<>();
                             emailUpdatePersonalisation.put(
                                     "email-address", notifyRequest.getDestination());
-                            emailUpdatePersonalisation.put(
-                                    "contact-us-link",
-                                    buildContactUsUrl("emailAddressUpdatedEmail"));
+                            emailUpdatePersonalisation.put("contact-us-link", buildContactUsUrl());
                             LOG.info("Sending EMAIL_UPDATED email using Notify");
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
@@ -116,7 +112,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             LOG.info("Sending DELETE_ACCOUNT email using Notify");
                             Map<String, Object> accountDeletedPersonalisation = new HashMap<>();
                             accountDeletedPersonalisation.put(
-                                    "contact-us-link", buildContactUsUrl("accountDeletedEmail"));
+                                    "contact-us-link", buildContactUsUrl());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     accountDeletedPersonalisation,
@@ -128,8 +124,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             LOG.info("Sending PHONE_NUMBER_UPDATED email using Notify");
                             Map<String, Object> phoneNumberUpdatedPersonalisation = new HashMap<>();
                             phoneNumberUpdatedPersonalisation.put(
-                                    "contact-us-link",
-                                    buildContactUsUrl("phoneNumberUpdatedEmail"));
+                                    "contact-us-link", buildContactUsUrl());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     phoneNumberUpdatedPersonalisation,
@@ -141,7 +136,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             LOG.info("Sending PASSWORD_UPDATED email using Notify");
                             Map<String, Object> passwordUpdatedPersonalisation = new HashMap<>();
                             passwordUpdatedPersonalisation.put(
-                                    "contact-us-link", buildContactUsUrl("passwordUpdatedEmail"));
+                                    "contact-us-link", buildContactUsUrl());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     passwordUpdatedPersonalisation,
@@ -167,12 +162,10 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
         return null;
     }
 
-    private String buildContactUsUrl(String referer) {
-        var queryParam = Map.of("referer", referer);
+    private String buildContactUsUrl() {
         return buildURI(
                         configurationService.getFrontendBaseUrl(),
-                        configurationService.getContactUsLinkRoute(),
-                        queryParam)
+                        configurationService.getContactUsLinkRoute())
                 .toString();
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
@@ -35,7 +35,7 @@ public class NotificationHandlerTest {
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String TEST_PHONE_NUMBER = "01234567890";
     private static final String FRONTEND_BASE_URL = "https://localhost:8080/frontend";
-    private static final String CONTACT_US_LINK_ROUTE = "contact-us";
+    private static final String CONTACT_US_LINK_ROUTE = "contact-gov-uk-one-login";
     private final Context context = mock(Context.class);
     private final NotificationService notificationService = mock(NotificationService.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
@@ -55,8 +55,7 @@ public class NotificationHandlerTest {
 
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321", SupportedLanguage.EN);
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=confirmEmailAddressEmail";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -100,8 +99,7 @@ public class NotificationHandlerTest {
 
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, EMAIL_UPDATED, SupportedLanguage.EN);
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=emailAddressUpdatedEmail";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -122,8 +120,7 @@ public class NotificationHandlerTest {
 
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, PASSWORD_UPDATED, SupportedLanguage.EN);
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=passwordUpdatedEmail";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -146,8 +143,7 @@ public class NotificationHandlerTest {
 
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, PHONE_NUMBER_UPDATED, SupportedLanguage.EN);
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=phoneNumberUpdatedEmail";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -170,8 +166,7 @@ public class NotificationHandlerTest {
 
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, DELETE_ACCOUNT, SupportedLanguage.EN);
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=accountDeletedEmail";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -205,8 +200,7 @@ public class NotificationHandlerTest {
 
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321", SupportedLanguage.EN);
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=confirmEmailAddressEmail";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/NotificationHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/NotificationHandlerIntegrationTest.java
@@ -47,8 +47,7 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
                 personalisation,
                 hasFieldWithValue(
                         "contact-us-link",
-                        equalTo(
-                                "http://localhost:3000/frontend/contact-us?referer=confirmEmailAddressEmail")));
+                        equalTo("http://localhost:3000/frontend/contact-gov-uk-one-login")));
     }
 
     @Test

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -153,7 +153,7 @@ variable "lambda_min_concurrency" {
 
 variable "contact_us_link_route" {
   type    = string
-  default = "contact-us"
+  default = "contact-gov-uk-one-login"
 }
 
 variable "localstack_endpoint" {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -96,8 +96,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                     Map<String, Object> notifyPersonalisation = new HashMap<>();
                     switch (notifyRequest.getNotificationType()) {
                         case ACCOUNT_CREATED_CONFIRMATION:
-                            notifyPersonalisation.put(
-                                    "contact-us-link", buildContactUsUrl("accountCreatedEmail"));
+                            notifyPersonalisation.put("contact-us-link", buildContactUsUrl());
                             notifyPersonalisation.put(
                                     "gov-uk-accounts-url",
                                     configurationService.getGovUKAccountsURL().toString());
@@ -111,9 +110,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notifyPersonalisation.put("validation-code", notifyRequest.getCode());
                             notifyPersonalisation.put(
                                     "email-address", notifyRequest.getDestination());
-                            notifyPersonalisation.put(
-                                    "contact-us-link",
-                                    buildContactUsUrl("confirmEmailAddressEmail"));
+                            notifyPersonalisation.put("contact-us-link", buildContactUsUrl());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
@@ -140,8 +137,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             Map<String, Object> passwordResetConfirmationPersonalisation =
                                     new HashMap<>();
                             passwordResetConfirmationPersonalisation.put(
-                                    "contact-us-link",
-                                    buildContactUsUrl("passwordResetConfirmationEmail"));
+                                    "contact-us-link", buildContactUsUrl());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     passwordResetConfirmationPersonalisation,
@@ -150,9 +146,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             break;
                         case PASSWORD_RESET_CONFIRMATION_SMS:
                             Map<String, Object> passwordResetConfirmationSmsPersonalisation =
-                                    Map.of(
-                                            "contact-us-link",
-                                            buildContactUsUrl("passwordResetConfirmationSms"));
+                                    Map.of("contact-us-link", buildContactUsUrl());
                             notificationService.sendText(
                                     notifyRequest.getDestination(),
                                     passwordResetConfirmationSmsPersonalisation,
@@ -163,9 +157,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notifyPersonalisation.put("validation-code", notifyRequest.getCode());
                             notifyPersonalisation.put(
                                     "email-address", notifyRequest.getDestination());
-                            notifyPersonalisation.put(
-                                    "contact-us-link",
-                                    buildContactUsUrl("passwordResetRequestEmail"));
+                            notifyPersonalisation.put("contact-us-link", buildContactUsUrl());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
@@ -187,8 +179,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                                     changeHowGetSecurityCodesConfirmationPersonalisation =
                                             new HashMap<>();
                             changeHowGetSecurityCodesConfirmationPersonalisation.put(
-                                    "contact-us-link",
-                                    buildContactUsUrl("changeCodesConfirmEmail"));
+                                    "contact-us-link", buildContactUsUrl());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     changeHowGetSecurityCodesConfirmationPersonalisation,
@@ -242,12 +233,10 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
         }
     }
 
-    private String buildContactUsUrl(String referer) {
-        var queryParam = Map.of("referer", referer);
+    private String buildContactUsUrl() {
         return buildURI(
                         configurationService.getFrontendBaseUrl(),
-                        configurationService.getContactUsLinkRoute(),
-                        queryParam)
+                        configurationService.getContactUsLinkRoute())
                 .toString();
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -75,8 +75,7 @@ public class NotificationHandlerTest {
                 new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321", SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=confirmEmailAddressEmail";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
         handler.handleRequest(sqsEvent, context);
 
@@ -97,8 +96,7 @@ public class NotificationHandlerTest {
                         TEST_EMAIL_ADDRESS, PASSWORD_RESET_CONFIRMATION, SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=passwordResetConfirmationEmail";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
         handler.handleRequest(sqsEvent, context);
 
@@ -120,8 +118,7 @@ public class NotificationHandlerTest {
                 new NotifyRequest(
                         TEST_PHONE_NUMBER, PASSWORD_RESET_CONFIRMATION_SMS, SupportedLanguage.EN);
         var sqsEvent = generateSQSEvent(objectMapper.writeValueAsString(notifyRequest));
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=passwordResetConfirmationSms";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
         handler.handleRequest(sqsEvent, context);
 
@@ -139,8 +136,7 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessAccountCreatedConfirmationFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
         String baseUrl = "http://account-management";
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=accountCreatedEmail";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
         var govUKAccountsUrl = URI.create("https://www.gov.uk/account");
         when(configService.getAccountManagementURI()).thenReturn(baseUrl);
         when(configService.getGovUKAccountsURL()).thenReturn(govUKAccountsUrl);
@@ -208,8 +204,7 @@ public class NotificationHandlerTest {
                 new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321", SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=confirmEmailAddressEmail";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
@@ -344,7 +339,7 @@ public class NotificationHandlerTest {
         handler.handleRequest(sqsEvent, context);
 
         Map<String, Object> personalisation = new HashMap<>();
-        personalisation.put("contact-us-link", buildContactUsUrl("accountCreatedEmail"));
+        personalisation.put("contact-us-link", buildContactUsUrl());
         personalisation.put("gov-uk-accounts-url", GOV_UK_ACCOUNTS_URL.toString());
 
         verify(notificationService)
@@ -369,8 +364,7 @@ public class NotificationHandlerTest {
                         SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
-        var contactUsLinkUrl =
-                "https://localhost:8080/frontend/contact-us?referer=passwordResetRequestEmail";
+        var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
         handler.handleRequest(sqsEvent, context);
 
@@ -413,12 +407,8 @@ public class NotificationHandlerTest {
                         SupportedLanguage.EN);
     }
 
-    private String buildContactUsUrl(String referer) {
-        var queryParam = Map.of("referer", referer);
-        return buildURI(
-                        configService.getFrontendBaseUrl(),
-                        configService.getContactUsLinkRoute(),
-                        queryParam)
+    private String buildContactUsUrl() {
+        return buildURI(configService.getFrontendBaseUrl(), configService.getContactUsLinkRoute())
                 .toString();
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
@@ -113,7 +113,7 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
     @ParameterizedTest
     @MethodSource("confirmationEmails")
     void shouldCallNotifyWhenValidAccountCreatedRequestIsAddedToQueue(
-            NotificationType notificationType, String referer) throws Json.JsonException {
+            NotificationType notificationType) throws Json.JsonException {
         handler.handleRequest(
                 createSqsEvent(
                         new NotifyRequest(
@@ -130,6 +130,6 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
                 personalisation,
                 hasFieldWithValue(
                         "contact-us-link",
-                        equalTo("http://localhost:3000/frontend/contact-us?referer=" + referer)));
+                        equalTo("http://localhost:3000/frontend/contact-gov-uk-one-login")));
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/NotifyIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/NotifyIntegrationTest.java
@@ -103,7 +103,7 @@ public abstract class NotifyIntegrationTest {
 
         @Override
         public String getContactUsLinkRoute() {
-            return "contact-us";
+            return "contact-gov-uk-one-login";
         }
     }
 }


### PR DESCRIPTION
## What?
Change the urls that take users to the contact form from the emails and SMSs they receive when they create a [GOV.UK](http://gov.uk/) One Login, sign in, or reset their password or 2FA method (account recovery).

- Remove "referer"
- Modify contact us route from "contact-us" to "contact-gov-uk-one-login"

## Why?

So that users go to the new ‘triage’ page rather than directly to the contact form.
