### PR TITLE
BAU: Don't provision concurrency if not needed

### DIFF
--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -77,7 +77,7 @@ resource "time_sleep" "wait_for_alias_to_reassign" {
 }
 
 resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrency_config" {
-  count = 1
+  count = local.authorizer_provisioned_concurrency == 0 ? 0 : 1
 
   function_name = aws_lambda_function.authorizer.function_name
   qualifier     = aws_lambda_alias.authorizer_alias.name


### PR DESCRIPTION
## What?

In the case that `local.authorizer_provisioned_concurrency` is 0, don't try to provision `aws_lambda_provisioned_concurrency_config`

## Why?

Fixes the following error when deploying to sandpit:
`Error: expected provisioned_concurrent_executions to be at least (1), got 0`
