### PR TITLE
ATO-47: Handle missing AIS URL

### DIFF
--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -29,13 +29,16 @@ module "processing-identity" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
-    ENVIRONMENT              = var.environment
-    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
-    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY                = local.redis_key
-    INTERNAl_SECTOR_URI      = var.internal_sector_uri
+    DYNAMO_ENDPOINT                            = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TXMA_AUDIT_QUEUE_URL                       = module.oidc_txma_audit.queue_url
+    ENVIRONMENT                                = var.environment
+    HEADERS_CASE_INSENSITIVE                   = var.use_localstack ? "true" : "false"
+    LOCALSTACK_ENDPOINT                        = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                                  = local.redis_key
+    INTERNAl_SECTOR_URI                        = var.internal_sector_uri
+    ACCOUNT_INTERVENTION_SERVICE_AUDIT_ENABLED = var.account_intervention_service_audit_enabled
+    ACCOUNT_INTERVENTION_SERVICE_ENABLED       = var.account_intervention_service_enabled
+    ACCOUNT_INTERVENTION_SERVICE_URI           = var.account_intervention_service_uri
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.ProcessingIdentityHandler::handleRequest"
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -74,7 +74,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public URI getAccountInterventionServiceURI() {
-        return URI.create(System.getenv("ACCOUNT_INTERVENTION_SERVICE_URI"));
+        return URI.create(System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_URI", ""));
     }
 
     public String getAccountManagementURI() {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ConfigurationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ConfigurationServiceTest.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
 import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
 import uk.gov.di.orchestration.shared.entity.DeliveryReceiptsNotificationType;
 
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -138,6 +139,16 @@ class ConfigurationServiceTest {
         assertEquals(configurationService.getNotifyCallbackBearerToken(), ssmParamValue);
         assertEquals(configurationService.getNotifyCallbackBearerToken(), ssmParamValue);
         verify(mock, times(1)).getParameter(request);
+    }
+
+    @Test
+    void shouldHandleMissingAISUrl() {
+        when(systemService.getOrDefault("ACCOUNT_INTERVENTION_SERVICE_URI", "")).thenReturn("");
+
+        ConfigurationService configurationService = new ConfigurationService();
+        configurationService.setSystemService(systemService);
+
+        assertEquals(configurationService.getAccountInterventionServiceURI(), URI.create(""));
     }
 
     private GetParameterRequest parameterRequest(String name) {


### PR DESCRIPTION
## What?

Pass the AIS environment variables to the processing identity handler
For additional safety, make things work when they're not present.

## Why?

As-was the processing-identity lambda could not start, as it had a dependency on AIS and the env vars were not being passed to the lambda
Trying to parse a null url throws an exception. We now default to an empty string, which is successfully parsed

## Related PRs
https://github.com/govuk-one-login/authentication-api/pull/3610
