### PR TITLE
Aut 1850/create interventions stub terraform

### DIFF
--- a/ci/terraform/interventions-api-stub/build.tfvars
+++ b/ci/terraform/interventions-api-stub/build.tfvars
@@ -1,0 +1,5 @@
+interventions_api_stub_release_zip_file = "./artifacts/interventions-api-stub.zip"
+shared_state_bucket                     = "digital-identity-dev-tfstate"
+logging_endpoint_arns = [
+  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+]

--- a/ci/terraform/interventions-api-stub/hello-world.tf
+++ b/ci/terraform/interventions-api-stub/hello-world.tf
@@ -1,0 +1,53 @@
+module "hello_world_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "hello-world-role"
+  vpc_arn     = local.authentication_vpc_arn
+}
+
+module "hello_world_lambda" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "hello-world"
+  path_part       = "hello-world"
+  endpoint_method = ["GET"]
+  environment     = var.environment
+
+  handler_environment_variables = {
+    ENVIRONMENT = var.environment
+  }
+  handler_function_name = "uk.gov.di.authentication.interventions.api.stub.lambda.HelloWorldHandler::handleRequest"
+  handler_runtime       = "java17"
+
+  rest_api_id      = aws_api_gateway_rest_api.interventions_api_stub.id
+  root_resource_id = aws_api_gateway_rest_api.interventions_api_stub.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.interventions_api_stub.execution_arn
+
+  memory_size                 = local.default_performance_parameters.memory
+  provisioned_concurrency     = local.default_performance_parameters.concurrency
+  max_provisioned_concurrency = local.default_performance_parameters.max_concurrency
+  scaling_trigger             = local.default_performance_parameters.scaling_trigger
+
+  source_bucket           = aws_s3_bucket.interventions_api_stub_source_bucket.bucket
+  lambda_zip_file         = aws_s3_object.interventions_api_stub_release_zip.key
+  lambda_zip_file_version = aws_s3_object.interventions_api_stub_release_zip.version_id
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+  ]
+  subnet_id                              = local.authentication_subnet_ids
+  lambda_role_arn                        = module.hello_world_role.arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+
+  use_localstack = false
+
+  depends_on = [
+    aws_api_gateway_rest_api.interventions_api_stub,
+  ]
+}

--- a/ci/terraform/interventions-api-stub/interventions-api-stub-gateway.tf
+++ b/ci/terraform/interventions-api-stub/interventions-api-stub-gateway.tf
@@ -68,7 +68,7 @@ resource "aws_api_gateway_stage" "interventions_api_stub_stage" {
   }
 
   depends_on = [
-    #    module.auth_userinfo_role,
+    module.hello_world_role,
     aws_api_gateway_deployment.interventions_api_stub_deployment
   ]
 
