### PR TITLE
AUT-1844:Implement Account Interventions Lambda to call the Account Interventions API

### DIFF
--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -24,12 +24,13 @@ module "account_interventions" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    ENVIRONMENT          = var.environment
-    TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
-    REDIS_KEY            = local.redis_key
+    DYNAMO_ENDPOINT                  = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT              = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT                      = var.environment
+    TXMA_AUDIT_QUEUE_URL             = module.oidc_txma_audit.queue_url
+    INTERNAl_SECTOR_URI              = var.internal_sector_uri
+    REDIS_KEY                        = local.redis_key
+    ACCOUNT_INTERVENTION_SERVICE_URI = var.account_intervention_service_uri
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AccountInterventionsHandler::handleRequest"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsInboundResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsInboundResponse.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+
+public record AccountInterventionsInboundResponse(
+        @Expose @Required Intervention intervention, @Expose @Required State state) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsRequest.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public record AccountInterventionsRequest(
+        @SerializedName("email") @Expose @Required String email) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsResponse.java
@@ -1,0 +1,9 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+
+public record AccountInterventionsResponse(
+        @Expose @Required boolean passwordResetRequired,
+        @Expose @Required boolean blocked,
+        @Expose @Required boolean temporarilySuspended) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/Intervention.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/Intervention.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+
+public record Intervention(
+        @Expose @Required String updatedAt,
+        @Expose @Required String appliedAt,
+        @Expose @Required String sentAt,
+        @Expose @Required String description,
+        @Expose @Required String reprovedIdentityAt,
+        @Expose @Required String resetPasswordAt) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/State.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/State.java
@@ -1,0 +1,10 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+
+public record State(
+        @Expose @Required boolean blocked,
+        @Expose @Required boolean suspended,
+        @Expose @Required boolean reproveIdentity,
+        @Expose @Required boolean resetPassword) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -1,18 +1,115 @@
 package uk.gov.di.authentication.frontendapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsRequest;
+import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsResponse;
+import uk.gov.di.authentication.frontendapi.services.AccountInterventionsService;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
+import uk.gov.di.authentication.shared.serialization.Json.JsonException;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.state.UserContext;
 
