### PR TITLE
ATO-196: Store internal pairwise identifier in access and refresh token stores

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -19,6 +19,7 @@ import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.oidc.exceptions.UserInfoException;
@@ -79,6 +80,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
     private static final Subject PUBLIC_SUBJECT = new Subject();
     private static final Subject INTERNAL_SUBJECT = new Subject();
+    private static final Subject INTERNAL_PAIRWISE_SUBJECT = new Subject();
     private static final Scope DOC_APP_SCOPES =
             new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);
     private static final Subject DOC_APP_PUBLIC_SUBJECT = new Subject();
@@ -135,7 +137,10 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var signedJWT = tokenSigner.signJwt(claimsSet);
         var accessToken = new BearerAccessToken(signedJWT.serialize());
         var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                new AccessTokenStore(
+                        accessToken.getValue(),
+                        INTERNAL_SUBJECT.getValue(),
+                        INTERNAL_PAIRWISE_SUBJECT.getValue());
         var accessTokenStoreString = objectMapper.writeValueAsString(accessTokenStore);
         redis.addToRedis(
                 ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT,
@@ -325,6 +330,86 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
+    @Nested
+    class AuthOrchSplitEnabled {
+        private static class UserInfoConfigurationService
+                extends UserInfoIntegrationTest.UserInfoConfigurationService {
+            @Override
+            public boolean isAuthOrchSplitEnabled() {
+                return true;
+            }
+        }
+
+        private static final UserInfo AUTH_USER_INFO =
+                new UserInfo(
+                        new JWTClaimsSet.Builder()
+                                .subject(INTERNAL_PAIRWISE_SUBJECT.getValue())
+                                .claim("email_verified", true)
+                                .claim("email", TEST_EMAIL_ADDRESS)
+                                .claim("phone_number_verified", true)
+                                .claim("phone_number", FORMATTED_PHONE_NUMBER)
+                                .build());
+
+        @BeforeEach
+        void setup() throws JOSEException, NoSuchAlgorithmException {
+            var configuration = new AuthOrchSplitEnabled.UserInfoConfigurationService();
+
+            handler = new UserInfoHandler(configuration);
+            var keyPair = KeyPairGenerator.getInstance("EC").generateKeyPair();
+            DOC_APP_CREDENTIAL =
+                    generateSignedJWT(new JWTClaimsSet.Builder().build(), keyPair).serialize();
+
+            userInfoStorageExtension.addAuthenticationUserInfoData(
+                    INTERNAL_PAIRWISE_SUBJECT.getValue(), AUTH_USER_INFO);
+        }
+
+        @Test
+        void shouldCallUserInfoWithAccessTokenAndReturn200()
+                throws Json.JsonException, ParseException {
+            var claimsSet =
+                    new JWTClaimsSet.Builder()
+                            .claim("scope", SCOPES)
+                            .issuer("issuer-id")
+                            .expirationTime(EXPIRY_DATE)
+                            .issueTime(NowHelper.now())
+                            .claim("client_id", "client-id-one")
+                            .subject(PUBLIC_SUBJECT.getValue())
+                            .jwtID(UUID.randomUUID().toString())
+                            .build();
+            var signedJWT = tokenSigner.signJwt(claimsSet);
+            var accessToken = new BearerAccessToken(signedJWT.serialize());
+            var accessTokenStore =
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
+            var accessTokenStoreString = objectMapper.writeValueAsString(accessTokenStore);
+            redis.addToRedis(
+                    ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT,
+                    accessTokenStoreString,
+                    300L);
+            setUpDynamo(null, null, 0, false);
+
+            var response =
+                    makeRequest(
+                            Optional.empty(),
+                            Map.of("Authorization", accessToken.toAuthorizationHeader()),
+                            Map.of());
+
+            assertThat(response, hasStatus(200));
+
+            var userInfoResponse = UserInfo.parse(response.getBody());
+            assertThat(userInfoResponse.getEmailVerified(), equalTo(true));
+            assertThat(userInfoResponse.getEmailAddress(), equalTo(TEST_EMAIL_ADDRESS));
+            assertThat(userInfoResponse.getPhoneNumber(), equalTo(FORMATTED_PHONE_NUMBER));
+            assertThat(userInfoResponse.getPhoneNumberVerified(), equalTo(true));
+            assertThat(userInfoResponse.getSubject(), equalTo(PUBLIC_SUBJECT));
+            assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(5));
+
+            assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(USER_INFO_RETURNED));
+        }
+    }
+
     public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet, KeyPair keyPair)
             throws JOSEException {
         var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
@@ -367,7 +452,10 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var signedJWT = tokenSigner.signJwt(claimsSet);
         var accessToken = new BearerAccessToken(signedJWT.serialize());
         var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                new AccessTokenStore(
+                        accessToken.getValue(),
+                        INTERNAL_SUBJECT.getValue(),
+                        INTERNAL_PAIRWISE_SUBJECT.getValue());
         redis.addToRedis(
                 ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT,
                 objectMapper.writeValueAsString(accessTokenStore),
@@ -393,7 +481,10 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var signedJWT = tokenSigner.signJwt(claimsSet);
         var accessToken = new BearerAccessToken(signedJWT.serialize());
         var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                new AccessTokenStore(
+                        accessToken.getValue(),
+                        INTERNAL_SUBJECT.getValue(),
+                        INTERNAL_PAIRWISE_SUBJECT.getValue());
         var accessTokenStoreString = objectMapper.writeValueAsString(accessTokenStore);
         redis.addToRedis(
                 ACCESS_TOKEN_PREFIX + APP_CLIENT_ID + "." + DOC_APP_PUBLIC_SUBJECT,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -251,17 +251,17 @@ public class TokenHandler
                                             authRequest.getScope(),
                                             additionalTokenClaims,
                                             clientSession.getDocAppSubjectId(),
-                                            vot,
                                             null,
                                             false,
                                             finalClaimsRequest,
                                             true,
                                             signingAlgorithm,
-                                            authCodeExchangeData.getClientSessionId()));
+                                            authCodeExchangeData.getClientSessionId(),
+                                            vot));
         } else {
             UserProfile userProfile =
                     dynamoService.getUserProfileByEmail(authCodeExchangeData.getEmail());
-            Subject subject =
+            Subject rpPairwiseSubject =
                     ClientSubjectHelper.getSubject(
                             userProfile,
                             clientRegistry,
@@ -276,14 +276,14 @@ public class TokenHandler
                                             new Subject(userProfile.getSubjectID()),
                                             authRequest.getScope(),
                                             additionalTokenClaims,
-                                            subject,
-                                            vot,
+                                            rpPairwiseSubject,
                                             userProfile.getClientConsent(),
                                             isConsentRequired,
                                             finalClaimsRequest,
                                             false,
                                             signingAlgorithm,
-                                            authCodeExchangeData.getClientSessionId()));
+                                            authCodeExchangeData.getClientSessionId(),
+                                            vot));
         }
 
         clientSessionService.saveClientSession(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -98,7 +98,7 @@ public class UserInfoService {
         try {
             var authUserInfo =
                     userInfoStorageService.getAuthenticationUserInfoData(
-                            accessTokenInfo.getAccessTokenStore().getInternalSubjectId());
+                            accessTokenInfo.getAccessTokenStore().getInternalPairwiseSubjectId());
 
             if (authUserInfo.isPresent()) {
                 tmpUserInfo = new UserInfo(JSONObjectUtils.parse(authUserInfo.get().getUserInfo()));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -51,6 +51,7 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -67,6 +68,8 @@ import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -103,8 +106,16 @@ public class TokenHandlerTest {
     private static final String TEST_EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String PHONE_NUMBER = "01234567890";
     private static final String REDIRECT_URI = "http://localhost/redirect";
+    private static final ByteBuffer SALT =
+            ByteBuffer.wrap("a-test-salt".getBytes(StandardCharsets.UTF_8));
+    private static final String RP_SECTOR_URI = "https://test.com";
+    private static final String RP_SECTOR_HOST = "test.com";
+    private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final Subject INTERNAL_SUBJECT = new Subject();
-    private static final Subject PUBLIC_SUBJECT = new Subject();
+    private static final Subject RP_PAIRWISE_SUBJECT =
+            new Subject(
+                    ClientSubjectHelper.calculatePairwiseIdentifier(
+                            INTERNAL_SUBJECT.getValue(), RP_SECTOR_HOST, SALT.array()));
     private static final Subject DOC_APP_USER_PUBLIC_SUBJECT = new Subject();
     private static final String AUDIENCE = "oidc-audience";
     private static final State STATE = new State();
@@ -143,7 +154,9 @@ public class TokenHandlerTest {
     @BeforeEach
     void setUp() {
         when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(BASE_URI));
+        when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
         when(configurationService.getSessionExpiry()).thenReturn(1234L);
+        when(dynamoService.getOrGenerateSalt(any())).thenCallRealMethod();
         handler =
                 new TokenHandler(
                         tokenService,
@@ -185,7 +198,7 @@ public class TokenHandlerTest {
         SignedJWT signedJWT =
                 generateIDToken(
                         CLIENT_ID,
-                        PUBLIC_SUBJECT,
+                        RP_PAIRWISE_SUBJECT,
                         "issuer-url",
                         new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate());
         OIDCTokenResponse tokenResponse =
@@ -224,14 +237,14 @@ public class TokenHandlerTest {
                         INTERNAL_SUBJECT,
                         SCOPES,
                         Map.of("nonce", NONCE),
-                        PUBLIC_SUBJECT,
-                        vtr.retrieveVectorOfTrustForToken(),
+                        RP_PAIRWISE_SUBJECT,
                         userProfile.getClientConsent(),
                         expectedConsentRequired,
                         null,
                         false,
                         JWSAlgorithm.ES256,
-                        CLIENT_SESSION_ID))
+                        CLIENT_SESSION_ID,
+                        vtr.retrieveVectorOfTrustForToken()))
                 .thenReturn(tokenResponse);
 
         APIGatewayProxyResponseEvent result =
@@ -256,7 +269,7 @@ public class TokenHandlerTest {
         SignedJWT signedJWT =
                 generateIDToken(
                         CLIENT_ID,
-                        PUBLIC_SUBJECT,
+                        RP_PAIRWISE_SUBJECT,
                         "issuer-url",
                         new RSAKeyGenerator(2048).algorithm(JWSAlgorithm.RS256).generate());
         OIDCTokenResponse tokenResponse =
@@ -296,14 +309,14 @@ public class TokenHandlerTest {
                         INTERNAL_SUBJECT,
                         SCOPES,
                         Map.of("nonce", NONCE),
-                        PUBLIC_SUBJECT,
-                        vtr.retrieveVectorOfTrustForToken(),
+                        RP_PAIRWISE_SUBJECT,
                         userProfile.getClientConsent(),
                         expectedConsentRequired,
                         null,
                         false,
                         JWSAlgorithm.RS256,
-                        CLIENT_SESSION_ID))
+                        CLIENT_SESSION_ID,
+                        vtr.retrieveVectorOfTrustForToken()))
                 .thenReturn(tokenResponse);
 
         APIGatewayProxyResponseEvent result =
@@ -342,7 +355,7 @@ public class TokenHandlerTest {
                 new RefreshTokenStore(refreshToken.getValue(), INTERNAL_SUBJECT.getValue());
         String tokenStoreString = objectMapper.writeValueAsString(tokenStore);
         when(redisConnectionService.popValue(
-                        REFRESH_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT.getValue()))
+                        REFRESH_TOKEN_PREFIX + CLIENT_ID + "." + RP_PAIRWISE_SUBJECT.getValue()))
                 .thenReturn(null);
         String redisKey = REFRESH_TOKEN_PREFIX + signedRefreshToken.getJWTClaimsSet().getJWTID();
         when(redisConnectionService.popValue(redisKey)).thenReturn(tokenStoreString);
@@ -350,7 +363,7 @@ public class TokenHandlerTest {
                         eq(CLIENT_ID),
                         eq(INTERNAL_SUBJECT),
                         eq(SCOPES.toStringList()),
-                        eq(PUBLIC_SUBJECT),
+                        eq(RP_PAIRWISE_SUBJECT),
                         eq(JWSAlgorithm.ES256)))
                 .thenReturn(tokenResponse);
 
