### PR TITLE
AUT-1826: Turned on CMK encryption for user profile table

### DIFF
--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -10,7 +10,8 @@ module "account_management_api_send_notification_role" {
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.parameter_policy.arn,
     module.account_management_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -18,4 +18,5 @@ locals {
   lambda_code_signing_configuration_arn   = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
   account_modifiers_encryption_policy_arn = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
   client_registry_encryption_policy_arn   = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
+  user_profile_encryption_policy_arn      = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
 }

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -10,7 +10,8 @@ module "account_management_api_update_email_role" {
     aws_iam_policy.dynamo_am_user_delete_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.parameter_policy.arn,
-    module.account_management_txma_audit.access_policy_arn
+    module.account_management_txma_audit.access_policy_arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -9,7 +9,8 @@ module "account_management_api_update_password_role" {
     aws_iam_policy.dynamo_am_user_write_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
-    module.account_management_txma_audit.access_policy_arn
+    module.account_management_txma_audit.access_policy_arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -9,7 +9,8 @@ module "account_management_api_update_phone_number_role" {
     aws_iam_policy.dynamo_am_user_write_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.parameter_policy.arn,
-    module.account_management_txma_audit.access_policy_arn
+    module.account_management_txma_audit.access_policy_arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -7,6 +7,7 @@ module "delivery_receipts_api_notify_callback_role" {
   policies_to_attach = concat([
     aws_iam_policy.parameter_policy.arn,
     aws_iam_policy.bulk_user_email_dynamo_encryption_key_kms_policy.arn,
+    local.user_profile_encryption_policy_arn,
   ], local.deploy_bulk_email_users_count == 1 ? [aws_iam_policy.bulk_user_email_receipts_dynamo_write_access[0].arn, aws_iam_policy.bulk_user_email_receipts_user_profile_dynamo_read_access.arn] : [])
 }
 

--- a/ci/terraform/delivery-receipts/shared.tf
+++ b/ci/terraform/delivery-receipts/shared.tf
@@ -18,4 +18,5 @@ locals {
   redis_key                                = "session"
   lambda_code_signing_configuration_arn    = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
   bulk_user_email_table_encryption_key_arn = data.terraform_remote_state.shared.outputs.bulk_user_email_table_encryption_key_arn
+  user_profile_encryption_policy_arn       = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
 }

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -11,7 +11,8 @@ module "oidc_auth_code_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -16,7 +16,8 @@ module "ipv_callback_role" {
     aws_iam_policy.ipv_token_auth_kms_policy.arn,
     aws_iam_policy.spot_queue_encryption_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -63,4 +63,5 @@ locals {
   authentication_callback_userinfo_encryption_key_arn = data.terraform_remote_state.shared.outputs.authentication_callback_userinfo_encryption_key_arn
   account_modifiers_encryption_policy_arn             = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
   client_registry_encryption_policy_arn               = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
+  user_profile_encryption_policy_arn                  = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
 }

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -11,7 +11,8 @@ module "frontend_api_start_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -12,7 +12,8 @@ module "oidc_token_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -123,7 +123,8 @@ resource "aws_dynamodb_table" "user_profile_table" {
   }
 
   server_side_encryption {
-    enabled = !var.use_localstack
+    enabled = true
+    kms_key_arn = aws_kms_key.user_profile_table_encryption_key.arn
   }
 
   point_in_time_recovery {

--- a/ci/terraform/shared/kms-policies.tf
+++ b/ci/terraform/shared/kms-policies.tf
@@ -41,3 +41,25 @@ data "aws_iam_policy_document" "client_registry_encryption_key_policy_document" 
     ]
   }
 }
+
+resource "aws_iam_policy" "user_profile_encryption_key_kms_policy" {
+  name        = "${var.environment}-user-profile-table-encryption-key-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS encryption of the user profile table"
+
+  policy = data.aws_iam_policy_document.user_profile_encryption_key_policy_document.json
+}
+
+data "aws_iam_policy_document" "user_profile_encryption_key_policy_document" {
+  statement {
+    sid    = "AllowAccessToUserProfileTableKmsEncryptionKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      aws_kms_key.user_profile_table_encryption_key.arn
+    ]
+  }
+}

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -523,3 +523,27 @@ resource "aws_kms_key" "client_registry_table_encryption_key" {
   })
   tags = local.default_tags
 }
