### PR TITLE
ATO-178: Remove isDocAppApiEnabled from ConfigurationService

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -18,19 +18,7 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
-        var configurationService = new JwksTestConfigurationService(false);
-        handler = new JwksHandler(configurationService);
-        var response = makeRequest(Optional.empty(), Map.of(), Map.of());
-
-        assertThat(response, hasStatus(200));
-        assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(1));
-
-        assertNoTxmaAuditEventsReceived(txmaAuditQueue);
-    }
-
-    @Test
-    void shouldReturn200And2KeysWhenDocAppIsEnabled() throws ParseException {
-        var configurationService = new JwksTestConfigurationService(true);
+        var configurationService = new JwksTestConfigurationService();
         handler = new JwksHandler(configurationService);
         var response = makeRequest(Optional.empty(), Map.of(), Map.of());
 
@@ -42,9 +30,7 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static class JwksTestConfigurationService extends IntegrationTestConfigurationService {
 
-        private final boolean docAppEnabled;
-
-        public JwksTestConfigurationService(boolean docAppEnabled) {
+        public JwksTestConfigurationService() {
             super(
                     auditTopic,
                     notificationsQueue,
@@ -54,12 +40,6 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters);
-            this.docAppEnabled = docAppEnabled;
-        }
-
-        @Override
-        public boolean isDocAppApiEnabled() {
-            return docAppEnabled;
         }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -18,7 +18,16 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
-        var configurationService = new JwksTestConfigurationService();
+        var configurationService =
+                new IntegrationTestConfigurationService(
+                        auditTopic,
+                        notificationsQueue,
+                        auditSigningKey,
+                        tokenSigner,
+                        ipvPrivateKeyJwtSigner,
+                        spotQueue,
+                        docAppPrivateKeyJwtSigner,
+                        configurationParameters);
         handler = new JwksHandler(configurationService);
         var response = makeRequest(Optional.empty(), Map.of(), Map.of());
 
@@ -26,20 +35,5 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(2));
 
         assertNoTxmaAuditEventsReceived(txmaAuditQueue);
-    }
-
-    private static class JwksTestConfigurationService extends IntegrationTestConfigurationService {
-
-        public JwksTestConfigurationService() {
-            super(
-                    auditTopic,
-                    notificationsQueue,
-                    auditSigningKey,
-                    tokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
-        }
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
@@ -58,10 +58,7 @@ public class JwksHandler
             List<JWK> signingKeys = new ArrayList<>();
 
             signingKeys.add(jwksService.getPublicTokenJwkWithOpaqueId());
-
-            if (configurationService.isDocAppApiEnabled()) {
-                signingKeys.add(jwksService.getPublicDocAppSigningJwkWithOpaqueId());
-            }
+            signingKeys.add(jwksService.getPublicDocAppSigningJwkWithOpaqueId());
 
             if (configurationService.isRsaSigningAvailable()) {
                 signingKeys.add(jwksService.getPublicTokenRsaJwkWithOpaqueId());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -820,7 +820,6 @@ class AuthorisationHandlerTest {
         @Test
         void shouldRedirectToLoginWhenRequestObjectIsValid() throws JOSEException {
             var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
-            when(configService.isDocAppApiEnabled()).thenReturn(true);
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(Optional.empty());
             var event = new APIGatewayProxyRequestEvent();
@@ -875,7 +874,6 @@ class AuthorisationHandlerTest {
         @Test
         void shouldRedirectToLoginWhenPostRequestObjectIsValid() throws JOSEException {
             var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
-            when(configService.isDocAppApiEnabled()).thenReturn(true);
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(Optional.empty());
             var event = new APIGatewayProxyRequestEvent();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -200,10 +200,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return URI.create(System.getenv().getOrDefault("DOC_APP_AUTHORISATION_URI", ""));
     }
 
-    public boolean isDocAppApiEnabled() {
-        return System.getenv().getOrDefault("DOC_APP_API_ENABLED", "false").equals("true");
-    }
-
     public URI getDocAppBackendURI() {
         return URI.create(System.getenv().getOrDefault("DOC_APP_BACKEND_URI", ""));
     }


### PR DESCRIPTION
## What?
Remove `isDocAppApiEnabled()` from `ConfigurationService`.

## Why?
Value is always `true` so method is redundant.

## Related PRs
https://github.com/govuk-one-login/authentication-api/pull/3536
