### PR TITLE
ATO-151: Add permissions for the protected subnet to Redis

### DIFF
--- a/ci/terraform/account-management/core.tf
+++ b/ci/terraform/account-management/core.tf
@@ -21,6 +21,8 @@ locals {
   allow_egress_security_group_id             = data.terraform_remote_state.core.outputs.allow_egress_security_group_id
   private_subnet_ids                         = data.terraform_remote_state.core.outputs.private_subnet_ids
   private_subnet_cidr_blocks                 = data.terraform_remote_state.core.outputs.private_subnet_cidr_blocks
+  protected_subnet_ids                       = data.terraform_remote_state.core.outputs.protected_subnet_ids
+  protected_subnet_cidr_blocks               = data.terraform_remote_state.core.outputs.protected_subnet_cidr_blocks
   public_subnet_ids                          = data.terraform_remote_state.core.outputs.public_subnet_ids
   public_subnet_cidr_blocks                  = data.terraform_remote_state.core.outputs.private_subnet_cidr_blocks
 }

--- a/ci/terraform/account-management/core.tf
+++ b/ci/terraform/account-management/core.tf
@@ -21,8 +21,6 @@ locals {
   allow_egress_security_group_id             = data.terraform_remote_state.core.outputs.allow_egress_security_group_id
   private_subnet_ids                         = data.terraform_remote_state.core.outputs.private_subnet_ids
   private_subnet_cidr_blocks                 = data.terraform_remote_state.core.outputs.private_subnet_cidr_blocks
-  protected_subnet_ids                       = data.terraform_remote_state.core.outputs.protected_subnet_ids
-  protected_subnet_cidr_blocks               = data.terraform_remote_state.core.outputs.protected_subnet_cidr_blocks
   public_subnet_ids                          = data.terraform_remote_state.core.outputs.public_subnet_ids
   public_subnet_cidr_blocks                  = data.terraform_remote_state.core.outputs.private_subnet_cidr_blocks
 }

