### PR TITLE
INCIDEN-542: Fix persistent session IDs

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -32,6 +32,7 @@ import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.DocAppJwksExtension;
@@ -85,6 +86,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String TEST_PASSWORD = "password";
     private static final KeyPair KEY_PAIR = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
     public static final String DUMMY_CLIENT_SESSION_ID = "456";
+    private static final String ARBITRARY_UNIX_TIMESTAMP = "1700558480962";
+    private static final String PERSISTENT_SESSION_ID =
+            IdGenerator.generate() + "--" + ARBITRARY_UNIX_TIMESTAMP;
 
     @RegisterExtension
     public static final DocAppJwksExtension jwksExtension = new DocAppJwksExtension();
@@ -154,7 +158,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 Optional.of(
                                         new HttpCookie(
                                                 "di-persistent-session-id",
-                                                "persistent-id-value"))),
+                                                PERSISTENT_SESSION_ID))),
                         constructQueryStringParameters(CLIENT_ID, null, "openid", "Cl.Cm"),
                         Optional.of("GET"));
 
@@ -172,9 +176,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHttpCookieFromMultiValueResponseHeaders(
                         response.getMultiValueHeaders(), "di-persistent-session-id");
         assertThat(persistentCookie.isPresent(), equalTo(true));
-        assertThat(persistentCookie.get().getValue(), containsString("persistent-id-value--"));
+        assertThat(persistentCookie.get().getValue(), containsString(PERSISTENT_SESSION_ID));
         assertTrue(
-                CookieHelper.isValidCookieWithDoubleDashedTimestamp(
+                CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
                         persistentCookie.get().getValue()));
 
         assertTxmaAuditEventsReceived(
@@ -191,7 +195,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 Optional.of(
                                         new HttpCookie(
                                                 "di-persistent-session-id",
-                                                "persistent-id-value"))),
+                                                PERSISTENT_SESSION_ID))),
                         constructQueryStringParameters(CLIENT_ID, null, "openid", "Cl.Cm", "en"),
                         Optional.of("GET"));
 
@@ -209,9 +213,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHttpCookieFromMultiValueResponseHeaders(
                         response.getMultiValueHeaders(), "di-persistent-session-id");
         assertThat(persistentCookie.isPresent(), equalTo(true));
-        assertThat(persistentCookie.get().getValue(), containsString("persistent-id-value--"));
+        assertThat(persistentCookie.get().getValue(), containsString(PERSISTENT_SESSION_ID));
         assertTrue(
-                CookieHelper.isValidCookieWithDoubleDashedTimestamp(
+                CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
                         persistentCookie.get().getValue()));
         var languageCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "lng");

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -31,7 +31,6 @@ import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
-import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
@@ -73,6 +72,7 @@ import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISAT
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromMultiValueResponseHeaders;
+import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -178,7 +178,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(persistentCookie.isPresent(), equalTo(true));
         assertThat(persistentCookie.get().getValue(), containsString(PERSISTENT_SESSION_ID));
         assertTrue(
-                CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+                isValidPersistentSessionCookieWithDoubleDashedTimestamp(
                         persistentCookie.get().getValue()));
 
         assertTxmaAuditEventsReceived(
@@ -215,7 +215,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(persistentCookie.isPresent(), equalTo(true));
         assertThat(persistentCookie.get().getValue(), containsString(PERSISTENT_SESSION_ID));
         assertTrue(
-                CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+                isValidPersistentSessionCookieWithDoubleDashedTimestamp(
                         persistentCookie.get().getValue()));
         var languageCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "lng");

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
@@ -62,6 +63,9 @@ import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.a
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+    private static final String ARBITRARY_UNIX_TIMESTAMP = "1700558480962";
+    private static final String PERSISTENT_SESSION_ID =
+            IdGenerator.generate() + "--" + ARBITRARY_UNIX_TIMESTAMP;
 
     @RegisterExtension public static final IPVStubExtension ipvStub = new IPVStubExtension();
 
