### PR TITLE
ATO-121: Change JAR required logic

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -600,7 +600,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 "client_id",
                                 CLIENT_ID,
                                 "scope",
-                                "openid",
+                                "openid doc-checking-app",
                                 "request",
                                 signedJWT.serialize()));
         var response =
@@ -653,7 +653,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         "request",
                         signedJWT.serialize(),
                         "scope",
-                        "openid");
+                        "openid doc-checking-app");
 
         var response =
                 makeRequest(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -162,7 +162,7 @@ public class AuthorisationHandler
 
     public APIGatewayProxyResponseEvent authoriseRequestHandler(
             APIGatewayProxyRequestEvent input, Context context) throws ClientNotFoundException {
-        var client = new ClientRegistry();
+        ClientRegistry client;
         var persistentSessionId =
                 orchestrationAuthorizationService.getExistingOrCreateNewPersistentSessionId(
                         input.getHeaders());
@@ -242,7 +242,7 @@ public class AuthorisationHandler
         }
 
         Optional<AuthRequestError> authRequestError;
-        if (orchestrationAuthorizationService.isJarValidationRequired(authRequest)) {
+        if (orchestrationAuthorizationService.isJarValidationRequired(client)) {
             if (authRequest.getRequestObject() == null) {
                 var errorMsg =
                         "JAR required for client but request does not contain Request Object";

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -208,11 +208,13 @@ public class AuthorisationHandler
                                     Collectors.toMap(
                                             Map.Entry::getKey, entry -> List.of(entry.getValue())));
             authRequest = AuthenticationRequest.parse(requestParameters);
+
             String clientId = authRequest.getClientID().getValue();
             client =
                     clientService
                             .getClient(clientId)
                             .orElseThrow(() -> new ClientNotFoundException(clientId));
+            updateAttachedLogFieldToLogs(CLIENT_ID, clientId);
         } catch (ParseException e) {
             if (e.getRedirectionURI() == null) {
                 LOG.warn(
@@ -240,10 +242,17 @@ public class AuthorisationHandler
         }
 
         Optional<AuthRequestError> authRequestError;
-        if (authRequest.getRequestObject() != null && configurationService.isDocAppApiEnabled()) {
-            LOG.info("RequestObject auth request received");
+        if (orchestrationAuthorizationService.isJarValidationRequired(authRequest)) {
+            if (authRequest.getRequestObject() == null) {
+                var errorMsg =
+                        "JAR required for client but request does not contain Request Object";
+                LOG.warn(errorMsg);
+                throw new RuntimeException(errorMsg);
+            }
+            LOG.info("Validating request using JAR");
             authRequestError = requestObjectService.validateRequestObject(authRequest);
         } else {
+            LOG.info("Validating request query params");
             authRequestError =
                     orchestrationAuthorizationService.validateAuthRequest(
                             authRequest, configurationService.isNonceRequired());
@@ -326,7 +335,6 @@ public class AuthorisationHandler
         session.addClientSession(clientSessionId);
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         updateAttachedLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
-        updateAttachedLogFieldToLogs(CLIENT_ID, authenticationRequest.getClientID().getValue());
         sessionService.save(session);
         LOG.info("Session saved successfully");
 
@@ -428,7 +436,6 @@ public class AuthorisationHandler
         session.addClientSession(clientSessionId);
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         updateAttachedLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
-        updateAttachedLogFieldToLogs(CLIENT_ID, authenticationRequest.getClientID().getValue());
         sessionService.save(session);
         LOG.info("Session saved successfully");
         return generateAuthRedirect(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
@@ -379,7 +379,7 @@ public class OrchestrationAuthorizationService {
                 configurationService.getSessionExpiry());
     }
 
-    public boolean isJarValidationRequired(AuthenticationRequest authRequest) {
-        return authRequest.getScope().contains(CustomScopeValue.DOC_CHECKING_APP);
+    public boolean isJarValidationRequired(ClientRegistry client) {
+        return client.getScopes().contains(CustomScopeValue.DOC_CHECKING_APP.getValue());
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
@@ -37,6 +37,7 @@ import uk.gov.di.authentication.oidc.entity.AuthRequestError;
 import uk.gov.di.authentication.oidc.exceptions.InvalidJWEException;
 import uk.gov.di.authentication.oidc.exceptions.InvalidPublicKeyException;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
@@ -376,5 +377,9 @@ public class OrchestrationAuthorizationService {
                 AUTHENTICATION_STATE_STORAGE_PREFIX + sessionId,
                 state.getValue(),
                 configurationService.getSessionExpiry());
+    }
+
+    public boolean isJarValidationRequired(AuthenticationRequest authRequest) {
+        return authRequest.getScope().contains(CustomScopeValue.DOC_CHECKING_APP);
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
@@ -183,10 +183,10 @@ class RequestObjectServiceTest {
     }
 
     @Test
-    void shouldReturnErrorWhenClientTypeIsNotApp() throws JOSEException {
+    void shouldReturnErrorWhenClientTypeIsNotAppOrWeb() throws JOSEException {
         var clientRegistry =
                 generateClientRegistry(
-                        ClientType.WEB.getValue(),
+                        "not-app-or-web",
                         new Scope(
                                 OIDCScopeValue.OPENID.getValue(),
                                 CustomScopeValue.DOC_CHECKING_APP.getValue()));
@@ -300,27 +300,6 @@ class RequestObjectServiceTest {
                         .claim("redirect_uri", REDIRECT_URI)
                         .claim("response_type", ResponseType.CODE.toString())
                         .claim("scope", "openid profile")
-                        .claim("nonce", NONCE.getValue())
-                        .claim("state", STATE.toString())
-                        .claim("client_id", CLIENT_ID.getValue())
-                        .issuer(CLIENT_ID.getValue())
-                        .build();
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
-        var requestObjectError = service.validateRequestObject(authRequest);
-
-        assertTrue(requestObjectError.isPresent());
-        assertThat(requestObjectError.get().errorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
-        assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
-    }
-
-    @Test
-    void shouldReturnErrorWhenRequestObjectDoesNotContainDocAppScope() throws JOSEException {
-        var jwtClaimsSet =
-                new JWTClaimsSet.Builder()
-                        .audience(AUDIENCE)
-                        .claim("redirect_uri", REDIRECT_URI)
-                        .claim("response_type", ResponseType.CODE.toString())
-                        .claim("scope", "openid")
                         .claim("nonce", NONCE.getValue())
                         .claim("state", STATE.toString())
                         .claim("client_id", CLIENT_ID.getValue())


### PR DESCRIPTION
## What?

- unrevert changes for ATO-21
- Change JAR required check to test scopes in client registry
 
## Why?

Previously this was checking the scopes inthe auth request. Change this to check the scopes in the client registry. This is because the acceptance tests do not send the doc check scope. It is unclear if the real requests contain this scope.

## Related PRs

#3475 
#3504 
