### PR TITLE
AUT-1826: Turned on CMK encryption for Doc App Credential table

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -15,7 +15,8 @@ module "oidc_authorize_role" {
     module.oidc_txma_audit.access_policy_arn,
     aws_iam_policy.orch_to_auth_kms_policy.arn,
     aws_iam_policy.auth_public_encryption_key_parameter_policy.arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    local.doc_app_auth_signing_key_arn
   ]
 }
 

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -12,7 +12,8 @@ module "doc_app_authorize_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    local.doc_app_auth_signing_key_arn
   ]
 }
 

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -12,7 +12,8 @@ module "doc_app_callback_role" {
     aws_iam_policy.dynamo_doc_app_write_access_policy.arn,
     aws_iam_policy.dynamo_doc_app_read_access_policy.arn,
     aws_iam_policy.doc_app_rp_client_id_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.doc_app_auth_signing_key_arn
   ]
 }
 

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -7,6 +7,7 @@ module "oidc_jwks_role" {
   policies_to_attach = [
     aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
     aws_iam_policy.doc_app_auth_kms_policy.arn,
+    local.doc_app_auth_signing_key_arn
   ]
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -65,4 +65,5 @@ locals {
   common_passwords_encryption_policy_arn              = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
   client_registry_encryption_policy_arn               = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
   identity_credentials_encryption_policy_arn          = data.terraform_remote_state.shared.outputs.identity_credentials_encryption_policy_arn
+  doc_app_credential_encryption_policy_arn            = data.terraform_remote_state.shared.outputs.doc_app_credential_encryption_policy_arn
 }

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -15,7 +15,8 @@ module "oidc_userinfo_role" {
     aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.identity_credentials_encryption_policy_arn
+    local.identity_credentials_encryption_policy_arn,
+    local.doc_app_auth_signing_key_arn
   ]
 }
 

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -229,7 +229,8 @@ resource "aws_dynamodb_table" "doc_app_credential_table" {
   }
 
   server_side_encryption {
-    enabled = !var.use_localstack
+    enabled     = true
+    kms_key_arn = aws_kms_key.doc_app_credential_table_encryption_key.arn
   }
 
   lifecycle {

--- a/ci/terraform/shared/kms-policies.tf
+++ b/ci/terraform/shared/kms-policies.tf
@@ -42,6 +42,28 @@ data "aws_iam_policy_document" "common_passwords_encryption_key_policy_document"
   }
 }
 
+resource "aws_iam_policy" "doc_app_credential_encryption_key_kms_policy" {
+  name        = "${var.environment}-doc-app-credential-table-encryption-key-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS encryption of the doc app credential table"
+
+  policy = data.aws_iam_policy_document.doc_app_credential_encryption_key_policy_document.json
+}
+
+data "aws_iam_policy_document" "doc_app_credential_encryption_key_policy_document" {
+  statement {
+    sid    = "AllowAccessToDocAppCredentialTableKmsEncryptionKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      aws_kms_key.doc_app_credential_table_encryption_key.arn
+    ]
+  }
+}
+
 resource "aws_iam_policy" "identity_credentials_encryption_key_kms_policy" {
   name        = "${var.environment}-identity-credentials-table-encryption-key-kms-policy"
   path        = "/"

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -524,6 +524,30 @@ resource "aws_kms_key" "common_passwords_table_encryption_key" {
   tags = local.default_tags
 }
 
+resource "aws_kms_key" "doc_app_credential_table_encryption_key" {
+  description              = "KMS encryption key for doc app credential table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}
+
 resource "aws_kms_key" "identity_credentials_table_encryption_key" {
   description              = "KMS encryption key for identity credentials table in DynamoDB"
   deletion_window_in_days  = 30

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -193,3 +193,7 @@ output "client_registry_encryption_policy_arn" {
 output "identity_credentials_encryption_policy_arn" {
   value = aws_iam_policy.identity_credentials_encryption_key_kms_policy.arn
 }
+
+output "doc_app_credential_encryption_policy_arn" {
+  value = aws_iam_policy.doc_app_credential_encryption_key_kms_policy.arn
+}


### PR DESCRIPTION
## What?

Turned on CMK encryption for the Doc App Credential table

## Why?

CMK encryption/decryption is being implemented in line with recommendations from the ITHC. Separate PRs are being made for the common passwords table's encryption and decryption capability. Decryption capability is being implemented first as when encryption and decryption capability are merged together there is down time as tables are encrypted before lambdas are able to decrypt them.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3552