@@ -95,7 +99,6 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     @Test
     void shouldRedirectToLoginWhenSuccessfullyProcessedIpvResponse() throws Json.JsonException {
         var sessionId = "some-session-id";
-        var persistentSessionId = "persistent-id-value";
         var sectorId = "test.com";
         var scope = new Scope(OIDCScopeValue.OPENID);
         var authRequestBuilder =
@@ -121,7 +124,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 "Cookie",
                                 format(
                                         "gs=%s.%s;di-persistent-session-id=%s",
-                                        sessionId, CLIENT_SESSION_ID, persistentSessionId)),
+                                        sessionId, CLIENT_SESSION_ID, PERSISTENT_SESSION_ID)),
                         new HashMap<>(
                                 Map.of(
                                         "state",
@@ -158,7 +161,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 pairwiseIdentifier,
                                 new LogIds(
                                         sessionId,
-                                        persistentSessionId,
+                                        PERSISTENT_SESSION_ID,
                                         "request-i",
                                         CLIENT_ID,
                                         CLIENT_SESSION_ID),

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -50,6 +50,7 @@ import uk.gov.di.authentication.shared.exceptions.NoSessionException;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -117,7 +118,9 @@ class IPVCallbackHandlerTest {
     private static final String SESSION_ID = "a-session-id";
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final String REQUEST_ID = "a-request-id";
-    private static final String PERSISTENT_SESSION_ID = "a-persistent-id";
+    private static final String ARBITRARY_UNIX_TIMESTAMP = "1700558480962";
+    private static final String PERSISTENT_SESSION_ID =
+            IdGenerator.generate() + "--" + ARBITRARY_UNIX_TIMESTAMP;
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final URI REDIRECT_URI = URI.create("test-uri");
     private static final State RP_STATE = new State();

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -643,7 +643,7 @@ public class AuthorisationHandler
         cookies.add(
                 CookieHelper.buildCookieString(
                         CookieHelper.PERSISTENT_COOKIE_NAME,
-                        CookieHelper.appendTimestampToCookieValue(persistentSessionId),
+                        persistentSessionId,
                         configurationService.getPersistentCookieMaxAge(),
                         configurationService.getSessionCookieAttributes(),
                         configurationService.getDomainName()));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -63,6 +63,7 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.helpers.DocAppSubjectIdHelper;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -142,13 +143,13 @@ class AuthorisationHandlerTest {
     private final InOrder inOrder = inOrder(auditService);
     private static final String EXPECTED_SESSION_COOKIE_STRING =
             "gs=a-session-id.client-session-id; Max-Age=3600; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;";
-    private static final String EXPECTED_PERSISTENT_COOKIE_STRING =
-            "di-persistent-session-id=a-persistent-session-id; Max-Age=34190000; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;";
-    private static final String EXPECTED_PERSISTENT_COOKIE_VALUE = "a-persistent-session-id";
+    private static final String EXPECTED_BASE_PERSISTENT_COOKIE_VALUE = IdGenerator.generate();
+    private static final String ARBITRARY_UNIX_TIMESTAMP = "1700558480962";
+    private static final String EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP =
+            EXPECTED_BASE_PERSISTENT_COOKIE_VALUE + "--" + ARBITRARY_UNIX_TIMESTAMP;
     private static final String EXPECTED_LANGUAGE_COOKIE_STRING =
             "lng=en; Max-Age=31536000; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;";
     private static final URI LOGIN_URL = URI.create("https://example.com");
-    private static final String PERSISTENT_SESSION_ID = "a-persistent-session-id";
     private static final String AWS_REQUEST_ID = "aws-request-id";
     private static final ClientID CLIENT_ID = new ClientID("test-id");
     private static final String SESSION_ID = "a-session-id";
@@ -195,7 +196,7 @@ class AuthorisationHandlerTest {
         when(queryParamsAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         when(orchestrationAuthorizationService.getExistingOrCreateNewPersistentSessionId(any()))
-                .thenReturn(PERSISTENT_SESSION_ID);
+                .thenReturn(EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP);
         when(orchestrationAuthorizationService.getEffectiveVectorOfTrust(any()))
                 .thenReturn(new VectorOfTrust(CredentialTrustLevel.MEDIUM_LEVEL));
         when(userContext.getClient()).thenReturn(Optional.of(generateClientRegistry()));
@@ -246,8 +247,11 @@ class AuthorisationHandlerTest {
             var diPersistentCookieString =
                     response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
             var sessionId =
-                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
-            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
+                    extractSessionId(
+                            diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
+            assertTrue(
+                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+                            sessionId));
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
@@ -261,7 +265,7 @@ class AuthorisationHandlerTest {
                             AuditService.UNKNOWN,
                             "123.123.123.123",
                             AuditService.UNKNOWN,
-                            PERSISTENT_SESSION_ID,
+                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -336,8 +340,11 @@ class AuthorisationHandlerTest {
             var diPersistentCookieString =
                     response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
             var sessionId =
-                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
-            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
+                    extractSessionId(
+                            diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
+            assertTrue(
+                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+                            sessionId));
             if (uiLocales.contains("en")) {
                 assertTrue(
                         response.getMultiValueHeaders()
@@ -363,7 +370,7 @@ class AuthorisationHandlerTest {
                             AuditService.UNKNOWN,
                             "123.123.123.123",
                             AuditService.UNKNOWN,
-                            PERSISTENT_SESSION_ID,
+                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -391,8 +398,11 @@ class AuthorisationHandlerTest {
             var diPersistentCookieString =
                     response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
             var sessionId =
-                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
-            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
+                    extractSessionId(
+                            diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
+            assertTrue(
+                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+                            sessionId));
 
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -407,7 +417,7 @@ class AuthorisationHandlerTest {
                             AuditService.UNKNOWN,
                             "123.123.123.123",
                             AuditService.UNKNOWN,
-                            PERSISTENT_SESSION_ID,
+                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -467,8 +477,11 @@ class AuthorisationHandlerTest {
             var diPersistentCookieString =
                     response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
             var sessionId =
-                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
-            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
+                    extractSessionId(
+                            diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
+            assertTrue(
+                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+                            sessionId));
 
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -483,7 +496,7 @@ class AuthorisationHandlerTest {
                             AuditService.UNKNOWN,
                             "123.123.123.123",
                             AuditService.UNKNOWN,
-                            PERSISTENT_SESSION_ID,
+                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -513,8 +526,11 @@ class AuthorisationHandlerTest {
             var diPersistentCookieString =
                     response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
             var sessionId =
-                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
-            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
+                    extractSessionId(
+                            diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
+            assertTrue(
+                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+                            sessionId));
 
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -529,7 +545,7 @@ class AuthorisationHandlerTest {
                             AuditService.UNKNOWN,
                             "123.123.123.123",
                             AuditService.UNKNOWN,
-                            PERSISTENT_SESSION_ID,
+                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -583,7 +599,7 @@ class AuthorisationHandlerTest {
                             "",
                             "123.123.123.123",
                             "",
-                            PERSISTENT_SESSION_ID,
+                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                             pair(
                                     "description",
                                     "Invalid request: Missing response_type parameter"));
@@ -627,7 +643,7 @@ class AuthorisationHandlerTest {
                             "",
                             "123.123.123.123",
                             "",
-                            PERSISTENT_SESSION_ID,
+                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                             pair("description", OAuth2Error.INVALID_SCOPE.getDescription()));
         }
 
@@ -665,7 +681,7 @@ class AuthorisationHandlerTest {
                             "",
                             "123.123.123.123",
                             "",
-                            PERSISTENT_SESSION_ID,
+                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                             pair("description", OAuth2Error.INVALID_SCOPE.getDescription()));
         }
 
@@ -740,7 +756,7 @@ class AuthorisationHandlerTest {
                             "",
                             "123.123.123.123",
                             "",
-                            PERSISTENT_SESSION_ID,
+                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                             pair(
                                     "description",
                                     "Invalid request: Invalid prompt parameter: Unknown prompt type: unrecognised"));
@@ -862,8 +878,11 @@ class AuthorisationHandlerTest {
             var diPersistentCookieString =
                     response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
             var sessionId =
-                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
-            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
+                    extractSessionId(
+                            diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
+            assertTrue(
+                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+                            sessionId));
             verify(sessionService).save(session);
 
             verify(requestObjectAuthorizeValidator).validate(any());
@@ -878,7 +897,7 @@ class AuthorisationHandlerTest {
                             AuditService.UNKNOWN,
                             "123.123.123.123",
                             AuditService.UNKNOWN,
-                            PERSISTENT_SESSION_ID,
+                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -915,8 +934,11 @@ class AuthorisationHandlerTest {
             var diPersistentCookieString =
                     response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).get(1);
             var sessionId =
-                    extractSessionId(diPersistentCookieString, EXPECTED_PERSISTENT_COOKIE_VALUE);
-            assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(sessionId));
+                    extractSessionId(
+                            diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
+            assertTrue(
+                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+                            sessionId));
             verify(sessionService).save(session);
 
             inOrder.verify(auditService)
@@ -929,7 +951,7 @@ class AuthorisationHandlerTest {
                             AuditService.UNKNOWN,
                             "123.123.123.123",
                             AuditService.UNKNOWN,
-                            PERSISTENT_SESSION_ID,
+                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                             pair("client-name", RP_CLIENT_NAME));
         }
     }
@@ -997,7 +1019,7 @@ class AuthorisationHandlerTest {
                     response.getMultiValueHeaders()
                             .get(ResponseHeaders.SET_COOKIE)
                             .get(1)
-                            .contains("a-persistent-session-id--"));
+                            .contains(EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP));
         }
 
         @Test
@@ -1091,7 +1113,7 @@ class AuthorisationHandlerTest {
                         "",
                         "123.123.123.123",
                         "",
-                        PERSISTENT_SESSION_ID,
+                        EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                         pair("description", errorObject.getDescription()));
     }
 
@@ -1124,7 +1146,7 @@ class AuthorisationHandlerTest {
                         "",
                         "123.123.123.123",
                         "",
-                        PERSISTENT_SESSION_ID,
+                        EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
                         pair("description", expectedError.getDescription()));
     }
 
@@ -1141,11 +1163,14 @@ class AuthorisationHandlerTest {
                         "",
                         "123.123.123.123",
                         "",
-                        PERSISTENT_SESSION_ID);
+                        EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP);
 
         LogEvent logEvent = logging.events().get(0);
 
-        assertThat(logEvent, hasContextData("persistentSessionId", PERSISTENT_SESSION_ID));
+        assertThat(
+                logEvent,
+                hasContextData(
+                        "persistentSessionId", EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP));
         assertThat(logEvent, hasContextData("awsRequestId", AWS_REQUEST_ID));
 
         return response;
@@ -1297,7 +1322,7 @@ class AuthorisationHandlerTest {
         }
     }
 
-    public static String extractSessionId(String input, String sessionIdPrefix) {
+    private static String extractSessionId(String input, String sessionIdPrefix) {
         String sessionIdPattern = sessionIdPrefix + "--[0-9]+";
         var pattern = Pattern.compile(sessionIdPattern);
         var matcher = pattern.matcher(input);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -61,7 +61,6 @@ import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
-import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.helpers.DocAppSubjectIdHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -112,6 +111,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISATION_REQUEST_ERROR;
 import static uk.gov.di.authentication.oidc.helper.RequestObjectTestHelper.generateSignedJWT;
+import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.hasContextData;
@@ -249,9 +249,7 @@ class AuthorisationHandlerTest {
             var sessionId =
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
-            assertTrue(
-                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
-                            sessionId));
+            assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
@@ -342,9 +340,7 @@ class AuthorisationHandlerTest {
             var sessionId =
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
-            assertTrue(
-                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
-                            sessionId));
+            assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
             if (uiLocales.contains("en")) {
                 assertTrue(
                         response.getMultiValueHeaders()
@@ -400,9 +396,7 @@ class AuthorisationHandlerTest {
             var sessionId =
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
-            assertTrue(
-                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
-                            sessionId));
+            assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -479,9 +473,7 @@ class AuthorisationHandlerTest {
             var sessionId =
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
-            assertTrue(
-                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
-                            sessionId));
+            assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -528,9 +520,7 @@ class AuthorisationHandlerTest {
             var sessionId =
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
-            assertTrue(
-                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
-                            sessionId));
+            assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
             verify(sessionService).save(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -880,9 +870,7 @@ class AuthorisationHandlerTest {
             var sessionId =
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
-            assertTrue(
-                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
-                            sessionId));
+            assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
             verify(sessionService).save(session);
 
             verify(requestObjectAuthorizeValidator).validate(any());
@@ -936,9 +924,7 @@ class AuthorisationHandlerTest {
             var sessionId =
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
-            assertTrue(
-                    CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
-                            sessionId));
+            assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
             verify(sessionService).save(session);
 
             inOrder.verify(auditService)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -86,7 +86,9 @@ class LogoutHandlerTest {
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final String SESSION_ID = IdGenerator.generate();
     private static final String CLIENT_SESSION_ID = IdGenerator.generate();
-    private static final String PERSISTENT_SESSION_ID = IdGenerator.generate();
+    private static final String ARBITRARY_UNIX_TIMESTAMP = "1700558480962";
+    private static final String PERSISTENT_SESSION_ID =
+            IdGenerator.generate() + "--" + ARBITRARY_UNIX_TIMESTAMP;
     private static final URI DEFAULT_LOGOUT_URI =
             URI.create("https://di-authentication-frontend.london.cloudapps.digital/signed-out");
     private static final URI CLIENT_LOGOUT_URI = URI.create("http://localhost/logout");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
@@ -64,6 +64,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
@@ -180,9 +181,7 @@ class OrchestrationAuthorizationServiceTest {
                 orchestrationAuthorizationService.getExistingOrCreateNewPersistentSessionId(
                         requestCookieHeader);
 
-        assertTrue(
-                CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
-                        persistentSessionId));
+        assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(persistentSessionId));
     }
 
     @ParameterizedTest

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
@@ -180,7 +180,9 @@ class OrchestrationAuthorizationServiceTest {
                 orchestrationAuthorizationService.getExistingOrCreateNewPersistentSessionId(
                         requestCookieHeader);
 
-        assertTrue(CookieHelper.isValidCookieWithDoubleDashedTimestamp(persistentSessionId));
+        assertTrue(
+                CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+                        persistentSessionId));
     }
 
     @ParameterizedTest

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
@@ -1,8 +1,5 @@
 package uk.gov.di.orchestration.shared.helpers;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.net.HttpCookie;
 import java.util.Arrays;
 import java.util.List;
@@ -14,14 +11,10 @@ import static java.lang.String.format;
 
 public class CookieHelper {
 
-    private static final Logger LOG = LogManager.getLogger(CookieHelper.class);
-
     public static final String REQUEST_COOKIE_HEADER = "Cookie";
     public static final String RESPONSE_COOKIE_HEADER = "Set-Cookie";
     public static final String PERSISTENT_COOKIE_NAME = "di-persistent-session-id";
     public static final String SESSION_COOKIE_NAME = "gs";
-
-    public static final String LANGUAGE_COOKIE_NAME = "lng";
 
     public static Optional<HttpCookie> getHttpCookieFromRequestHeaders(
             Map<String, String> headers, String cookieName) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
@@ -11,11 +11,11 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
+import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp;
 
 public class CookieHelper {
 
     private static final Logger LOG = LogManager.getLogger(CookieHelper.class);
-
     public static final String REQUEST_COOKIE_HEADER = "Cookie";
     public static final String RESPONSE_COOKIE_HEADER = "Set-Cookie";
     public static final String PERSISTENT_COOKIE_NAME = "di-persistent-session-id";
@@ -123,12 +123,11 @@ public class CookieHelper {
         // we should just generate a new one to get back on track. It will be possible to remove
         // this 13 months after it is first merged(== the expiry time of that cookie at the point of
         // issue in November 2023) i.e. 26/11/2024
-        String VALID_PERSISTENT_SESSION_ID_FORMAT_REGEX = "[A-Za-z0-9-_]{27}--\\d{13}";
-        if (!persistentId.matches(VALID_PERSISTENT_SESSION_ID_FORMAT_REGEX)) {
-            return Optional.empty();
+        if (isValidPersistentSessionCookieWithDoubleDashedTimestamp(persistentId)) {
+            return Optional.of(persistentId);
         }
 
-        return Optional.of(persistentId);
+        return Optional.empty();
     }
 
     private static Optional<HttpCookie> parseStringToHttpCookie(String cookie) {
@@ -173,11 +172,5 @@ public class CookieHelper {
 
     public static String appendTimestampToCookieValue(String cookieValue) {
         return cookieValue + "--" + NowHelper.now().getTime();
-    }
-
-    public static boolean isValidPersistentSessionCookieWithDoubleDashedTimestamp(
-            String cookieValue) {
-        String persistentSessionIdPattern = "[A-Za-z0-9-_]{27}--\\d{13}";
-        return cookieValue.matches(persistentSessionIdPattern);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
@@ -121,8 +121,8 @@ public class CookieHelper {
         // Temporary measure, as commit 75a10df4376397d5a454b87b5cee689e13a71e20 introduced a bug
         // whereby persistent session ID could end up as --<timestamp>--<timestamp>. In these cases
         // we should just generate a new one to get back on track. It will be possible to remove
-        // this 13 months after it is first merged(== the expiry time of that cookie at the point of
-        // issue in November 2023) i.e. 26/11/2024
+        // this 18 months after it is first merged(== the expiry time of that cookie at the point of
+        // issue in November 2023) i.e. 26/05/2025
         if (isValidPersistentSessionCookieWithDoubleDashedTimestamp(persistentId)) {
             return Optional.of(persistentId);
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
+import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.isOldPersistentSessionCookieWithoutTimestamp;
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp;
 
 public class CookieHelper {
@@ -125,6 +126,10 @@ public class CookieHelper {
         // issue in November 2023) i.e. 26/05/2025
         if (isValidPersistentSessionCookieWithDoubleDashedTimestamp(persistentId)) {
             return Optional.of(persistentId);
+        }
+
+        if (isOldPersistentSessionCookieWithoutTimestamp(persistentId)) {
+            return Optional.of(appendTimestampToCookieValue(persistentId));
         }
 
         return Optional.empty();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
@@ -118,6 +118,16 @@ public class CookieHelper {
         }
         final String persistentId = cookieValues[0];
 
+        // Temporary measure, as commit 75a10df4376397d5a454b87b5cee689e13a71e20 introduced a bug
+        // whereby persistent session ID could end up as --<timestamp>--<timestamp>. In these cases
+        // we should just generate a new one to get back on track. It will be possible to remove
+        // this 13 months after it is first merged(== the expiry time of that cookie at the point of
+        // issue in November 2023) i.e. 26/11/2024
+        String VALID_PERSISTENT_SESSION_ID_FORMAT_REGEX = "[A-Za-z0-9-_]{27}--\\d{13}";
+        if (!persistentId.matches(VALID_PERSISTENT_SESSION_ID_FORMAT_REGEX)) {
+            return Optional.empty();
+        }
+
         return Optional.of(persistentId);
     }
 
@@ -165,8 +175,9 @@ public class CookieHelper {
         return cookieValue + "--" + NowHelper.now().getTime();
     }
 
-    public static boolean isValidCookieWithDoubleDashedTimestamp(String cookieValue) {
-        String sessionIdPattern = ".*--\\d+";
-        return cookieValue.matches(sessionIdPattern);
+    public static boolean isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+            String cookieValue) {
+        String persistentSessionIdPattern = "[A-Za-z0-9-_]{27}--\\d{13}";
+        return cookieValue.matches(persistentSessionIdPattern);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
@@ -8,6 +8,7 @@ import static uk.gov.di.authentication.shared.helpers.CookieHelper.appendTimesta
 public class PersistentIdHelper {
     public static final String PERSISTENT_ID_HEADER_NAME = "di-persistent-session-id";
     public static final String PERSISTENT_ID_UNKNOWN_VALUE = "unknown";
+    public static final String PERSISTENT_SESSION_ID_PATTERN = "[A-Za-z0-9-_]{27}--\\d{13}";
 
     public static String extractPersistentIdFromHeaders(Map<String, String> headers) {
         if (Objects.isNull(headers)
@@ -33,8 +34,7 @@ public class PersistentIdHelper {
                 CookieHelper.parsePersistentCookie(headers)
                         .orElse(appendTimestampToCookieValue(IdGenerator.generate()));
 
-        String VALID_PERSISTENT_SESSION_ID_FORMAT_REGEX = "[A-Za-z0-9-_]{27}--\\d{13}";
-        if (parsedOrGeneratedCookie.matches(VALID_PERSISTENT_SESSION_ID_FORMAT_REGEX)) {
+        if (isValidPersistentSessionCookieWithDoubleDashedTimestamp(parsedOrGeneratedCookie)) {
             return parsedOrGeneratedCookie;
         }
 
@@ -47,5 +47,10 @@ public class PersistentIdHelper {
                                                         + parsedOrGeneratedCookie));
 
         return appendTimestampToCookieValue(sanitisedCookie);
+    }
+
+    public static boolean isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+            String cookieValue) {
+        return cookieValue.matches(PERSISTENT_SESSION_ID_PATTERN);
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
@@ -14,7 +14,6 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.PERSISTENT_COOKIE_NAME;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.REQUEST_COOKIE_HEADER;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.RESPONSE_COOKIE_HEADER;
@@ -97,7 +96,7 @@ public class CookieHelperTest {
 
         Optional<String> id = parsePersistentCookie(headers);
 
-        assertTrue(id.isEmpty());
+        assertEmpty(id);
     }
 
     @ParameterizedTest(name = "with header {0}")

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.helpers;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -13,6 +14,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.PERSISTENT_COOKIE_NAME;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.REQUEST_COOKIE_HEADER;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.RESPONSE_COOKIE_HEADER;
@@ -31,6 +33,10 @@ public class CookieHelperTest {
         return Stream.of(RESPONSE_COOKIE_HEADER, RESPONSE_COOKIE_HEADER.toLowerCase());
     }
 
+    private static final String ARBITRARY_UNIX_TIMESTAMP = "1700558480962";
+    private static final String PERSISTENT_SESSION_ID_COOKIE_VALUE =
+            IdGenerator.generate() + "--" + ARBITRARY_UNIX_TIMESTAMP;
+
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
     void shouldReturnIdsFromValidSessionCookieStringWithMultipleCookies(String header) {
@@ -48,12 +54,14 @@ public class CookieHelperTest {
     @MethodSource("inputs")
     void shouldReturnIdsFromValidPersistentCookieStringWithMultipleCookies(String header) {
         String cookieString =
-                "Version=1; di-persistent-session-id=a-persistent-id;gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts";
+                String.format(
+                        "Version=1; di-persistent-session-id=%s;gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts",
+                        PERSISTENT_SESSION_ID_COOKIE_VALUE);
         Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString));
 
         String id = parsePersistentCookie(headers).orElseThrow();
 
-        assertEquals("a-persistent-id", id);
+        assertEquals(PERSISTENT_SESSION_ID_COOKIE_VALUE, id);
     }
 
     @ParameterizedTest(name = "with header {0}")
@@ -71,12 +79,25 @@ public class CookieHelperTest {
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
     void shouldReturnIdsFromValidPersistentCookie(String header) {
-        HttpCookie cookie = new HttpCookie("di-persistent-session-id", "a-persistent-id");
+        HttpCookie cookie =
+                new HttpCookie("di-persistent-session-id", PERSISTENT_SESSION_ID_COOKIE_VALUE);
         Map<String, String> headers = Map.ofEntries(Map.entry(header, cookie.toString()));
 
         String id = parsePersistentCookie(headers).orElseThrow();
 
-        assertEquals("a-persistent-id", id);
+        assertEquals(PERSISTENT_SESSION_ID_COOKIE_VALUE, id);
+    }
+
+    @Test
+    void shouldNotReturnIdFromInvalidPersistentCookie() {
+        String existingPersistentSessionId = "--1700558480962--1700558480963";
+        HttpCookie cookie = new HttpCookie("di-persistent-session-id", existingPersistentSessionId);
+        Map<String, String> headers =
+                Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, cookie.toString()));
+
+        Optional<String> id = parsePersistentCookie(headers);
+
+        assertTrue(id.isEmpty());
     }
 
     @ParameterizedTest(name = "with header {0}")
@@ -146,7 +167,7 @@ public class CookieHelperTest {
     @MethodSource("responseInputs")
     void shouldReturnIdsFromPersistentCookieStringWithMultipleValuesMap(String header) {
         Map<String, List<String>> cookieMap = new HashMap<>();
-        String persistentCookie = "di-persistent-session-id=a-persistent-id";
+        String persistentCookie = "di-persistent-session-id=" + PERSISTENT_SESSION_ID_COOKIE_VALUE;
         String sessionCookie = "gs=session-id.456";
         cookieMap.put(header, List.of(persistentCookie, sessionCookie));
 
@@ -154,7 +175,7 @@ public class CookieHelperTest {
                 getHttpCookieFromMultiValueResponseHeaders(cookieMap, PERSISTENT_COOKIE_NAME)
                         .orElseThrow();
 
-        assertEquals("a-persistent-id", httpCookie.getValue());
+        assertEquals(PERSISTENT_SESSION_ID_COOKIE_VALUE, httpCookie.getValue());
     }
 
     @ParameterizedTest(name = "with header {0}")

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.PERSISTENT_COOKIE_NAME;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.REQUEST_COOKIE_HEADER;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.RESPONSE_COOKIE_HEADER;
@@ -97,6 +98,21 @@ public class CookieHelperTest {
         Optional<String> id = parsePersistentCookie(headers);
 
         assertEmpty(id);
+    }
+
+    @Test
+    void shouldAppendTimestampToPersistentCookieWhenMissing() {
+        String existingPersistentSessionId = IdGenerator.generate();
+        HttpCookie cookie = new HttpCookie("di-persistent-session-id", existingPersistentSessionId);
+        Map<String, String> headers =
+                Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, cookie.toString()));
+
+        Optional<String> id = parsePersistentCookie(headers);
+
+        assertTrue(id.get().startsWith(existingPersistentSessionId));
+        assertTrue(
+                PersistentIdHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(
+                        id.get()));
     }
 
     @ParameterizedTest(name = "with header {0}")

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
@@ -115,6 +115,21 @@ class PersistentIdHelperTest {
     }
 
     @Test
+    void shouldAppendTimestampToPersistentIdWhenMissing() {
+        String oldPersistentId = IdGenerator.generate();
+
+        String cookieString =
+                String.format(
+                        "Version=1; di-persistent-session-id=%s;gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts",
+                        oldPersistentId);
+        Map<String, String> inputHeaders = Map.of(CookieHelper.REQUEST_COOKIE_HEADER, cookieString);
+        String persistentId =
+                PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(inputHeaders);
+        assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(persistentId));
+        assertTrue(persistentId.startsWith(oldPersistentId));
+    }
+
+    @Test
     void shouldGenerateNewPersistentIdFromGetExistingOrCreateWhenMissing() {
         String cookieString =
                 "Version=1; gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts";

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp;
 
 class PersistentIdHelperTest {
     private static final String ARBITRARY_UNIX_TIMESTAMP = "1700558480962";
@@ -78,8 +79,7 @@ class PersistentIdHelperTest {
         Map<String, String> inputHeaders = Map.of(CookieHelper.REQUEST_COOKIE_HEADER, cookieString);
         String persistentId =
                 PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(inputHeaders);
-        assertTrue(
-                CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(persistentId));
+        assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(persistentId));
     }
 
     @Test
@@ -92,8 +92,7 @@ class PersistentIdHelperTest {
         Map<String, String> inputHeaders = Map.of(CookieHelper.REQUEST_COOKIE_HEADER, cookieString);
         String persistentId =
                 PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(inputHeaders);
-        assertTrue(
-                CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(persistentId));
+        assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(persistentId));
         assertTrue(persistentId.contains(PERSISTENT_SESSION_ID_COOKIE_VALUE));
     }
 
@@ -111,8 +110,7 @@ class PersistentIdHelperTest {
         Map<String, String> inputHeaders = Map.of(CookieHelper.REQUEST_COOKIE_HEADER, cookieString);
         String persistentId =
                 PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(inputHeaders);
-        assertTrue(
-                CookieHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp(persistentId));
+        assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(persistentId));
         assertFalse(persistentId.contains(corruptedPersistentId));
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
@@ -98,7 +98,7 @@ class PersistentIdHelperTest {
 
     // This relates to a short period where it was possible to have a format like
     // --1700558480962--1700558480963--1700558480964; see commit
-    // 75a10df4376397d5a454b87b5cee689e13a71e20; will not be needed from 26/11/2024
+    // 75a10df4376397d5a454b87b5cee689e13a71e20; will not be needed from 26/05/2025
     @Test
     void shouldReturnNewPersistentIdWithATimestampWhenCorruptedFormatExists() {
         String corruptedPersistentId = "--1700558480962--1700558480963";


### PR DESCRIPTION
Note to reviewer: Please review this PR especially carefully. This has been deployed to Sandpit at the time of writing, so it should be possible to empirically compare behaviours between Sandpit and other environments. Please also treat the code logic with particular scepticism, as we are introducing changes on top of changes, and if we get this wrong, it will become very complex indeed to apply a fix that works for all possible users.

## What?
- Change the formatting behaviour around how we set `persistent-session-id`

## Why?
- Amends changes introduced in 75a10df4376397d5a454b87b5cee689e13a71e20
- For a time, users have ended up with:
1. Double timestamps in the session ID
2. Losing the existing UUID-style IDs from the beginning of the existing session ID

- The changes in this commit attempt to resolve that for a number of possible starting points:
1. No existing persistent-session-id
2. An 'old style' persistent-session-id which could look like `s1mZGVHhkM-bU-kTBrjVwXuFUW0`
3. A corrupted persistent-session-id, which could look like `--1700558480962--1700558480963--1700558480964` (seemingly up to a maximum of three timestamps) so something like `--1700558480962` is also possible

Scenario 3 applies only to users who already had a `persistent-session-id` and who used the site between the point of the amended PR taking effect and whenever this PR takes effect.

## Related PRs
- Amends: https://github.com/govuk-one-login/authentication-api/pull/3453
