### PR TITLE
AUT-1826: Added Common Passwords Table CMK Policies

### DIFF
--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -17,5 +17,6 @@ data "terraform_remote_state" "shared" {
 locals {
   lambda_code_signing_configuration_arn   = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
   account_modifiers_encryption_policy_arn = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
+  common_passwords_encryption_policy_arn  = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
   client_registry_encryption_policy_arn   = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
 }

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -9,7 +9,8 @@ module "account_management_api_update_password_role" {
     aws_iam_policy.dynamo_am_user_write_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
-    module.account_management_txma_audit.access_policy_arn
+    module.account_management_txma_audit.access_policy_arn,
+    local.common_passwords_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -15,6 +15,7 @@ module "frontend_api_login_role" {
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
+    local.common_passwords_encryption_policy_arn,
     local.client_registry_encryption_policy_arn
   ]
 }

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -16,7 +16,8 @@ module "frontend_api_reset_password_role" {
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    local.common_passwords_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -62,5 +62,6 @@ locals {
   vpce_id                                             = var.support_auth_orch_split ? data.terraform_remote_state.auth-ext-api[0].outputs.vpce_id : ""
   authentication_callback_userinfo_encryption_key_arn = data.terraform_remote_state.shared.outputs.authentication_callback_userinfo_encryption_key_arn
   account_modifiers_encryption_policy_arn             = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
+  common_passwords_encryption_policy_arn              = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
   client_registry_encryption_policy_arn               = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
 }

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -14,6 +14,7 @@ module "frontend_api_signup_role" {
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
+    local.common_passwords_encryption_policy_arn,
     local.client_registry_encryption_policy_arn
   ]
 }

--- a/ci/terraform/shared/kms-policies.tf
+++ b/ci/terraform/shared/kms-policies.tf
@@ -20,6 +20,28 @@ data "aws_iam_policy_document" "account_modifiers_encryption_key_policy_document
   }
 }
 
+resource "aws_iam_policy" "common_passwords_encryption_key_kms_policy" {
+  name        = "${var.environment}-common-passwords-table-encryption-key-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS encryption of the common passwords table"
+
+  policy = data.aws_iam_policy_document.common_passwords_encryption_key_policy_document.json
+}
+
+data "aws_iam_policy_document" "common_passwords_encryption_key_policy_document" {
+  statement {
+    sid    = "AllowAccessToCommonPasswordsTableKmsEncryptionKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      aws_kms_key.common_passwords_table_encryption_key.arn
+    ]
+  }
+}
+
 resource "aws_iam_policy" "client_registry_encryption_key_kms_policy" {
   name        = "${var.environment}-client-registry-table-encryption-key-kms-policy"
   path        = "/"

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -500,6 +500,30 @@ resource "aws_kms_key" "user_credentials_table_encryption_key" {
   tags = local.default_tags
 }
 
+resource "aws_kms_key" "common_passwords_table_encryption_key" {
+  description              = "KMS encryption key for common passwords table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}
+
 resource "aws_kms_key" "client_registry_table_encryption_key" {
   description              = "KMS encryption key for client registry table in DynamoDB"
   deletion_window_in_days  = 30

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -182,6 +182,10 @@ output "account_modifiers_encryption_policy_arn" {
   value = aws_iam_policy.account_modifiers_encryption_key_kms_policy.arn
 }
 
+output "common_passwords_encryption_policy_arn" {
+  value = aws_iam_policy.common_passwords_encryption_key_kms_policy.arn
+}
+
 output "client_registry_encryption_policy_arn" {
   value = aws_iam_policy.client_registry_encryption_key_kms_policy.arn
 }

--- a/ci/terraform/utils/common_passwords_update_lambda.tf
+++ b/ci/terraform/utils/common_passwords_update_lambda.tf
@@ -7,6 +7,7 @@ module "common_passwords_update_lambda_role" {
   policies_to_attach = [
     aws_iam_policy.common_passwords_s3_read_access.arn,
     aws_iam_policy.common_passwords_dynamo_full_access.arn,
+    local.common_passwords_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/utils/shared.tf
+++ b/ci/terraform/utils/shared.tf
@@ -21,4 +21,5 @@ locals {
     memory  = 1024,
     timeout = 900,
   }
+  common_passwords_encryption_policy_arn = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
 }


### PR DESCRIPTION
## What?

Added CMK decryption capability to lambdas that interact with the common passwords table.

## Why?

CMK encryption/decryption is being implemented in line with recommendations from the ITHC. Separate PRs are being made for the common passwords table's encryption and decryption capability. Decryption capability is being implemented first as when encryption and decryption capability are merged together there is down time as tables are encrypted before lambdas are able to decrypt them.

Another PR will follow encrypting the table after this has been merged
