### PR TITLE
ATO-193: Set the Orch redirect url in all environments

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -53,6 +53,7 @@ module "authorize" {
     DOC_APP_DECOUPLE_ENABLED             = var.doc_app_decouple_enabled
     DYNAMO_ENDPOINT                      = var.use_localstack ? var.lambda_dynamo_endpoint : null
     CUSTOM_DOC_APP_CLAIM_ENABLED         = var.custom_doc_app_claim_enabled
+    ORCH_REDIRECT_URI                    = var.orch_redirect_uri
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
   rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -29,4 +29,5 @@ AZUx4RCDu+VWAZpPi1NaF5XWvkFNFwH+MyLkATh90UEJDe+ayKW6AXFcRQ==
 -----END PUBLIC KEY-----
 EOT
 
-orch_client_id = "orchestrationAuth"
+orch_client_id    = "orchestrationAuth"
+orch_redirect_uri = "https://oidc.build.account.gov.uk/orchestration-redirect"

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -30,3 +30,4 @@ EOT
 
 orch_client_id          = "orchestrationAuth"
 support_auth_orch_split = false
+orch_redirect_uri       = "https://oidc.integration.account.gov.uk/orchestration-redirect"

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -28,4 +28,5 @@ AZUx4RCDu+VWAZpPi1NaF5XWvkFNFwH+MyLkATh90UEJDe+ayKW6AXFcRQ==
 -----END PUBLIC KEY-----
 EOT
 
-orch_client_id = "orchestrationAuth"
+orch_client_id    = "orchestrationAuth"
+orch_redirect_uri = "https://oidc.account.gov.uk/orchestration-redirect"

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -48,3 +48,5 @@ orch_client_id = "orchestrationAuth"
 support_auth_orch_split = true
 
 orch_frontend_api_gateway_integration_enabled = true
+
+orch_redirect_uri = "https://oidc.sandpit.account.gov.uk/orchestration-redirect"

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -8,3 +8,4 @@ logging_endpoint_arns                = []
 shared_state_bucket                  = "di-auth-staging-tfstate"
 test_clients_enabled                 = true
 internal_sector_uri                  = "https://identity.staging.account.gov.uk"
+orch_redirect_uri                    = "https://oidc.staging.account.gov.uk/orchestration-redirect"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -485,6 +485,11 @@ variable "account_intervention_service_uri" {
   type    = string
 }
 
+variable "orch_redirect_uri" {
+  type        = string
+  description = "The redirect URI set by Orchestration in the OAuth2 authorize request to Authentication"
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What?

Pass through the correct redirect url for the orch->auth OAuth flow. The currently deployed code just has `orchestration-redirect` as a default, so the redirect goes to the `signin.` domain, which is not correct.

## Related PRs
Draft until https://github.com/govuk-one-login/authentication-frontend/pull/1217 goes in