### PR TITLE
BAU: Skip Sonar checks on merge group

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -202,14 +202,17 @@ jobs:
       - run-integration-tests
     steps:
       - name: Check out repository code
+        if: github.event_name != 'merge_group'
         uses: actions/checkout@v3
       - name: Set up JDK 17
+        if: github.event_name != 'merge_group'
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Build Cache
+        if: github.event_name != 'merge_group'
         uses: actions/cache@v3
         with:
           path: |
@@ -219,6 +222,7 @@ jobs:
             !*/build/jacoco
           key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Cache Unit Test Reports
+        if: github.event_name != 'merge_group'
         uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
@@ -232,6 +236,7 @@ jobs:
             !delivery-receipts-integration-tests/build/jacoco/
             !delivery-receipts-integration-tests/build/reports/
       - name: Cache Test Reports
+        if: github.event_name != 'merge_group'
         uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-integration-test-reports-${{ github.sha }}
@@ -243,7 +248,7 @@ jobs:
             delivery-receipts-integration-tests/build/jacoco/
             delivery-receipts-integration-tests/build/reports/
       - name: Run SonarCloud Analysis
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This should speed up the merge queues, and we don't need this check at this stage
