### PR TITLE
ATO-175: Add AccountInterventionService

### DIFF
--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -9,6 +9,7 @@ version "unspecified"
 dependencies {
 
     implementation project(path: ':ipv-api')
+    implementation project(path: ':orchestration-shared')
     testImplementation project(path: ':ipv-api')
     compileOnly             configurations.kms,
             configurations.lambda,

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -9,7 +9,6 @@ version "unspecified"
 dependencies {
 
     implementation project(path: ':ipv-api')
-    implementation project(path: ':orchestration-shared')
     testImplementation project(path: ':ipv-api')
     compileOnly             configurations.kms,
             configurations.lambda,
@@ -23,6 +22,7 @@ dependencies {
             configurations.bouncycastle,
             configurations.cloudwatch,
             project(":shared"),
+            project(":orchestration-shared"),
             project(":client-registry-api"),
             project(":doc-checking-app-api"),
             project(":auth-external-api")

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccountInterventionResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccountInterventionResponse.java
@@ -1,0 +1,3 @@
+package uk.gov.di.authentication.oidc.entity;
+
+public record AccountInterventionResponse(AccountInterventionStatus state, String auditLevel) {}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccountInterventionResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccountInterventionResponse.java
@@ -1,3 +1,6 @@
 package uk.gov.di.authentication.oidc.entity;
 
-public record AccountInterventionResponse(AccountInterventionStatus state, String auditLevel) {}
+import com.google.gson.annotations.Expose;
+
+public record AccountInterventionResponse(
+        @Expose AccountInterventionStatus state, @Expose String auditLevel) {}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccountInterventionStatus.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccountInterventionStatus.java
@@ -1,0 +1,4 @@
+package uk.gov.di.authentication.oidc.entity;
+
+public record AccountInterventionStatus(
+        boolean blocked, boolean suspended, boolean reproveIdentity, boolean resetPassword) {}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccountInterventionStatus.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccountInterventionStatus.java
@@ -1,4 +1,10 @@
 package uk.gov.di.authentication.oidc.entity;
 
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
 public record AccountInterventionStatus(
-        boolean blocked, boolean suspended, boolean reproveIdentity, boolean resetPassword) {}
+        @Expose boolean blocked,
+        @Expose boolean suspended,
+        @Expose @SerializedName("reproveIdentity") boolean reproveIdentity,
+        @Expose @SerializedName("resetPassword") boolean resetPassword) {}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AccountInterventionException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AccountInterventionException.java
@@ -1,7 +1,7 @@
 package uk.gov.di.authentication.oidc.exceptions;
 
 public class AccountInterventionException extends RuntimeException {
-    public AccountInterventionException(Exception cause) {
-        super(cause);
+    public AccountInterventionException(String message, Exception cause) {
+        super(message, cause);
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AccountInterventionException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AccountInterventionException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+public class AccountInterventionException extends RuntimeException {
+    public AccountInterventionException(Exception cause) {
+        super(cause);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccountInterventionService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccountInterventionService.java
@@ -6,7 +6,6 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.AccountInterventionResponse;
 import uk.gov.di.authentication.oidc.entity.AccountInterventionStatus;
 import uk.gov.di.authentication.oidc.exceptions.AccountInterventionException;
-import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
 import java.io.IOException;
@@ -19,19 +18,13 @@ import java.net.http.HttpResponse;
 public class AccountInterventionService {
 
     private static final Logger LOGGER = LogManager.getLogger(AccountInterventionService.class);
-    private final boolean accountInterventionsAuditEnabled;
     private final boolean accountInterventionsEnabled;
     private final HttpClient httpClient;
     private final URI accountInterventionServiceURI;
-    private final AuditService auditService;
 
-    public AccountInterventionService(
-            ConfigurationService configService, AuditService auditService, HttpClient httpClient) {
-        this.accountInterventionsAuditEnabled =
-                configService.isAccountInterventionServiceAuditEnabled();
+    public AccountInterventionService(ConfigurationService configService, HttpClient httpClient) {
         this.accountInterventionsEnabled = configService.isAccountInterventionServiceEnabled();
         this.accountInterventionServiceURI = configService.getAccountInterventionServiceURI();
-        this.auditService = auditService;
         this.httpClient = httpClient;
     }
 
@@ -40,10 +33,6 @@ public class AccountInterventionService {
         try {
             if (accountInterventionsEnabled) {
                 return retrieveAccountStatus(internalSubjectId);
-            }
-
-            if (accountInterventionsAuditEnabled) {
-                sendAuditEvent();
             }
 
             return new AccountInterventionStatus(false, false, false, false);
@@ -72,6 +61,4 @@ public class AccountInterventionService {
 
         return response.state();
     }
-
-    private void sendAuditEvent() {}
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccountInterventionService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccountInterventionService.java
@@ -1,11 +1,12 @@
 package uk.gov.di.authentication.oidc.services;
 
-import com.google.gson.Gson;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.AccountInterventionResponse;
 import uk.gov.di.authentication.oidc.entity.AccountInterventionStatus;
 import uk.gov.di.authentication.oidc.exceptions.AccountInterventionException;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
 import java.io.IOException;
@@ -37,14 +38,14 @@ public class AccountInterventionService {
 
             return new AccountInterventionStatus(false, false, false, false);
 
-        } catch (IOException | URISyntaxException | InterruptedException e) {
+        } catch (IOException | URISyntaxException | InterruptedException | Json.JsonException e) {
             throw new AccountInterventionException(
-                    "Unable to connect to Account Intervention Service", e);
+                    "Problem communicating with Account Intervention Service", e);
         }
     }
 
     private AccountInterventionStatus retrieveAccountStatus(String internalPairwiseSubjectId)
-            throws IOException, InterruptedException, URISyntaxException {
+            throws IOException, InterruptedException, URISyntaxException, Json.JsonException {
 
         HttpRequest request =
                 HttpRequest.newBuilder()
@@ -57,7 +58,9 @@ public class AccountInterventionService {
 
         String body = httpResponse.body();
 
-        var response = new Gson().fromJson(body, AccountInterventionResponse.class);
+        var response =
+                SerializationService.getInstance()
+                        .readValue(body, AccountInterventionResponse.class);
 
         return response.state();
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccountInterventionService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccountInterventionService.java
@@ -1,0 +1,76 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.google.gson.Gson;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.oidc.entity.AccountInterventionResponse;
+import uk.gov.di.authentication.oidc.entity.AccountInterventionStatus;
+import uk.gov.di.authentication.oidc.exceptions.AccountInterventionException;
+import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class AccountInterventionService {
+
+    private static final Logger LOGGER = LogManager.getLogger(AccountInterventionService.class);
+    private final boolean accountInterventionsAuditEnabled;
+    private final boolean accountInterventionsEnabled;
+    private final HttpClient httpClient;
+    private final URI accountInterventionServiceURI;
+    private final AuditService auditService;
+
+    public AccountInterventionService(
+            ConfigurationService configService, AuditService auditService, HttpClient httpClient) {
+        this.accountInterventionsAuditEnabled =
+                configService.isAccountInterventionServiceAuditEnabled();
+        this.accountInterventionsEnabled = configService.isAccountInterventionServiceEnabled();
+        this.accountInterventionServiceURI = configService.getAccountInterventionServiceURI();
+        this.auditService = auditService;
+        this.httpClient = httpClient;
+    }
+
+    public AccountInterventionStatus getAccountStatus(String internalSubjectId)
+            throws AccountInterventionException {
+        try {
+            if (accountInterventionsEnabled) {
+                return retrieveAccountStatus(internalSubjectId);
+            }
+
+            if (accountInterventionsAuditEnabled) {
+                sendAuditEvent();
+            }
+
+            return new AccountInterventionStatus(false, false, false, false);
+
+        } catch (IOException | URISyntaxException | InterruptedException e) {
+            throw new AccountInterventionException(e);
+        }
+    }
+
+    private AccountInterventionStatus retrieveAccountStatus(String internalSubjectId)
+            throws IOException, InterruptedException, URISyntaxException {
+
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(accountInterventionServiceURI.resolve(internalSubjectId))
+                        .GET()
+                        .build();
+
+        HttpResponse<String> httpResponse =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        String body = httpResponse.body();
+
+        var response = new Gson().fromJson(body, AccountInterventionResponse.class);
+
+        return response.state();
+    }
+
+    private void sendAuditEvent() {}
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccountInterventionService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccountInterventionService.java
@@ -49,7 +49,8 @@ public class AccountInterventionService {
             return new AccountInterventionStatus(false, false, false, false);
 
         } catch (IOException | URISyntaxException | InterruptedException e) {
-            throw new AccountInterventionException(e);
+            throw new AccountInterventionException(
+                    "Unable to connect to Account Intervention Service", e);
         }
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccountInterventionService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccountInterventionService.java
@@ -28,11 +28,11 @@ public class AccountInterventionService {
         this.httpClient = httpClient;
     }
 
-    public AccountInterventionStatus getAccountStatus(String internalSubjectId)
+    public AccountInterventionStatus getAccountStatus(String internalPairwiseSubjectId)
             throws AccountInterventionException {
         try {
             if (accountInterventionsEnabled) {
-                return retrieveAccountStatus(internalSubjectId);
+                return retrieveAccountStatus(internalPairwiseSubjectId);
             }
 
             return new AccountInterventionStatus(false, false, false, false);
@@ -43,12 +43,12 @@ public class AccountInterventionService {
         }
     }
 
-    private AccountInterventionStatus retrieveAccountStatus(String internalSubjectId)
+    private AccountInterventionStatus retrieveAccountStatus(String internalPairwiseSubjectId)
             throws IOException, InterruptedException, URISyntaxException {
 
         HttpRequest request =
                 HttpRequest.newBuilder()
-                        .uri(accountInterventionServiceURI.resolve(internalSubjectId))
+                        .uri(accountInterventionServiceURI.resolve(internalPairwiseSubjectId))
                         .GET()
                         .build();
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccountInterventionServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccountInterventionServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.oidc.entity.AccountInterventionStatus;
+import uk.gov.di.authentication.oidc.exceptions.AccountInterventionException;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
@@ -15,6 +16,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -125,5 +127,22 @@ class AccountInterventionServiceTest {
         assertEquals(false, status.suspended());
         assertEquals(false, status.reproveIdentity());
         assertEquals(false, status.resetPassword());
+    }
+
+    @Test
+    void shouldThrowAccountInterventionExceptionWhenExceptionThrownByHttpClient()
+            throws URISyntaxException, IOException, InterruptedException {
+
+        var internalSubjectId = "some-internal-subject-id";
+        var accountInterventionService = new AccountInterventionService(config, audit, httpClient);
+        var httpResponse = mock(HttpResponse.class);
+
+        when(httpClient.send(any(), any())).thenThrow(new IOException("Test IO Exception"));
+
+        assertThrows(
+                AccountInterventionException.class,
+                () -> {
+                    accountInterventionService.getAccountStatus(internalSubjectId);
+                });
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccountInterventionServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccountInterventionServiceTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.oidc.entity.AccountInterventionStatus;
 import uk.gov.di.authentication.oidc.exceptions.AccountInterventionException;
-import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
 import java.io.IOException;
@@ -26,7 +25,6 @@ import static org.mockito.Mockito.when;
 class AccountInterventionServiceTest {
 
     private final ConfigurationService config = mock(ConfigurationService.class);
-    private final AuditService audit = mock(AuditService.class);
     private final HttpClient httpClient = mock(HttpClient.class);
 
     private static String ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE =
@@ -70,7 +68,6 @@ class AccountInterventionServiceTest {
     void setup() throws URISyntaxException {
         when(config.getAccountInterventionServiceURI()).thenReturn(new URI(BASE_AIS_URL));
         when(config.isAccountInterventionServiceEnabled()).thenReturn(true);
-        when(config.isAccountInterventionServiceAuditEnabled()).thenReturn(true);
     }
 
     @Test
@@ -78,7 +75,7 @@ class AccountInterventionServiceTest {
             throws URISyntaxException, IOException, InterruptedException {
 
         var internalSubjectId = "some-internal-subject-id";
-        var ais = new AccountInterventionService(config, audit, httpClient);
+        var ais = new AccountInterventionService(config, httpClient);
         var httpResponse = mock(HttpResponse.class);
         var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
 
@@ -97,7 +94,7 @@ class AccountInterventionServiceTest {
     void shouldReturnAccountStatus() throws URISyntaxException, IOException, InterruptedException {
 
         var internalSubjectId = "some-internal-subject-id";
-        var accountInterventionService = new AccountInterventionService(config, audit, httpClient);
+        var accountInterventionService = new AccountInterventionService(config, httpClient);
         var httpResponse = mock(HttpResponse.class);
 
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
@@ -118,7 +115,7 @@ class AccountInterventionServiceTest {
         when(config.isAccountInterventionServiceEnabled()).thenReturn(false);
 
         var internalSubjectId = "some-internal-subject-id";
-        var ais = new AccountInterventionService(config, audit, httpClient);
+        var ais = new AccountInterventionService(config, httpClient);
         var status = ais.getAccountStatus(internalSubjectId);
 
         verifyNoInteractions(httpClient);
@@ -134,7 +131,7 @@ class AccountInterventionServiceTest {
             throws URISyntaxException, IOException, InterruptedException {
 
         var internalSubjectId = "some-internal-subject-id";
-        var accountInterventionService = new AccountInterventionService(config, audit, httpClient);
+        var accountInterventionService = new AccountInterventionService(config, httpClient);
         var httpResponse = mock(HttpResponse.class);
 
         when(httpClient.send(any(), any())).thenThrow(new IOException("Test IO Exception"));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccountInterventionServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccountInterventionServiceTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.oidc.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import uk.gov.di.authentication.oidc.entity.AccountInterventionStatus;
 import uk.gov.di.authentication.oidc.exceptions.AccountInterventionException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
@@ -48,20 +47,6 @@ class AccountInterventionServiceTest {
             }
             """;
 
-    private static String ACCOUNT_INTERVENTION_SERVICE_RESPONSE_ALL_CLEAR =
-            """
-            {
-                "state": {
-                    "blocked": false,
-                    "suspended": false,
-                    "reproveIdentity": false,
-                    "resetPassword": false
-                }
-            }
-            """;
-
-    private static AccountInterventionStatus accountStatusClear =
-            new AccountInterventionStatus(false, false, false, false);
     private static String BASE_AIS_URL = "http://example.com/somepath/";
 
     @BeforeEach
@@ -72,7 +57,7 @@ class AccountInterventionServiceTest {
 
     @Test
     void shouldConstructWellFormedRequestToAccountInterventionService()
-            throws URISyntaxException, IOException, InterruptedException {
+            throws IOException, InterruptedException {
 
         var internalPairwiseSubjectId = "some-internal-subject-id";
         var ais = new AccountInterventionService(config, httpClient);
@@ -91,7 +76,7 @@ class AccountInterventionServiceTest {
     }
 
     @Test
-    void shouldReturnAccountStatus() throws URISyntaxException, IOException, InterruptedException {
+    void shouldReturnAccountStatus() throws IOException, InterruptedException {
 
         var internalPairwiseSubjectId = "some-internal-subject-id";
         var accountInterventionService = new AccountInterventionService(config, httpClient);
@@ -109,8 +94,7 @@ class AccountInterventionServiceTest {
     }
 
     @Test
-    void shouldReturnAccountStatusAllClearWhenDisabled()
-            throws URISyntaxException, IOException, InterruptedException {
+    void shouldReturnAccountStatusAllClearWhenDisabled() {
 
         when(config.isAccountInterventionServiceEnabled()).thenReturn(false);
 
@@ -128,7 +112,7 @@ class AccountInterventionServiceTest {
 
     @Test
     void shouldThrowAccountInterventionExceptionWhenExceptionThrownByHttpClient()
-            throws URISyntaxException, IOException, InterruptedException {
+            throws IOException, InterruptedException {
 
         var internalPairwiseSubjectId = "some-internal-subject-id";
         var accountInterventionService = new AccountInterventionService(config, httpClient);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccountInterventionServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccountInterventionServiceTest.java
@@ -41,7 +41,7 @@ class AccountInterventionServiceTest {
                     "blocked": false,
                     "suspended": true,
                     "reproveIdentity": true,
-                    "resetPassword": false\s
+                    "resetPassword": false
                 },
                 "auditLevel": "standard",
                 "history": []
@@ -55,7 +55,7 @@ class AccountInterventionServiceTest {
                     "blocked": false,
                     "suspended": false,
                     "reproveIdentity": false,
-                    "resetPassword": false\s
+                    "resetPassword": false
                 }
             }
             """;
@@ -74,7 +74,7 @@ class AccountInterventionServiceTest {
     void shouldConstructWellFormedRequestToAccountInterventionService()
             throws URISyntaxException, IOException, InterruptedException {
 
-        var internalSubjectId = "some-internal-subject-id";
+        var internalPairwiseSubjectId = "some-internal-subject-id";
         var ais = new AccountInterventionService(config, httpClient);
         var httpResponse = mock(HttpResponse.class);
         var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
@@ -82,25 +82,25 @@ class AccountInterventionServiceTest {
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
         when(httpResponse.body()).thenReturn("{\"foo\": \"bar\"}");
 
-        ais.getAccountStatus(internalSubjectId);
+        ais.getAccountStatus(internalPairwiseSubjectId);
 
         verify(httpClient).send(httpRequestCaptor.capture(), any());
         var requestUri = httpRequestCaptor.getValue();
 
-        assertEquals(BASE_AIS_URL + internalSubjectId, requestUri.uri().toString());
+        assertEquals(BASE_AIS_URL + internalPairwiseSubjectId, requestUri.uri().toString());
     }
 
     @Test
     void shouldReturnAccountStatus() throws URISyntaxException, IOException, InterruptedException {
 
-        var internalSubjectId = "some-internal-subject-id";
+        var internalPairwiseSubjectId = "some-internal-subject-id";
         var accountInterventionService = new AccountInterventionService(config, httpClient);
         var httpResponse = mock(HttpResponse.class);
 
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
         when(httpResponse.body()).thenReturn(ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE);
 
-        var status = accountInterventionService.getAccountStatus(internalSubjectId);
+        var status = accountInterventionService.getAccountStatus(internalPairwiseSubjectId);
 
         assertEquals(false, status.blocked());
         assertEquals(true, status.suspended());
@@ -114,9 +114,9 @@ class AccountInterventionServiceTest {
 
         when(config.isAccountInterventionServiceEnabled()).thenReturn(false);
 
-        var internalSubjectId = "some-internal-subject-id";
+        var internalPairwiseSubjectId = "some-internal-subject-id";
         var ais = new AccountInterventionService(config, httpClient);
-        var status = ais.getAccountStatus(internalSubjectId);
+        var status = ais.getAccountStatus(internalPairwiseSubjectId);
 
         verifyNoInteractions(httpClient);
 
@@ -130,7 +130,7 @@ class AccountInterventionServiceTest {
     void shouldThrowAccountInterventionExceptionWhenExceptionThrownByHttpClient()
             throws URISyntaxException, IOException, InterruptedException {
 
-        var internalSubjectId = "some-internal-subject-id";
+        var internalPairwiseSubjectId = "some-internal-subject-id";
         var accountInterventionService = new AccountInterventionService(config, httpClient);
         var httpResponse = mock(HttpResponse.class);
 
@@ -139,7 +139,7 @@ class AccountInterventionServiceTest {
         assertThrows(
                 AccountInterventionException.class,
                 () -> {
-                    accountInterventionService.getAccountStatus(internalSubjectId);
+                    accountInterventionService.getAccountStatus(internalPairwiseSubjectId);
                 });
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccountInterventionServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccountInterventionServiceTest.java
@@ -95,13 +95,13 @@ class AccountInterventionServiceTest {
     void shouldReturnAccountStatus() throws URISyntaxException, IOException, InterruptedException {
 
         var internalSubjectId = "some-internal-subject-id";
-        var ais = new AccountInterventionService(config, audit, httpClient);
+        var accountInterventionService = new AccountInterventionService(config, audit, httpClient);
         var httpResponse = mock(HttpResponse.class);
 
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
         when(httpResponse.body()).thenReturn(ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE);
 
-        var status = ais.getAccountStatus(internalSubjectId);
+        var status = accountInterventionService.getAccountStatus(internalSubjectId);
 
         assertEquals(false, status.blocked());
         assertEquals(true, status.suspended());


### PR DESCRIPTION
## What?

Add AccountInterventionService and associated classes.

The AccountInterventionService is a proxy wrapper to the external Account Intervention Service. Our representation makes an HTTP call to the actual service and parses the result into our internal representation. At this stage we are only interested in a subset of the returned information, namely the account status.

If the Account Intervention Service is disabled our `AccountInterventionService` will return an AccountStatus with all false values, indicating there is no intervention.

If the Account Intervention Service is enabled, but we encounter an exception at any point when connecting to the service, we catch the exception and rethrow an "AccountInterventionException"

## Why?

Required for integration with Account Intervention Service
