### PR TITLE
ATO-181: Integrate API Gateway with Orchestration frontend Network Load Balancer

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -578,14 +578,16 @@ EOF
 }
 
 resource "aws_api_gateway_resource" "orch_frontend_resource" {
+  count       = var.orch_frontend_api_gateway_integration_enabled ? 1 : 0
   rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
   parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   path_part   = "orch-frontend"
 }
 
 resource "aws_api_gateway_method" "orch_frontend_method" {
+  count       = var.orch_frontend_api_gateway_integration_enabled ? 1 : 0
   rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  resource_id = aws_api_gateway_resource.orch_frontend_resource.id
+  resource_id = aws_api_gateway_resource.orch_frontend_resource[0].id
   http_method = "GET"
 
   depends_on = [
@@ -595,28 +597,31 @@ resource "aws_api_gateway_method" "orch_frontend_method" {
 }
 
 data "aws_cloudformation_stack" "orch_frontend_stack" {
-  name = "${var.environment}-orch-frontend"
+  count = var.orch_frontend_api_gateway_integration_enabled ? 1 : 0
+  name  = "${var.environment}-orch-frontend"
 }
 
 locals {
-  nlb_dns_name = data.aws_cloudformation_stack.orch_frontend_stack.outputs["OrchFrontendNlbDnsName"]
-  nlb_arn      = data.aws_cloudformation_stack.orch_frontend_stack.outputs["OrchFrontendNlbArn"]
+  nlb_dns_name = length(data.aws_cloudformation_stack.orch_frontend_stack) > 0 ? data.aws_cloudformation_stack.orch_frontend_stack[0].outputs["OrchFrontendNlbDnsName"] : null
+  nlb_arn      = length(data.aws_cloudformation_stack.orch_frontend_stack) > 0 ? data.aws_cloudformation_stack.orch_frontend_stack[0].outputs["OrchFrontendNlbArn"] : null
 }
 
 resource "aws_api_gateway_vpc_link" "orch_frontend_nlb_vpc_link" {
+  count       = var.orch_frontend_api_gateway_integration_enabled ? 1 : 0
   name        = "orch-frontend-nlb-vpc-link"
   target_arns = [local.nlb_arn]
 }
 
 resource "aws_api_gateway_integration" "orch_frontend_nlb_integration" {
+  count       = var.orch_frontend_api_gateway_integration_enabled ? 1 : 0
   rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
-  resource_id = aws_api_gateway_resource.orch_frontend_resource.id
-  http_method = aws_api_gateway_method.orch_frontend_method.http_method
+  resource_id = aws_api_gateway_resource.orch_frontend_resource[0].id
+  http_method = aws_api_gateway_method.orch_frontend_method[0].http_method
 
   type                    = "HTTP_PROXY"
   uri                     = "http://${local.nlb_dns_name}/"
   integration_http_method = "GET"
 
   connection_type = "VPC_LINK"
-  connection_id   = aws_api_gateway_vpc_link.orch_frontend_nlb_vpc_link.id
+  connection_id   = aws_api_gateway_vpc_link.orch_frontend_nlb_vpc_link[0].id
 }

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -46,3 +46,5 @@ extended_feature_flags_enabled = true
 orch_client_id = "orchestrationAuth"
 
 support_auth_orch_split = true
+
+orch_frontend_api_gateway_integration_enabled = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -464,6 +464,12 @@ variable "orch_client_id" {
   default = ""
 }
 
+variable "orch_frontend_api_gateway_integration_enabled" {
+  description = "Flag to enable API Gateway integration with the Orchestration frontend"
+  type        = bool
+  default     = false
+}
+
 variable "deploy_account_interventions_count" {
   type = string
 }


### PR DESCRIPTION
## What?
Integrate existing API Gateway with Orch frontend Network Load Balancer (NLB)

## Why?
- API Gateway does not support integration of private Application Load Balancer (ALB)
- NLB and VPC Link are used instead, which sit in between API Gateway and ALB.

## Related PRs
[ATO-180](https://github.com/govuk-one-login/authentication-api/pull/3566) adds the ALB and NLB to the Orchestration frontend


[ATO-180]: https://govukverify.atlassian.net/browse/ATO-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