### PR TITLE
ATO-128: Remove isNonceRequired flag

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -77,7 +77,7 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
                                     "Request contains invalid claims"),
                             redirectURI));
         }
-        if (authRequest.getNonce() == null && configurationService.isNonceRequired()) {
+        if (authRequest.getNonce() == null) {
             LOG.error("Nonce is missing from authRequest");
             return Optional.of(
                     new AuthRequestError(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
@@ -78,7 +78,6 @@ class QueryParamsAuthorizeValidatorTest {
                         + "\n-----END PUBLIC KEY-----\n";
         when(configurationService.getOrchestrationToAuthenticationEncryptionPublicKey())
                 .thenReturn(publicCertificateAsPem);
-        when(configurationService.isNonceRequired()).thenReturn(true);
     }
 
     @AfterEach
@@ -150,28 +149,6 @@ class QueryParamsAuthorizeValidatorTest {
         var errorObject =
                 queryParamsAuthorizeValidator.validate(
                         generateAuthRequest(REDIRECT_URI.toString(), responseType, scope));
-
-        assertTrue(errorObject.isEmpty());
-    }
-
-    @Test
-    void
-            shouldSuccessfullyValidateAuthRequestWhenNonceIsNotIncludedButOptionalButGivenEnvironment() {
-        when(configurationService.isNonceRequired()).thenReturn(false);
-        when(dynamoClientService.getClient(CLIENT_ID.toString()))
-                .thenReturn(
-                        Optional.of(
-                                generateClientRegistry(
-                                        REDIRECT_URI.toString(), CLIENT_ID.toString())));
-        var authRequest =
-                new AuthenticationRequest.Builder(
-                                new ResponseType(ResponseType.Value.CODE),
-                                new Scope(OIDCScopeValue.OPENID),
-                                CLIENT_ID,
-                                URI.create(REDIRECT_URI.toString()))
-                        .state(STATE)
-                        .build();
-        var errorObject = queryParamsAuthorizeValidator.validate(authRequest);
 
         assertTrue(errorObject.isEmpty());
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -21,7 +21,6 @@ import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -341,10 +340,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         } else {
             return false;
         }
-    }
-
-    public boolean isNonceRequired() {
-        return !Objects.equals("staging", getEnvironment());
     }
 
     public boolean isNotifyTemplatePerLanguage() {


### PR DESCRIPTION
## What?
- Remove `isNonceRequired` method which permits nonce to be absent in staging environment.
- All requests to`/authorize` are now required to contain a nonce.

## Why?

- The flag was used for a specific situation where nonces weren't being sent in staging. This situation is no longer relevant.