@@ -394,7 +407,7 @@ public class TokenHandlerTest {
                 new RefreshTokenStore(refreshToken.getValue(), INTERNAL_SUBJECT.getValue());
         String tokenStoreString = objectMapper.writeValueAsString(tokenStore);
         when(redisConnectionService.popValue(
-                        REFRESH_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT.getValue()))
+                        REFRESH_TOKEN_PREFIX + CLIENT_ID + "." + RP_PAIRWISE_SUBJECT.getValue()))
                 .thenReturn(null);
         String redisKey = REFRESH_TOKEN_PREFIX + signedRefreshToken.getJWTClaimsSet().getJWTID();
         when(redisConnectionService.popValue(redisKey)).thenReturn(tokenStoreString);
@@ -402,7 +415,7 @@ public class TokenHandlerTest {
                         eq(CLIENT_ID),
                         eq(INTERNAL_SUBJECT),
                         eq(SCOPES.toStringList()),
-                        eq(PUBLIC_SUBJECT),
+                        eq(RP_PAIRWISE_SUBJECT),
                         eq(JWSAlgorithm.RS256)))
                 .thenReturn(tokenResponse);
 
@@ -547,7 +560,7 @@ public class TokenHandlerTest {
         SignedJWT signedJWT =
                 generateIDToken(
                         DOC_APP_CLIENT_ID.getValue(),
-                        PUBLIC_SUBJECT,
+                        RP_PAIRWISE_SUBJECT,
                         "issuer-url",
                         new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate());
         OIDCTokenResponse tokenResponse =
@@ -588,13 +601,13 @@ public class TokenHandlerTest {
                         new Scope(DOC_CHECKING_APP, OIDCScopeValue.OPENID),
                         Map.of("nonce", NONCE),
                         DOC_APP_USER_PUBLIC_SUBJECT,
-                        vtr.retrieveVectorOfTrustForToken(),
                         null,
                         false,
                         null,
                         true,
                         JWSAlgorithm.ES256,
-                        CLIENT_SESSION_ID))
+                        CLIENT_SESSION_ID,
+                        vtr.retrieveVectorOfTrustForToken()))
                 .thenReturn(tokenResponse);
 
         var result =
