### PR TITLE
ATO-203: Only parse claims if non-null

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
@@ -44,8 +44,11 @@ public class RequestObjectToAuthRequestHelper {
                                     URI.create((String) jwtClaimsSet.getClaim("redirect_uri")))
                             .state(new State(jwtClaimsSet.getClaim("state").toString()))
                             .nonce(new Nonce(jwtClaimsSet.getClaim("nonce").toString()))
-                            .claims(parseOidcClaims(jwtClaimsSet.getClaim("claims").toString()))
                             .requestObject(authRequest.getRequestObject());
+
+            if (Objects.nonNull(jwtClaimsSet.getClaim("claims"))) {
+                builder.claims(parseOidcClaims(jwtClaimsSet.getClaim("claims").toString()));
+            }
 
             if (Objects.nonNull(jwtClaimsSet.getClaim("vtr"))) {
                 transformVtr(builder, jwtClaimsSet);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
@@ -213,6 +213,36 @@ class RequestObjectToAuthRequestHelperTest {
         assertThat(transformedAuthRequest.getRequestObject(), equalTo(signedJWT));
     }
 
+    @Test
+    void shouldSuccessfullyParseAnAuthOnlyRequest() throws JOSEException {
+        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
+        var jwtClaimsSet =
+                getClaimsSetBuilder(scope)
+                        .claim("claims", null)
+                        .claim("vtr", List.of("Cl.Cm"))
+                        .build();
+        var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
+        var authRequest =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                new Scope(OIDCScopeValue.OPENID),
+                                CLIENT_ID,
+                                null)
+                        .requestObject(signedJWT)
+                        .build();
+
+        var transformedAuthRequest = RequestObjectToAuthRequestHelper.transform(authRequest);
+
+        assertThat(transformedAuthRequest.getState(), equalTo(STATE));
+        assertThat(transformedAuthRequest.getNonce(), equalTo(NONCE));
+        assertThat(transformedAuthRequest.getRedirectionURI(), equalTo(REDIRECT_URI));
+        assertThat(transformedAuthRequest.getScope(), equalTo(scope));
+        assertThat(transformedAuthRequest.getClientID(), equalTo(CLIENT_ID));
+        assertThat(transformedAuthRequest.getResponseType(), equalTo(ResponseType.CODE));
+        assertThat(transformedAuthRequest.getRequestObject(), equalTo(signedJWT));
+    }
+
     private JWTClaimsSet.Builder getClaimsSetBuilder(Scope scope) {
         return new JWTClaimsSet.Builder()
                 .audience(AUDIENCE)


### PR DESCRIPTION
## What?

Only read claims from JAR request if non-null

## Why?

Otherwise error thrown on auth requests or when claims otherwise null

## Related PRs
https://github.com/govuk-one-login/authentication-api/pull/3604