### PR TITLE
ATO-228: Add missing env vars to authentication callback lambda

### DIFF
--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -27,23 +27,26 @@ module "authentication_callback" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT                                = var.environment
-    REDIS_KEY                                  = local.redis_key
-    SUPPORT_AUTH_ORCH_SPLIT                    = var.support_auth_orch_split
-    DYNAMO_ENDPOINT                            = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT                        = var.use_localstack ? var.localstack_endpoint : null
-    TXMA_AUDIT_QUEUE_URL                       = module.oidc_txma_audit.queue_url
-    INTERNAl_SECTOR_URI                        = var.internal_sector_uri
-    IDENTITY_ENABLED                           = var.ipv_api_enabled
-    IPV_AUTHORISATION_CLIENT_ID                = var.ipv_authorisation_client_id
-    IPV_AUTHORISATION_URI                      = var.ipv_authorisation_uri
-    ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS       = local.orch_to_auth_signing_key_alias_name
-    AUTHENTICATION_BACKEND_URI                 = "https://${local.di_auth_ext_api_id}-${local.vpce_id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
-    ORCH_CLIENT_ID                             = var.orch_client_id
-    LOGIN_URI                                  = "https://${local.frontend_fqdn}/"
     ACCOUNT_INTERVENTION_SERVICE_AUDIT_ENABLED = var.account_intervention_service_audit_enabled
     ACCOUNT_INTERVENTION_SERVICE_ENABLED       = var.account_intervention_service_enabled
     ACCOUNT_INTERVENTION_SERVICE_URI           = var.account_intervention_service_uri
+    AUTHENTICATION_BACKEND_URI                 = "https://${local.di_auth_ext_api_id}-${local.vpce_id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
+    DYNAMO_ENDPOINT                            = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT                                = var.environment
+    IDENTITY_ENABLED                           = var.ipv_api_enabled
+    INTERNAl_SECTOR_URI                        = var.internal_sector_uri
+    IPV_AUDIENCE                               = var.ipv_audience
+    IPV_AUTHORISATION_CALLBACK_URI             = var.ipv_authorisation_callback_uri
+    IPV_AUTHORISATION_CLIENT_ID                = var.ipv_authorisation_client_id
+    IPV_AUTHORISATION_URI                      = var.ipv_authorisation_uri
+    IPV_TOKEN_SIGNING_KEY_ALIAS                = local.ipv_token_auth_key_alias_name
+    LOCALSTACK_ENDPOINT                        = var.use_localstack ? var.localstack_endpoint : null
+    LOGIN_URI                                  = "https://${local.frontend_fqdn}/"
+    ORCH_CLIENT_ID                             = var.orch_client_id
+    ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS       = local.orch_to_auth_signing_key_alias_name
+    REDIS_KEY                                  = local.redis_key
+    SUPPORT_AUTH_ORCH_SPLIT                    = var.support_auth_orch_split
+    TXMA_AUDIT_QUEUE_URL                       = module.oidc_txma_audit.queue_url
   }
 
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler::handleRequest"

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -29,18 +29,18 @@ module "ipv-authorize" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT                    = var.environment
-    TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY                      = local.redis_key
     DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT                    = var.environment
     IDENTITY_ENABLED               = var.ipv_api_enabled
-    IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
+    INTERNAl_SECTOR_URI            = var.internal_sector_uri
+    IPV_AUDIENCE                   = var.ipv_audience
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
-    IPV_AUDIENCE                   = var.ipv_audience
+    IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
     IPV_TOKEN_SIGNING_KEY_ALIAS    = local.ipv_token_auth_key_alias_name
-    INTERNAl_SECTOR_URI            = var.internal_sector_uri
+    LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                      = local.redis_key
+    TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVAuthorisationHandler::handleRequest"
 

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -33,22 +33,22 @@ module "ipv-callback" {
 
   handler_environment_variables = {
     DYNAMO_ENDPOINT                 = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TXMA_AUDIT_QUEUE_URL            = module.oidc_txma_audit.queue_url
     ENVIRONMENT                     = var.environment
     IDENTITY_ENABLED                = var.ipv_api_enabled
-    IPV_TOKEN_SIGNING_KEY_ALIAS     = local.ipv_token_auth_key_alias_name
-    IPV_AUTHORISATION_CLIENT_ID     = var.ipv_authorisation_client_id
+    INTERNAl_SECTOR_URI             = var.internal_sector_uri
+    IPV_AUDIENCE                    = var.ipv_audience
     IPV_AUTHORISATION_CALLBACK_URI  = var.ipv_authorisation_callback_uri
+    IPV_AUTHORISATION_CLIENT_ID     = var.ipv_authorisation_client_id
     IPV_AUTHORISATION_URI           = var.ipv_authorisation_uri
     IPV_BACKEND_URI                 = var.ipv_backend_uri
-    IPV_AUDIENCE                    = var.ipv_audience
     IPV_NO_SESSION_RESPONSE_ENABLED = var.ipv_no_session_response_enabled
-    LOGIN_URI                       = "https://${local.frontend_fqdn}/"
+    IPV_TOKEN_SIGNING_KEY_ALIAS     = local.ipv_token_auth_key_alias_name
     LOCALSTACK_ENDPOINT             = var.use_localstack ? var.localstack_endpoint : null
+    LOGIN_URI                       = "https://${local.frontend_fqdn}/"
     OIDC_API_BASE_URL               = local.api_base_url
     REDIS_KEY                       = local.redis_key
     SPOT_QUEUE_URL                  = aws_sqs_queue.spot_request_queue.id
-    INTERNAl_SECTOR_URI             = var.internal_sector_uri
+    TXMA_AUDIT_QUEUE_URL            = module.oidc_txma_audit.queue_url
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 


### PR DESCRIPTION
## What?
Added for requests to IPV Core:
- IPV_TOKEN_SIGNING_KEY_ALIAS
- IPV_AUDIENCE
- IPV_AUTHORISATION_CALLBACK_URI

Additionally sorted env var lists for easier comparison

## Why?
These vars are required to generate and sign the request to IPV Core. This is done in the AuthenticationCallback lambda when the split is turned on
