### PR TITLE
ATO-100: Remove isDocAppApiEnabled flag

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -48,7 +48,6 @@ module "authorize" {
     DOC_APP_JWKS_URL                     = var.doc_app_jwks_endpoint
     DOC_APP_ENCRYPTION_KEY_ID            = var.doc_app_encryption_key_id
     DOC_APP_TOKEN_SIGNING_KEY_ALIAS      = local.doc_app_auth_key_alias_name
-    DOC_APP_API_ENABLED                  = var.doc_app_api_enabled
     DOC_APP_DOMAIN                       = var.doc_app_domain
     DOC_APP_DECOUPLE_ENABLED             = var.doc_app_decouple_enabled
     DYNAMO_ENDPOINT                      = var.use_localstack ? var.lambda_dynamo_endpoint : null

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -1,4 +1,3 @@
-doc_app_api_enabled                 = true
 doc_app_cri_data_endpoint           = "credentials/issue"
 doc_app_backend_uri                 = "https://build-doc-app-cri-stub.london.cloudapps.digital"
 doc_app_domain                      = "https://build-doc-app-cri-stub.london.cloudapps.digital"

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -1,4 +1,3 @@
-doc_app_api_enabled                = true
 doc_app_cri_data_endpoint          = "userinfo"
 doc_app_backend_uri                = "https://api-backend-api.review-b.integration.account.gov.uk"
 doc_app_domain                     = "https://api.review-b.integration.account.gov.uk"

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -20,7 +20,6 @@ module "jwks" {
 
   handler_environment_variables = {
     ENVIRONMENT                     = var.environment
-    DOC_APP_API_ENABLED             = var.doc_app_api_enabled
     DOC_APP_TOKEN_SIGNING_KEY_ALIAS = local.doc_app_auth_key_alias_name
     LOCALSTACK_ENDPOINT             = var.use_localstack ? var.localstack_endpoint : null
     TOKEN_SIGNING_KEY_ALIAS         = local.id_token_signing_key_alias_name

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -11,7 +11,6 @@ notify_template_map = {
 }
 
 custom_doc_app_claim_enabled     = true
-doc_app_api_enabled              = true
 doc_app_cri_data_endpoint        = "userinfo"
 doc_app_cri_data_v2_endpoint     = "userinfo/v2"
 doc_app_use_cri_data_v2_endpoint = true

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -1,5 +1,4 @@
 custom_doc_app_claim_enabled       = true
-doc_app_api_enabled                = true
 ipv_capacity_allowed               = true
 ipv_api_enabled                    = true
 doc_app_authorisation_client_id    = "authOrchestratorDocApp"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -350,11 +350,6 @@ variable "doc_app_authorisation_client_id" {
   default = "undefined"
 }
 
-variable "doc_app_api_enabled" {
-  type    = bool
-  default = false
-}
-
 variable "doc_app_domain" {
   type    = string
   default = "undefined"

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -59,7 +59,6 @@ test {
     environment "STUB_RELYING_PARTY_REDIRECT_URI", "https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
     environment "TERMS_CONDITIONS_VERSION", "1.0"
     environment "HEADERS_CASE_INSENSITIVE", "true"
-    environment "DOC_APP_API_ENABLED", "true"
     environment "IDENTITY_ENABLED", "false"
     environment "TRACING_ENABLED", "false"
     environment "INTERNAl_SECTOR_URI", "https://test.account.gov.uk"

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -18,19 +18,19 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
-        var configurationService = new JwksTestConfigurationService(false);
+        var configurationService = new JwksTestConfigurationService();
         handler = new JwksHandler(configurationService);
         var response = makeRequest(Optional.empty(), Map.of(), Map.of());
 
         assertThat(response, hasStatus(200));
-        assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(1));
+        assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(2));
 
         assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
-    void shouldReturn200And2KeysWhenDocAppIsEnabled() throws ParseException {
-        var configurationService = new JwksTestConfigurationService(true);
+    void shouldReturn200And2Keys() throws ParseException {
+        var configurationService = new JwksTestConfigurationService();
         handler = new JwksHandler(configurationService);
         var response = makeRequest(Optional.empty(), Map.of(), Map.of());
 
@@ -42,9 +42,7 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static class JwksTestConfigurationService extends IntegrationTestConfigurationService {
 
-        private final boolean docAppEnabled;
-
-        public JwksTestConfigurationService(boolean docAppEnabled) {
+        public JwksTestConfigurationService() {
             super(
                     auditTopic,
                     notificationsQueue,
@@ -54,12 +52,6 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters);
-            this.docAppEnabled = docAppEnabled;
-        }
-
-        @Override
-        public boolean isDocAppApiEnabled() {
-            return docAppEnabled;
         }
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
@@ -58,10 +58,7 @@ public class JwksHandler
             List<JWK> signingKeys = new ArrayList<>();
 
             signingKeys.add(jwksService.getPublicTokenJwkWithOpaqueId());
-
-            if (configurationService.isDocAppApiEnabled()) {
-                signingKeys.add(jwksService.getPublicDocAppSigningJwkWithOpaqueId());
-            }
+            signingKeys.add(jwksService.getPublicDocAppSigningJwkWithOpaqueId());
 
             if (configurationService.isRsaSigningAvailable()) {
                 signingKeys.add(jwksService.getPublicTokenRsaJwkWithOpaqueId());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -820,7 +820,6 @@ class AuthorisationHandlerTest {
         @Test
         void shouldRedirectToLoginWhenRequestObjectIsValid() throws JOSEException {
             var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
-            when(configService.isDocAppApiEnabled()).thenReturn(true);
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(Optional.empty());
             var event = new APIGatewayProxyRequestEvent();
@@ -875,7 +874,6 @@ class AuthorisationHandlerTest {
         @Test
         void shouldRedirectToLoginWhenPostRequestObjectIsValid() throws JOSEException {
             var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
-            when(configService.isDocAppApiEnabled()).thenReturn(true);
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(Optional.empty());
             var event = new APIGatewayProxyRequestEvent();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -200,10 +200,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return URI.create(System.getenv().getOrDefault("DOC_APP_AUTHORISATION_URI", ""));
     }
 
-    public boolean isDocAppApiEnabled() {
-        return System.getenv().getOrDefault("DOC_APP_API_ENABLED", "false").equals("true");
-    }
-
     public URI getDocAppBackendURI() {
         return URI.create(System.getenv().getOrDefault("DOC_APP_BACKEND_URI", ""));
     }


### PR DESCRIPTION
## What?

- Remove `DOC_APP_API_ENABLED` environment variable.
- Remove `ConfigurationService.isDocAppApiEnabled` method.

## Why?

- Value is always `true` so env variable and method are redundant.
