### PR TITLE
BAU: Upgrade localstack provider

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -104,14 +104,12 @@ jobs:
       - build
     services:
       localstack:
-        image: localstack/localstack:2.3.2
+        image: localstack/localstack:3.0.0
         env:
-          SERVICES: "lambda, apigateway, iam, ec2, sqs, s3, sts, kms, sns, ssm"
-          DEFAULT_REGION: eu-west-2
+          SERVICES: "lambda, apigateway, iam, ec2, sqs, s3, sts, kms, sns, ssm, events"
           GATEWAY_LISTEN: 0.0.0.0:45678
           LOCALSTACK_HOST: localhost:45678
           TEST_AWS_ACCOUNT_ID: 123456789012
-          KMS_PROVIDER: local-kms
         options: >-
           --add-host "notify.internal:host-gateway"
           --add-host "subscriber.internal:host-gateway"
@@ -177,9 +175,9 @@ jobs:
       - build
     services:
       localstack:
-        image: localstack/localstack:2.3.2
+        image: localstack/localstack:3.0.0
         env:
-          SERVICES: "lambda, apigateway, iam, ec2, sqs, s3, sts, kms, sns, ssm"
+          SERVICES: "lambda, apigateway, iam, ec2, sqs, s3, sts, kms, sns, ssm, events"
           DEFAULT_REGION: eu-west-2
           GATEWAY_LISTEN: 0.0.0.0:45678
           LOCALSTACK_HOST: localhost:45678

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,13 @@ version: '3.8'
 
 services:
   aws:
-    image: localstack/localstack:2.3.2@sha256:78c4d09852a90b158a95ac5108439a1f43e09f862739045be91cc5f431076f86
+    image: localstack/localstack:3.0.0@sha256:7a94d763dfc27d9b2a7e1c9441c279df9008c6c73427a2f98184f43274de2f53
     environment:
-      SERVICES: iam, ec2, sqs, s3, sts, kms, sns, ssm, cloudwatch
+      SERVICES: iam, ec2, sqs, s3, sts, kms, sns, ssm, cloudwatch, events
       GATEWAY_LISTEN: 0.0.0.0:45678
       LOCALSTACK_HOST: localhost:45678
-      DEFAULT_REGION: eu-west-2
       TEST_AWS_ACCOUNT_ID: 123456789012
       DEBUG: "1"
-      KMS_PROVIDER: local-kms
     extra_hosts:
       - "notify.internal:host-gateway"
       - "subscriber.internal:host-gateway"


### PR DESCRIPTION
Version 3 supports latest AWS SDKs. This will unblock #3598 
Remove unused config params.

