### PR TITLE
DO NOT MERGE: AUT-1826: added CMK encryption to doc app table

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -14,7 +14,8 @@ module "oidc_authorize_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     aws_iam_policy.orch_to_auth_kms_policy.arn,
-    aws_iam_policy.auth_public_encryption_key_parameter_policy.arn
+    aws_iam_policy.auth_public_encryption_key_parameter_policy.arn,
+    local.doc_app_auth_signing_key_arn
   ]
 }
 

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -11,7 +11,8 @@ module "doc_app_authorize_role" {
     aws_iam_policy.doc_app_auth_kms_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.doc_app_auth_signing_key_arn
   ]
 }
 

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -12,7 +12,8 @@ module "doc_app_callback_role" {
     aws_iam_policy.dynamo_doc_app_write_access_policy.arn,
     aws_iam_policy.dynamo_doc_app_read_access_policy.arn,
     aws_iam_policy.doc_app_rp_client_id_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.doc_app_auth_signing_key_arn
   ]
 }
 

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -7,6 +7,7 @@ module "oidc_jwks_role" {
   policies_to_attach = [
     aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
     aws_iam_policy.doc_app_auth_kms_policy.arn,
+    local.doc_app_auth_signing_key_arn
   ]
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -62,4 +62,5 @@ locals {
   vpce_id                                             = var.support_auth_orch_split ? data.terraform_remote_state.auth-ext-api[0].outputs.vpce_id : ""
   authentication_callback_userinfo_encryption_key_arn = data.terraform_remote_state.shared.outputs.authentication_callback_userinfo_encryption_key_arn
   account_modifiers_encryption_policy_arn             = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
+  doc_app_credential_encryption_policy_arn            = data.terraform_remote_state.shared.outputs.doc_app_credential_encryption_policy_arn
 }

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -13,7 +13,8 @@ module "oidc_userinfo_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.doc_app_auth_signing_key_arn
   ]
 }
 

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -229,7 +229,8 @@ resource "aws_dynamodb_table" "doc_app_credential_table" {
   }
 
   server_side_encryption {
-    enabled = !var.use_localstack
+    enabled = true
+    kms_key_arn = aws_kms_key.doc_app_credential_table_encryption_key
   }
 
   lifecycle {

--- a/ci/terraform/shared/kms-policies.tf
+++ b/ci/terraform/shared/kms-policies.tf
@@ -19,3 +19,25 @@ data "aws_iam_policy_document" "account_modifiers_encryption_key_policy_document
     ]
   }
 }
+
+resource "aws_iam_policy" "doc_app_credential_encryption_key_kms_policy" {
+  name        = "${var.environment}-doc-app-credential-table-encryption-key-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS encryption of the doc app credential table"
+
+  policy = data.aws_iam_policy_document.doc_app_credential_encryption_key_policy_document.json
+}
+
+data "aws_iam_policy_document" "doc_app_credential_encryption_key_policy_document" {
+  statement {
+    sid    = "AllowAccessToDocAppCredentialTableKmsEncryptionKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      aws_kms_key.doc_app_credential_table_encryption_key.arn
+    ]
+  }
+}

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -499,3 +499,28 @@ resource "aws_kms_key" "user_credentials_table_encryption_key" {
   })
   tags = local.default_tags
 }
+
+resource "aws_kms_key" "doc_app_credential_table_encryption_key" {
+  description              = "KMS encryption key for doc app credential table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}
+

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -181,3 +181,7 @@ output "authentication_callback_userinfo_encryption_key_arn" {
 output "account_modifiers_encryption_policy_arn" {
   value = aws_iam_policy.account_modifiers_encryption_key_kms_policy.arn
 }
+
+output "doc_app_credential_encryption_policy_arn" {
+  value = aws_iam_policy.doc_app_credential_encryption_key_kms_policy.arn
+}


### PR DESCRIPTION
## What?

Implemented CMK encryption/decryption capability to doc_app_credential table and all lambdas that require access to the table.


## Why?

The Fidus ITHC recommended adding CMK encryption to dynamodb tables. This is to improve confidentiality and integrity of dynamodb tables and improve control over encryption/decryption processes.
