### PR TITLE
ATO-182: IPV request testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v0.72.2
     hooks:
       - id: cfn-python-lint
-        exclude: ^(ci|.github)/.*|docker-compose.*|.pre-commit-config.yaml$
+        exclude: ^(ci|.github)/.*|docker-compose.*|.pre-commit-config.yaml|.*.approved.json$
         files: ^.*\.(json|yml|yaml)$
 
   - repo: https://github.com/govuk-one-login/pre-commit-hooks.git

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -418,6 +418,11 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
         }
 
         @Override
+        public URI getIPVAuthorisationURI() {
+            return URI.create("https://ipv.gov.uk/authorize");
+        }
+
+        @Override
         public String getIPVAuthorisationClientId() {
             return IPV_CLIENT_ID;
         }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/PackageSettings.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/PackageSettings.java
@@ -1,0 +1,14 @@
+package uk.gov.di.authentication.ipv;
+
+import org.approvaltests.core.ApprovalFailureReporter;
+import org.approvaltests.reporters.AutoApproveWhenEmptyReporter;
+import org.approvaltests.reporters.JunitReporter;
+
+public class PackageSettings {
+    public static ApprovalFailureReporter UseReporter =
+            new AutoApproveWhenEmptyReporter(new JunitReporter());
+    public static ApprovalFailureReporter FrontloadedReporter =
+            new AutoApproveWhenEmptyReporter(new JunitReporter());
+    public static String UseApprovalSubdirectory = "approvals";
+    public static String ApprovalBaseDirectory = "../resources";
+}

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -18,17 +18,20 @@ import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.approvaltests.JsonApprovals;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
+import uk.gov.di.authentication.sharedtest.helper.TestClockHelper;
 
 import java.net.URI;
 import java.security.KeyPair;
@@ -47,9 +50,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static uk.gov.di.authentication.ipv.services.IPVAuthorisationService.STATE_STORAGE_PREFIX;
 
 class IPVAuthorisationServiceTest {
@@ -71,7 +72,10 @@ class IPVAuthorisationServiceTest {
     private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
     private final IPVAuthorisationService authorisationService =
             new IPVAuthorisationService(
-                    configurationService, redisConnectionService, kmsConnectionService);
+                    configurationService,
+                    redisConnectionService,
+                    kmsConnectionService,
+                    TestClockHelper.getInstance());
     private PrivateKey privateKey;
 
     @BeforeEach
@@ -208,22 +212,28 @@ class IPVAuthorisationServiceTest {
                         .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
                         .build();
         when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(signResult);
-        var state = new State();
+        var state = new State("test-state");
         var scope = new Scope(OIDCScopeValue.OPENID);
         var pairwise = new Subject("pairwise-identifier");
         var claims = "{\"name\":{\"essential\":true}}";
 
-        var encryptedJWT =
-                authorisationService.constructRequestJWT(
-                        state,
-                        scope,
-                        pairwise,
-                        claims,
-                        "journey-id",
-                        "test@test.com",
-                        List.of("Cl.Cm.P2", "Cl.Cm.PCL200"));
+        EncryptedJWT encryptedJWT;
+        try (var mockIdGenerator = mockStatic(IdGenerator.class)) {
+            mockIdGenerator.when(IdGenerator::generate).thenReturn("test-jti");
+            encryptedJWT =
+                    authorisationService.constructRequestJWT(
+                            state,
+                            scope,
+                            pairwise,
+                            claims,
+                            "journey-id",
+                            "test@test.com",
+                            List.of("Cl.Cm.P2", "Cl.Cm.PCL200"));
+        }
 
         var signedJWTResponse = decryptJWT(encryptedJWT);
+
+        JsonApprovals.verifyAsJson(signedJWTResponse.getJWTClaimsSet().toJSONObject());
 
         assertThat(
                 signedJWTResponse.getJWTClaimsSet().getClaim("client_id"), equalTo(IPV_CLIENT_ID));

--- a/ipv-api/src/test/resources/uk/gov/di/authentication/ipv/services/approvals/IPVAuthorisationServiceTest.shouldConstructASignedRequestJWT.approved.json
+++ b/ipv-api/src/test/resources/uk/gov/di/authentication/ipv/services/approvals/IPVAuthorisationServiceTest.shouldConstructASignedRequestJWT.approved.json
@@ -1,0 +1,21 @@
+{
+  "sub": "pairwise-identifier",
+  "iss": "ipv-client-id",
+  "response_type": "code",
+  "client_id": "ipv-client-id",
+  "govuk_signin_journey_id": "journey-id",
+  "aud": "http://ipv/",
+  "nbf": 1196676930,
+  "email_address": "test@test.com",
+  "vtr": [
+    "Cl.Cm.P2",
+    "Cl.Cm.PCL200"
+  ],
+  "scope": "openid",
+  "claims": "{\"name\":{\"essential\":true}}",
+  "state": "test-state",
+  "redirect_uri": "http://localhost/oidc/ipv/callback",
+  "exp": 1196677110,
+  "iat": 1196676930,
+  "jti": "test-jti"
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TestClockHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TestClockHelper.java
@@ -1,0 +1,14 @@
+package uk.gov.di.authentication.sharedtest.helper;
+
+import uk.gov.di.authentication.shared.helpers.NowHelper.NowClock;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class TestClockHelper {
+    public static NowClock getInstance() {
+        return new NowClock(
+                Clock.fixed(Instant.parse("2007-12-03T10:15:30.00Z"), ZoneId.of("UTC")));
+    }
+}


### PR DESCRIPTION
## What?

Add an approvals test for the IPV request

## Why?

Not only does this catch formatting issues (for example the `claims` claim is an escaped string rather than a JSON object), it also serves as self updating documentation. I've found it reasonably hard work to figure out what this request actually looked like, and was debugging tests. 