--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -4,7 +4,7 @@ locals {
 
 resource "aws_elasticache_subnet_group" "account_management_redis_session_store" {
   name       = "${var.environment}-acct-mgmt-redis-session-store-cache-subnet"
-  subnet_ids = [local.private_subnet_ids, local.protected_subnet_ids]
+  subnet_ids = local.private_subnet_ids
 
   tags = local.default_tags
 }

--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -4,7 +4,7 @@ locals {
 
 resource "aws_elasticache_subnet_group" "account_management_redis_session_store" {
   name       = "${var.environment}-acct-mgmt-redis-session-store-cache-subnet"
-  subnet_ids = local.private_subnet_ids
+  subnet_ids = [local.private_subnet_ids, local.protected_subnet_ids]
 
   tags = local.default_tags
 }

--- a/ci/terraform/account-management/security-groups.tf
+++ b/ci/terraform/account-management/security-groups.tf
@@ -19,17 +19,6 @@ resource "aws_security_group_rule" "allow_incoming_am_redis_from_private_subnet"
   type        = "ingress"
 }
 
-resource "aws_security_group_rule" "allow_incoming_am_redis_from_protected_subnet" {
-  description       = "Allow ingress to AM session Redis from protected subnet"
-  security_group_id = aws_security_group.am_redis_security_group.id
-
-  from_port   = local.redis_port_number
-  protocol    = "tcp"
-  cidr_blocks = local.protected_subnet_cidr_blocks
-  to_port     = local.redis_port_number
-  type        = "ingress"
-}
-
 resource "aws_security_group" "allow_access_to_am_redis" {
   name_prefix = "${var.environment}-allow-access-to-acct-mgmt-redis-"
   description = "Allow outgoing access to the Account Management API Redis session store"

--- a/ci/terraform/account-management/security-groups.tf
+++ b/ci/terraform/account-management/security-groups.tf
@@ -9,6 +9,7 @@ resource "aws_security_group" "am_redis_security_group" {
 }
 
 resource "aws_security_group_rule" "allow_incoming_am_redis_from_private_subnet" {
+  description       = "Allow ingress to AM session Redis from private subnet"
   security_group_id = aws_security_group.am_redis_security_group.id
 
   from_port   = local.redis_port_number
@@ -19,6 +20,7 @@ resource "aws_security_group_rule" "allow_incoming_am_redis_from_private_subnet"
 }
 
 resource "aws_security_group_rule" "allow_incoming_am_redis_from_protected_subnet" {
+  description       = "Allow ingress to AM session Redis from protected subnet"
   security_group_id = aws_security_group.am_redis_security_group.id
 
   from_port   = local.redis_port_number

--- a/ci/terraform/account-management/security-groups.tf
+++ b/ci/terraform/account-management/security-groups.tf
@@ -18,6 +18,16 @@ resource "aws_security_group_rule" "allow_incoming_am_redis_from_private_subnet"
   type        = "ingress"
 }
 
+resource "aws_security_group_rule" "allow_incoming_am_redis_from_protected_subnet" {
+  security_group_id = aws_security_group.am_redis_security_group.id
+
+  from_port   = local.redis_port_number
+  protocol    = "tcp"
+  cidr_blocks = local.protected_subnet_cidr_blocks
+  to_port     = local.redis_port_number
+  type        = "ingress"
+}
+
 resource "aws_security_group" "allow_access_to_am_redis" {
   name_prefix = "${var.environment}-allow-access-to-acct-mgmt-redis-"
   description = "Allow outgoing access to the Account Management API Redis session store"

--- a/ci/terraform/auth-external-api/shared.tf
+++ b/ci/terraform/auth-external-api/shared.tf
@@ -19,7 +19,7 @@ data "terraform_remote_state" "shared" {
 locals {
   authentication_vpc_arn                    = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
   authentication_security_group_id          = data.terraform_remote_state.shared.outputs.authentication_security_group_id
-  authentication_subnet_ids                 = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
+  authentication_private_subnet_ids         = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
   audit_signing_key_arn                     = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
   events_topic_encryption_key_arn           = data.terraform_remote_state.shared.outputs.events_topic_encryption_key_arn
   lambda_code_signing_configuration_arn     = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn

--- a/ci/terraform/auth-external-api/shared.tf
+++ b/ci/terraform/auth-external-api/shared.tf
@@ -1,4 +1,3 @@
-
 data "terraform_remote_state" "shared" {
   backend = "s3"
   config = {

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -57,7 +57,7 @@ module "auth_token" {
   security_group_ids = [
     local.authentication_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.auth_token_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -53,7 +53,7 @@ module "auth_userinfo" {
   security_group_ids = [
     local.authentication_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.auth_userinfo_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/interventions-api-stub/lambda.tf
+++ b/ci/terraform/interventions-api-stub/lambda.tf
@@ -33,7 +33,7 @@ module "account_interventions_stub_lambda" {
   security_group_ids = [
     local.authentication_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.account_interventions_stub_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/interventions-api-stub/shared.tf
+++ b/ci/terraform/interventions-api-stub/shared.tf
@@ -18,7 +18,6 @@ locals {
   authentication_vpc_arn                 = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
   lambda_code_signing_configuration_arn  = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
   authentication_security_group_id       = data.terraform_remote_state.shared.outputs.authentication_security_group_id
-  authentication_subnet_ids              = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
+  authentication_private_subnet_ids      = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
 }
-

--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -53,7 +53,7 @@ module "account_interventions" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_orch_auth_code_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -58,7 +58,7 @@ module "account_recovery" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_account_recovery_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -53,7 +53,7 @@ module "auth-code" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_auth_code_role.arn
   environment                            = var.environment
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -58,7 +58,7 @@ module "orch_auth_code" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_orch_auth_code_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -67,7 +67,7 @@ module "authentication_callback" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_api_authentication_callback_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -79,7 +79,7 @@ module "authorize" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_protected_subnet_ids
   lambda_role_arn                        = module.oidc_authorize_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -79,7 +79,7 @@ module "authorize" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_protected_subnet_ids
+  subnet_id                              = var.authorize_protected_subnet_enabled ? local.authentication_protected_subnet_ids : local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_authorize_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -62,7 +62,7 @@ module "doc-app-authorize" {
     local.authentication_oidc_redis_security_group_id,
     local.authentication_egress_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.doc_app_authorize_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -66,7 +66,7 @@ module "doc-app-callback" {
     local.authentication_oidc_redis_security_group_id,
     local.authentication_egress_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.doc_app_callback_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -51,7 +51,7 @@ module "identity_progress" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.identity_progress_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -64,7 +64,7 @@ module "ipv-authorize" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_protected_subnet_ids
   lambda_role_arn                        = module.ipv_authorize_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -64,7 +64,7 @@ module "ipv-authorize" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_protected_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.ipv_authorize_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -71,7 +71,7 @@ module "ipv-callback" {
     local.authentication_egress_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.ipv_callback_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -52,7 +52,7 @@ module "ipv-capacity" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.ipv_capacity_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -45,7 +45,7 @@ module "jwks" {
 
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_ids                     = [local.authentication_security_group_id]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_jwks_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -61,7 +61,7 @@ module "login" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_login_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -59,7 +59,7 @@ module "logout" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_logout_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -59,7 +59,7 @@ module "mfa" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_mfa_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -58,7 +58,7 @@ module "processing-identity" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.ipv_processing_identity_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -47,7 +47,7 @@ module "register" {
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   security_group_ids                     = [local.authentication_security_group_id]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.client_registry_role.arn
   environment                            = var.environment
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -58,7 +58,7 @@ module "reset-password-request" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_reset_password_request_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -65,7 +65,7 @@ module "reset_password" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_reset_password_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -50,3 +50,5 @@ support_auth_orch_split = true
 orch_frontend_api_gateway_integration_enabled = true
 
 orch_redirect_uri = "https://oidc.sandpit.account.gov.uk/orchestration-redirect"
+
+authorize_protected_subnet_enabled = true

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -58,7 +58,7 @@ module "send_notification" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_send_notification_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -38,7 +38,8 @@ locals {
   authentication_security_group_id                    = data.terraform_remote_state.shared.outputs.authentication_security_group_id
   authentication_egress_security_group_id             = data.terraform_remote_state.shared.outputs.authentication_egress_security_group_id
   authentication_oidc_redis_security_group_id         = data.terraform_remote_state.shared.outputs.authentication_oidc_redis_security_group_id
-  authentication_subnet_ids                           = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
+  authentication_private_subnet_ids                   = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
+  authentication_protected_subnet_ids                 = data.terraform_remote_state.shared.outputs.authentication_protected_subnet_ids
   id_token_signing_key_alias_name                     = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_name
   id_token_signing_key_arn                            = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
   ipv_token_auth_key_alias_name                       = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_alias_name

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -58,7 +58,7 @@ module "signup" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_signup_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -88,7 +88,7 @@ resource "aws_lambda_function" "spot_response_lambda" {
 
   vpc_config {
     security_group_ids = [local.authentication_egress_security_group_id]
-    subnet_ids         = local.authentication_subnet_ids
+    subnet_ids         = local.authentication_private_subnet_ids
   }
   environment {
     variables = merge({

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -50,8 +50,11 @@ data "aws_iam_policy_document" "email_queue_policy_document" {
     effect = "Allow"
 
     principals {
-      type        = "AWS"
-      identifiers = [module.frontend_api_send_notification_role.arn, module.frontend_api_mfa_role.arn, module.frontend_api_reset_password_request_role.arn, module.frontend_api_reset_password_role.arn]
+      type = "AWS"
+      identifiers = [
+        module.frontend_api_send_notification_role.arn, module.frontend_api_mfa_role.arn,
+        module.frontend_api_reset_password_request_role.arn, module.frontend_api_reset_password_role.arn
+      ]
     }
 
     actions = [

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -165,7 +165,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
 
   vpc_config {
     security_group_ids = [local.authentication_egress_security_group_id]
-    subnet_ids         = local.authentication_subnet_ids
+    subnet_ids         = local.authentication_private_subnet_ids
   }
   environment {
     variables = merge(var.notify_template_map, {

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -58,7 +58,7 @@ module "start" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_start_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -83,7 +83,7 @@ module "token" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_token_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -39,7 +39,7 @@ module "trustmarks" {
 
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_ids                     = [local.authentication_security_group_id]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_trustmarks_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -51,7 +51,7 @@ module "update" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.client_update_role.arn
   environment                            = var.environment
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -57,7 +57,7 @@ module "update_profile" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_update_profile_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -56,7 +56,7 @@ module "userexists" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_user_exists_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -63,7 +63,7 @@ module "userinfo" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_userinfo_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -140,7 +140,6 @@ variable "localstack_endpoint" {
   default = "http://localhost:45678/"
 }
 
-
 variable "redis_use_tls" {
   type    = string
   default = "true"
@@ -488,6 +487,12 @@ variable "account_intervention_service_uri" {
 variable "orch_redirect_uri" {
   type        = string
   description = "The redirect URI set by Orchestration in the OAuth2 authorize request to Authentication"
+}
+
+variable "authorize_protected_subnet_enabled" {
+  description = "Flag to move authorize lambda to protected subnet"
+  type        = bool
+  default     = false
 }
 
 locals {

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -62,7 +62,7 @@ module "verify_code" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_verify_code_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -62,7 +62,7 @@ module "verify_mfa_code" {
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_verify_mfa_code_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -38,7 +38,7 @@ module "openid_configuration_discovery" {
 
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_ids                     = [local.authentication_security_group_id]
-  subnet_id                              = local.authentication_subnet_ids
+  subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.openid_configuration_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/shared/core.tf
+++ b/ci/terraform/shared/core.tf
@@ -21,4 +21,6 @@ locals {
   allow_egress_security_group_id             = data.terraform_remote_state.core.outputs.allow_egress_security_group_id
   private_subnet_ids                         = data.terraform_remote_state.core.outputs.private_subnet_ids
   private_subnet_cidr_blocks                 = data.terraform_remote_state.core.outputs.private_subnet_cidr_blocks
+  protected_subnet_ids                       = data.terraform_remote_state.core.outputs.protected_subnet_ids
+  protected_subnet_cidr_blocks               = data.terraform_remote_state.core.outputs.protected_subnet_cidr_blocks
 }

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -1,4 +1,3 @@
-
 output "redis_host" {
   value = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
 }
@@ -129,12 +128,14 @@ output "events_topic_encryption_key_arn" {
 }
 
 output "stub_rp_client_credentials" {
-  value = [for i, rp in var.stub_rp_clients : {
-    client_name = rp.client_name
-    client_id   = random_string.stub_rp_client_id[i].result
-    private_key = tls_private_key.stub_rp_client_private_key[i].private_key_pem
-    public_key  = tls_private_key.stub_rp_client_private_key[i].public_key_pem
-  }]
+  value = [
+    for i, rp in var.stub_rp_clients : {
+      client_name = rp.client_name
+      client_id   = random_string.stub_rp_client_id[i].result
+      private_key = tls_private_key.stub_rp_client_private_key[i].private_key_pem
+      public_key  = tls_private_key.stub_rp_client_private_key[i].public_key_pem
+    }
+  ]
   sensitive = true
 }
 

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -28,8 +28,12 @@ output "authentication_oidc_redis_security_group_id" {
   value = aws_security_group.allow_access_to_oidc_redis.id
 }
 
-output "authentication_subnet_ids" {
+output "authentication_private_subnet_ids" {
   value = local.private_subnet_ids
+}
+
+output "authentication_protected_subnet_ids" {
+  value = local.protected_subnet_ids
 }
 
 output "lambda_iam_role_arn" {

--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -6,7 +6,7 @@ resource "aws_elasticache_subnet_group" "sessions_store" {
   count = var.use_localstack ? 0 : 1
 
   name       = "${var.environment}-session-store-cache-subnet"
-  subnet_ids = local.private_subnet_ids
+  subnet_ids = [local.private_subnet_ids, local.protected_subnet_ids]
 }
 
 resource "random_password" "redis_password" {

--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -6,7 +6,7 @@ resource "aws_elasticache_subnet_group" "sessions_store" {
   count = var.use_localstack ? 0 : 1
 
   name       = "${var.environment}-session-store-cache-subnet"
-  subnet_ids = [local.private_subnet_ids, local.protected_subnet_ids]
+  subnet_ids = local.private_subnet_ids
 }
 
 resource "random_password" "redis_password" {

--- a/ci/terraform/shared/security-groups.tf
+++ b/ci/terraform/shared/security-groups.tf
@@ -9,7 +9,7 @@ resource "aws_security_group" "redis_security_group" {
 }
 
 resource "aws_security_group_rule" "allow_incoming_redis_from_private_subnet" {
-  description       = "Allow ingress to AM session Redis from private subnet"
+  description       = "Allow ingress to Redis from private subnet"
   security_group_id = aws_security_group.redis_security_group.id
 
   from_port   = local.redis_port_number
@@ -20,7 +20,7 @@ resource "aws_security_group_rule" "allow_incoming_redis_from_private_subnet" {
 }
 
 resource "aws_security_group_rule" "allow_incoming_redis_from_protected_subnet" {
-  description       = "Allow ingress to AM session Redis from protected subnet"
+  description       = "Allow ingress to Redis from protected subnet"
   security_group_id = aws_security_group.redis_security_group.id
 
   from_port   = local.redis_port_number

--- a/ci/terraform/shared/security-groups.tf
+++ b/ci/terraform/shared/security-groups.tf
@@ -28,6 +28,16 @@ resource "aws_security_group_rule" "allow_incoming_redis_from_private_subnet" {
   type        = "ingress"
 }
 
+resource "aws_security_group_rule" "allow_incoming_redis_from_protected_subnet" {
+  security_group_id = aws_security_group.redis_security_group.id
+
+  from_port   = local.redis_port_number
+  protocol    = "tcp"
+  cidr_blocks = local.protected_subnet_cidr_blocks
+  to_port     = local.redis_port_number
+  type        = "ingress"
+}
+
 resource "aws_security_group_rule" "allow_connection_to_oidc_redis" {
   security_group_id = aws_security_group.allow_access_to_oidc_redis.id
 

--- a/ci/terraform/shared/security-groups.tf
+++ b/ci/terraform/shared/security-groups.tf
@@ -8,17 +8,8 @@ resource "aws_security_group" "redis_security_group" {
   }
 }
 
-resource "aws_security_group" "allow_access_to_oidc_redis" {
-  name_prefix = "${var.environment}-allow-access-to-oidc-redis-"
-  description = "Allow outgoing access to the OIDC Redis session store"
-  vpc_id      = local.vpc_id
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_security_group_rule" "allow_incoming_redis_from_private_subnet" {
+  description       = "Allow ingress to AM session Redis from private subnet"
   security_group_id = aws_security_group.redis_security_group.id
 
   from_port   = local.redis_port_number
@@ -29,6 +20,7 @@ resource "aws_security_group_rule" "allow_incoming_redis_from_private_subnet" {
 }
 
 resource "aws_security_group_rule" "allow_incoming_redis_from_protected_subnet" {
+  description       = "Allow ingress to AM session Redis from protected subnet"
   security_group_id = aws_security_group.redis_security_group.id
 
   from_port   = local.redis_port_number
@@ -36,6 +28,16 @@ resource "aws_security_group_rule" "allow_incoming_redis_from_protected_subnet" 
   cidr_blocks = local.protected_subnet_cidr_blocks
   to_port     = local.redis_port_number
   type        = "ingress"
+}
+
+resource "aws_security_group" "allow_access_to_oidc_redis" {
+  name_prefix = "${var.environment}-allow-access-to-oidc-redis-"
+  description = "Allow outgoing access to the OIDC Redis session store"
+  vpc_id      = local.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "allow_connection_to_oidc_redis" {

--- a/ci/terraform/test-services/delete-synthetics-user.tf
+++ b/ci/terraform/test-services/delete-synthetics-user.tf
@@ -41,7 +41,7 @@ module "delete-synthetics-user" {
   security_group_ids = [
     local.authentication_security_group_id,
   ]
-  subnet_id = local.authentication_subnet_ids
+  subnet_id = local.authentication_private_subnet_ids
 
   lambda_role_arn                        = module.test_services_api_delete-synthetics-user_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/test-services/shared.tf
+++ b/ci/terraform/test-services/shared.tf
@@ -18,6 +18,6 @@ locals {
   redis_key                             = "session"
   lambda_code_signing_configuration_arn = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
   authentication_vpc_arn                = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
-  authentication_subnet_ids             = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
+  authentication_private_subnet_ids     = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
   authentication_security_group_id      = data.terraform_remote_state.shared.outputs.authentication_security_group_id
 }

--- a/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
@@ -61,7 +61,7 @@ resource "aws_lambda_function" "bulk_user_email_audience_loader_lambda" {
 
   vpc_config {
     security_group_ids = [local.authentication_security_group_id]
-    subnet_ids         = local.authentication_subnet_ids
+    subnet_ids         = local.authentication_private_subnet_ids
   }
 
   environment {

--- a/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
@@ -1,4 +1,3 @@
-
 module "bulk_user_email_audience_loader_lambda_role" {
   count       = local.deploy_bulk_email_users_count
   source      = "../modules/lambda-role"

--- a/ci/terraform/utils/bulk_user_email_send_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_send_lambda.tf
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "bulk_user_email_send_lambda" {
 
   vpc_config {
     security_group_ids = [local.authentication_egress_security_group_id]
-    subnet_ids         = local.authentication_subnet_ids
+    subnet_ids         = local.authentication_private_subnet_ids
   }
 
   environment {

--- a/ci/terraform/utils/bulk_user_email_send_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_send_lambda.tf
@@ -1,4 +1,3 @@
-
 module "bulk_user_email_send_lambda_role" {
   count       = local.deploy_bulk_email_users_count
   source      = "../modules/lambda-role"

--- a/ci/terraform/utils/shared.tf
+++ b/ci/terraform/utils/shared.tf
@@ -15,7 +15,6 @@ locals {
   lambda_code_signing_configuration_arn    = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
   authentication_vpc_arn                   = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
   authentication_private_subnet_ids        = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
-  authentication_protected_subnet_ids      = data.terraform_remote_state.shared.outputs.authentication_protected_subnet_ids
   authentication_security_group_id         = data.terraform_remote_state.shared.outputs.authentication_security_group_id
   authentication_egress_security_group_id  = data.terraform_remote_state.shared.outputs.authentication_egress_security_group_id
   default_performance_parameters = {

--- a/ci/terraform/utils/shared.tf
+++ b/ci/terraform/utils/shared.tf
@@ -14,7 +14,8 @@ locals {
   lambda_env_vars_encryption_kms_key_arn   = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
   lambda_code_signing_configuration_arn    = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
   authentication_vpc_arn                   = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
-  authentication_subnet_ids                = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
+  authentication_private_subnet_ids        = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
+  authentication_protected_subnet_ids      = data.terraform_remote_state.shared.outputs.authentication_protected_subnet_ids
   authentication_security_group_id         = data.terraform_remote_state.shared.outputs.authentication_security_group_id
   authentication_egress_security_group_id  = data.terraform_remote_state.shared.outputs.authentication_egress_security_group_id
   default_performance_parameters = {


### PR DESCRIPTION
## What?

Add permissions for the protected subnet to Redis

## Why?

To allow the AuthorisationHandler to connect to Redis once moved into the protected subnet which was set up to filter traffic through the network firewall

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/560
