### PR TITLE
ATO-194: Pass split enabled flag to correct lambda

### DIFF
--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -24,12 +24,11 @@ module "auth_userinfo" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT             = var.environment
-    TXMA_AUDIT_QUEUE_URL    = module.auth_ext_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT     = null
-    DYNAMO_ENDPOINT         = null
-    INTERNAl_SECTOR_URI     = var.internal_sector_uri
-    SUPPORT_AUTH_ORCH_SPLIT = var.support_auth_orch_split
+    ENVIRONMENT          = var.environment
+    TXMA_AUDIT_QUEUE_URL = module.auth_ext_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT  = null
+    DYNAMO_ENDPOINT      = null
+    INTERNAl_SECTOR_URI  = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.external.lambda.UserInfoHandler::handleRequest"
   handler_runtime       = "java17"

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -35,6 +35,7 @@ module "userinfo" {
     TOKEN_SIGNING_KEY_RSA_ALIAS = aws_kms_alias.id_token_signing_key_alias.name
     IDENTITY_ENABLED            = var.ipv_api_enabled
     INTERNAl_SECTOR_URI         = var.internal_sector_uri
+    SUPPORT_AUTH_ORCH_SPLIT     = var.support_auth_orch_split
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest"
 


### PR DESCRIPTION
## What?

Pass the the auth/orch split flag to the oidc userinfo lambda rather than the auth external one

## Why?

This is the lambda which uses it
