### PR TITLE
ATO-NONE: Fix codeowners file to make all teams codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-* @govuk-one-login/auth-team
-* @govuk-one-login/auth-leads
-* @govuk-one-login/orchestration-leads
-* @govuk-one-login/orchestration-team
+* @govuk-one-login/auth-team @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads @govuk-one-login/orchestration-team


### PR DESCRIPTION
## What?

Fix codeowners file to make all teams codeowners
## Why?

Format of codeowners file was incorrect, so only orchestration team were codeowners