@@ -78,18 +78,18 @@ resource "aws_api_gateway_stage" "interventions_api_stub_stage" {
 resource "aws_api_gateway_deployment" "interventions_api_stub_deployment" {
   rest_api_id = aws_api_gateway_rest_api.interventions_api_stub.id
 
-  #  triggers = {
-  #    redeployment = sha1(jsonencode([
-  #      module.auth_userinfo.integration_trigger_value,
-  #      module.auth_userinfo.method_trigger_value,
-  #    ]))
-  #  }
+  triggers = {
+    redeployment = sha1(jsonencode([
+      module.hello_world_lambda.integration_trigger_value,
+      module.hello_world_lambda.method_trigger_value,
+    ]))
+  }
   lifecycle {
     create_before_destroy = true
   }
-  #  depends_on = [
-  #    module.auth_userinfo,
-  #  ]
+  depends_on = [
+    module.hello_world_lambda,
+  ]
 }
 
 resource "aws_api_gateway_method_settings" "interventions_api_stub_logging_settings" {

--- a/ci/terraform/interventions-api-stub/interventions-api-stub-gateway.tf
+++ b/ci/terraform/interventions-api-stub/interventions-api-stub-gateway.tf
@@ -1,0 +1,129 @@
+data "aws_vpc" "auth_shared_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["${var.environment}-shared-vpc"]
+  }
+}
+
+data "aws_vpc_endpoint" "auth_api_vpc_endpoint" {
+  vpc_id       = data.aws_vpc.auth_shared_vpc.id
+  service_name = "com.amazonaws.eu-west-2.execute-api"
+  tags = {
+    environment = var.environment
+    terraform   = "core"
+  }
+}
+
+resource "aws_api_gateway_rest_api" "interventions_api_stub" {
+  name = "${var.environment}-di-interventions-api-stub"
+
+  tags   = local.default_tags
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "execute-api:Invoke",
+            "Resource": [
+                "execute-api:/*"
+            ]
+        },
+        {
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "execute-api:Invoke",
+            "Resource": [
+                "execute-api:/*"
+            ],
+            "Condition" : {
+                "StringNotEquals": {
+                    "aws:SourceVpce": "${data.aws_vpc_endpoint.auth_api_vpc_endpoint.id}"
+                }
+            }
+        }
+    ]
+}
+EOF
+  endpoint_configuration {
+    types            = ["PRIVATE"]
+    vpc_endpoint_ids = [data.aws_vpc_endpoint.auth_api_vpc_endpoint.id]
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "interventions_api_stub_stage" {
+  deployment_id         = aws_api_gateway_deployment.interventions_api_stub_deployment.id
+  rest_api_id           = aws_api_gateway_rest_api.interventions_api_stub.id
+  stage_name            = var.environment
+  cache_cluster_enabled = false
+  xray_tracing_enabled  = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.interventions_api_stub_stage_access_logs.arn
+    format          = local.access_logging_template
+  }
+
+  depends_on = [
+    #    module.auth_userinfo_role,
+    aws_api_gateway_deployment.interventions_api_stub_deployment
+  ]
+
+  tags = local.default_tags
+}
+
+resource "aws_api_gateway_deployment" "interventions_api_stub_deployment" {
+  rest_api_id = aws_api_gateway_rest_api.interventions_api_stub.id
+
+  #  triggers = {
+  #    redeployment = sha1(jsonencode([
+  #      module.auth_userinfo.integration_trigger_value,
+  #      module.auth_userinfo.method_trigger_value,
+  #    ]))
+  #  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  #  depends_on = [
+  #    module.auth_userinfo,
+  #  ]
+}
+
+resource "aws_api_gateway_method_settings" "interventions_api_stub_logging_settings" {
+  count = var.enable_api_gateway_execution_logging ? 1 : 0
+
+  rest_api_id = aws_api_gateway_rest_api.interventions_api_stub.id
+  stage_name  = aws_api_gateway_stage.interventions_api_stub_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    metrics_enabled    = true
+    data_trace_enabled = local.request_tracing_allowed
+    logging_level      = "INFO"
+    caching_enabled    = false
+  }
+  depends_on = [
+    aws_api_gateway_stage.interventions_api_stub_stage
+  ]
+}
+
+resource "aws_cloudwatch_log_group" "interventions_api_stub_stage_access_logs" {
+  name              = "${var.environment}-auth-interventions-api-stub-access-logs"
+  retention_in_days = var.cloudwatch_log_retention
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "interventions_api_stub_access_log_subscription" {
+  count           = length(var.logging_endpoint_arns)
+  name            = "${var.environment}-auth-interventions-api-stub-access-logs-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.interventions_api_stub_stage_access_logs.name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}

--- a/ci/terraform/interventions-api-stub/s3-objects.tf
+++ b/ci/terraform/interventions-api-stub/s3-objects.tf
@@ -1,0 +1,19 @@
+resource "aws_s3_bucket" "interventions_api_stub_source_bucket" {
+  bucket_prefix = "${var.environment}-int-api-stub-source-"
+}
+
+resource "aws_s3_bucket_versioning" "interventions_api_stub_source_bucket_versioning" {
+  bucket = aws_s3_bucket.interventions_api_stub_source_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_object" "interventions_api_stub_release_zip" {
+  bucket = aws_s3_bucket.interventions_api_stub_source_bucket.bucket
+  key    = "interventions-api-stub-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.interventions_api_stub_release_zip_file
+  source_hash            = filemd5(var.interventions_api_stub_release_zip_file)
+}

--- a/ci/terraform/interventions-api-stub/sandpit.tfvars
+++ b/ci/terraform/interventions-api-stub/sandpit.tfvars
@@ -1,8 +1,2 @@
 environment         = "sandpit"
 shared_state_bucket = "digital-identity-dev-tfstate"
-
-logging_endpoint_arns  = []
-internal_sector_uri    = "https://identity.sandpit.account.gov.uk"
-lambda_max_concurrency = 0
-lambda_min_concurrency = 0
-endpoint_memory_size   = 1536

--- a/ci/terraform/interventions-api-stub/shared.tf
+++ b/ci/terraform/interventions-api-stub/shared.tf
@@ -1,0 +1,16 @@
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket                      = var.shared_state_bucket
+    key                         = "${var.environment}-shared-terraform.tfstate"
+    role_arn                    = var.deployer_role_arn
+    region                      = var.aws_region
+    endpoint                    = null
+    iam_endpoint                = null
+    sts_endpoint                = null
+    skip_credentials_validation = false
+    skip_metadata_api_check     = false
+    force_path_style            = false
+  }
+}
+

