### PR TITLE
AUT-1826: Turned on CMK encryption for Common Passwords table

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -258,7 +258,8 @@ resource "aws_dynamodb_table" "common_passwords_table" {
   }
 
   server_side_encryption {
-    enabled = !var.use_localstack
+    enabled     = true
+    kms_key_arn = aws_kms_key.common_passwords_table_encryption_key.arn
   }
 
   point_in_time_recovery {


### PR DESCRIPTION
## What?

Turned on CMK encryption for the Common Passwordstable

## Why?

CMK encryption/decryption is being implemented in line with recommendations from the ITHC. Separate PRs are being made for the common passwords table's encryption and decryption capability. Decryption capability is being implemented first as when encryption and decryption capability are merged together there is down time as tables are encrypted before lambdas are able to decrypt them.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3580