@@ -616,7 +629,8 @@ public class TokenHandlerTest {
                 .withSubjectID(INTERNAL_SUBJECT.getValue())
                 .withCreated(LocalDateTime.now().toString())
                 .withUpdated(LocalDateTime.now().toString())
-                .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
+                .withPublicSubjectID(new Subject().getValue())
+                .withSalt(SALT)
                 .withClientConsent(
                         new ClientConsent(
                                 CLIENT_ID, claims, LocalDateTime.now(ZoneId.of("UTC")).toString()));
@@ -630,7 +644,7 @@ public class TokenHandlerTest {
                         .generate();
         ECDSASigner signer = new ECDSASigner(ecSigningKey);
         return TokenGeneratorHelper.generateSignedToken(
-                CLIENT_ID, BASE_URI, SCOPES.toStringList(), signer, PUBLIC_SUBJECT, "KEY_ID");
+                CLIENT_ID, BASE_URI, SCOPES.toStringList(), signer, RP_PAIRWISE_SUBJECT, "KEY_ID");
     }
 
     private SignedJWT createSignedRsaRefreshToken() throws JOSEException {
@@ -638,7 +652,7 @@ public class TokenHandlerTest {
                 new RSASSASigner(
                         new RSAKeyGenerator(2048).algorithm(JWSAlgorithm.RS256).generate());
         return TokenGeneratorHelper.generateSignedToken(
-                CLIENT_ID, BASE_URI, SCOPES.toStringList(), signer, PUBLIC_SUBJECT, "KEY_ID");
+                CLIENT_ID, BASE_URI, SCOPES.toStringList(), signer, RP_PAIRWISE_SUBJECT, "KEY_ID");
     }
 
     private PrivateKeyJWT generatePrivateKeyJWT(PrivateKey privateKey) throws JOSEException {
@@ -662,8 +676,8 @@ public class TokenHandlerTest {
                 .withContacts(singletonList(TEST_EMAIL))
                 .withPublicKey(
                         Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()))
-                .withSectorIdentifierUri("https://test.com")
-                .withSubjectType("public");
+                .withSectorIdentifierUri(RP_SECTOR_URI)
+                .withSubjectType("pairwise");
     }
 
     private APIGatewayProxyResponseEvent generateApiGatewayRequest(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -110,12 +110,18 @@ public class TokenHandlerTest {
             ByteBuffer.wrap("a-test-salt".getBytes(StandardCharsets.UTF_8));
     private static final String RP_SECTOR_URI = "https://test.com";
     private static final String RP_SECTOR_HOST = "test.com";
+
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
+    private static final String INTERNAL_SECTOR_HOST = "test.account.gov.uk";
     private static final Subject INTERNAL_SUBJECT = new Subject();
     private static final Subject RP_PAIRWISE_SUBJECT =
             new Subject(
                     ClientSubjectHelper.calculatePairwiseIdentifier(
                             INTERNAL_SUBJECT.getValue(), RP_SECTOR_HOST, SALT.array()));
+    private static final Subject INTERNAL_PAIRWISE_SUBJECT =
+            new Subject(
+                    ClientSubjectHelper.calculatePairwiseIdentifier(
+                            INTERNAL_SUBJECT.getValue(), INTERNAL_SECTOR_HOST, SALT.array()));
     private static final Subject DOC_APP_USER_PUBLIC_SUBJECT = new Subject();
     private static final String AUDIENCE = "oidc-audience";
     private static final State STATE = new State();
@@ -238,6 +244,7 @@ public class TokenHandlerTest {
                         SCOPES,
                         Map.of("nonce", NONCE),
                         RP_PAIRWISE_SUBJECT,
+                        INTERNAL_PAIRWISE_SUBJECT,
                         userProfile.getClientConsent(),
                         expectedConsentRequired,
                         null,
@@ -310,6 +317,7 @@ public class TokenHandlerTest {
                         SCOPES,
                         Map.of("nonce", NONCE),
                         RP_PAIRWISE_SUBJECT,
+                        INTERNAL_PAIRWISE_SUBJECT,
                         userProfile.getClientConsent(),
                         expectedConsentRequired,
                         null,
@@ -352,7 +360,10 @@ public class TokenHandlerTest {
                         SCOPES.toStringList(), SCOPES.toStringList()))
                 .thenReturn(true);
         RefreshTokenStore tokenStore =
-                new RefreshTokenStore(refreshToken.getValue(), INTERNAL_SUBJECT.getValue());
+                new RefreshTokenStore(
+                        refreshToken.getValue(),
+                        INTERNAL_SUBJECT.getValue(),
+                        INTERNAL_PAIRWISE_SUBJECT.getValue());
         String tokenStoreString = objectMapper.writeValueAsString(tokenStore);
         when(redisConnectionService.popValue(
                         REFRESH_TOKEN_PREFIX + CLIENT_ID + "." + RP_PAIRWISE_SUBJECT.getValue()))
@@ -364,6 +375,7 @@ public class TokenHandlerTest {
                         eq(INTERNAL_SUBJECT),
                         eq(SCOPES.toStringList()),
                         eq(RP_PAIRWISE_SUBJECT),
+                        eq(INTERNAL_PAIRWISE_SUBJECT),
                         eq(JWSAlgorithm.ES256)))
                 .thenReturn(tokenResponse);
 
@@ -404,7 +416,10 @@ public class TokenHandlerTest {
                         SCOPES.toStringList(), SCOPES.toStringList()))
                 .thenReturn(true);
         RefreshTokenStore tokenStore =
-                new RefreshTokenStore(refreshToken.getValue(), INTERNAL_SUBJECT.getValue());
+                new RefreshTokenStore(
+                        refreshToken.getValue(),
+                        INTERNAL_SUBJECT.getValue(),
+                        INTERNAL_PAIRWISE_SUBJECT.getValue());
         String tokenStoreString = objectMapper.writeValueAsString(tokenStore);
         when(redisConnectionService.popValue(
                         REFRESH_TOKEN_PREFIX + CLIENT_ID + "." + RP_PAIRWISE_SUBJECT.getValue()))
@@ -416,6 +431,7 @@ public class TokenHandlerTest {
                         eq(INTERNAL_SUBJECT),
                         eq(SCOPES.toStringList()),
                         eq(RP_PAIRWISE_SUBJECT),
+                        eq(INTERNAL_PAIRWISE_SUBJECT),
                         eq(JWSAlgorithm.RS256)))
                 .thenReturn(tokenResponse);
 
