### PR TITLE
BAU: Set production lambdas to 1.5GB mem

### DIFF
--- a/ci/terraform/account-management/production-overrides.tfvars
+++ b/ci/terraform/account-management/production-overrides.tfvars
@@ -13,7 +13,7 @@ cloudwatch_log_retention = 5
 
 performance_tuning = {
   authorizer = {
-    memory          = 1024
+    memory          = 1536
     concurrency     = 3
     max_concurrency = 10
     scaling_trigger = 0.6

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -67,28 +67,28 @@ EOT
 
 performance_tuning = {
   register = {
-    memory          = 512
+    memory          = 1536
     concurrency     = 0
     max_concurrency = 0
     scaling_trigger = 0
   }
 
   update = {
-    memory          = 512
+    memory          = 1536
     concurrency     = 0
     max_concurrency = 0
     scaling_trigger = 0
   }
 
   reset-password = {
-    memory          = 1024
+    memory          = 1536
     concurrency     = 2
     max_concurrency = 10
     scaling_trigger = 0.5
   }
 
   reset-password-request = {
-    memory          = 1024
+    memory          = 1536
     concurrency     = 2
     max_concurrency = 10
     scaling_trigger = 0.5


### PR DESCRIPTION
Dynatrace integration requires this as a minimum