### PR TITLE
AUT-1843: Create code and infra for "HelloWorld" Account Interventions Lambda

### DIFF
--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -1,0 +1,73 @@
+module "frontend_api_account_interventions_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-account-interventions-role"
+  vpc_arn     = local.authentication_vpc_arn
+  count       = var.deploy_account_interventions_count
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
+  ]
+}
+
+module "account_interventions" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "account-interventions"
+  path_part       = "account-interventions"
+  endpoint_method = ["POST"]
+  environment     = var.environment
+
+  handler_environment_variables = {
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT          = var.environment
+    TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
+    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    REDIS_KEY            = local.redis_key
+  }
+
+  handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AccountInterventionsHandler::handleRequest"
+
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  memory_size                 = lookup(var.performance_tuning, "account-interventions", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "account-interventions", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "account-interventions", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "account-interventions", local.default_performance_parameters).scaling_trigger
+
+  source_bucket           = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
+  subnet_id                              = local.authentication_subnet_ids
+  lambda_role_arn                        = module.frontend_api_orch_auth_code_role.arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+  api_key_required                       = true
+
+  use_localstack = var.use_localstack
+  count          = var.deploy_account_interventions_count
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_frontend_api,
+    aws_api_gateway_resource.connect_resource,
+    aws_api_gateway_resource.wellknown_resource,
+  ]
+}

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -57,7 +57,8 @@ locals {
     application = "oidc-api"
   }
 
-  request_tracing_allowed = contains(["build", "sandpit"], var.environment)
+  request_tracing_allowed            = contains(["build", "sandpit"], var.environment)
+  deploy_account_interventions_count = contains(["build", "sandpit"], var.environment) ? 1 : 0
 
   access_logging_template = jsonencode({
     requestId            = "$context.requestId"
@@ -78,3 +79,5 @@ locals {
 data "aws_caller_identity" "current" {}
 
 data "aws_partition" "current" {}
+
+

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -464,6 +464,11 @@ variable "orch_client_id" {
   default = ""
 }
 
+variable "deploy_account_interventions_count" {
+  type = string
+}
+
+
 variable "account_intervention_service_audit_enabled" {
   default = false
   type    = bool

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -1,0 +1,18 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+
+public class AccountInterventionsHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        return generateApiGatewayProxyResponse(200, "Hello world");
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -1,0 +1,22 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class AccountInterventionsHandlerTest {
+
+    @Test
+    void shouldReturn200ForSuccessfulRequest() {
+        var handler = new AccountInterventionsHandler();
+        var context = mock(Context.class);
+        var event = new APIGatewayProxyRequestEvent();
+
+        var result = handler.handleRequest(event, context);
+        assertEquals(200, result.getStatusCode());
+        assertEquals("Hello world", result.getBody());
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -1,0 +1,28 @@
+package uk.gov.di.authentication.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.frontendapi.lambda.AccountInterventionsHandler;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+    @BeforeEach
+    void setup() throws Json.JsonException {
+        handler = new AccountInterventionsHandler();
+    }
+
+    @Test
+    void shouldReturn200StatusAndCheckBody() {
+        var response = makeRequest(Optional.empty(), Map.of(), Map.of());
+        assertThat(response, hasStatus(200));
+        assertTrue(response.getBody().contains("Hello world"));
+    }
+}


### PR DESCRIPTION
## What?

- Create new AccountInterventionsAPI handler
- Create infra/terraform scripts to create API Gateway endpoint for the new lambda
- Create corresponding unit test to capture handler request & response
-  Add integration tests to the AccountInterventionsAPIHandler
- Enable deployment in build and sandpit only

## Why?

This provides a skeleton for building the actual code/logic for the Account Interventions lambda