--- a/ci/terraform/interventions-api-stub/shared.tf
+++ b/ci/terraform/interventions-api-stub/shared.tf
@@ -14,3 +14,11 @@ data "terraform_remote_state" "shared" {
   }
 }
 
+locals {
+  authentication_vpc_arn                 = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
+  lambda_code_signing_configuration_arn  = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
+  authentication_security_group_id       = data.terraform_remote_state.shared.outputs.authentication_security_group_id
+  authentication_subnet_ids              = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
+  lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
+}
+

--- a/ci/terraform/interventions-api-stub/site.tf
+++ b/ci/terraform/interventions-api-stub/site.tf
@@ -1,0 +1,24 @@
+locals {
+  // Using a local rather than the default_tags option on the AWS provider, as the latter has known issues which produce errors on apply.
+  default_tags = {
+    environment = var.environment
+    application = "interventions-api-stub"
+  }
+
+  request_tracing_allowed = contains(["build", "sandpit"], var.environment)
+
+  access_logging_template = jsonencode({
+    requestId            = "$context.requestId"
+    ip                   = "$context.identity.sourceIp"
+    userAgent            = "$context.identity.userAgent"
+    requestTime          = "$context.requestTime"
+    httpMethod           = "$context.httpMethod"
+    resourcePath         = "$context.resourcePath"
+    status               = "$context.status"
+    protocol             = "$context.protocol"
+    responseLength       = "$context.responseLength"
+    integrationStatus    = "$context.integration.integrationStatus"
+    integrationLatency   = "$context.integration.latency"
+    integrationRequestId = "$context.integration.requestId"
+  })
+}

--- a/ci/terraform/interventions-api-stub/variables.tf
+++ b/ci/terraform/interventions-api-stub/variables.tf
@@ -33,3 +33,37 @@ variable "logging_endpoint_arns" {
   default     = []
   description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
 }
+
+variable "lambda_max_concurrency" {
+  default = 0
+}
+
+variable "scaling_trigger" {
+  default = 0.7
+}
+
+variable "lambda_min_concurrency" {
+  default     = 0
+  type        = number
+  description = "The number of lambda instance to keep 'warm'"
+}
+
+variable "endpoint_memory_size" {
+  default = 1536
+  type    = number
+}
+
+variable "interventions_api_stub_release_zip_file" {
+  default     = "../../../interventions-api-stub/build/distributions/interventions-api-stub.zip"
+  description = "Location of the Lambda ZIP file - defaults to build output folder when built locally"
+  type        = string
+}
+
+locals {
+  default_performance_parameters = {
+    memory          = var.endpoint_memory_size
+    concurrency     = var.lambda_min_concurrency
+    max_concurrency = var.lambda_max_concurrency
+    scaling_trigger = var.scaling_trigger
+  }
+}