+
+resource "aws_kms_key" "user_profile_table_encryption_key" {
+  description              = "KMS encryption key for user profile table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -185,3 +185,7 @@ output "account_modifiers_encryption_policy_arn" {
 output "client_registry_encryption_policy_arn" {
   value = aws_iam_policy.client_registry_encryption_key_kms_policy.arn
 }
+
+output "user_profile_encryption_policy_arn" {
+  value = aws_iam_policy.user_profile_encryption_key_kms_policy.arn
+}

--- a/ci/terraform/utils/bulk_test_user_create_lambda.tf
+++ b/ci/terraform/utils/bulk_test_user_create_lambda.tf
@@ -8,6 +8,7 @@ module "bulk_test_user_create_lambda_role" {
     aws_iam_policy.user_profile_dynamo_write_access.arn,
     aws_iam_policy.user_credentials_dynamo_write_access.arn,
     aws_iam_policy.bulk_test_user_s3_read_access.arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/utils/bulk_test_user_delete_lambda.tf
+++ b/ci/terraform/utils/bulk_test_user_delete_lambda.tf
@@ -7,6 +7,7 @@ module "bulk_test_user_delete_lambda_role" {
   policies_to_attach = [
     aws_iam_policy.user_profile_dynamo_delete_access.arn,
     aws_iam_policy.user_credentials_dynamo_delete_access.arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
@@ -10,7 +10,8 @@ module "bulk_user_email_audience_loader_lambda_role" {
     aws_iam_policy.bulk_user_email_audience_loader_dynamo_read_access[0].arn,
     aws_iam_policy.bulk_user_email_audience_loader_dynamo_write_access[0].arn,
     aws_iam_policy.bulk_user_email_dynamo_encryption_key_kms_policy[0].arn,
-    aws_iam_policy.bulk_user_email_audience_loader_lambda_invocation_policy[0].arn
+    aws_iam_policy.bulk_user_email_audience_loader_lambda_invocation_policy[0].arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/utils/bulk_user_email_send_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_send_lambda.tf
@@ -10,7 +10,8 @@ module "bulk_user_email_send_lambda_role" {
     aws_iam_policy.bulk_user_email_send_dynamo_read_access[0].arn,
     aws_iam_policy.bulk_user_email_send_dynamo_write_access[0].arn,
     aws_iam_policy.bulk_user_email_dynamo_encryption_key_kms_policy[0].arn,
-    aws_iam_policy.txma_audit_queue_access_policy.arn
+    aws_iam_policy.txma_audit_queue_access_policy.arn,
+    local.user_profile_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/utils/shared.tf
+++ b/ci/terraform/utils/shared.tf
@@ -17,6 +17,7 @@ locals {
   authentication_subnet_ids                = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
   authentication_security_group_id         = data.terraform_remote_state.shared.outputs.authentication_security_group_id
   authentication_egress_security_group_id  = data.terraform_remote_state.shared.outputs.authentication_egress_security_group_id
+  user_profile_encryption_policy_arn       = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
   default_performance_parameters = {
     memory  = 1024,
     timeout = 900,


### PR DESCRIPTION
## What?

Turned on CMK encryption for the user profile table

## Why?

CMK encryption/decryption is being implemented in line with recommendations from the ITHC. Separate PRs are being made for the common passwords table's encryption and decryption capability. Decryption capability is being implemented first as when encryption and decryption capability are merged together there is down time as tables are encrypted before lambdas are able to decrypt them.

## Related PRs

PR applying policies before turning on encryption:
https://github.com/govuk-one-login/authentication-api/pull/3554
