### PR TITLE
ATO-91: Add auth code to AUTH_CODE_ISSUED audit

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -54,6 +54,7 @@ import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class DocAppCallbackHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -321,7 +322,12 @@ public class DocAppCallbackHandler
                             session.getEmailAddress(),
                             IpAddressHelper.extractIpAddress(input),
                             AuditService.UNKNOWN,
-                            AuditService.UNKNOWN);
+                            AuditService.UNKNOWN,
+                            pair("internalSubjectId", AuditService.UNKNOWN),
+                            pair("isNewAccount", session.isNewAccount()),
+                            pair("rpPairwiseId", AuditService.UNKNOWN),
+                            pair("nonce", authenticationRequest.getNonce()),
+                            pair("authCode", authCode));
 
                     return generateApiGatewayProxyResponse(
                             302,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -299,7 +299,8 @@ public class AuthCodeHandler
                     pair("internalSubjectId", internalSubjectId),
                     pair("isNewAccount", session.isNewAccount()),
                     pair("rpPairwiseId", rpPairwiseId),
-                    pair("nonce", authenticationRequest.getNonce()));
+                    pair("nonce", authenticationRequest.getNonce()),
+                    pair("authCode", authCode));
 
             cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
             cloudwatchMetricsService.incrementSignInByClient(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -360,7 +360,8 @@ public class AuthenticationCallbackHandler
                         pair("internalSubjectId", AuditService.UNKNOWN),
                         pair("isNewAccount", userInfo.getClaim("new_account")),
                         pair("rpPairwiseId", userInfo.getClaim("rp_client_id")),
-                        pair("nonce", authenticationRequest.getNonce()));
+                        pair("nonce", authenticationRequest.getNonce()),
+                        pair("authCode", authCode.getValue()));
 
                 return generateApiGatewayProxyResponse(
                         302,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -242,7 +242,8 @@ class AuthCodeHandlerTest {
                         pair("internalSubjectId", SUBJECT.getValue()),
                         pair("isNewAccount", AccountState.NEW),
                         pair("rpPairwiseId", expectedRpPairwiseId),
-                        pair("nonce", NONCE));
+                        pair("nonce", NONCE),
+                        pair("authCode", authorizationCode));
 
         var dimensions =
                 Map.of(
@@ -324,7 +325,8 @@ class AuthCodeHandlerTest {
                         pair("internalSubjectId", AuditService.UNKNOWN),
                         pair("isNewAccount", AccountState.UNKNOWN),
                         pair("rpPairwiseId", AuditService.UNKNOWN),
-                        pair("nonce", NONCE));
+                        pair("nonce", NONCE),
+                        pair("authCode", authorizationCode));
 
         var expectedDimensions =
                 Map.of(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -205,7 +205,8 @@ class AuthenticationCallbackHandlerTest {
                         eq(pair("internalSubjectId", AuditService.UNKNOWN)),
                         eq(pair("isNewAccount", "true")),
                         eq(pair("rpPairwiseId", PAIRWISE_SUBJECT_ID.getValue())),
-                        eq(pair("nonce", RP_NONCE)));
+                        eq(pair("nonce", RP_NONCE)),
+                        eq(pair("authCode", AUTH_CODE_RP_TO_ORCH)));
     }
 
     @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -206,7 +206,7 @@ class AuthenticationCallbackHandlerTest {
                         eq(pair("isNewAccount", "true")),
                         eq(pair("rpPairwiseId", PAIRWISE_SUBJECT_ID.getValue())),
                         eq(pair("nonce", RP_NONCE)),
-                        eq(pair("authCode", AUTH_CODE_RP_TO_ORCH)));
+                        eq(pair("authCode", AUTH_CODE_RP_TO_ORCH.getValue())));
     }
 
     @Test


### PR DESCRIPTION
## What?
Add auth code to AUTH_CODE_ISSUED audit event

## Why?

HMRC requirements
