### PR TITLE
AUT-1826: Turned on CMK encryption for Client Registry table

### DIFF
--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -7,7 +7,8 @@ module "account_management_api_authorizer_role" {
   policies_to_attach = [
     aws_iam_policy.lambda_kms_policy.arn,
     aws_iam_policy.dynamo_am_client_registry_read_access_policy.arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -9,7 +9,8 @@ module "account_management_api_send_notification_role" {
     aws_iam_policy.dynamo_am_client_registry_read_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.parameter_policy.arn,
-    module.account_management_txma_audit.access_policy_arn
+    module.account_management_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -17,4 +17,5 @@ data "terraform_remote_state" "shared" {
 locals {
   lambda_code_signing_configuration_arn   = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
   account_modifiers_encryption_policy_arn = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
+  client_registry_encryption_policy_arn   = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
 }

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -13,7 +13,8 @@ module "frontend_api_account_recovery_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -10,7 +10,8 @@ module "oidc_auth_code_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -14,7 +14,8 @@ module "frontend_api_orch_auth_code_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.auth_code_dynamo_encryption_key_kms_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -13,7 +13,8 @@ module "oidc_api_authentication_callback_role" {
     aws_iam_policy.ipv_public_encryption_key_parameter_policy.arn,
     aws_iam_policy.orch_to_auth_kms_policy.arn,
     aws_iam_policy.authentication_callback_userinfo_encryption_key_kms_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -14,7 +14,8 @@ module "oidc_authorize_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     aws_iam_policy.orch_to_auth_kms_policy.arn,
-    aws_iam_policy.auth_public_encryption_key_parameter_policy.arn
+    aws_iam_policy.auth_public_encryption_key_parameter_policy.arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -11,7 +11,8 @@ module "doc_app_authorize_role" {
     aws_iam_policy.doc_app_auth_kms_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -14,7 +14,8 @@ module "ipv_authorize_role" {
     aws_iam_policy.ipv_token_auth_kms_policy.arn,
     aws_iam_policy.ipv_public_encryption_key_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -15,7 +15,8 @@ module "ipv_callback_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.ipv_token_auth_kms_policy.arn,
     aws_iam_policy.spot_queue_encryption_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -14,7 +14,8 @@ module "frontend_api_login_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -11,7 +11,8 @@ module "oidc_logout_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -11,7 +11,8 @@ module "frontend_api_mfa_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -13,7 +13,8 @@ module "ipv_processing_identity_role" {
     aws_iam_policy.pepper_parameter_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -9,7 +9,8 @@ module "client_registry_role" {
     aws_iam_policy.dynamo_client_registry_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -15,7 +15,8 @@ module "frontend_api_reset_password_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -11,7 +11,8 @@ module "frontend_api_send_notification_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -62,4 +62,5 @@ locals {
   vpce_id                                             = var.support_auth_orch_split ? data.terraform_remote_state.auth-ext-api[0].outputs.vpce_id : ""
   authentication_callback_userinfo_encryption_key_arn = data.terraform_remote_state.shared.outputs.authentication_callback_userinfo_encryption_key_arn
   account_modifiers_encryption_policy_arn             = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
+  client_registry_encryption_policy_arn               = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
 }

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -13,7 +13,8 @@ module "frontend_api_signup_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -10,7 +10,8 @@ module "frontend_api_start_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -11,7 +11,8 @@ module "oidc_token_role" {
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -9,7 +9,8 @@ module "client_update_role" {
     aws_iam_policy.dynamo_client_registry_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -12,7 +12,8 @@ module "frontend_api_update_profile_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -12,7 +12,8 @@ module "frontend_api_user_exists_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -13,7 +13,8 @@ module "oidc_userinfo_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -14,7 +14,8 @@ module "frontend_api_verify_code_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -14,7 +14,8 @@ module "frontend_api_verify_mfa_code_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn
   ]
 }
 

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -168,7 +168,8 @@ resource "aws_dynamodb_table" "client_registry_table" {
   }
 
   server_side_encryption {
-    enabled = !var.use_localstack
+    enabled = true
+    kms_key_arn = aws_kms_key.client_registry_table_encryption_key.arn
   }
 
   lifecycle {

--- a/ci/terraform/shared/kms-policies.tf
+++ b/ci/terraform/shared/kms-policies.tf
@@ -19,3 +19,25 @@ data "aws_iam_policy_document" "account_modifiers_encryption_key_policy_document
     ]
   }
 }
+
+resource "aws_iam_policy" "client_registry_encryption_key_kms_policy" {
+  name        = "${var.environment}-client-registry-table-encryption-key-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS encryption of the client registry table"
+
+  policy = data.aws_iam_policy_document.client_registry_encryption_key_policy_document.json
+}
+
+data "aws_iam_policy_document" "client_registry_encryption_key_policy_document" {
+  statement {
+    sid    = "AllowAccessToClientRegistryTableKmsEncryptionKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      aws_kms_key.client_registry_table_encryption_key.arn
+    ]
+  }
+}

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -499,3 +499,27 @@ resource "aws_kms_key" "user_credentials_table_encryption_key" {
   })
   tags = local.default_tags
 }
+
+resource "aws_kms_key" "client_registry_table_encryption_key" {
+  description              = "KMS encryption key for client registry table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -181,3 +181,7 @@ output "authentication_callback_userinfo_encryption_key_arn" {
 output "account_modifiers_encryption_policy_arn" {
   value = aws_iam_policy.account_modifiers_encryption_key_kms_policy.arn
 }
+
+output "client_registry_encryption_policy_arn" {
+  value = aws_iam_policy.client_registry_encryption_key_kms_policy.arn
+}


### PR DESCRIPTION
## What?

Turned on CMK encryption for the identity credentials table

## Why?

CMK encryption/decryption is being implemented in line with recommendations from the ITHC. Separate PRs are being made for the common passwords table's encryption and decryption capability. Decryption capability is being implemented first as when encryption and decryption capability are merged together there is down time as tables are encrypted before lambdas are able to decrypt them.


## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3546
