### PR TITLE
ATO-21: Permit unconfigured clients to make JAR requests

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -600,7 +600,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 "client_id",
                                 CLIENT_ID,
                                 "scope",
-                                "openid doc-checking-app",
+                                "openid",
                                 "request",
                                 signedJWT.serialize()));
         var response =
@@ -653,7 +653,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         "request",
                         signedJWT.serialize(),
                         "scope",
-                        "openid doc-checking-app");
+                        "openid");
 
         var response =
                 makeRequest(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -242,20 +242,21 @@ public class AuthorisationHandler
         }
 
         Optional<AuthRequestError> authRequestError;
-        if (orchestrationAuthorizationService.isJarValidationRequired(client)) {
-            if (authRequest.getRequestObject() == null) {
-                var errorMsg =
-                        "JAR required for client but request does not contain Request Object";
-                LOG.warn(errorMsg);
-                throw new RuntimeException(errorMsg);
-            }
-            LOG.info("Validating request using JAR");
-            authRequestError = requestObjectService.validateRequestObject(authRequest);
-        } else {
+        boolean isJarValidationRequired =
+                orchestrationAuthorizationService.isJarValidationRequired(client);
+        if (isJarValidationRequired && authRequest.getRequestObject() == null) {
+            String errorMsg = "JAR required for client but request does not contain Request Object";
+            LOG.warn(errorMsg);
+            throw new RuntimeException(errorMsg);
+        }
+        if (authRequest.getRequestObject() == null) {
             LOG.info("Validating request query params");
             authRequestError =
                     orchestrationAuthorizationService.validateAuthRequest(
                             authRequest, configurationService.isNonceRequired());
+        } else {
+            LOG.info("Validating request object");
+            authRequestError = requestObjectService.validateRequestObject(authRequest);
         }
 
         if (authRequestError.isPresent()) {


### PR DESCRIPTION
## What?

Modify the request validation logic to enable clients who are not configured to require JAR to pass it in anyway
