### PR TITLE
AUT-1467: Set deploy_bulk_email_users_count to 0 in all environments -> destroy infrastructure

### DIFF
--- a/ci/terraform/delivery-receipts/site.tf
+++ b/ci/terraform/delivery-receipts/site.tf
@@ -46,7 +46,7 @@ locals {
   }
 
   request_tracing_allowed       = contains(["build", "sandpit"], var.environment)
-  deploy_bulk_email_users_count = contains(["build", "sandpit"], var.environment) ? 0 : 1
+  deploy_bulk_email_users_count = 0
 
   access_logging_template = jsonencode({
     requestId            = "$context.requestId"

--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -59,7 +59,7 @@ locals {
   }
 
   request_tracing_allowed       = contains(["build", "sandpit"], var.environment)
-  deploy_bulk_email_users_count = contains(["build", "sandpit"], var.environment) ? 0 : 1
+  deploy_bulk_email_users_count = 0
 }
 
 data "aws_caller_identity" "current" {}

--- a/ci/terraform/utils/site.tf
+++ b/ci/terraform/utils/site.tf
@@ -52,7 +52,7 @@ locals {
   }
 
   request_tracing_allowed                     = contains(["build", "sandpit"], var.environment)
-  deploy_bulk_email_users_count               = contains(["build", "sandpit"], var.environment) ? 0 : 1
+  deploy_bulk_email_users_count               = 0
   bulk_user_email_audience_loader_lambda_name = "${var.environment}-bulk-user-email-audience-loader-lambda"
 }
 


### PR DESCRIPTION


## What?

Set deploy_bulk_email_users_count to 0 in all environments -> destroy infrastructure

This sets the counts for:

    * The bulk-email-users table;
    * The bulk-email-sender;
    * The bulk-email-loader
   
to 0 in all environments (this was already done for build and sandpit). This will mean that the lambdas are no longer deployed in these environments, and the table (including data) is destroyed.

## Why?

Bulk email facility no longer in use so tearing down resources.

## Related PRs

They can be brought back by reverting this PR and #3485 

