### PR TITLE
AUT-1826: added CMK encryption to account modifiers table

### DIFF
--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -11,6 +11,7 @@ module "account_management_api_remove_account_role" {
     module.account_management_txma_audit.access_policy_arn,
     aws_iam_policy.dynamo_am_account_modifiers_read_access_policy.arn,
     aws_iam_policy.dynamo_am_account_modifiers_delete_access_policy.arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -15,5 +15,6 @@ data "terraform_remote_state" "shared" {
 }
 
 locals {
-  lambda_code_signing_configuration_arn = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
+  lambda_code_signing_configuration_arn   = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
+  account_modifiers_encryption_policy_arn = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
 }

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -12,7 +12,8 @@ module "frontend_api_account_recovery_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -77,6 +77,7 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.doc-app-authorize.method_trigger_value,
       module.orch_auth_code.integration_trigger_value,
       module.orch_auth_code.method_trigger_value,
+      local.account_modifiers_encryption_policy_arn
     ]))
   }
 

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -13,7 +13,8 @@ module "frontend_api_orch_auth_code_role" {
     aws_iam_policy.dynamo_auth_code_store_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.auth_code_dynamo_encryption_key_kms_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -10,7 +10,8 @@ module "doc_app_authorize_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.doc_app_auth_kms_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -13,7 +13,8 @@ module "ipv_authorize_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.ipv_token_auth_kms_policy.arn,
     aws_iam_policy.ipv_public_encryption_key_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -13,7 +13,8 @@ module "frontend_api_login_role" {
     aws_iam_policy.pepper_parameter_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -10,7 +10,8 @@ module "frontend_api_mfa_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -12,7 +12,8 @@ module "ipv_processing_identity_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.pepper_parameter_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -10,7 +10,8 @@ module "frontend_api_reset_password_request_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -14,7 +14,8 @@ module "frontend_api_reset_password_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -10,7 +10,8 @@ module "frontend_api_send_notification_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -61,4 +61,5 @@ locals {
   di_auth_ext_api_id                                  = var.support_auth_orch_split ? data.terraform_remote_state.auth-ext-api[0].outputs.di_auth_ext_api_id : ""
   vpce_id                                             = var.support_auth_orch_split ? data.terraform_remote_state.auth-ext-api[0].outputs.vpce_id : ""
   authentication_callback_userinfo_encryption_key_arn = data.terraform_remote_state.shared.outputs.authentication_callback_userinfo_encryption_key_arn
+  account_modifiers_encryption_policy_arn             = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
 }

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -12,7 +12,8 @@ module "frontend_api_signup_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -11,7 +11,8 @@ module "frontend_api_update_profile_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -12,6 +12,7 @@ module "frontend_api_user_exists_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -13,7 +13,8 @@ module "frontend_api_verify_code_role" {
     aws_iam_policy.dynamo_account_modifiers_write_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -13,7 +13,8 @@ module "frontend_api_verify_mfa_code_role" {
     aws_iam_policy.dynamo_account_modifiers_write_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -290,7 +290,8 @@ resource "aws_dynamodb_table" "account_modifiers_table" {
   }
 
   server_side_encryption {
-    enabled = !var.use_localstack
+    enabled     = true
+    kms_key_arn = aws_kms_key.account_modifiers_table_encryption_key.arn
   }
 
   lifecycle {

--- a/ci/terraform/shared/kms-policies.tf
+++ b/ci/terraform/shared/kms-policies.tf
@@ -1,0 +1,21 @@
+resource "aws_iam_policy" "account_modifiers_encryption_key_kms_policy" {
+  name        = "${var.environment}-account-modifiers-table-encryption-key-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS encryption of the account modifiers table"
+
+  policy = data.aws_iam_policy_document.account_modifiers_encryption_key_policy_document.json
+}
+
+data "aws_iam_policy_document" "account_modifiers_encryption_key_policy_document" {
+  statement {
+    sid    = "AllowAccessToAccountModifiersTableKmsEncryptionKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      aws_kms_key.account_modifiers_table_encryption_key.arn
+    ]
+  }
+}

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -451,3 +451,51 @@ resource "aws_kms_alias" "authentication_callback_userinfo_encryption_key_alias"
   name          = "alias/${var.environment}-authentication-callback-userinfo-encryption-key-alias"
   target_key_id = aws_kms_key.authentication_callback_userinfo_encryption_key.key_id
 }
+
+resource "aws_kms_key" "account_modifiers_table_encryption_key" {
+  description              = "KMS encryption key for account modifiers table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}
+
+resource "aws_kms_key" "user_credentials_table_encryption_key" {
+  description              = "KMS encryption key for user credentials table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -177,3 +177,7 @@ output "auth_code_store_signing_configuration_arn" {
 output "authentication_callback_userinfo_encryption_key_arn" {
   value = aws_kms_key.authentication_callback_userinfo_encryption_key.arn
 }
+
+output "account_modifiers_encryption_policy_arn" {
+  value = aws_iam_policy.account_modifiers_encryption_key_kms_policy.arn
+}


### PR DESCRIPTION
## What?

Implemented CMK encryption/decryption capability to account modifiers table and all lambdas that require access to the table.

## Why?

The Fidus ITHC recommended adding CMK encryption to dynamodb tables. This is to improve confidentiality and integrity of dynamodb tables and improve control over encryption/decryption processes.