### PR TITLE
BAU: Create custom JwsSigner

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/jwt/KmsJwsSigner.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/jwt/KmsJwsSigner.java
@@ -9,7 +9,6 @@ import com.nimbusds.jose.jca.JCAContext;
 import com.nimbusds.jose.util.Base64URL;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec.ECDSA_SHA_256;
@@ -54,7 +53,7 @@ public class KmsJwsSigner implements JWSSigner {
 
     @Override
     public Set<JWSAlgorithm> supportedJWSAlgorithms() {
-        return Collections.emptySet();
+        return Set.of(JWSAlgorithm.RS256, JWSAlgorithm.ES256);
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/jwt/KmsJwsSigner.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/jwt/KmsJwsSigner.java
@@ -1,0 +1,28 @@
+package uk.gov.di.authentication.shared.jwt;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.jca.JCAContext;
+import com.nimbusds.jose.util.Base64URL;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class KmsJwsSigner implements JWSSigner {
+    @Override
+    public Base64URL sign(JWSHeader header, byte[] signingInput) throws JOSEException {
+        return new Base64URL("");
+    }
+
+    @Override
+    public Set<JWSAlgorithm> supportedJWSAlgorithms() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public JCAContext getJCAContext() {
+        return new JCAContext();
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/jwt/KmsJwsSigner.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/jwt/KmsJwsSigner.java
@@ -11,17 +11,25 @@ import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import java.util.Collections;
 import java.util.Set;
 
+import static software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256;
+
 public class KmsJwsSigner implements JWSSigner {
 
     private final KmsConnectionService kms;
+    private final String rsaSigningKeyId;
 
-    public KmsJwsSigner(KmsConnectionService kms) {
+    public KmsJwsSigner(KmsConnectionService kms, String rsaSigningKeyId) {
         this.kms = kms;
+        this.rsaSigningKeyId = rsaSigningKeyId;
     }
 
     @Override
     public Base64URL sign(JWSHeader header, byte[] signingInput) throws JOSEException {
-        return new Base64URL("");
+        if (signingInput.length == 0) {
+            return new Base64URL("");
+        }
+
+        return Base64URL.encode(kms.sign(rsaSigningKeyId, RSASSA_PKCS1_V1_5_SHA_256, signingInput));
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/jwt/KmsJwsSigner.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/jwt/KmsJwsSigner.java
@@ -4,6 +4,7 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.jca.JCAContext;
 import com.nimbusds.jose.util.Base64URL;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
@@ -11,16 +12,19 @@ import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import java.util.Collections;
 import java.util.Set;
 
+import static software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec.ECDSA_SHA_256;
 import static software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256;
 
 public class KmsJwsSigner implements JWSSigner {
 
     private final KmsConnectionService kms;
     private final String rsaSigningKeyId;
+    private final String ecSigningKeyId;
 
-    public KmsJwsSigner(KmsConnectionService kms, String rsaSigningKeyId) {
+    public KmsJwsSigner(KmsConnectionService kms, String rsaSigningKeyId, String ecSigningKeyId) {
         this.kms = kms;
         this.rsaSigningKeyId = rsaSigningKeyId;
+        this.ecSigningKeyId = ecSigningKeyId;
     }
 
     @Override
@@ -29,7 +33,23 @@ public class KmsJwsSigner implements JWSSigner {
             return new Base64URL("");
         }
 
-        return Base64URL.encode(kms.sign(rsaSigningKeyId, RSASSA_PKCS1_V1_5_SHA_256, signingInput));
+        var signingKey =
+                header.getAlgorithm() == JWSAlgorithm.RS256 ? rsaSigningKeyId : ecSigningKeyId;
+
+        var signingAlgorithm =
+                header.getAlgorithm() == JWSAlgorithm.RS256
+                        ? RSASSA_PKCS1_V1_5_SHA_256
+                        : ECDSA_SHA_256;
+
+        var signedOutput = kms.sign(signingKey, signingAlgorithm, signingInput);
+
+        if (header.getAlgorithm() == JWSAlgorithm.RS256) {
+            return Base64URL.encode(signedOutput);
+        } else {
+            return Base64URL.encode(
+                    ECDSA.transcodeSignatureToConcat(
+                            signedOutput, ECDSA.getSignatureByteArrayLength(JWSAlgorithm.ES256)));
+        }
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/jwt/KmsJwsSigner.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/jwt/KmsJwsSigner.java
@@ -6,11 +6,19 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.jca.JCAContext;
 import com.nimbusds.jose.util.Base64URL;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import java.util.Collections;
 import java.util.Set;
 
 public class KmsJwsSigner implements JWSSigner {
+
+    private final KmsConnectionService kms;
+
+    public KmsJwsSigner(KmsConnectionService kms) {
+        this.kms = kms;
+    }
+
     @Override
     public Base64URL sign(JWSHeader header, byte[] signingInput) throws JOSEException {
         return new Base64URL("");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
@@ -3,12 +3,14 @@ package uk.gov.di.authentication.shared.services;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 
 import java.net.URI;
 import java.util.Optional;
@@ -53,6 +55,17 @@ public class KmsConnectionService {
     public SignResponse sign(SignRequest signRequest) {
         LOG.info("Calling KMS with SignRequest and KeyId {}", signRequest.keyId());
         return kmsClient.sign(signRequest);
+    }
+
+    public byte[] sign(String keyId, SigningAlgorithmSpec algorithm, byte[] data) {
+        var signRequest =
+                SignRequest.builder()
+                        .message(SdkBytes.fromByteArray(data))
+                        .keyId(keyId)
+                        .signingAlgorithm(algorithm)
+                        .build();
+
+        return sign(signRequest).signature().asByteArray();
     }
 
     private void warmUp(String keyId) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
@@ -1,8 +1,10 @@
 package uk.gov.di.authentication.shared.jwt;
 
+import com.amazonaws.util.Base64;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.util.Base64URL;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
@@ -19,7 +21,7 @@ class KmsJwsSignerTest {
 
     @Test
     void shouldReturnEmptyBaseUrlWithNoData() throws JOSEException {
-        var signer = new KmsJwsSigner(kms, "rsa-signing-key");
+        var signer = new KmsJwsSigner(kms, "rsa-signing-key", "ec-signing-key");
         var header = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
         var emptyData = new byte[0];
 
@@ -28,7 +30,7 @@ class KmsJwsSignerTest {
 
     @Test
     void shouldSignDataWithRS256IfNonEmpty() throws JOSEException {
-        var signer = new KmsJwsSigner(kms, "rsa-signing-key");
+        var signer = new KmsJwsSigner(kms, "rsa-signing-key", "ec-signing-key");
         var header = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
         var data = "input".getBytes();
 
@@ -36,5 +38,27 @@ class KmsJwsSignerTest {
                 .thenReturn("output".getBytes());
 
         assertThat(signer.sign(header, data), is(Base64URL.encode("output")));
+    }
+
+    @Test
+    void shouldSignDataWithES256IfNonEmpty() throws JOSEException {
+        var signer = new KmsJwsSigner(kms, "rsa-signing-key", "ec-signing-key");
+        var header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+        var data = "input".getBytes();
+
+        // "output" signed with disposable key
+        var output =
+                Base64.decode(
+                        "MEUCICPb0OfprJaOLMB8mTsZniBwShawFyxujrtriH4gykAXAiEAjHJfq/lM2XgbvzjzBn1Lw9nMdLjzbCserDIw7MfzfPs=");
+
+        when(kms.sign("ec-signing-key", SigningAlgorithmSpec.ECDSA_SHA_256, data))
+                .thenReturn(output);
+
+        var expectedOutput =
+                Base64URL.encode(
+                        ECDSA.transcodeSignatureToConcat(
+                                output, ECDSA.getSignatureByteArrayLength(JWSAlgorithm.ES256)));
+
+        assertThat(signer.sign(header, data), is(expectedOutput));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
@@ -1,0 +1,22 @@
+package uk.gov.di.authentication.shared.jwt;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.util.Base64URL;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class KmsJwsSignerTest {
+
+    @Test
+    void shouldReturnEmptyBaseUrlWithNoData() throws JOSEException {
+        var signer = new KmsJwsSigner();
+        var header = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
+        var emptyData = new byte[0];
+
+        assertThat(signer.sign(header, emptyData), is(new Base64URL("")));
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
@@ -8,7 +8,10 @@ import com.nimbusds.jose.util.Base64URL;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
+import java.util.Set;
+
 import static com.nimbusds.jose.JWSAlgorithm.ES256;
+import static com.nimbusds.jose.JWSAlgorithm.RS256;
 import static com.nimbusds.jose.crypto.impl.ECDSA.getSignatureByteArrayLength;
 import static com.nimbusds.jose.crypto.impl.ECDSA.transcodeSignatureToConcat;
 import static org.hamcrest.CoreMatchers.is;
@@ -59,5 +62,10 @@ class KmsJwsSignerTest {
                         transcodeSignatureToConcat(output, getSignatureByteArrayLength(ES256)));
 
         assertThat(signer.sign(header, data), is(expectedOutput));
+    }
+
+    @Test
+    void shouldOnlySupportRS256AndES256Signing() {
+        assertThat(signer.supportedJWSAlgorithms(), is(Set.of(RS256, ES256)));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
@@ -5,15 +5,19 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.util.Base64URL;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
 class KmsJwsSignerTest {
 
+    private final KmsConnectionService kms = mock(KmsConnectionService.class);
+
     @Test
     void shouldReturnEmptyBaseUrlWithNoData() throws JOSEException {
-        var signer = new KmsJwsSigner();
+        var signer = new KmsJwsSigner(kms);
         var header = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
         var emptyData = new byte[0];
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
@@ -5,11 +5,13 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.util.Base64URL;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class KmsJwsSignerTest {
 
@@ -17,10 +19,22 @@ class KmsJwsSignerTest {
 
     @Test
     void shouldReturnEmptyBaseUrlWithNoData() throws JOSEException {
-        var signer = new KmsJwsSigner(kms);
+        var signer = new KmsJwsSigner(kms, "rsa-signing-key");
         var header = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
         var emptyData = new byte[0];
 
         assertThat(signer.sign(header, emptyData), is(new Base64URL("")));
+    }
+
+    @Test
+    void shouldSignDataWithRS256IfNonEmpty() throws JOSEException {
+        var signer = new KmsJwsSigner(kms, "rsa-signing-key");
+        var header = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
+        var data = "input".getBytes();
+
+        when(kms.sign("rsa-signing-key", SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256, data))
+                .thenReturn("output".getBytes());
+
+        assertThat(signer.sign(header, data), is(Base64URL.encode("output")));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/jwt/KmsJwsSignerTest.java
@@ -4,24 +4,27 @@ import com.amazonaws.util.Base64;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.util.Base64URL;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
+import static com.nimbusds.jose.JWSAlgorithm.ES256;
+import static com.nimbusds.jose.crypto.impl.ECDSA.getSignatureByteArrayLength;
+import static com.nimbusds.jose.crypto.impl.ECDSA.transcodeSignatureToConcat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec.ECDSA_SHA_256;
+import static software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256;
 
 class KmsJwsSignerTest {
 
     private final KmsConnectionService kms = mock(KmsConnectionService.class);
+    private final KmsJwsSigner signer = new KmsJwsSigner(kms, "rsa-signing-key", "ec-signing-key");
 
     @Test
     void shouldReturnEmptyBaseUrlWithNoData() throws JOSEException {
-        var signer = new KmsJwsSigner(kms, "rsa-signing-key", "ec-signing-key");
         var header = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
         var emptyData = new byte[0];
 
@@ -30,11 +33,10 @@ class KmsJwsSignerTest {
 
     @Test
     void shouldSignDataWithRS256IfNonEmpty() throws JOSEException {
-        var signer = new KmsJwsSigner(kms, "rsa-signing-key", "ec-signing-key");
         var header = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
         var data = "input".getBytes();
 
-        when(kms.sign("rsa-signing-key", SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256, data))
+        when(kms.sign("rsa-signing-key", RSASSA_PKCS1_V1_5_SHA_256, data))
                 .thenReturn("output".getBytes());
 
         assertThat(signer.sign(header, data), is(Base64URL.encode("output")));
@@ -42,8 +44,7 @@ class KmsJwsSignerTest {
 
     @Test
     void shouldSignDataWithES256IfNonEmpty() throws JOSEException {
-        var signer = new KmsJwsSigner(kms, "rsa-signing-key", "ec-signing-key");
-        var header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+        var header = new JWSHeader.Builder(ES256).build();
         var data = "input".getBytes();
 
         // "output" signed with disposable key
@@ -51,13 +52,11 @@ class KmsJwsSignerTest {
                 Base64.decode(
                         "MEUCICPb0OfprJaOLMB8mTsZniBwShawFyxujrtriH4gykAXAiEAjHJfq/lM2XgbvzjzBn1Lw9nMdLjzbCserDIw7MfzfPs=");
 
-        when(kms.sign("ec-signing-key", SigningAlgorithmSpec.ECDSA_SHA_256, data))
-                .thenReturn(output);
+        when(kms.sign("ec-signing-key", ECDSA_SHA_256, data)).thenReturn(output);
 
         var expectedOutput =
                 Base64URL.encode(
-                        ECDSA.transcodeSignatureToConcat(
-                                output, ECDSA.getSignatureByteArrayLength(JWSAlgorithm.ES256)));
+                        transcodeSignatureToConcat(output, getSignatureByteArrayLength(ES256)));
 
         assertThat(signer.sign(header, data), is(expectedOutput));
     }


### PR DESCRIPTION
This will tidy up the code by implementing a `JwsSigner` that delegates signing operations to AWS KMS, as part of Nimbus' interface, so our token signing becomes 

```
var jwt = new SignedJwt(headers, claims);
jwt.sign(new KmsJwsSigner(kms, rsaSigningKeyAlias, ecSigningKeyAlias);
```

This PR is a draft because `TokenService` needs a bit of tidy-up before we can use this to sign tokens in the proper.
