### PR TITLE
ATO-194: re add feature flag to userinfo

### DIFF
--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -24,11 +24,12 @@ module "auth_userinfo" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    TXMA_AUDIT_QUEUE_URL = module.auth_ext_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT  = null
-    DYNAMO_ENDPOINT      = null
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    ENVIRONMENT             = var.environment
+    TXMA_AUDIT_QUEUE_URL    = module.auth_ext_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT     = null
+    DYNAMO_ENDPOINT         = null
+    INTERNAl_SECTOR_URI     = var.internal_sector_uri
+    SUPPORT_AUTH_ORCH_SPLIT = var.support_auth_orch_split
   }
   handler_function_name = "uk.gov.di.authentication.external.lambda.UserInfoHandler::handleRequest"
   handler_runtime       = "java17"


### PR DESCRIPTION
## What?

Re-add the feature flag

## Why?

I didn't think it was used, but it is

## Related PRs

Partially reverts https://github.com/govuk-one-login/authentication-api/pull/3562