### PR TITLE
ATO-210: Grant KMS access

### DIFF
--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -13,6 +13,7 @@ module "oidc_userinfo_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
+    aws_iam_policy.authentication_callback_userinfo_encryption_key_kms_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.identity_credentials_encryption_policy_arn


### PR DESCRIPTION
## What?

The userinfo lambda needs access to the auth callback userinfo table key

