### PR TITLE
BAU: Remove unused dependencies on glassfish

### DIFF
--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     testImplementation configurations.bouncycastle,
             configurations.apache,
             configurations.nimbus,
-            configurations.glassfish,
             configurations.gson,
             configurations.tests,
             configurations.sqs,

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ ext {
         nimbusds_oauth_version: "10.13.2",
         nimbusds_jwt_version: "9.29",
         junit: "5.10.1",
-        glassfish_version: "3.0.8",
         xray: "2.14.0"
     ]
 
@@ -68,7 +67,6 @@ subprojects {
         bouncycastle
         cloudwatch
         dynamodb
-        glassfish
         govuk_notify
         gson
         hamcrest
@@ -108,11 +106,6 @@ subprojects {
                 "software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_v2_version}"
 
         lambda "software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_v2_version}"
-
-        glassfish "org.glassfish.jersey.core:jersey-client:${dependencyVersions.glassfish_version}",
-                "org.glassfish.jersey.inject:jersey-hk2:${dependencyVersions.glassfish_version}",
-                "org.glassfish.jersey.media:jersey-media-json-jackson:${dependencyVersions.glassfish_version}",
-                "jakarta.activation:jakarta.activation-api:2.1.1"
 
         govuk_notify "uk.gov.service.notify:notifications-java-client:3.19.1-RELEASE"
 

--- a/delivery-receipts-integration-tests/build.gradle
+++ b/delivery-receipts-integration-tests/build.gradle
@@ -8,7 +8,6 @@ version "unspecified"
 
 dependencies {
     testImplementation configurations.nimbus,
-            configurations.glassfish,
             configurations.tests,
             configurations.lambda,
             configurations.lettuce

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -8,7 +8,6 @@ version "unspecified"
 
 dependencies {
     testImplementation configurations.tests,
-            configurations.glassfish,
             configurations.apache,
             configurations.gson,
             configurations.nimbus,

--- a/orchestration-shared-test/build.gradle
+++ b/orchestration-shared-test/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     implementation configurations.tests,
             configurations.lambda,
             configurations.apache,
-            configurations.glassfish,
             configurations.nimbus,
             configurations.lettuce,
             configurations.dynamodb,

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/httpstub/HttpStubExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/httpstub/HttpStubExtension.java
@@ -1,12 +1,13 @@
 package uk.gov.di.orchestration.sharedtest.httpstub;
 
-import jakarta.ws.rs.core.UriBuilder;
+import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -94,7 +95,11 @@ public class HttpStubExtension implements AfterAllCallback {
     }
 
     public URI uri(String path) {
-        return baseUri().path(path).build();
+        try {
+            return baseUri().setPath(path).build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public List<RecordedRequest> getRecordedRequests() {
@@ -115,8 +120,8 @@ public class HttpStubExtension implements AfterAllCallback {
                 .collect(Collectors.toList());
     }
 
-    private UriBuilder baseUri() {
-        return UriBuilder.fromUri("http://localhost").port(getHttpPort());
+    private URIBuilder baseUri() {
+        return new URIBuilder().setHost("localhost").setScheme("http").setPort(getHttpPort());
     }
 
     @Override

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     implementation configurations.tests,
             configurations.lambda,
             configurations.apache,
-            configurations.glassfish,
             configurations.nimbus,
             configurations.lettuce,
             configurations.dynamodb,

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/HttpStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/HttpStubExtension.java
@@ -1,12 +1,13 @@
 package uk.gov.di.authentication.sharedtest.httpstub;
 
-import jakarta.ws.rs.core.UriBuilder;
+import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -94,7 +95,11 @@ public class HttpStubExtension implements AfterAllCallback {
     }
 
     public URI uri(String path) {
-        return baseUri().path(path).build();
+        try {
+            return baseUri().setPath(path).build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public List<RecordedRequest> getRecordedRequests() {
@@ -115,8 +120,8 @@ public class HttpStubExtension implements AfterAllCallback {
                 .collect(Collectors.toList());
     }
 
-    private UriBuilder baseUri() {
-        return UriBuilder.fromUri("http://localhost").port(getHttpPort());
+    private URIBuilder baseUri() {
+        return new URIBuilder().setHost("localhost").setScheme("http").setPort(getHttpPort());
     }
 
     @Override


### PR DESCRIPTION
## What?
Remove the glassfish depedencies

## Why?

It seems that this dependency was only used to build out some URLs in tests, but was widely referenced. Fewer dependencies is almost always better
