### PR TITLE
BAU: Make redis connection service a singleton

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -90,7 +90,7 @@ public class SendOtpNotificationHandler
                         configurationService.getSqsEndpointUri());
         this.codeGeneratorService = new CodeGeneratorService();
         this.codeStorageService =
-                new CodeStorageService(new RedisConnectionService(configurationService));
+                new CodeStorageService(RedisConnectionService.getInstance(configurationService));
         this.dynamoService = new DynamoService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.clientService = new DynamoClientService(configurationService);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -78,7 +78,7 @@ public class UpdateEmailHandler
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
         this.codeStorageService =
-                new CodeStorageService(new RedisConnectionService(configurationService));
+                new CodeStorageService(RedisConnectionService.getInstance(configurationService));
         this.auditService = new AuditService(configurationService);
         this.configurationService = configurationService;
     }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -76,7 +76,7 @@ public class UpdatePhoneNumberHandler
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
         this.codeStorageService =
-                new CodeStorageService(new RedisConnectionService(configurationService));
+                new CodeStorageService(RedisConnectionService.getInstance(configurationService));
         this.auditService = new AuditService(configurationService);
         this.configurationService = configurationService;
     }

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -73,7 +73,7 @@ public class DocAppAuthorizeHandler
         this.authorisationService =
                 new DocAppAuthorisationService(
                         configurationService,
-                        new RedisConnectionService(configurationService),
+                        RedisConnectionService.getInstance(configurationService),
                         kmsConnectionService,
                         new JwksService(configurationService, kmsConnectionService));
         this.auditService = new AuditService(configurationService);
