### PR TITLE
BAU: Control non-determinism in `TokenService`

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.oidc.entity.BackChannelLogoutMessage;
 import uk.gov.di.authentication.oidc.services.HttpRequestService;
 import uk.gov.di.authentication.shared.helpers.LogLineHelper;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper.NowClock;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -41,7 +42,9 @@ public class BackChannelLogoutRequestHandler implements RequestHandler<SQSEvent,
     public BackChannelLogoutRequestHandler() {
         this.instance = ConfigurationService.getInstance();
         this.httpRequestService = new HttpRequestService();
-        this.tokenService = new TokenService(instance, null, new KmsConnectionService(instance));
+        this.tokenService =
+                new TokenService(
+                        instance, null, new KmsConnectionService(instance), NowHelper.utcClock());
         this.clock = new NowClock(Clock.systemUTC());
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
@@ -99,7 +100,11 @@ public class TokenHandler
         this.configurationService = configurationService;
         this.redisConnectionService = new RedisConnectionService(configurationService);
         this.tokenService =
-                new TokenService(configurationService, this.redisConnectionService, kms);
+                new TokenService(
+                        configurationService,
+                        this.redisConnectionService,
+                        kms,
+                        NowHelper.utcClock());
         this.dynamoService = new DynamoService(configurationService);
         this.authorisationCodeService =
                 new AuthorisationCodeService(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
@@ -7,7 +7,7 @@ import java.util.Date;
 
 public class NowHelper {
 
-    private static final NowClock clock = new NowClock(Clock.systemUTC());
+    private static final NowClock clock = utcClock();
 
     public static Date now() {
         return clock.now();
@@ -23,6 +23,10 @@ public class NowHelper {
 
     public static String toTimestampString(Date date) {
         return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS").format(date);
+    }
+
+    public static NowClock utcClock() {
+        return new NowClock(Clock.systemUTC());
     }
 
     public static class NowClock {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -38,7 +38,6 @@ import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper.NowClock;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -247,14 +246,14 @@ public class TokenService {
 
         LOG.info("Generating IdToken");
         URI trustMarkUri = buildURI(configService.getOidcApiBaseURL().get(), "/trustmark");
-        Date expiryDate = NowHelper.nowPlus(configService.getIDTokenExpiry(), ChronoUnit.SECONDS);
+        Date expiryDate = nowClock.nowPlus(configService.getIDTokenExpiry(), ChronoUnit.SECONDS);
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(
                         new Issuer(configService.getOidcApiBaseURL().get()),
                         subject,
                         List.of(new Audience(clientId)),
                         expiryDate,
-                        NowHelper.now());
+                        nowClock.now());
 
         idTokenClaims.setAccessTokenHash(accessTokenHash);
         idTokenClaims.setSessionID(new SessionID(journeyId));
@@ -284,7 +283,7 @@ public class TokenService {
 
         LOG.info("Generating AccessToken");
         Date expiryDate =
-                NowHelper.nowPlus(configService.getAccessTokenExpiry(), ChronoUnit.SECONDS);
+                nowClock.nowPlus(configService.getAccessTokenExpiry(), ChronoUnit.SECONDS);
         var jwtID = UUID.randomUUID().toString();
 
         LOG.info("AccessToken being created with JWTID: {}", jwtID);
@@ -294,7 +293,7 @@ public class TokenService {
                         .claim("scope", scopes)
                         .issuer(configService.getOidcApiBaseURL().get())
                         .expirationTime(expiryDate)
-                        .issueTime(NowHelper.now())
+                        .issueTime(nowClock.now())
                         .claim("client_id", clientId)
                         .subject(subject.getValue())
                         .jwtID(jwtID);
@@ -337,14 +336,14 @@ public class TokenService {
             Subject subject,
             JWSAlgorithm signingAlgorithm) {
         LOG.info("Generating RefreshToken");
-        Date expiryDate = NowHelper.nowPlus(configService.getSessionExpiry(), ChronoUnit.SECONDS);
+        Date expiryDate = nowClock.nowPlus(configService.getSessionExpiry(), ChronoUnit.SECONDS);
         var jwtId = IdGenerator.generate();
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
                         .claim("scope", scopes)
                         .issuer(configService.getOidcApiBaseURL().get())
                         .expirationTime(expiryDate)
-                        .issueTime(NowHelper.now())
+                        .issueTime(nowClock.now())
                         .claim("client_id", clientId)
                         .subject(subject.getValue())
                         .jwtID(jwtId)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -39,6 +39,7 @@ import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.NowHelper.NowClock;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
@@ -63,6 +64,7 @@ public class TokenService {
     private final ConfigurationService configService;
     private final RedisConnectionService redisConnectionService;
     private final KmsConnectionService kmsConnectionService;
+    private final NowClock nowClock;
     private static final JWSAlgorithm TOKEN_ALGORITHM = JWSAlgorithm.ES256;
     private static final Logger LOG = LogManager.getLogger(TokenService.class);
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
@@ -75,10 +77,12 @@ public class TokenService {
     public TokenService(
             ConfigurationService configService,
             RedisConnectionService redisConnectionService,
-            KmsConnectionService kmsConnectionService) {
+            KmsConnectionService kmsConnectionService,
+            NowClock nowClock) {
         this.configService = configService;
         this.redisConnectionService = redisConnectionService;
         this.kmsConnectionService = kmsConnectionService;
+        this.nowClock = nowClock;
     }
 
     public OIDCTokenResponse generateTokenResponse(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -476,6 +476,12 @@ public class TokenServiceTest {
                 .saveWithExpiry(
                         accessTokenKey, objectMapper.writeValueAsString(accessTokenStore), 300L);
 
+        var accessToken =
+                SignedJWT.parse(tokenResponse.getOIDCTokens().getAccessToken().getValue());
+
+        assertThat(accessToken.getJWTClaimsSet().getIssueTime().getTime(), is(0L));
+        assertThat(accessToken.getJWTClaimsSet().getExpirationTime().getTime(), is(300 * 1000L));
+
         var header = (JWSHeader) tokenResponse.getOIDCTokens().getIDToken().getHeader();
 
         assertThat(tokenResponse.getOIDCTokens().getAccessToken().getLifetime(), is(300L));

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -91,7 +91,12 @@ public class TokenServiceTest {
             new NowClock(Clock.fixed(new Date(0).toInstant(), ZoneId.systemDefault()));
     private final TokenService tokenService =
             new TokenService(
-                    configurationService, redisConnectionService, kmsConnectionService, clock);
+                    configurationService, redisConnectionService, kmsConnectionService, clock) {
+                @Override
+                protected String newJwtId() {
+                    return "jwt-id";
+                }
+            };
     private static final Subject PUBLIC_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Subject INTERNAL_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Scope SCOPES =
@@ -500,6 +505,7 @@ public class TokenServiceTest {
                         AccessTokenHash.compute(responseAccessToken, JWSAlgorithm.ES256, null)
                                 .toString()));
 
+        assertThat(responseIdToken.getJWTClaimsSet().getJWTID(), is("jwt-id"));
         assertThat(
                 responseIdToken.getJWTClaimsSet().getStringClaim("sid"), is("client-session-id"));
         assertThat(responseIdToken.getJWTClaimsSet().getIssueTime().getTime(), is(0L));
@@ -519,6 +525,7 @@ public class TokenServiceTest {
 
         var accessToken = SignedJWT.parse(responseAccessToken.getValue());
 
+        assertThat(accessToken.getJWTClaimsSet().getJWTID(), is("jwt-id"));
         assertThat(accessToken.getJWTClaimsSet().getIssueTime().getTime(), is(0L));
         assertThat(accessToken.getJWTClaimsSet().getExpirationTime().getTime(), is(300 * 1000L));
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -84,7 +84,11 @@ public class TokenServiceTest {
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
     private final TokenService tokenService =
-            new TokenService(configurationService, redisConnectionService, kmsConnectionService);
+            new TokenService(
+                    configurationService,
+                    redisConnectionService,
+                    kmsConnectionService,
+                    NowHelper.utcClock());
     private static final Subject PUBLIC_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Subject INTERNAL_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Scope SCOPES =


### PR DESCRIPTION
- BAU: New static method to provide a UTC clock
- BAU: Inject a `NowClock` into `TokenService`
- BAU: Use `NowClock` instead of `NowHelper`
- BAU: Update tests with stubbed calls to `NowClock` using a fixed time
- BAU: Add assertions against iat/exp for access tokens
- BAU: Separate assertions for access tokens and id tokens
- BAU: Allow the source of random JWT id to be overridden for tests

## What?

Please include a summary of the change.

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
