### PR TITLE
AUT 1851: Create new stub lambda (placeholder for Account Interventions API stub)

### DIFF
--- a/.github/workflows/build-api-modules.yml
+++ b/.github/workflows/build-api-modules.yml
@@ -25,6 +25,7 @@ jobs:
         - test-services-api
         - utils
         - auth-external-api
+        - interventions-api-stub
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -49,10 +50,10 @@ jobs:
 
     - name: Set up Gradle
       uses: gradle/gradle-build-action@v2
-    
+
     - name: Build ${{ matrix.module }}
       run: ./gradlew --no-daemon :${{ matrix.module }}:buildZip
-    
+
     - name: Upload ${{ matrix.module }} to source bucket
       working-directory: ${{ matrix.module }}/build/distributions
       run: |
@@ -62,7 +63,7 @@ jobs:
           --body ${{ matrix.module }}.zip`
         VERSION=`echo $S3_RESPONSE | jq .VersionId -r`
         echo "VERSION=$VERSION" >> $GITHUB_ENV
-    
+
     - name: Start signing job for ${{ matrix.module }}
       run: |
         SIGNER_RESPONSE=`aws signer start-signing-job \

--- a/.github/workflows/deploy-interventions-api-stub.yml
+++ b/.github/workflows/deploy-interventions-api-stub.yml
@@ -1,0 +1,50 @@
+name: Deploy Account Interventions API Stub
+
+env:
+  GHA_ROLE: arn:aws:iam::761723964695:role/build-auth-deploy-pipeline-GitHubActionsRole-160U5ADTRKQ2O
+  DESTINATION_BUCKET: di-auth-lambda-signed-20220215170204376200000002
+  ARTIFACT_BUCKET: build-auth-deploy-pipeli-githubartifactsourcebuck-1o4hcrnik6ayv
+
+on:
+  workflow_run:
+    workflows: ["Build modules"]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.GHA_ROLE }}
+          aws-region: eu-west-2
+
+      - name: Download and copy Account Interventions API Stub signed lambda zip
+        working-directory: ci/terraform/interventions-api-stub
+        run: |
+          aws s3 cp s3://di-auth-lambda-signed-20220215170204376200000002 ./artifacts \
+            --recursive --exclude "*" \
+            --include "signed-interventions-api-stub-${{ github.sha }}-*"
+          mv artifacts/signed-interventions-api-stub-*.zip artifacts/interventions-api-stub.zip
+
+      - name: Upload Account Interventions API Stub Terraform files
+        working-directory: ci/terraform
+        run: |
+          zip -r interventions-api-stub.zip .
+          S3_RESPONSE=`aws s3api put-object \
+            --bucket $ARTIFACT_BUCKET \
+            --key interventions-api-stub.zip \
+            --body interventions-api-stub.zip \
+            --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG"`
+          VERSION=`echo $S3_RESPONSE | jq .VersionId -r`
+          echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/ci/terraform/interventions-api-stub/sandpit.tfvars
+++ b/ci/terraform/interventions-api-stub/sandpit.tfvars
@@ -1,0 +1,8 @@
+environment         = "sandpit"
+shared_state_bucket = "digital-identity-dev-tfstate"
+
+logging_endpoint_arns  = []
+internal_sector_uri    = "https://identity.sandpit.account.gov.uk"
+lambda_max_concurrency = 0
+lambda_min_concurrency = 0
+endpoint_memory_size   = 1536

--- a/interventions-api-stub/build.gradle
+++ b/interventions-api-stub/build.gradle
@@ -1,0 +1,35 @@
+plugins {
+    id 'java'
+    id "jacoco"
+}
+
+group = 'uk.gov.di.authentication.interventions-api-stub'
+version = 'unspecified'
+
+dependencies {
+    compileOnly configurations.lambda
+
+    implementation project(":shared")
+
+    testImplementation configurations.tests,
+            configurations.lambda
+
+    testRuntimeOnly configurations.test_runtime
+}
+
+test {
+    useJUnitPlatform()
+    environment "TRACING_ENABLED", "false"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
+}

--- a/interventions-api-stub/build.gradle
+++ b/interventions-api-stub/build.gradle
@@ -27,6 +27,14 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
+task buildZip(type: Zip) {
+    from compileJava
+    from processResources
+    into("lib") {
+        from configurations.runtimeClasspath
+    }
+}
+
 jacocoTestReport {
     reports {
         xml.enabled true

--- a/interventions-api-stub/src/main/java/uk/gov/di/authentication/interventions/api/stub/lambda/HelloWorldHandler.java
+++ b/interventions-api-stub/src/main/java/uk/gov/di/authentication/interventions/api/stub/lambda/HelloWorldHandler.java
@@ -1,0 +1,19 @@
+package uk.gov.di.authentication.interventions.api.stub.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+
+public class HelloWorldHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        var event = new APIGatewayProxyRequestEvent();
+
+        return generateApiGatewayProxyResponse(200, "Hello world");
+    }
+}

--- a/interventions-api-stub/src/test/java/uk/gov/di/authentication/interventions/api/stub/lambda/HelloWorldHandlerTest.java
+++ b/interventions-api-stub/src/test/java/uk/gov/di/authentication/interventions/api/stub/lambda/HelloWorldHandlerTest.java
@@ -1,0 +1,22 @@
+package uk.gov.di.authentication.interventions.api.stub.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class HelloWorldHandlerTest {
+
+    @Test
+    void shouldReturn200ForSuccessfulRequest() {
+        var handler = new HelloWorldHandler();
+        var context = mock(Context.class);
+        var event = new APIGatewayProxyRequestEvent();
+
+        var result = handler.handleRequest(event, context);
+        assertEquals(200, result.getStatusCode());
+        assertEquals("Hello world", result.getBody());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,4 +15,5 @@ include 'doc-checking-app-api'
 include 'utils'
 include 'test-services-api'
 include 'auth-external-api'
+include 'interventions-api-stub'
 


### PR DESCRIPTION
## What?
- Create new stub lambda with HelloWorld lambda
- Note: Other tickets will flesh out the infrastructure as code as well as the 'real' code needed to simulate the Account Interventions API; this is purely placeholder material

## Why?
- This provides a skeleton for building the actual code/logic to stub out another team's API (the 'Account Interventions API')