@@ -81,7 +81,7 @@ public class DocAppAuthorizeHandler
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(
-                        new RedisConnectionService(configurationService),
+                        RedisConnectionService.getInstance(configurationService),
                         clientSessionService,
                         configurationService);
     }

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -111,7 +111,7 @@ public class DocAppCallbackHandler
         this.authorisationService =
                 new DocAppAuthorisationService(
                         configurationService,
-                        new RedisConnectionService(configurationService),
+                        RedisConnectionService.getInstance(configurationService),
                         kmsConnectionService,
                         new JwksService(configurationService, kmsConnectionService));
         this.tokenService = new DocAppCriService(configurationService, kmsConnectionService);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -96,7 +96,7 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
         this.authorisationService =
                 new IPVAuthorisationService(
                         configurationService,
-                        new RedisConnectionService(configurationService),
+                        RedisConnectionService.getInstance(configurationService),
                         new KmsConnectionService(configurationService));
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -117,7 +117,7 @@ public class IPVCallbackHandler
         this.ipvAuthorisationService =
                 new IPVAuthorisationService(
                         configurationService,
-                        new RedisConnectionService(configurationService),
+                        RedisConnectionService.getInstance(configurationService),
                         kmsConnectionService);
         this.ipvTokenService = new IPVTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -101,7 +101,7 @@ public class AuthenticationCallbackHandler
     public AuthenticationCallbackHandler(ConfigurationService configurationService) {
 
         var kmsConnectionService = new KmsConnectionService(configurationService);
-        var redisConnectionService = new RedisConnectionService(configurationService);
+        var redisConnectionService = RedisConnectionService.getInstance(configurationService);
         this.configurationService = configurationService;
         this.authorisationService = new AuthenticationAuthorizationService(redisConnectionService);
         this.tokenService =

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -146,7 +146,7 @@ public class AuthorisationHandler
         this.docAppAuthorisationService =
                 new DocAppAuthorisationService(
                         configurationService,
-                        new RedisConnectionService(configurationService),
+                        RedisConnectionService.getInstance(configurationService),
                         kmsConnectionService,
                         new JwksService(configurationService, kmsConnectionService));
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -97,7 +97,7 @@ public class TokenHandler
         var kms = new KmsConnectionService(configurationService);
 
         this.configurationService = configurationService;
-        this.redisConnectionService = new RedisConnectionService(configurationService);
+        this.redisConnectionService = RedisConnectionService.getInstance(configurationService);
         this.tokenService =
                 new TokenService(configurationService, this.redisConnectionService, kms);
         this.dynamoService = new DynamoService(configurationService);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -72,7 +72,7 @@ public class UserInfoHandler
                         new AuthenticationUserInfoStorageService(configurationService));
         this.accessTokenService =
                 new AccessTokenService(
-                        new RedisConnectionService(configurationService),
+                        RedisConnectionService.getInstance(configurationService),
                         new DynamoClientService(configurationService),
                         new TokenValidationService(
                                 new JwksService(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
@@ -78,7 +78,7 @@ public class OrchestrationAuthorizationService {
                 new DynamoClientService(configurationService),
                 new IPVCapacityService(configurationService),
                 new KmsConnectionService(configurationService),
-                new RedisConnectionService(configurationService));
+                RedisConnectionService.getInstance(configurationService));
     }
 
     public boolean isClientRedirectUriValid(ClientID clientID, URI redirectURI)

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -331,13 +331,12 @@ public class RedisExtension
 
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
-        redis.close();
         client.shutdown();
     }
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        redis = new RedisConnectionService(configurationService);
+        redis = RedisConnectionService.getInstance(configurationService);
         RedisURI.Builder builder =
                 RedisURI.builder()
                         .withHost(configurationService.getRedisHost())

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
@@ -29,12 +29,7 @@ public class AuthorisationCodeService {
     }
 
     public AuthorisationCodeService(ConfigurationService configurationService) {
-        this.redisConnectionService =
-                new RedisConnectionService(
-                        configurationService.getRedisHost(),
-                        configurationService.getRedisPort(),
-                        configurationService.getUseRedisTLS(),
-                        configurationService.getRedisPassword());
+        this.redisConnectionService = RedisConnectionService.getInstance(configurationService);
         this.authorisationCodeExpiry = configurationService.getAuthCodeExpiry();
         this.objectMapper = SerializationService.getInstance();
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSessionService.java
@@ -31,12 +31,7 @@ public class ClientSessionService {
 
     public ClientSessionService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
-        this.redisConnectionService =
-                new RedisConnectionService(
-                        configurationService.getRedisHost(),
-                        configurationService.getRedisPort(),
-                        configurationService.getUseRedisTLS(),
-                        configurationService.getRedisPassword());
+        this.redisConnectionService = RedisConnectionService.getInstance(configurationService);
         objectMapper = SerializationService.getInstance();
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CodeStorageService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CodeStorageService.java
@@ -34,7 +34,7 @@ public class CodeStorageService {
     private static final long MFA_ATTEMPTS_COUNTER_TIME_TO_LIVE_SECONDS = 900;
 
     public CodeStorageService(ConfigurationService configurationService) {
-        this(new RedisConnectionService(configurationService));
+        this(RedisConnectionService.getInstance(configurationService));
     }
 
     public CodeStorageService(RedisConnectionService redisConnectionService) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationService.java
@@ -36,7 +36,7 @@ public class NoSessionOrchestrationService {
 
     public NoSessionOrchestrationService(ConfigurationService configurationService) {
         this(
-                new RedisConnectionService(configurationService),
+                RedisConnectionService.getInstance(configurationService),
                 new ClientSessionService(configurationService),
                 configurationService);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/RedisConnectionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/RedisConnectionService.java
@@ -14,34 +14,36 @@ import java.util.Optional;
 import static io.lettuce.core.support.ConnectionPoolSupport.createGenericObjectPool;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
-public class RedisConnectionService implements AutoCloseable {
+public class RedisConnectionService {
 
     public static final String REDIS_CONNECTION_ERROR = "Error getting Redis connection";
-    private final RedisClient client;
+    private static RedisConnectionService instance;
 
     private final GenericObjectPool<StatefulRedisConnection<String, String>> pool;
 
-    public RedisConnectionService(
-            String host, int port, boolean useSsl, Optional<String> password, boolean warmup) {
+    private RedisConnectionService(
+            String host, int port, boolean useSsl, Optional<String> password) {
         RedisURI.Builder builder = RedisURI.builder().withHost(host).withPort(port).withSsl(useSsl);
         password.ifPresent(s -> builder.withPassword(s.toCharArray()));
         RedisURI redisURI = builder.build();
-        this.client = RedisClient.create(redisURI);
+        RedisClient client = RedisClient.create(redisURI);
         this.pool = createGenericObjectPool(client::connect, new GenericObjectPoolConfig<>());
-        if (warmup) warmUp();
+        warmUp();
     }
 
-    public RedisConnectionService(
-            String host, int port, boolean useSsl, Optional<String> password) {
-        this(host, port, useSsl, password, true);
-    }
-
-    public RedisConnectionService(ConfigurationService configurationService) {
+    private RedisConnectionService(ConfigurationService configurationService) {
         this(
                 configurationService.getRedisHost(),
                 configurationService.getRedisPort(),
                 configurationService.getUseRedisTLS(),
                 configurationService.getRedisPassword());
+    }
+
+    public static RedisConnectionService getInstance(ConfigurationService configurationService) {
+        if (instance == null) {
+            instance = new RedisConnectionService(configurationService);
+        }
+        return instance;
     }
 
     @FunctionalInterface
@@ -96,12 +98,6 @@ public class RedisConnectionService implements AutoCloseable {
     private void warmUp() {
         segmentedFunctionCall(
                 "Redis: warmUp", () -> executeCommand(RedisServerCommands::clientGetname));
-    }
-
-    @Override
-    public void close() {
-        pool.close();
-        client.shutdown();
     }
 
     public static class RedisConnectionException extends RuntimeException {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -35,13 +35,7 @@ public class SessionService {
     }
 
     public SessionService(ConfigurationService configurationService) {
-        this(
-                configurationService,
-                new RedisConnectionService(
-                        configurationService.getRedisHost(),
-                        configurationService.getRedisPort(),
-                        configurationService.getUseRedisTLS(),
-                        configurationService.getRedisPassword()));
+        this(configurationService, RedisConnectionService.getInstance(configurationService));
     }
 
     public Session createSession() {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -335,13 +335,12 @@ public class RedisExtension
 
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
-        redis.close();
         client.shutdown();
     }
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        redis = new RedisConnectionService(configurationService);
+        redis = RedisConnectionService.getInstance(configurationService);
         RedisURI.Builder builder =
                 RedisURI.builder()
                         .withHost(configurationService.getRedisHost())

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
@@ -29,12 +29,7 @@ public class AuthorisationCodeService {
     }
 
     public AuthorisationCodeService(ConfigurationService configurationService) {
-        this.redisConnectionService =
-                new RedisConnectionService(
-                        configurationService.getRedisHost(),
-                        configurationService.getRedisPort(),
-                        configurationService.getUseRedisTLS(),
-                        configurationService.getRedisPassword());
+        this.redisConnectionService = RedisConnectionService.getInstance(configurationService);
         this.authorisationCodeExpiry = configurationService.getAuthCodeExpiry();
         this.objectMapper = SerializationService.getInstance();
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
@@ -31,12 +31,7 @@ public class ClientSessionService {
 
     public ClientSessionService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
-        this.redisConnectionService =
-                new RedisConnectionService(
-                        configurationService.getRedisHost(),
-                        configurationService.getRedisPort(),
-                        configurationService.getUseRedisTLS(),
-                        configurationService.getRedisPassword());
+        this.redisConnectionService = RedisConnectionService.getInstance(configurationService);
         objectMapper = SerializationService.getInstance();
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -34,7 +34,7 @@ public class CodeStorageService {
     private static final long MFA_ATTEMPTS_COUNTER_TIME_TO_LIVE_SECONDS = 900;
 
     public CodeStorageService(ConfigurationService configurationService) {
-        this(new RedisConnectionService(configurationService));
+        this(RedisConnectionService.getInstance(configurationService));
     }
 
     public CodeStorageService(RedisConnectionService redisConnectionService) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/NoSessionOrchestrationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/NoSessionOrchestrationService.java
@@ -36,7 +36,7 @@ public class NoSessionOrchestrationService {
 
     public NoSessionOrchestrationService(ConfigurationService configurationService) {
         this(
-                new RedisConnectionService(configurationService),
+                RedisConnectionService.getInstance(configurationService),
                 new ClientSessionService(configurationService),
                 configurationService);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -35,13 +35,7 @@ public class SessionService {
     }
 
     public SessionService(ConfigurationService configurationService) {
-        this(
-                configurationService,
-                new RedisConnectionService(
-                        configurationService.getRedisHost(),
-                        configurationService.getRedisPort(),
-                        configurationService.getUseRedisTLS(),
-                        configurationService.getRedisPassword()));
+        this(configurationService, RedisConnectionService.getInstance(configurationService));
     }
 
     public Session createSession() {


### PR DESCRIPTION
Previously, constructing a single handler may result in several instances of the redis connection service, each with its own connection pool. Making this a singleton should have several advantages. Firstly, it should result in fewer connections being made at runtime, which will help with scalability and performance. Secondly, it fixes the issue with integration tests failing locally due to running out of file handles. Before this change running the integration test suite opened in excess of 300 redis connections. After this change 4 connections are opened.

