### PR TITLE
AUT-1843: Use local rather than variable for deploy_account_interventions_count

### DIFF
--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -3,7 +3,7 @@ module "frontend_api_account_interventions_role" {
   environment = var.environment
   role_name   = "frontend-api-account-interventions-role"
   vpc_arn     = local.authentication_vpc_arn
-  count       = var.deploy_account_interventions_count
+  count       = local.deploy_account_interventions_count
 
   policies_to_attach = [
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
@@ -63,7 +63,7 @@ module "account_interventions" {
   api_key_required                       = true
 
   use_localstack = var.use_localstack
-  count          = var.deploy_account_interventions_count
+  count          = local.deploy_account_interventions_count
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_frontend_api,

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -470,11 +470,6 @@ variable "orch_frontend_api_gateway_integration_enabled" {
   default     = false
 }
 
-variable "deploy_account_interventions_count" {
-  type = string
-}
-
-
 variable "account_intervention_service_audit_enabled" {
   default = false
   type    = bool


### PR DESCRIPTION
## What?

Use local rather than variable for deploy_account_interventions_count.

## Why?

Fixes failing build:

'Error: No value for required variable'

## Related PRs

#3570 