--- a/ci/terraform/interventions-api-stub/variables.tf
+++ b/ci/terraform/interventions-api-stub/variables.tf
@@ -1,0 +1,35 @@
+variable "environment" {
+  type = string
+}
+
+variable "enable_api_gateway_execution_logging" {
+  default     = true
+  description = "Whether to enable logging of API gateway runs"
+}
+
+variable "shared_state_bucket" {
+  type    = string
+  default = "digital-identity-dev-tfstate"
+}
+
+variable "deployer_role_arn" {
+  default     = null
+  description = "The name of the AWS role to assume, leave blank when running locally"
+  type        = string
+}
+
+variable "aws_region" {
+  default = "eu-west-2"
+}
+
+variable "cloudwatch_log_retention" {
+  default     = 1
+  type        = number
+  description = "The number of day to retain Cloudwatch logs for"
+}
+
+variable "logging_endpoint_arns" {
+  type        = list(string)
+  default     = []
+  description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
+}

--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -18,13 +18,14 @@ function usage() {
   Requires a GDS CLI, AWS CLI and jq installed and configured.
 
   Usage:
-    $0 [-b|--build] [-c|--clean] [-s|--shared] [-o|--oidc] [-a|--account-management] [-t|--test-services] [--audit] [--destroy] [-p|--prompt] [-x|--auth-external]
+    $0 [-b|--build] [-c|--clean] [-s|--shared] [-i|--interventions] [-o|--oidc] [-a|--account-management] [-t|--test-services] [--audit] [--destroy] [-p|--prompt] [-x|--auth-external]
 
   Options:
     -b, --build               run gradle build and buildZip tasks (default)
     -c, --clean               run gradle clean before build
     -s, --shared              run the shared terraform (default)
     -o, --oidc                run the oidc terraform (default)
+    -i, --interventions       run the account interventions API stub terraform (default)
     -a, --account-management  run the account management terraform (default)
     --audit                   run the audit terraform
     -d, --delivery-receipts   run the delivery receipts terraform
@@ -43,6 +44,7 @@ AUDIT=0
 AUTH_EXTERNAL_API=0
 BUILD=0
 OIDC=0
+INTERVENTIONS=0
 RECEIPTS=0
 SHARED=0
 UTILS=0
@@ -54,6 +56,7 @@ if [[ $# == 0 ]]; then
   AUTH_EXTERNAL_API=1
   BUILD=1
   OIDC=1
+  INTERVENTIONS=1
   SHARED=1
 fi
 while [[ $# -gt 0 ]]; do
@@ -75,6 +78,9 @@ while [[ $# -gt 0 ]]; do
     ;;
   -o | --oidc)
     OIDC=1
+    ;;
+  -i | --interventions)
+    INTERVENTIONS=1
     ;;
   -s | --shared)
     SHARED=1
@@ -127,8 +133,13 @@ echo "done!"
 if [[ $SHARED == "1" ]]; then
   runTerraform "shared" "${TERRAFORM_OPTS}"
 fi
+
 if [[ $OIDC == "1" ]]; then
   runTerraform "oidc" "${TERRAFORM_OPTS}"
+fi
+
+if [[ $INTERVENTIONS == "1" ]]; then
+  runTerraform "interventions-api-stub" "${TERRAFORM_OPTS}"
 fi
 
 if [[ $AM == "1" ]]; then


### PR DESCRIPTION
## What?

Creates a new api gateway wired up with a placeholder hello world endpoint for the interventions stub. This will only be deployed in build (although we will ensure that via the pipeline rather than in this terraform - this work will follow).

This has been tested in sandpit.

## Why?

We want something in build to replicate the Account Interventions API. We currently don’t have an API where these Stubs can live. This creates a new terraform module and create a new API gateway where these Stubs will sit behind. 

## Related PRs

We introduced the new module [here](https://github.com/govuk-one-login/authentication-api/pull/3567).
