### PR TITLE
ATO-226: Re-add handle request method for tracing

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -80,6 +80,12 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
     }
 
     @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        return super.handleRequest(input, context);
+    }
+
+    @Override
     public APIGatewayProxyResponseEvent handleRequestWithUserContext(
             APIGatewayProxyRequestEvent input,
             Context context,


### PR DESCRIPTION
## What?

Re-add removed handleRequest method

## Why?

Dynatrace and other tracing relies on this via reflection

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3610/files#diff-4eaf51fdc1367b3d55185e1560bf5be8270db1c0ff27122192e5a6f187d09b72L74-L79