@@ -600,6 +616,7 @@ public class TokenHandlerTest {
                         DOC_APP_USER_PUBLIC_SUBJECT,
                         new Scope(DOC_CHECKING_APP, OIDCScopeValue.OPENID),
                         Map.of("nonce", NONCE),
+                        DOC_APP_USER_PUBLIC_SUBJECT,
                         DOC_APP_USER_PUBLIC_SUBJECT,
                         null,
                         false,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -56,6 +56,7 @@ class AccessTokenServiceTest {
             mock(TokenValidationService.class);
     private final DynamoClientService clientService = mock(DynamoClientService.class);
     private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
+    private static final Subject INTERNAL_PAIRWISE_SUBJECT = new Subject();
     private static final Subject SUBJECT = new Subject("some-subject");
     private static final List<String> SCOPES =
             List.of(
@@ -119,7 +120,9 @@ class AccessTokenServiceTest {
                 .thenReturn(
                         objectMapper.writeValueAsString(
                                 new AccessTokenStore(
-                                        accessToken.getValue(), INTERNAL_SUBJECT.getValue())));
+                                        accessToken.getValue(),
+                                        INTERNAL_SUBJECT.getValue(),
+                                        INTERNAL_PAIRWISE_SUBJECT.getValue())));
 
         var accessTokenInfo =
                 validationService.parse(accessToken.toAuthorizationHeader(), identityEnabled);
@@ -145,7 +148,9 @@ class AccessTokenServiceTest {
                 .thenReturn(
                         objectMapper.writeValueAsString(
                                 new AccessTokenStore(
-                                        accessToken.getValue(), INTERNAL_SUBJECT.getValue())));
+                                        accessToken.getValue(),
+                                        INTERNAL_SUBJECT.getValue(),
+                                        INTERNAL_PAIRWISE_SUBJECT.getValue())));
 
         var accessTokenInfo = validationService.parse(accessToken.toAuthorizationHeader(), true);
 
