### PR TITLE
AUT-1988: fixed audit event logging incorrect subjectID

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -133,9 +133,9 @@ public class UserInfoHandler
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
-                Objects.isNull(accessTokenStore.getSubjectID())
+                Objects.isNull(userInfo.getSubject())
                         ? AuditService.UNKNOWN
-                        : accessTokenStore.getSubjectID(),
+                        : userInfo.getSubject().getValue(),
                 Objects.isNull(userInfo.getEmailAddress())
                         ? AuditService.UNKNOWN
                         : userInfo.getEmailAddress(),

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
@@ -89,7 +89,7 @@ class UserInfoHandlerTest {
                         any(),
                         any(),
                         any(),
-                        eq("testSubjectId"),
+                        eq(TEST_SUBJECT.getValue()),
                         eq("test@test.com"),
                         any(),
                         eq("0123456789"),

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -13,7 +13,8 @@ module "auth_token_role" {
     aws_iam_policy.dynamo_access_token_store_read_access_policy.arn,
     aws_iam_policy.dynamo_access_token_store_write_access_policy.arn,
     aws_iam_policy.auth_code_dynamo_encryption_key_kms_policy.arn,
-    aws_iam_policy.access_token_store_signing_key_kms_policy.arn
+    aws_iam_policy.access_token_store_signing_key_kms_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn
   ]
 }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
@@ -51,6 +51,8 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
     private static final Subject TEST_SUBJECT = new Subject();
     private static final List<String> TEST_CLAIMS = List.of("test-claim-1");
     private static final String TEST_SECTOR_IDENTIFIER = "sectorIdentifier";
+    private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String TEST_PASSWORD = "password-1";
 
     @RegisterExtension
     protected static final AuthCodeExtension authCodeStoreExtension = new AuthCodeExtension(180);
@@ -72,6 +74,8 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                         docAppPrivateKeyJwtSigner);
 
         handler = new TokenHandler(configurationService);
+
+        userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, TEST_SUBJECT);
 
         authCodeStoreExtension.saveAuthCode(
                 TEST_SUBJECT.getValue(),


### PR DESCRIPTION
## What?

Updated the submitAuditEvent method calls used in the UserInfoHandler and TokenHandler to use the internal pairwise ID as a parameter instead of incorrectly passed subjectID. Also updated corresponding unit tests and integration test so that they match the audit event accepting the pairwise id and not the subject id.

## Why?

The submitAuditEvent was previously incorrectly accepting the subject id for the internal pairwise ID argument.
