### PR TITLE
AUT-1826: identity credentials CMK decryption

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -16,7 +16,8 @@ module "ipv_callback_role" {
     aws_iam_policy.ipv_token_auth_kms_policy.arn,
     aws_iam_policy.spot_queue_encryption_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    local.identity_credentials_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -14,7 +14,8 @@ module "ipv_processing_identity_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    local.identity_credentials_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -64,4 +64,5 @@ locals {
   account_modifiers_encryption_policy_arn             = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
   common_passwords_encryption_policy_arn              = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
   client_registry_encryption_policy_arn               = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
+  identity_credentials_encryption_policy_arn          = data.terraform_remote_state.shared.outputs.identity_credentials_encryption_policy_arn
 }

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -11,7 +11,8 @@ module "ipv_spot_response_role" {
     aws_iam_policy.spot_response_sqs_read_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.identity_credentials_encryption_policy_arn
   ]
 
   depends_on = [

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -14,7 +14,8 @@ module "oidc_userinfo_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    local.identity_credentials_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/shared/kms-policies.tf
+++ b/ci/terraform/shared/kms-policies.tf
@@ -42,6 +42,28 @@ data "aws_iam_policy_document" "common_passwords_encryption_key_policy_document"
   }
 }
 
+resource "aws_iam_policy" "identity_credentials_encryption_key_kms_policy" {
+  name        = "${var.environment}-identity-credentials-table-encryption-key-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS encryption of the identity credentials table"
+
+  policy = data.aws_iam_policy_document.identity_credentials_encryption_key_policy_document.json
+}
+
+data "aws_iam_policy_document" "identity_credentials_encryption_key_policy_document" {
+  statement {
+    sid    = "AllowAccessToIdentityCredentialsTableKmsEncryptionKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      aws_kms_key.identity_credentials_table_encryption_key.arn
+    ]
+  }
+}
+
 resource "aws_iam_policy" "client_registry_encryption_key_kms_policy" {
   name        = "${var.environment}-client-registry-table-encryption-key-kms-policy"
   path        = "/"
@@ -63,3 +85,4 @@ data "aws_iam_policy_document" "client_registry_encryption_key_policy_document" 
     ]
   }
 }
+

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -524,6 +524,30 @@ resource "aws_kms_key" "common_passwords_table_encryption_key" {
   tags = local.default_tags
 }
 
+resource "aws_kms_key" "identity_credentials_table_encryption_key" {
+  description              = "KMS encryption key for identity credentials table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}
+
 resource "aws_kms_key" "client_registry_table_encryption_key" {
   description              = "KMS encryption key for client registry table in DynamoDB"
   deletion_window_in_days  = 30

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -189,3 +189,7 @@ output "common_passwords_encryption_policy_arn" {
 output "client_registry_encryption_policy_arn" {
   value = aws_iam_policy.client_registry_encryption_key_kms_policy.arn
 }
+
+output "identity_credentials_encryption_policy_arn" {
+  value = aws_iam_policy.identity_credentials_encryption_key_kms_policy.arn
+}


### PR DESCRIPTION
## What?

Added CMK decryption capability to lambdas that interact with the identity credentials table.

## Why?

CMK encryption/decryption is being implemented in line with recommendations from the ITHC. Separate PRs are being made for the identity credentials table's encryption and decryption capability. Decryption capability is being implemented first as when encryption and decryption capability are merged together there is down time as tables are encrypted before lambdas are able to decrypt them.

Another PR will follow encrypting the table after this has been merged

