### PR TITLE
AUT-1764: Enable auth-orch split in build

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -29,5 +29,6 @@ AZUx4RCDu+VWAZpPi1NaF5XWvkFNFwH+MyLkATh90UEJDe+ayKW6AXFcRQ==
 -----END PUBLIC KEY-----
 EOT
 
-orch_client_id    = "orchestrationAuth"
-orch_redirect_uri = "https://oidc.build.account.gov.uk/orchestration-redirect"
+orch_client_id          = "orchestrationAuth"
+orch_redirect_uri       = "https://oidc.build.account.gov.uk/orchestration-redirect"
+support_auth_orch_split = true


### PR DESCRIPTION
## What?

Enable the auth orch split in the build environment
It is already enabled for the auth external API through to integration

## Why?

Testing in advance of go-live

## Related PRs
Must be merged in conjunction with 
https://github.com/govuk-one-login/authentication-frontend/pull/1234