### PR TITLE
ATO-203: Read 'claims' claim from JAR

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
@@ -9,6 +9,7 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.serialization.Json;
@@ -43,6 +44,7 @@ public class RequestObjectToAuthRequestHelper {
                                     URI.create((String) jwtClaimsSet.getClaim("redirect_uri")))
                             .state(new State(jwtClaimsSet.getClaim("state").toString()))
                             .nonce(new Nonce(jwtClaimsSet.getClaim("nonce").toString()))
+                            .claims(parseOidcClaims(jwtClaimsSet.getClaim("claims").toString()))
                             .requestObject(authRequest.getRequestObject());
 
             if (Objects.nonNull(jwtClaimsSet.getClaim("vtr"))) {
@@ -82,6 +84,18 @@ public class RequestObjectToAuthRequestHelper {
         } else {
             LOG.warn("Cannot parse Vectors of Trust");
             throw new RuntimeException("Cannot parse Vectors of Trust");
+        }
+    }
+
+    private static OIDCClaimsRequest parseOidcClaims(String claims) {
+        if (claims == null || claims.isEmpty()) {
+            throw new IllegalArgumentException("Claims must not be null or empty");
+        }
+        try {
+            return OIDCClaimsRequest.parse(claims);
+        } catch (com.nimbusds.oauth2.sdk.ParseException e) {
+            LOG.warn("Failed to parse OIDC claims: " + e.getMessage(), e);
+            throw new RuntimeException("Failed to parse OIDC claims", e);
         }
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -156,6 +156,8 @@ class AuthorisationHandlerTest {
     private static final String REDIRECT_URI = "https://localhost:8080";
     private static final String DOC_APP_REDIRECT_URI = "/doc-app-authorisation";
     private static final String SCOPE = "email openid profile";
+    private static final String CLAIMS =
+            "{\"userinfo\":{\"https://vocab.account.gov.uk/v1/coreIdentityJWT\":{\"essential\":true},\"https://vocab.account.gov.uk/v1/address\":null}}";
     private static final String RESPONSE_TYPE = "code";
     private static final String TEST_ORCHESTRATOR_CLIENT_ID = "test-orch-client-id";
     private static final String RP_CLIENT_NAME = "test-rp-client-name";
@@ -1187,6 +1189,7 @@ class AuthorisationHandlerTest {
                         .claim("state", STATE)
                         .claim("nonce", NONCE.getValue())
                         .claim("scope", "openid doc-checking-app")
+                        .claim("claims", CLAIMS)
                         .issuer(CLIENT_ID.getValue())
                         .build();
 
@@ -1342,6 +1345,7 @@ class AuthorisationHandlerTest {
                 .claim("state", STATE.getValue())
                 .claim("nonce", NONCE.getValue())
                 .claim("client_id", CLIENT_ID.getValue())
+                .claim("claims", CLAIMS)
                 .issuer(CLIENT_ID.getValue())
                 .build();
     }


### PR DESCRIPTION
## What?

Include the `claims` claim when transforming a request object to an authentication request.

## Why?

When a request object is present in a request to `/authorize`, it is transformed in order to generate a properly formed authentication request. The `claims` claim wasn't being handled in the `transform` method and so was missing from the authentication request.