+import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.GET;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 
-public class AccountInterventionsHandler
-        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInterventionsRequest> {
+    private static final Logger LOG = LogManager.getLogger(AccountInterventionsHandler.class);
+    private final AccountInterventionsService accountInterventionsService;
+
+    protected AccountInterventionsHandler(
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
+            AuthenticationService authenticationService,
+            AccountInterventionsService accountInterventionsService) {
+        super(
+                AccountInterventionsRequest.class,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
+        this.accountInterventionsService = accountInterventionsService;
+    }
+
+    public AccountInterventionsHandler(ConfigurationService configurationService) {
+        super(AccountInterventionsRequest.class, configurationService);
+        accountInterventionsService = new AccountInterventionsService();
+    }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
-        return generateApiGatewayProxyResponse(200, "Hello world");
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            AccountInterventionsRequest request,
+            UserContext userContext) {
+        attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
+        LOG.info("Request received to the AccountInterventionsHandler");
+
+        var userProfile = authenticationService.getUserProfileByEmailMaybe(request.email());
+        if (userProfile.isEmpty()) {
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1049);
+        }
+
+        try {
+            var internalPairwiseId =
+                    ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                                    userProfile.get(),
+                                    configurationService.getInternalSectorUri(),
+                                    authenticationService)
+                            .getValue();
+            var accountInterventionsEndpoint =
+                    configurationService.getAccountInterventionServiceURI().toString();
+            var accountInterventionsURI =
+                    buildURI(accountInterventionsEndpoint, "/v1/ais/" + internalPairwiseId);
+            var accountInterventionsInboundRequest = new HTTPRequest(GET, accountInterventionsURI);
+            var accountInterventionsInboundResponse =
+                    accountInterventionsService.sendAccountInterventionsOutboundRequest(
+                            accountInterventionsInboundRequest);
+            LOG.info("Generating Account Interventions outbound response for frontend");
+            var accountInterventionsResponse =
+                    new AccountInterventionsResponse(
+                            accountInterventionsInboundResponse.state().resetPassword(),
+                            accountInterventionsInboundResponse.state().blocked(),
+                            accountInterventionsInboundResponse.state().suspended());
+            return generateApiGatewayProxyResponse(200, accountInterventionsResponse, true);
+        } catch (UnsuccessfulAccountInterventionsResponseException e) {
+            LOG.debug(
+                    "Error in Account Interventions response HttpCode: {}, ErrorMessage: {}.",
+                    e.getHttpCode(),
+                    e.getMessage());
+            if (e.getHttpCode() == 429) {
+                return generateApiGatewayProxyErrorResponse(429, ErrorResponse.ERROR_1051);
+            }
+            if (e.getHttpCode() == 500) {
+                return generateApiGatewayProxyErrorResponse(500, ErrorResponse.ERROR_1052);
+            }
+            if (e.getHttpCode() == 502) {
+                return generateApiGatewayProxyErrorResponse(502, ErrorResponse.ERROR_1053);
+            }
+            if (e.getHttpCode() == 504) {
+                return generateApiGatewayProxyErrorResponse(504, ErrorResponse.ERROR_1054);
+            }
+            return generateApiGatewayProxyErrorResponse(e.getHttpCode(), ErrorResponse.ERROR_1055);
+        } catch (JsonException e) {
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+        }
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
@@ -1,0 +1,54 @@
+package uk.gov.di.authentication.frontendapi.services;
+
+import com.google.gson.JsonParseException;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsInboundResponse;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.SerializationService;
+
+import java.io.IOException;
+
+import static java.lang.String.format;
+
+public class AccountInterventionsService {
+
+    private static final Logger LOG = LogManager.getLogger(AccountInterventionsService.class);
+    private final Json objectMapper = SerializationService.getInstance();
+
+    public AccountInterventionsInboundResponse sendAccountInterventionsOutboundRequest(
+            HTTPRequest request) throws UnsuccessfulAccountInterventionsResponseException {
+
+        try {
+            LOG.info("Sending account interventions outbound request");
+            var response = request.send();
+            if (!response.indicatesSuccess()) {
+                throw new UnsuccessfulAccountInterventionsResponseException(
+                        format(
+                                "Error %s when attempting to call Account Interventions outbound endpoint: %s",
+                                response.getStatusCode(), response.getContent()),
+                        response.getStatusCode());
+            }
+            LOG.info("Received successful account interventions outbound response");
+            return parseResponse(response);
+        } catch (IOException e) {
+            throw new UnsuccessfulAccountInterventionsResponseException(
+                    "Error when attempting to call Account Interventions outbound endpoint", e);
+        } catch (ParseException | Json.JsonException | JsonParseException e) {
+            throw new UnsuccessfulAccountInterventionsResponseException(
+                    "Error parsing HTTP response", e);
+        }
+    }
+
+    private AccountInterventionsInboundResponse parseResponse(HTTPResponse response)
+            throws Json.JsonException, ParseException, JsonParseException {
+        return objectMapper.readValue(
+                response.getContentAsJSONObject().toString(),
+                AccountInterventionsInboundResponse.class,
+                true);
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsServiceTest.java
@@ -1,0 +1,138 @@
+package uk.gov.di.authentication.frontendapi.services;
+
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+class AccountInterventionsServiceTest {
+
+    private static final String FIELD_UPDATED_AT = "updatedAt";
+    private static final String FIELD_APPLIED_AT = "appliedAt";
+    private static final String FIELD_SENT_AT = "sentAt";
+    private static final String FIELD_DESCRIPTION = "description";
+    private static final String FIELD_REPROVED_IDENTITY_AT = "reprovedIdentityAt";
+    private static final String FIELD_RESET_PASSWORD_AT = "resetPasswordAt";
+    private static final String FIELD_BLOCKED = "blocked";
+    private static final String FIELD_SUSPENDED = "suspended";
+    private static final String FIELD_REPROVE_IDENTITY = "reproveIdentity";
+    private static final String FIELD_RESET_PASSWORD = "resetPassword";
+    private static final String FIELD_INTERVENTION = "intervention";
+    private static final String FIELD_STATE = "state";
+    private static final String DATE_TIME = "2023-01-01T00:00:00Z";
+    private static final String DESCRIPTION = "intervention-description";
+
+    @Mock private HTTPRequest mockRequest;
+
+    @Mock private HTTPResponse mockResponse;
+
+    private AccountInterventionsService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = new AccountInterventionsService();
+    }
+
+    @Test
+    void testSendAccountInterventionsOutboundRequestSuccess() throws Exception {
+        var interventionJson = new JSONObject();
+        interventionJson.put(FIELD_UPDATED_AT, DATE_TIME);
+        interventionJson.put(FIELD_APPLIED_AT, DATE_TIME);
+        interventionJson.put(FIELD_SENT_AT, DATE_TIME);
+        interventionJson.put(FIELD_DESCRIPTION, DESCRIPTION);
+        interventionJson.put(FIELD_REPROVED_IDENTITY_AT, DATE_TIME);
+        interventionJson.put(FIELD_RESET_PASSWORD_AT, DATE_TIME);
+
+        var stateJson = new JSONObject();
+        stateJson.put(FIELD_BLOCKED, true);
+        stateJson.put(FIELD_SUSPENDED, false);
+        stateJson.put(FIELD_REPROVE_IDENTITY, true);
+        stateJson.put(FIELD_RESET_PASSWORD, false);
+
+        var responseContent = new JSONObject();
+        responseContent.put(FIELD_INTERVENTION, interventionJson);
+        responseContent.put(FIELD_STATE, stateJson);
+
+        when(mockRequest.send()).thenReturn(mockResponse);
+        when(mockResponse.indicatesSuccess()).thenReturn(true);
+        when(mockResponse.getContentAsJSONObject()).thenReturn(responseContent);
+
+        var result = service.sendAccountInterventionsOutboundRequest(mockRequest);
+        assertNotNull(result);
+        assertEquals(DATE_TIME, result.intervention().updatedAt());
+        assertEquals(DATE_TIME, result.intervention().appliedAt());
+        assertEquals(DATE_TIME, result.intervention().sentAt());
+        assertEquals(DESCRIPTION, result.intervention().description());
+        assertEquals(DATE_TIME, result.intervention().reprovedIdentityAt());
+        assertEquals(DATE_TIME, result.intervention().resetPasswordAt());
+        assertTrue(result.state().blocked());
+        assertFalse(result.state().suspended());
+        assertTrue(result.state().reproveIdentity());
+        assertFalse(result.state().resetPassword());
+    }
+
+    @Test
+    void testSendAccountInterventionsOutboundRequestHttpError() throws Exception {
+        when(mockRequest.send()).thenReturn(mockResponse);
+        when(mockResponse.indicatesSuccess()).thenReturn(false);
+        assertThrows(
+                UnsuccessfulAccountInterventionsResponseException.class,
+                () -> service.sendAccountInterventionsOutboundRequest(mockRequest));
+    }
+
+    @Test
+    void testSendAccountInterventionsOutboundRequestIOException() throws Exception {
+        when(mockRequest.send()).thenThrow(new IOException());
+        assertThrows(
+                UnsuccessfulAccountInterventionsResponseException.class,
+                () -> service.sendAccountInterventionsOutboundRequest(mockRequest));
+    }
+
+    @Test
+    void testSendAccountInterventionsOutboundRequestParseException() throws Exception {
+        when(mockRequest.send()).thenReturn(mockResponse);
+        when(mockResponse.indicatesSuccess()).thenReturn(true);
+        when(mockResponse.getContentAsJSONObject())
+                .thenThrow(new ParseException("parse-exception-message"));
+        assertThrows(
+                UnsuccessfulAccountInterventionsResponseException.class,
+                () -> service.sendAccountInterventionsOutboundRequest(mockRequest));
+    }
+
+    @Test
+    void testParseResponseWithMissingOrNullFields() throws Exception {
+        var incompleteInterventionJson = new JSONObject();
+        incompleteInterventionJson.put(FIELD_UPDATED_AT, null);
+        incompleteInterventionJson.put(FIELD_APPLIED_AT, null);
+
+        var incompleteStateJson = new JSONObject();
+        incompleteStateJson.put(FIELD_BLOCKED, null);
+
+        var incompleteResponseContent = new JSONObject();
+        incompleteResponseContent.put(FIELD_INTERVENTION, incompleteInterventionJson);
+        incompleteResponseContent.put(FIELD_STATE, incompleteStateJson);
+
+        when(mockRequest.send()).thenReturn(mockResponse);
+        when(mockResponse.indicatesSuccess()).thenReturn(true);
+        when(mockResponse.getContentAsJSONObject()).thenReturn(incompleteResponseContent);
+
+        assertThrows(
+                UnsuccessfulAccountInterventionsResponseException.class,
+                () -> service.sendAccountInterventionsOutboundRequest(mockRequest));
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -1,28 +1,119 @@
 package uk.gov.di.authentication.api;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsRequest;
+import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsResponse;
 import uk.gov.di.authentication.frontendapi.lambda.AccountInterventionsHandler;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.AccountInterventionsStubExtension;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    public static final String CLIENT_SESSION_ID = "some-client-session-id";
+    private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String TEST_PASSWORD = "password-1";
+    private static final String INTERNAl_SECTOR_HOST = "test.account.gov.uk";
+    private static final Subject SUBJECT = new Subject();
+
+    @RegisterExtension
+    public static final AccountInterventionsStubExtension accountInterventionsStubExtension =
+            new AccountInterventionsStubExtension();
+
+    protected static final ConfigurationService
+            ACCOUNT_INTERVENTIONS_HANDLER_CONFIGURATION_SERVICE =
+                    new AccountInterventionsTestConfigurationService(
+                            accountInterventionsStubExtension);
+
     @BeforeEach
-    void setup() throws Json.JsonException {
-        handler = new AccountInterventionsHandler();
+    void setup() throws JOSEException, Json.JsonException {
+        handler =
+                new AccountInterventionsHandler(
+                        ACCOUNT_INTERVENTIONS_HANDLER_CONFIGURATION_SERVICE);
+        accountInterventionsStubExtension.init(setupUserAndRetrieveUserId());
+        txmaAuditQueue.clear();
     }
 
     @Test
-    void shouldReturn200StatusAndCheckBody() {
-        var response = makeRequest(Optional.empty(), Map.of(), Map.of());
+    void shouldReturnSuccessful200Response() throws Json.JsonException {
+        var response =
+                makeRequest(
+                        Optional.of(new AccountInterventionsRequest(TEST_EMAIL_ADDRESS)),
+                        getHeaders(),
+                        Map.of());
         assertThat(response, hasStatus(200));
-        assertTrue(response.getBody().contains("Hello world"));
+        var accountInterventionsResponse = new AccountInterventionsResponse(false, false, false);
+        assertThat(
+                response,
+                hasBody(objectMapper.writeValueAsStringCamelCase(accountInterventionsResponse)));
+        assertEquals(
+                response.getBody(),
+                "{\"passwordResetRequired\":false,\"blocked\":false,\"temporarilySuspended\":false}");
+    }
+
+    private Map<String, String> getHeaders() throws Json.JsonException {
+        Map<String, String> headers = new HashMap<>();
+        var sessionId = redis.createSession();
+        redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
+        headers.put("Session-Id", sessionId);
+        return headers;
+    }
+
+    private static class AccountInterventionsTestConfigurationService
+            extends IntegrationTestConfigurationService {
+
+        private final AccountInterventionsStubExtension accountInterventionsStubExtension;
+
+        public AccountInterventionsTestConfigurationService(
+                AccountInterventionsStubExtension accountInterventionsStubExtension) {
+            super(
+                    auditTopic,
+                    notificationsQueue,
+                    auditSigningKey,
+                    tokenSigner,
+                    ipvPrivateKeyJwtSigner,
+                    spotQueue,
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
+            this.accountInterventionsStubExtension = accountInterventionsStubExtension;
+        }
+
+        @Override
+        public URI getAccountInterventionServiceURI() {
+            try {
+                return new URIBuilder()
+                        .setHost("localhost")
+                        .setPort(accountInterventionsStubExtension.getHttpPort())
+                        .setScheme("http")
+                        .build();
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private String setupUserAndRetrieveUserId() {
+        userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, SUBJECT);
+        byte[] salt = userStore.addSalt(TEST_EMAIL_ADDRESS);
+        return ClientSubjectHelper.calculatePairwiseIdentifier(
+                SUBJECT.getValue(), INTERNAl_SECTOR_HOST, salt);
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountInterventionsStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountInterventionsStubExtension.java
@@ -1,0 +1,37 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import uk.gov.di.authentication.sharedtest.httpstub.HttpStubExtension;
+
+public class AccountInterventionsStubExtension extends HttpStubExtension {
+
+    public AccountInterventionsStubExtension(int port) {
+        super(port);
+    }
+
+    public AccountInterventionsStubExtension() {
+        super();
+    }
+
+    public void init(String userId) {
+        register(
+                "/v1/ais/" + userId,
+                200,
+                "application/json",
+                "{"
+                        + "  \"intervention\": {"
+                        + "    \"updatedAt\": 1696969322935,"
+                        + "    \"appliedAt\": 1696869005821,"
+                        + "    \"sentAt\": 1696869003456,"
+                        + "    \"description\": \"AIS_USER_PASSWORD_RESET_AND_IDENTITY_VERIFIED\","
+                        + "    \"reprovedIdentityAt\": 1696969322935,"
+                        + "    \"resetPasswordAt\": 1696875903456"
+                        + "  },"
+                        + "  \"state\": {"
+                        + "    \"blocked\": false,"
+                        + "    \"suspended\": false,"
+                        + "    \"reproveIdentity\": false,"
+                        + "    \"resetPassword\": false"
+                        + "  }"
+                        + "}");
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -61,7 +61,12 @@ public enum ErrorResponse {
             1048,
             "User entered invalid email verification code for changing how to receive security codes too many times"),
     ERROR_1049(1049, "Email from session does not have a user profile"),
-    ERROR_1050(1050, "Authorization Auth Code not enabled");
+    ERROR_1050(1050, "Authorization Auth Code not enabled"),
+    ERROR_1051(1051, "Account Interventions API throttled"),
+    ERROR_1052(1052, "Account Interventions API response Server Error"),
+    ERROR_1053(1053, "Account Interventions API Bad Gateway"),
+    ERROR_1054(1054, "Account Interventions API Gateway Timeout"),
+    ERROR_1055(1055, "Account Interventions API Unexpected Error");
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnsuccessfulAccountInterventionsResponseException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnsuccessfulAccountInterventionsResponseException.java
@@ -1,0 +1,20 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class UnsuccessfulAccountInterventionsResponseException extends Exception {
+
+    private final int httpCode;
+
+    public UnsuccessfulAccountInterventionsResponseException(String message, int code) {
+        super(message);
+        this.httpCode = code;
+    }
+
+    public UnsuccessfulAccountInterventionsResponseException(String message, Throwable cause) {
+        super(message, cause);
+        this.httpCode = 0;
+    }
+
+    public int getHttpCode() {
+        return httpCode;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -49,6 +49,15 @@ public class ApiGatewayResponseHelper {
         return generateApiGatewayProxyResponse(statusCode, objectMapper.writeValueAsString(body));
     }
 
+    public static <T> APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
+            int statusCode, T body, boolean camelCase) throws JsonException {
+        return generateApiGatewayProxyResponse(
+                statusCode,
+                camelCase
+                        ? objectMapper.writeValueAsStringCamelCase(body)
+                        : objectMapper.writeValueAsString(body));
+    }
+
     public static <T> APIGatewayProxyResponseEvent generateApiGatewayProxyErrorResponse(
             int statusCode, ErrorResponse errorResponse) {
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/serialization/Json.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/serialization/Json.java
@@ -7,7 +7,11 @@ public interface Json {
 
     <T> T readValue(String body, Class<T> klass, Validator validator) throws JsonException;
 
+    <T> T readValue(String jsonString, Class<T> clazz, boolean useCamelCase) throws JsonException;
+
     String writeValueAsString(Object object) throws JsonException;
+
+    String writeValueAsStringCamelCase(Object object) throws JsonException;
 
     class JsonException extends Exception {
         public JsonException(Exception e) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -635,4 +635,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     public String getNotifyTemplateId(String templateName) {
         return System.getenv(templateName);
     }
+
+    public URI getAccountInterventionServiceURI() {
+        return URI.create(System.getenv("ACCOUNT_INTERVENTION_SERVICE_URI"));
+    }
 }


### PR DESCRIPTION
## What?
Add the logic to the Account Interventions Lambda so it can accept a request, call out to the Account Interventions API, handle the response and then return it to the frontend. 

- Make the Account Interventions Lambda accept a request which contains email
- Create Account Interventions Stub Extension which can be used by the Integration test
- Uses existing `ACCOUNT_INTERVENTION_SERVICE_URI` in config
- Calculate the user’s internal pairwise ID required as `userID` 
- Make a GET request to the Account Interventions API using this Path `/v1/ais/{userId}`
- Return response to frontend

## Why?

Implement Account Interventions backend tasks for scenarios where where account will need to be flagged, suspended or deleted.