### PR TITLE
Bump org.eclipse.jetty:jetty-server from 11.0.13 to 11.0.18

### DIFF
--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -19,7 +19,7 @@ dependencies {
             configurations.sqs,
             configurations.ssm,
             configurations.cloudwatch,
-            "org.eclipse.jetty:jetty-server:11.0.13",
+            "org.eclipse.jetty:jetty-server:11.0.18",
             "com.google.code.gson:gson:2.10.1"
 
     implementation project(":shared")


### PR DESCRIPTION
## What?

Jetty security vulnerabilities in version 11.0.13 shown in [https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-server/11.0.13](url)

https://govukverify.atlassian.net/browse/AUT-1825

## Why?

ITHC report identified vulnerabilities. Major version update to 12.0.2 was attempted but the change in functionality resulted in a refactor and unclear issues during integration testing.