@@ -247,7 +252,9 @@ class AccessTokenServiceTest {
                 .thenReturn(
                         objectMapper.writeValueAsString(
                                 new AccessTokenStore(
-                                        accessToken.getValue(), INTERNAL_SUBJECT.getValue())));
+                                        accessToken.getValue(),
+                                        INTERNAL_SUBJECT.getValue(),
+                                        INTERNAL_PAIRWISE_SUBJECT.getValue())));
 
         var accessTokenException =
                 assertThrows(
@@ -298,7 +305,8 @@ class AccessTokenServiceTest {
                         objectMapper.writeValueAsString(
                                 new AccessTokenStore(
                                         createSignedAccessToken(null, false).getValue(),
-                                        INTERNAL_SUBJECT.getValue())));
+                                        INTERNAL_SUBJECT.getValue(),
+                                        INTERNAL_PAIRWISE_SUBJECT.getValue())));
 
         var accessTokenException =
                 assertThrows(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -74,6 +74,7 @@ class UserInfoServiceTest {
             mock(CloudwatchMetricsService.class);
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
+    private static final Subject INTERNAL_PAIRWISE_SUBJECT = new Subject();
     private static final Subject SUBJECT = new Subject("some-subject");
     private static final Subject DOC_APP_SUBJECT = new Subject("some-subject");
     private static final List<String> SCOPES =
@@ -134,7 +135,10 @@ class UserInfoServiceTest {
                 .thenReturn(generateUserprofile());
 
         var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                new AccessTokenStore(
+                        accessToken.getValue(),
+                        INTERNAL_SUBJECT.getValue(),
+                        INTERNAL_PAIRWISE_SUBJECT.getValue());
         var accessTokenInfo =
                 new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
 
@@ -156,18 +160,15 @@ class UserInfoServiceTest {
             throws JOSEException, AccessTokenException {
         when(configurationService.isIdentityEnabled()).thenReturn(false);
         when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
-
         accessToken = createSignedAccessToken(null);
         var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                new AccessTokenStore(
+                        accessToken.getValue(),
+                        INTERNAL_SUBJECT.getValue(),
+                        INTERNAL_PAIRWISE_SUBJECT.getValue());
         var accessTokenInfo =
                 new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
-        var testUserInfo =
-                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
-
-        when(userInfoStorageService.getAuthenticationUserInfoData(
-                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
-                .thenReturn(Optional.of(testUserInfo));
+        givenThereIsUserInfo();
 
         var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
 
@@ -193,7 +194,10 @@ class UserInfoServiceTest {
                     .thenReturn(generateUserprofile());
 
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
@@ -217,19 +221,16 @@ class UserInfoServiceTest {
                         throws JOSEException, AccessTokenException {
             when(configurationService.isIdentityEnabled()).thenReturn(true);
             when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
-
             accessToken = createSignedAccessToken(null);
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
-            var testUserInfo =
-                    new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
-
-            when(userInfoStorageService.getAuthenticationUserInfoData(
-                            accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
-                    .thenReturn(Optional.of(testUserInfo));
+            givenThereIsUserInfo();
 
             var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
 
@@ -269,7 +270,10 @@ class UserInfoServiceTest {
                     .thenReturn(Optional.of(identityCredentials));
 
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore,
@@ -332,7 +336,10 @@ class UserInfoServiceTest {
                     .thenReturn(Optional.of(identityCredentials));
 
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore,
@@ -342,12 +349,7 @@ class UserInfoServiceTest {
                                     .map(ClaimsSetRequest.Entry::getClaimName)
                                     .collect(Collectors.toList()),
                             CLIENT_ID);
-            var testUserInfo =
-                    new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
-
-            when(userInfoStorageService.getAuthenticationUserInfoData(
-                            accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
-                    .thenReturn(Optional.of(testUserInfo));
+            givenThereIsUserInfo();
 
             var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
 
@@ -386,7 +388,10 @@ class UserInfoServiceTest {
                     .thenReturn(generateUserprofile());
 
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), scopes, null, CLIENT_ID);
@@ -414,16 +419,14 @@ class UserInfoServiceTest {
             var scopes = List.of(OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.EMAIL.getValue());
 
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), scopes, null, CLIENT_ID);
-            var testUserInfo =
-                    new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
-
-            when(userInfoStorageService.getAuthenticationUserInfoData(
-                            accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
-                    .thenReturn(Optional.of(testUserInfo));
+            givenThereIsUserInfo();
 
             var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
 
@@ -453,7 +456,10 @@ class UserInfoServiceTest {
                     .thenReturn(Optional.of(identityCredentials));
 
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore,
@@ -496,7 +502,10 @@ class UserInfoServiceTest {
                     .thenReturn(Optional.of(identityCredentials));
 
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore,
@@ -506,12 +515,7 @@ class UserInfoServiceTest {
                                     .map(ClaimsSetRequest.Entry::getClaimName)
                                     .collect(Collectors.toList()),
                             CLIENT_ID);
-            var testUserInfo =
-                    new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
-
-            when(userInfoStorageService.getAuthenticationUserInfoData(
-                            accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
-                    .thenReturn(Optional.of(testUserInfo));
+            givenThereIsUserInfo();
 
             var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
 
@@ -549,7 +553,10 @@ class UserInfoServiceTest {
                     .thenReturn(Optional.of(docAppCredential));
 
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
@@ -578,7 +585,10 @@ class UserInfoServiceTest {
                     .thenReturn(Optional.of(docAppCredential));
 
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
@@ -598,7 +608,10 @@ class UserInfoServiceTest {
                             OIDCScopeValue.OPENID.getValue(),
                             CustomScopeValue.DOC_CHECKING_APP.getValue());
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), DOC_APP_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            DOC_APP_SUBJECT.getValue(),
+                            DOC_APP_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore,
@@ -622,7 +635,10 @@ class UserInfoServiceTest {
                             OIDCScopeValue.OPENID.getValue(),
                             CustomScopeValue.DOC_CHECKING_APP.getValue());
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), DOC_APP_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            DOC_APP_SUBJECT.getValue(),
+                            DOC_APP_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore,
@@ -649,7 +665,10 @@ class UserInfoServiceTest {
                     .thenReturn(userProfile);
             when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(salt);
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
@@ -674,7 +693,10 @@ class UserInfoServiceTest {
                     .thenReturn(userProfile);
             when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(salt);
             var accessTokenStore =
-                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+                    new AccessTokenStore(
+                            accessToken.getValue(),
+                            INTERNAL_SUBJECT.getValue(),
+                            INTERNAL_PAIRWISE_SUBJECT.getValue());
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
@@ -737,5 +759,14 @@ class UserInfoServiceTest {
                 .incrementCounter(
                         "ClaimIssued",
                         Map.of("Environment", "test", "Client", CLIENT_ID, "Claim", v3));
+    }
+
+    private void givenThereIsUserInfo() {
+        var testUserInfo =
+                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+
+        when(userInfoStorageService.getAuthenticationUserInfoData(
+                        INTERNAL_PAIRWISE_SUBJECT.getValue()))
+                .thenReturn(Optional.of(testUserInfo));
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -265,6 +265,10 @@ public class RedisExtension
         redis.saveWithExpiry(key, value, expiry);
     }
 
+    public String getFromRedis(String key) {
+        return redis.getValue(key);
+    }
+
     public void flushData() {
         try (StatefulRedisConnection<String, String> connection = client.connect()) {
             connection.sync().flushall();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AccessTokenStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AccessTokenStore.java
@@ -8,11 +8,15 @@ public class AccessTokenStore {
 
     @Expose private String internalSubjectId;
 
+    @Expose private String internalPairwiseSubjectId = "missing";
+
     public AccessTokenStore() {}
 
-    public AccessTokenStore(String token, String internalSubjectId) {
+    public AccessTokenStore(
+            String token, String internalSubjectId, String internalPairwiseSubjectId) {
         this.token = token;
         this.internalSubjectId = internalSubjectId;
+        this.internalPairwiseSubjectId = internalPairwiseSubjectId;
     }
 
     public String getToken() {
@@ -21,5 +25,9 @@ public class AccessTokenStore {
 
     public String getInternalSubjectId() {
         return internalSubjectId;
+    }
+
+    public String getInternalPairwiseSubjectId() {
+        return internalPairwiseSubjectId;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/RefreshTokenStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/RefreshTokenStore.java
@@ -13,15 +13,25 @@ public class RefreshTokenStore {
     @SerializedName("internal_subject_id")
     private String internalSubjectId;
 
+    @Expose
+    @SerializedName("internal_pairwise_subject_id")
+    private String internalPairwiseSubjectId = "missing";
+
     public RefreshTokenStore() {}
 
-    public RefreshTokenStore(String refreshToken, String internalSubjectId) {
+    public RefreshTokenStore(
+            String refreshToken, String internalSubjectId, String internalPairwiseSubjectId) {
         this.refreshToken = refreshToken;
         this.internalSubjectId = internalSubjectId;
+        this.internalPairwiseSubjectId = internalPairwiseSubjectId;
     }
 
     public String getInternalSubjectId() {
         return internalSubjectId;
+    }
+
+    public String getInternalPairwiseSubjectId() {
+        return internalPairwiseSubjectId;
     }
 
     public String getRefreshToken() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -86,14 +86,14 @@ public class TokenService {
             Subject internalSubject,
             Scope authRequestScopes,
             Map<String, Object> additionalTokenClaims,
-            Subject subject,
-            String vot,
+            Subject rpPairwiseSubject,
             List<ClientConsent> clientConsents,
             boolean isConsentRequired,
             OIDCClaimsRequest claimsRequest,
             boolean isDocAppJourney,
             JWSAlgorithm signingAlgorithm,
-            String journeyId) {
+            String journeyId,
+            String vot) {
         List<String> scopesForToken;
         if (isConsentRequired) {
             scopesForToken = calculateScopesForToken(clientConsents, clientID, authRequestScopes);
@@ -108,7 +108,7 @@ public class TokenService {
                                         clientID,
                                         internalSubject,
                                         scopesForToken,
-                                        subject,
+                                        rpPairwiseSubject,
                                         claimsRequest,
                                         signingAlgorithm));
         AccessTokenHash accessTokenHash =
@@ -122,7 +122,7 @@ public class TokenService {
                         () ->
                                 generateIDToken(
                                         clientID,
-                                        subject,
+                                        rpPairwiseSubject,
                                         additionalTokenClaims,
                                         accessTokenHash,
                                         vot,
@@ -138,7 +138,7 @@ public class TokenService {
                                             clientID,
                                             internalSubject,
                                             scopesForToken,
-                                            subject,
+                                            rpPairwiseSubject,
                                             signingAlgorithm));
             return new OIDCTokenResponse(new OIDCTokens(idToken, accessToken, refreshToken));
         } else {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -66,6 +66,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -87,6 +88,7 @@ public class TokenServiceTest {
             new TokenService(configurationService, redisConnectionService, kmsConnectionService);
     private static final Subject PUBLIC_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Subject INTERNAL_SUBJECT = SubjectHelper.govUkSignInSubject();
+    private static final Subject INTERNAL_PAIRWISE_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Scope SCOPES =
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PHONE);
     private static final String VOT = CredentialTrustLevel.MEDIUM_LEVEL.getValue();
@@ -146,6 +148,7 @@ public class TokenServiceTest {
                         SCOPES_OFFLINE_ACCESS,
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
+                        INTERNAL_PAIRWISE_SUBJECT,
                         Collections.singletonList(
                                 new ClientConsent(
                                         CLIENT_ID,
@@ -164,7 +167,8 @@ public class TokenServiceTest {
         RefreshTokenStore refreshTokenStore =
                 new RefreshTokenStore(
                         tokenResponse.getOIDCTokens().getRefreshToken().getValue(),
-                        INTERNAL_SUBJECT.getValue());
+                        INTERNAL_SUBJECT.getValue(),
+                        INTERNAL_PAIRWISE_SUBJECT.getValue());
         ArgumentCaptor<String> redisKey = ArgumentCaptor.forClass(String.class);
         verify(redisConnectionService)
                 .saveWithExpiry(
@@ -203,6 +207,7 @@ public class TokenServiceTest {
                         SCOPES_OFFLINE_ACCESS,
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
+                        INTERNAL_PAIRWISE_SUBJECT,
                         Collections.singletonList(
                                 new ClientConsent(
                                         CLIENT_ID,
@@ -240,7 +245,8 @@ public class TokenServiceTest {
         RefreshTokenStore refreshTokenStore =
                 new RefreshTokenStore(
                         tokenResponse.getOIDCTokens().getRefreshToken().getValue(),
-                        INTERNAL_SUBJECT.getValue());
+                        INTERNAL_SUBJECT.getValue(),
+                        INTERNAL_PAIRWISE_SUBJECT.getValue());
 
         ArgumentCaptor<String> redisKey = ArgumentCaptor.forClass(String.class);
         verify(redisConnectionService)
@@ -274,6 +280,7 @@ public class TokenServiceTest {
                         SCOPES,
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
+                        INTERNAL_PAIRWISE_SUBJECT,
                         Collections.singletonList(
                                 new ClientConsent(
                                         CLIENT_ID,
@@ -289,6 +296,50 @@ public class TokenServiceTest {
         assertSuccessfulTokenResponse(tokenResponse);
 
         assertNull(tokenResponse.getOIDCTokens().getRefreshToken());
+    }
+
+    @Test
+    void shouldNotIncludeInternalIdentifiersInTokens() throws ParseException, JOSEException {
+        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
+        when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
+        createSignedIdToken();
+        createSignedAccessToken();
+        Map<String, Object> additionalTokenClaims = new HashMap<>();
+        additionalTokenClaims.put("nonce", nonce);
+        Set<String> claimsForListOfScopes =
+                ValidScopes.getClaimsForListOfScopes(SCOPES_OFFLINE_ACCESS.toStringList());
+        OIDCTokenResponse tokenResponse =
+                tokenService.generateTokenResponse(
+                        CLIENT_ID,
+                        INTERNAL_SUBJECT,
+                        SCOPES_OFFLINE_ACCESS,
+                        additionalTokenClaims,
+                        PUBLIC_SUBJECT,
+                        INTERNAL_PAIRWISE_SUBJECT,
+                        Collections.singletonList(
+                                new ClientConsent(
+                                        CLIENT_ID,
+                                        claimsForListOfScopes,
+                                        LocalDateTime.now(ZoneId.of("UTC")).toString())),
+                        false,
+                        null,
+                        false,
+                        JWSAlgorithm.ES256,
+                        "client-session-id",
+                        VOT);
+
+        var parsedAccessToken =
+                SignedJWT.parse(tokenResponse.getOIDCTokens().getAccessToken().getValue())
+                        .getPayload()
+                        .toString();
+        assertFalse(parsedAccessToken.contains(INTERNAL_SUBJECT.getValue()));
+        assertFalse(parsedAccessToken.contains(INTERNAL_PAIRWISE_SUBJECT.getValue()));
+        var parsedRefreshToken =
+                SignedJWT.parse(tokenResponse.getOIDCTokens().getRefreshToken().getValue())
+                        .getPayload()
+                        .toString();
+        assertFalse(parsedRefreshToken.contains(INTERNAL_SUBJECT.getValue()));
+        assertFalse(parsedRefreshToken.contains(INTERNAL_PAIRWISE_SUBJECT.getValue()));
     }
 
     @Test
@@ -466,7 +517,8 @@ public class TokenServiceTest {
         AccessTokenStore accessTokenStore =
                 new AccessTokenStore(
                         tokenResponse.getOIDCTokens().getAccessToken().getValue(),
-                        INTERNAL_SUBJECT.getValue());
+                        INTERNAL_SUBJECT.getValue(),
+                        INTERNAL_PAIRWISE_SUBJECT.getValue());
         verify(redisConnectionService)
                 .saveWithExpiry(
                         accessTokenKey, objectMapper.writeValueAsString(accessTokenStore), 300L);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -146,7 +146,6 @@ public class TokenServiceTest {
                         SCOPES_OFFLINE_ACCESS,
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
-                        VOT,
                         Collections.singletonList(
                                 new ClientConsent(
                                         CLIENT_ID,
@@ -156,7 +155,8 @@ public class TokenServiceTest {
                         null,
                         false,
                         JWSAlgorithm.ES256,
-                        "client-session-id");
+                        "client-session-id",
+                        VOT);
 
         assertSuccessfulTokenResponse(tokenResponse);
 
@@ -203,7 +203,6 @@ public class TokenServiceTest {
                         SCOPES_OFFLINE_ACCESS,
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
-                        VOT,
                         Collections.singletonList(
                                 new ClientConsent(
                                         CLIENT_ID,
@@ -213,7 +212,8 @@ public class TokenServiceTest {
                         oidcClaimsRequest,
                         false,
                         JWSAlgorithm.ES256,
-                        "client-session-id");
+                        "client-session-id",
+                        VOT);
 
         assertSuccessfulTokenResponse(tokenResponse);
 
@@ -274,7 +274,6 @@ public class TokenServiceTest {
                         SCOPES,
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
-                        VOT,
                         Collections.singletonList(
                                 new ClientConsent(
                                         CLIENT_ID,
@@ -284,7 +283,8 @@ public class TokenServiceTest {
                         null,
                         false,
                         JWSAlgorithm.ES256,
-                        "client-session-id");
+                        "client-session-id",
+                        VOT);
 
         assertSuccessfulTokenResponse(tokenResponse);
 


### PR DESCRIPTION
## What?

Best to review this one commit-wise. There's a bit of tidying to make the second part possible. 

The main change here is to persist the internal pairwise identifier in the access token store and the refresh token store. This is needed to retrieve the auth user info response from dynamo DB in order to service the RP's userinfo request.
