### PR TITLE
ATO-133: Persist return codes in DynamoDB // ATO-134: Bypass SPoT

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -32,23 +32,26 @@ module "ipv-callback" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DYNAMO_ENDPOINT                 = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    ENVIRONMENT                     = var.environment
-    IDENTITY_ENABLED                = var.ipv_api_enabled
-    INTERNAl_SECTOR_URI             = var.internal_sector_uri
-    IPV_AUDIENCE                    = var.ipv_audience
-    IPV_AUTHORISATION_CALLBACK_URI  = var.ipv_authorisation_callback_uri
-    IPV_AUTHORISATION_CLIENT_ID     = var.ipv_authorisation_client_id
-    IPV_AUTHORISATION_URI           = var.ipv_authorisation_uri
-    IPV_BACKEND_URI                 = var.ipv_backend_uri
-    IPV_NO_SESSION_RESPONSE_ENABLED = var.ipv_no_session_response_enabled
-    IPV_TOKEN_SIGNING_KEY_ALIAS     = local.ipv_token_auth_key_alias_name
-    LOCALSTACK_ENDPOINT             = var.use_localstack ? var.localstack_endpoint : null
-    LOGIN_URI                       = "https://${local.frontend_fqdn}/"
-    OIDC_API_BASE_URL               = local.api_base_url
-    REDIS_KEY                       = local.redis_key
-    SPOT_QUEUE_URL                  = aws_sqs_queue.spot_request_queue.id
-    TXMA_AUDIT_QUEUE_URL            = module.oidc_txma_audit.queue_url
+    DYNAMO_ENDPOINT                             = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT                                 = var.environment
+    IDENTITY_ENABLED                            = var.ipv_api_enabled
+    INTERNAl_SECTOR_URI                         = var.internal_sector_uri
+    ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED = var.account_intervention_service_action_enabled
+    ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled
+    ACCOUNT_INTERVENTION_SERVICE_URI            = var.account_intervention_service_uri
+    IPV_AUDIENCE                                = var.ipv_audience
+    IPV_AUTHORISATION_CALLBACK_URI              = var.ipv_authorisation_callback_uri
+    IPV_AUTHORISATION_CLIENT_ID                 = var.ipv_authorisation_client_id
+    IPV_AUTHORISATION_URI                       = var.ipv_authorisation_uri
+    IPV_BACKEND_URI                             = var.ipv_backend_uri
+    IPV_NO_SESSION_RESPONSE_ENABLED             = var.ipv_no_session_response_enabled
+    IPV_TOKEN_SIGNING_KEY_ALIAS                 = local.ipv_token_auth_key_alias_name
+    LOCALSTACK_ENDPOINT                         = var.use_localstack ? var.localstack_endpoint : null
+    LOGIN_URI                                   = "https://${local.frontend_fqdn}/"
+    OIDC_API_BASE_URL                           = local.api_base_url
+    REDIS_KEY                                   = local.redis_key
+    SPOT_QUEUE_URL                              = aws_sqs_queue.spot_request_queue.id
+    TXMA_AUDIT_QUEUE_URL                        = module.oidc_txma_audit.queue_url
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
@@ -13,7 +13,8 @@ public enum IPVAuditableEvent implements AuditableEvent {
     IPV_SPOT_REQUESTED,
     PROCESSING_IDENTITY_REQUEST,
     IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED,
-    IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED;
+    IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED,
+    AUTH_CODE_ISSUED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -67,10 +67,6 @@ public class IPVCallbackHelper {
     private final SessionService sessionService;
     private final AwsSqsClient sqsClient;
 
-    private IPVCallbackHelper() {
-        this(ConfigurationService.getInstance());
-    }
-
     public IPVCallbackHelper(ConfigurationService configurationService) {
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
@@ -174,11 +170,17 @@ public class IPVCallbackHelper {
     }
 
     public void doAccountIntervention(AccountInterventionStatus accountInterventionStatus) {
-        segmentedFunctionCall(
-                "AIS: getAccountStatus",
-                () ->
-                        this.accountInterventionService.doAccountIntervention(
-                                accountInterventionStatus));
+        if (accountInterventionStatus.blocked()) {
+            LOG.info("Account is blocked");
+            // TODO: (ATO-171) back channel logout + (ATO-170) redirect to blocked page
+        } else if (accountInterventionStatus.suspended()
+                || accountInterventionStatus.resetPassword()
+                || accountInterventionStatus.reproveIdentity()) {
+            LOG.info(
+                    "Account is suspended, requires a password reset, or requires identity to be reproved");
+            // TODO: (ATO-171) back channel logout + (ATO-170) redirect to suspended
+            // page
+        }
     }
 
     public Optional<ErrorObject> validateUserIdentityResponse(UserInfo userIdentityUserInfo)

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -1,0 +1,359 @@
+package uk.gov.di.authentication.ipv.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
+import uk.gov.di.authentication.ipv.entity.IpvCallbackException;
+import uk.gov.di.authentication.ipv.entity.LogIds;
+import uk.gov.di.authentication.ipv.entity.SPOTClaims;
+import uk.gov.di.authentication.ipv.entity.SPOTRequest;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.IdentityClaims;
+import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
+import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
+import uk.gov.di.orchestration.shared.entity.Session;
+import uk.gov.di.orchestration.shared.entity.UserProfile;
+import uk.gov.di.orchestration.shared.entity.ValidClaims;
+import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
+import uk.gov.di.orchestration.shared.serialization.Json;
+import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
+import uk.gov.di.orchestration.shared.services.AccountInterventionService;
+import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.AuthCodeResponseGenerationService;
+import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
+import uk.gov.di.orchestration.shared.services.AwsSqsClient;
+import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.DynamoClientService;
+import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
+import uk.gov.di.orchestration.shared.services.DynamoService;
+import uk.gov.di.orchestration.shared.services.SerializationService;
+import uk.gov.di.orchestration.shared.services.SessionService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VOT;
+import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VTM;
+import static uk.gov.di.orchestration.shared.entity.ValidClaims.RETURN_CODE;
+import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
+
+public class IPVCallbackHelper {
+    private static final Logger LOG = LogManager.getLogger(IPVCallbackHelper.class);
+    protected final Json objectMapper;
+    private final AccountInterventionService accountInterventionService;
+    private final AuditService auditService;
+    private final AuthCodeResponseGenerationService authCodeResponseService;
+    private final AuthorisationCodeService authorisationCodeService;
+    private final CloudwatchMetricsService cloudwatchMetricsService;
+    private final ConfigurationService configurationService;
+    private final DynamoClientService dynamoClientService;
+    private final DynamoIdentityService dynamoIdentityService;
+    private final DynamoService dynamoService;
+    private final SessionService sessionService;
+    private final AwsSqsClient sqsClient;
+
+    private IPVCallbackHelper() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public IPVCallbackHelper(ConfigurationService configurationService) {
+        this.auditService = new AuditService(configurationService);
+        this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
+        this.accountInterventionService =
+                new AccountInterventionService(
+                        configurationService, cloudwatchMetricsService, auditService);
+        this.authorisationCodeService = new AuthorisationCodeService(configurationService);
+        this.configurationService = configurationService;
+        this.dynamoClientService = new DynamoClientService(configurationService);
+        this.dynamoIdentityService = new DynamoIdentityService(configurationService);
+        this.dynamoService = new DynamoService(configurationService);
+        this.objectMapper = SerializationService.getInstance();
+        this.sessionService = new SessionService(configurationService);
+        this.sqsClient =
+                new AwsSqsClient(
+                        configurationService.getAwsRegion(),
+                        configurationService.getSpotQueueUri(),
+                        configurationService.getSqsEndpointUri());
+        this.authCodeResponseService =
+                new AuthCodeResponseGenerationService(configurationService, dynamoService);
+    }
+
+    public IPVCallbackHelper(
+            AccountInterventionService accountInterventionService,
+            AuditService auditService,
+            AuthCodeResponseGenerationService authCodeResponseService,
+            AuthorisationCodeService authorisationCodeService,
+            CloudwatchMetricsService cloudwatchMetricsService,
+            ConfigurationService configurationService,
+            DynamoClientService dynamoClientService,
+            DynamoIdentityService dynamoIdentityService,
+            DynamoService dynamoService,
+            SerializationService objectMapper,
+            SessionService sessionService,
+            AwsSqsClient sqsClient) {
+        this.accountInterventionService = accountInterventionService;
+        this.auditService = auditService;
+        this.authCodeResponseService = authCodeResponseService;
+        this.authorisationCodeService = authorisationCodeService;
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
+        this.configurationService = configurationService;
+        this.dynamoClientService = dynamoClientService;
+        this.dynamoIdentityService = dynamoIdentityService;
+        this.dynamoService = dynamoService;
+        this.objectMapper = objectMapper;
+        this.sessionService = sessionService;
+        this.sqsClient = sqsClient;
+    }
+
+    public APIGatewayProxyResponseEvent generateAuthenticationErrorResponse(
+            AuthenticationRequest authenticationRequest,
+            ErrorObject errorObject,
+            boolean noSessionErrorResponse,
+            String clientSessionId,
+            String sessionId) {
+        LOG.warn(
+                "Error in IPV AuthorisationResponse. ErrorCode: {}. ErrorDescription: {}. No Session Error: {}",
+                errorObject.getCode(),
+                errorObject.getDescription(),
+                noSessionErrorResponse);
+        auditService.submitAuditEvent(
+                IPVAuditableEvent.IPV_UNSUCCESSFUL_AUTHORISATION_RESPONSE_RECEIVED,
+                clientSessionId,
+                sessionId,
+                authenticationRequest.getClientID().getValue(),
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN);
+        var errorResponse =
+                new AuthenticationErrorResponse(
+                        authenticationRequest.getRedirectionURI(),
+                        errorObject,
+                        authenticationRequest.getState(),
+                        authenticationRequest.getResponseMode());
+        return generateApiGatewayProxyResponse(
+                302, "", Map.of(ResponseHeaders.LOCATION, errorResponse.toURI().toString()), null);
+    }
+
+    public AccountInterventionStatus getAccountInterventionStatus(
+            String internalPairwiseSubjectId) {
+        var accountInterventionStatus =
+                segmentedFunctionCall(
+                        "AIS: getAccountStatus",
+                        () ->
+                                this.accountInterventionService.getAccountStatus(
+                                        internalPairwiseSubjectId));
+        cloudwatchMetricsService.incrementCounter(
+                "AISResult",
+                Map.of(
+                        "blocked",
+                        String.valueOf(accountInterventionStatus.blocked()),
+                        "suspended",
+                        String.valueOf(accountInterventionStatus.suspended()),
+                        "resetPassword",
+                        String.valueOf(accountInterventionStatus.resetPassword()),
+                        "reproveIdentity",
+                        String.valueOf(accountInterventionStatus.reproveIdentity())));
+        return accountInterventionStatus;
+    }
+
+    public Optional<ErrorObject> validateUserIdentityResponse(UserInfo userIdentityUserInfo)
+            throws IpvCallbackException {
+        LOG.info("Validating userinfo response");
+        if (!LevelOfConfidence.MEDIUM_LEVEL
+                .getValue()
+                .equals(userIdentityUserInfo.getClaim(VOT.getValue()))) {
+            LOG.warn("IPV missing vot or vot not P2.");
+            return Optional.of(OAuth2Error.ACCESS_DENIED);
+        }
+        var trustmarkURL =
+                buildURI(configurationService.getOidcApiBaseURL().orElseThrow(), "/trustmark")
+                        .toString();
+
+        if (!trustmarkURL.equals(userIdentityUserInfo.getClaim(VTM.getValue()))) {
+            LOG.warn("VTM does not contain expected trustmark URL");
+            throw new IpvCallbackException("IPV trustmark is invalid");
+        }
+        return Optional.empty();
+    }
+
+    public APIGatewayProxyResponseEvent processReturnCode(
+            ClientRegistry clientRegistry,
+            AuthenticationRequest authRequest,
+            String clientSessionId,
+            UserProfile userProfile,
+            Session session,
+            ClientSession clientSession,
+            Subject rpPairwiseSubject,
+            String internalPairwiseSubjectId,
+            UserInfo userIdentityUserInfo,
+            String ipAddress,
+            String persistentSessionId)
+            throws UserNotFoundException {
+        if (!clientRegistry.getClaims().contains(RETURN_CODE.getValue())
+                || authRequest
+                                .getOIDCClaims()
+                                .getUserInfoClaimsRequest()
+                                .get(RETURN_CODE.getValue())
+                        == null) {
+            LOG.warn("SPOT will not be invoked. Returning Error to RP");
+            var errorResponse =
+                    new AuthenticationErrorResponse(
+                            authRequest.getRedirectionURI(),
+                            OAuth2Error.ACCESS_DENIED,
+                            authRequest.getState(),
+                            authRequest.getResponseMode());
+            return generateApiGatewayProxyResponse(
+                    302,
+                    "",
+                    Map.of(ResponseHeaders.LOCATION, errorResponse.toURI().toString()),
+                    null);
+        }
+
+        LOG.warn("SPOT will not be invoked due to returnCode. Returning authCode to RP");
+        segmentedFunctionCall(
+                "saveIdentityClaims",
+                () -> saveIdentityClaimsToDynamo(rpPairwiseSubject, userIdentityUserInfo));
+        var authCode =
+                authorisationCodeService.generateAndSaveAuthorisationCode(
+                        clientSessionId, userProfile.getEmail(), clientSession);
+
+        var authenticationResponse =
+                new AuthenticationSuccessResponse(
+                        authRequest.getRedirectionURI(),
+                        authCode,
+                        null,
+                        null,
+                        authRequest.getState(),
+                        null,
+                        authRequest.getResponseMode());
+
+        var dimensions =
+                authCodeResponseService.getDimensions(
+                        session, clientSession, clientSessionId, false, false);
+
+        var subjectId = authCodeResponseService.getSubjectId(session);
+        auditService.submitAuditEvent(
+                IPVAuditableEvent.AUTH_CODE_ISSUED,
+                clientSessionId,
+                session.getSessionId(),
+                authRequest.getClientID().getValue(),
+                internalPairwiseSubjectId,
+                Objects.isNull(session.getEmailAddress())
+                        ? AuditService.UNKNOWN
+                        : session.getEmailAddress(),
+                ipAddress,
+                AuditService.UNKNOWN,
+                persistentSessionId,
+                pair("internalSubjectId", subjectId),
+                pair("isNewAccount", session.isNewAccount()),
+                pair("rpPairwiseId", rpPairwiseSubject.getValue()),
+                pair("nonce", authRequest.getNonce()),
+                pair("authCode", authCode));
+
+        var isTestJourney =
+                dynamoClientService.isTestJourney(clientSessionId, session.getEmailAddress());
+        LOG.info("Is journey a test journey: {}", isTestJourney);
+
+        cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
+        cloudwatchMetricsService.incrementSignInByClient(
+                session.isNewAccount(),
+                clientSessionId,
+                clientSession.getClientName(),
+                isTestJourney);
+
+        authCodeResponseService.saveSession(false, sessionService, session);
+
+        LOG.info("Generating auth code response");
+        return generateApiGatewayProxyResponse(
+                302,
+                "",
+                Map.of(ResponseHeaders.LOCATION, authenticationResponse.toURI().toString()),
+                null);
+    }
+
+    public void queueSPOTRequest(
+            LogIds logIds,
+            String sectorIdentifier,
+            UserProfile userProfile,
+            Subject pairwiseSubject,
+            UserInfo userIdentityUserInfo,
+            String clientId)
+            throws JsonException {
+        LOG.info("Constructing SPOT request ready to queue");
+        var spotClaimsBuilder =
+                SPOTClaims.builder()
+                        .withClaim(VOT.getValue(), userIdentityUserInfo.getClaim(VOT.getValue()))
+                        .withClaim(
+                                IdentityClaims.CREDENTIAL_JWT.getValue(),
+                                userIdentityUserInfo
+                                        .toJSONObject()
+                                        .get(IdentityClaims.CREDENTIAL_JWT.getValue()))
+                        .withClaim(
+                                IdentityClaims.CORE_IDENTITY.getValue(),
+                                userIdentityUserInfo
+                                        .toJSONObject()
+                                        .get(IdentityClaims.CORE_IDENTITY.getValue()))
+                        .withVtm(
+                                buildURI(
+                                                configurationService
+                                                        .getOidcApiBaseURL()
+                                                        .orElseThrow(),
+                                                "/trustmark")
+                                        .toString());
+
+        var spotRequest =
+                new SPOTRequest(
+                        spotClaimsBuilder.build(),
+                        userProfile.getSubjectID(),
+                        dynamoService.getOrGenerateSalt(userProfile),
+                        sectorIdentifier,
+                        pairwiseSubject.getValue(),
+                        logIds,
+                        clientId);
+        var spotRequestString = objectMapper.writeValueAsString(spotRequest);
+        sqsClient.send(spotRequestString);
+        LOG.info("SPOT request placed on queue");
+    }
+
+    public void saveIdentityClaimsToDynamo(
+            Subject rpPairwiseSubject, UserInfo userIdentityUserInfo) {
+        LOG.info("Checking for additional identity claims to save to dynamo");
+        var additionalClaims = new HashMap<String, String>();
+        ValidClaims.getAllValidClaims().stream()
+                .filter(t -> !t.equals(ValidClaims.CORE_IDENTITY_JWT.getValue()))
+                .filter(claim -> Objects.nonNull(userIdentityUserInfo.toJSONObject().get(claim)))
+                .forEach(
+                        finalClaim ->
+                                additionalClaims.put(
+                                        finalClaim,
+                                        userIdentityUserInfo
+                                                .toJSONObject()
+                                                .get(finalClaim)
+                                                .toString()));
+        LOG.info("Additional identity claims present: {}", !additionalClaims.isEmpty());
+
+        dynamoIdentityService.saveIdentityClaims(
+                rpPairwiseSubject.getValue(),
+                additionalClaims,
+                (String) userIdentityUserInfo.getClaim(VOT.getValue()),
+                userIdentityUserInfo.getClaim(IdentityClaims.CORE_IDENTITY.getValue()).toString());
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -270,6 +270,7 @@ public class IPVCallbackHandler
                         LOG.info(
                                 "Account is suspended, requires a password reset, or requires identity to be reproved");
                     }
+
                     return generateAuthenticationErrorResponse(
                             authRequest,
                             new ErrorObject(ACCESS_DENIED_CODE, errorObject.get().getDescription()),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -172,16 +172,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                                         internalPairwiseSubjectId, auditContext));
 
         if (configurationService.isAccountInterventionServiceActionEnabled()) {
-            if (aisResult.blocked()) {
-                // TODO: back channel logout + redirect to blocked page
-                LOG.info("Account is blocked");
-            } else if (aisResult.suspended()
-                    || aisResult.resetPassword()
-                    || aisResult.reproveIdentity()) {
-                // TODO back channel logout + redirect to suspended page
-                LOG.info(
-                        "Account is suspended, requires a password reset, or requires identity to be reproved");
-            }
+            accountInterventionService.doAccountIntervention(aisResult);
         }
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -172,7 +172,17 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                                         internalPairwiseSubjectId, auditContext));
 
         if (configurationService.isAccountInterventionServiceActionEnabled()) {
-            accountInterventionService.doAccountIntervention(aisResult);
+            if (aisResult.blocked()) {
+                LOG.info("Account is blocked");
+                // TODO: (ATO-171) back channel logout + (ATO-170) redirect to blocked page
+            } else if (aisResult.suspended()
+                    || aisResult.resetPassword()
+                    || aisResult.reproveIdentity()) {
+                LOG.info(
+                        "Account is suspended, requires a password reset, or requires identity to be reproved");
+                // TODO: (ATO-171) back channel logout + (ATO-170) redirect to suspended
+                // page
+            }
         }
     }
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -1,0 +1,519 @@
+package uk.gov.di.authentication.ipv.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
+import uk.gov.di.authentication.ipv.entity.IpvCallbackException;
+import uk.gov.di.authentication.ipv.entity.LogIds;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
+import uk.gov.di.orchestration.shared.entity.Session;
+import uk.gov.di.orchestration.shared.entity.UserProfile;
+import uk.gov.di.orchestration.shared.entity.ValidClaims;
+import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
+import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.orchestration.shared.helpers.IdGenerator;
+import uk.gov.di.orchestration.shared.helpers.SaltHelper;
+import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
+import uk.gov.di.orchestration.shared.services.AccountInterventionService;
+import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.AuthCodeResponseGenerationService;
+import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
+import uk.gov.di.orchestration.shared.services.AwsSqsClient;
+import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.DynamoClientService;
+import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
+import uk.gov.di.orchestration.shared.services.DynamoService;
+import uk.gov.di.orchestration.shared.services.SerializationService;
+import uk.gov.di.orchestration.shared.services.SessionService;
+import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Named.named;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
+
+class IPVCallbackHelperTest {
+    private final AccountInterventionService accountInterventionService =
+            mock(AccountInterventionService.class);
+    private final AuditService auditService = mock(AuditService.class);
+    private final AuthCodeResponseGenerationService authCodeResponseService =
+            mock(AuthCodeResponseGenerationService.class);
+    private final AuthorisationCodeService authorisationCodeService =
+            mock(AuthorisationCodeService.class);
+    private final CloudwatchMetricsService cloudwatchMetricsService =
+            mock(CloudwatchMetricsService.class);
+    private static final ConfigurationService configurationService =
+            mock(ConfigurationService.class);
+    private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
+    private final DynamoIdentityService dynamoIdentityService = mock(DynamoIdentityService.class);
+    private final DynamoService dynamoService = mock(DynamoService.class);
+    private final SessionService sessionService = mock(SessionService.class);
+    private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
+
+    private static final String OIDC_BASE_URL = "https://base-url.com";
+    private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
+    private static final URI REDIRECT_URI = URI.create("test-uri");
+    private static final String SESSION_ID = "a-session-id";
+    private static final String CLIENT_SESSION_ID = "a-client-session-id";
+    private static final String ARBITRARY_UNIX_TIMESTAMP = "1700558480962";
+    private static final String IP_ADDRESS = "123.123.123.123";
+    private static final String PERSISTENT_SESSION_ID =
+            IdGenerator.generate() + "--" + ARBITRARY_UNIX_TIMESTAMP;
+    private static final String TEST_EMAIL_ADDRESS = "test@test.com";
+    private static final Subject PUBLIC_SUBJECT =
+            new Subject("TsEVC7vg0NPAmzB33vRUFztL2c0-fecKWKcc73fuDhc");
+    private static final Subject SUBJECT = new Subject("subject-id");
+    private static final ClientID CLIENT_ID = new ClientID();
+    private static final String CLIENT_NAME = "client-name";
+    private static final String INTERNAL_PAIRWISE_ID = "internal-pairwise-id";
+    private static final String INTERNAL_PAIRWISE_ID_WITH_INTERVENTION =
+            "internal-pairwise-id-with-intervention";
+    private static final Subject RP_PAIRWISE_SUBJECT = new Subject("rp-pairwise-id");
+    private static final State RP_STATE = new State();
+    private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
+    private static final ClientRegistry clientWithReturnCodes = generateClientWithReturnCodes();
+    private static final ClientRegistry clientWithoutReturnCodes =
+            generateClientWithoutReturnCodes();
+    private static final UserProfile userProfile = generateUserProfile();
+
+    private final UserInfo validUserIdentityUserInfo =
+            new UserInfo(
+                    new JSONObject(
+                            Map.of(
+                                    "sub", "sub-val",
+                                    "vot", "P2",
+                                    "vtm", OIDC_BASE_URL + "/trustmark",
+                                    "https://vocab.account.gov.uk/v1/coreIdentity", "core-identity",
+                                    "https://vocab.account.gov.uk/v1/passport", "passport")));
+    private final String expectedCommonSubject =
+            ClientSubjectHelper.calculatePairwiseIdentifier(
+                    SUBJECT.getValue(), "test.account.gov.uk", SaltHelper.generateNewSalt());
+
+    @RegisterExtension
+    private final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(IPVCallbackHelper.class);
+
+    private final Session session =
+            new Session(SESSION_ID)
+                    .setEmailAddress(TEST_EMAIL_ADDRESS)
+                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+
+    private static final ClientSession clientSession =
+            new ClientSession(
+                    generateAuthRequest(new OIDCClaimsRequest()).toParameters(),
+                    null,
+                    null,
+                    CLIENT_NAME);
+
+    private IPVCallbackHelper helper;
+
+    private static Stream<Arguments> internalPairwiseIds() {
+        return Stream.of(
+                Arguments.of(
+                        INTERNAL_PAIRWISE_ID,
+                        Map.of(
+                                "blocked",
+                                "false",
+                                "suspended",
+                                "false",
+                                "resetPassword",
+                                "false",
+                                "reproveIdentity",
+                                "false"),
+                        new AccountInterventionStatus(false, false, false, false)),
+                Arguments.of(
+                        INTERNAL_PAIRWISE_ID_WITH_INTERVENTION,
+                        Map.of(
+                                "blocked",
+                                "false",
+                                "suspended",
+                                "true",
+                                "resetPassword",
+                                "false",
+                                "reproveIdentity",
+                                "false"),
+                        new AccountInterventionStatus(false, true, false, false)));
+    }
+
+    private static Stream<Arguments> returnCodeClaims() {
+        var successfulLogMessage =
+                "SPOT will not be invoked due to returnCode. Returning authCode to RP";
+        var errorLogMessage = "SPOT will not be invoked. Returning Error to RP";
+
+        var claimsSetRequest =
+                new ClaimsSetRequest()
+                        .add(ValidClaims.ADDRESS.getValue())
+                        .add(ValidClaims.PASSPORT.getValue())
+                        .add(ValidClaims.CORE_IDENTITY_JWT.getValue());
+        var authRequestWithoutReturnCode =
+                generateAuthRequest(
+                        new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest));
+
+        var authRequestWithReturnCode =
+                generateAuthRequest(
+                        new OIDCClaimsRequest()
+                                .withUserInfoClaimsRequest(
+                                        claimsSetRequest.add(ValidClaims.RETURN_CODE.getValue())));
+
+        var successResponse =
+                new AuthenticationSuccessResponse(
+                                authRequestWithReturnCode.getRedirectionURI(),
+                                AUTH_CODE,
+                                null,
+                                null,
+                                authRequestWithReturnCode.getState(),
+                                null,
+                                authRequestWithReturnCode.getResponseMode())
+                        .toURI()
+                        .toString();
+        var successResponseEvent =
+                generateApiGatewayProxyResponse(
+                        302, "", Map.of(ResponseHeaders.LOCATION, successResponse), null);
+
+        var errorResponse =
+                new AuthenticationErrorResponse(
+                                URI.create(REDIRECT_URI.toString()),
+                                OAuth2Error.ACCESS_DENIED,
+                                RP_STATE,
+                                null)
+                        .toURI()
+                        .toString();
+        var errorResponseEvent =
+                generateApiGatewayProxyResponse(
+                        302, "", Map.of(ResponseHeaders.LOCATION, errorResponse), null);
+
+        return Stream.of(
+                Arguments.of(
+                        named("clientWithReturnCodes", clientWithReturnCodes),
+                        named("authRequestWithReturnCode", authRequestWithReturnCode),
+                        successfulLogMessage,
+                        successResponseEvent),
+                Arguments.of(
+                        named("clientWithReturnCodes", clientWithReturnCodes),
+                        named("authRequestWithoutReturnCode", authRequestWithoutReturnCode),
+                        errorLogMessage,
+                        errorResponseEvent),
+                Arguments.of(
+                        named("clientWithoutReturnCodes", clientWithoutReturnCodes),
+                        named("authRequestWithReturnCode", authRequestWithReturnCode),
+                        errorLogMessage,
+                        errorResponseEvent),
+                Arguments.of(
+                        named("clientWithoutReturnCodes", clientWithoutReturnCodes),
+                        named("authRequestWithoutReturnCode", authRequestWithoutReturnCode),
+                        errorLogMessage,
+                        errorResponseEvent));
+    }
+
+    @BeforeEach
+    void setUp() {
+        helper =
+                new IPVCallbackHelper(
+                        accountInterventionService,
+                        auditService,
+                        authCodeResponseService,
+                        authorisationCodeService,
+                        cloudwatchMetricsService,
+                        configurationService,
+                        dynamoClientService,
+                        dynamoIdentityService,
+                        dynamoService,
+                        SerializationService.getInstance(),
+                        sessionService,
+                        sqsClient);
+        when(accountInterventionService.getAccountStatus(INTERNAL_PAIRWISE_ID))
+                .thenReturn(new AccountInterventionStatus(false, false, false, false));
+        when(accountInterventionService.getAccountStatus(INTERNAL_PAIRWISE_ID_WITH_INTERVENTION))
+                .thenReturn(new AccountInterventionStatus(false, true, false, false));
+        when(authorisationCodeService.generateAndSaveAuthorisationCode(
+                        anyString(), anyString(), any(ClientSession.class)))
+                .thenReturn(AUTH_CODE);
+        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_BASE_URL));
+        when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
+    }
+
+    @Test
+    void shouldReturnAuthenticationErrorResponse() {
+        var authRequest = generateAuthRequest(new OIDCClaimsRequest());
+        var errorObject = new ErrorObject("error_object", "Error object description");
+
+        var response =
+                helper.generateAuthenticationErrorResponse(
+                        authRequest, errorObject, false, CLIENT_SESSION_ID, SESSION_ID);
+        var expectedURI =
+                new AuthenticationErrorResponse(
+                                URI.create(REDIRECT_URI.toString()), errorObject, RP_STATE, null)
+                        .toURI()
+                        .toString();
+
+        assertThat(
+                logging.events(),
+                hasItem(
+                        withMessageContaining(
+                                "Error in IPV AuthorisationResponse. ErrorCode: error_object. ErrorDescription: Error object description. No Session Error: false")));
+        verify(auditService)
+                .submitAuditEvent(
+                        IPVAuditableEvent.IPV_UNSUCCESSFUL_AUTHORISATION_RESPONSE_RECEIVED,
+                        CLIENT_SESSION_ID,
+                        SESSION_ID,
+                        authRequest.getClientID().getValue(),
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN);
+        assertEquals(302, response.getStatusCode());
+        assertEquals(expectedURI, response.getHeaders().get(ResponseHeaders.LOCATION));
+    }
+
+    @ParameterizedTest
+    @MethodSource("internalPairwiseIds")
+    void shouldReturnAccountInterventionStatus(
+            String internalPairwiseId,
+            Map<String, String> expectedIncrementCounterMap,
+            AccountInterventionStatus expectedAISResult) {
+        var response = helper.getAccountInterventionStatus(internalPairwiseId);
+
+        verify(accountInterventionService).getAccountStatus(internalPairwiseId);
+        verify(cloudwatchMetricsService).incrementCounter("AISResult", expectedIncrementCounterMap);
+        assertEquals(expectedAISResult, response);
+    }
+
+    @Test
+    void shouldReturnEmptyErrorObjectIfValidUserIdentity() throws IpvCallbackException {
+        var response = helper.validateUserIdentityResponse(validUserIdentityUserInfo);
+
+        assertEquals(Optional.empty(), response);
+    }
+
+    @Test
+    void shouldReturnAccessDeniedIfIPVMissingVoTOrVotNotP2() throws IpvCallbackException {
+        var invalidVoTUserIdentityUserInfo =
+                new UserInfo(
+                        new JSONObject(
+                                Map.of(
+                                        "sub", "sub-val",
+                                        "vot", "P0",
+                                        "vtm", OIDC_BASE_URL + "/trustmark")));
+
+        var response = helper.validateUserIdentityResponse(invalidVoTUserIdentityUserInfo);
+
+        assertEquals(Optional.of(OAuth2Error.ACCESS_DENIED), response);
+    }
+
+    @Test
+    void shouldThrowIpvCallbackExceptionIfTrustmarkIsInvalid() {
+        var invalidTrustmarkUserIdentityUserInfo =
+                new UserInfo(
+                        new JSONObject(
+                                Map.of(
+                                        "sub", "sub-val",
+                                        "vot", "P2",
+                                        "vtm", "invalidBaseUrl" + "/trustmark")));
+
+        var exception =
+                assertThrows(
+                        IpvCallbackException.class,
+                        () ->
+                                helper.validateUserIdentityResponse(
+                                        invalidTrustmarkUserIdentityUserInfo),
+                        "Expected to throw IpvCallbackException");
+
+        assertEquals("IPV trustmark is invalid", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("returnCodeClaims")
+    void shouldReturnAppropriateResponseDependingOnReturnCodePermissionsAndRequest(
+            ClientRegistry client,
+            AuthenticationRequest authRequest,
+            String expectedLogMessage,
+            APIGatewayProxyResponseEvent expectedResponse)
+            throws UserNotFoundException {
+        var response =
+                helper.processReturnCode(
+                        client,
+                        authRequest,
+                        CLIENT_SESSION_ID,
+                        userProfile,
+                        session,
+                        clientSession,
+                        RP_PAIRWISE_SUBJECT,
+                        INTERNAL_PAIRWISE_ID,
+                        validUserIdentityUserInfo,
+                        IP_ADDRESS,
+                        PERSISTENT_SESSION_ID);
+
+        assertThat(logging.events(), hasItem(withMessageContaining(expectedLogMessage)));
+        assertEquals(302, response.getStatusCode());
+        assertEquals(expectedResponse, response);
+    }
+
+    @Test
+    void shouldQueueSPOTRequestIfValidFormat() throws JsonException {
+        helper.queueSPOTRequest(
+                new LogIds(),
+                "sector-identifier",
+                userProfile,
+                SUBJECT,
+                validUserIdentityUserInfo,
+                CLIENT_ID.getValue());
+
+        assertThat(
+                logging.events(),
+                hasItem(withMessageContaining("Constructing SPOT request ready to queue")));
+        var spotRequestString =
+                "{\"in_claims\":{\"https://vocab.account.gov.uk/v1/coreIdentity\":\"core-identity\",\"https://vocab.account.gov.uk/v1/credentialJWT\":null,\"vot\":\"P2\",\"vtm\":\"https://base-url.com/trustmark\"},\"in_local_account_id\":\"subject-id\",\"in_salt\":null,\"in_rp_sector_id\":\"sector-identifier\",\"out_sub\":\"subject-id\",\"log_ids\":{\"session_id\":null,\"persistent_session_id\":null,\"request_id\":null,\"client_id\":null,\"client_session_id\":null},\"out_audience\":\""
+                        + CLIENT_ID.getValue()
+                        + "\"}";
+        verify(sqsClient).send(spotRequestString);
+        assertThat(
+                logging.events(), hasItem(withMessageContaining("SPOT request placed on queue")));
+    }
+
+    @Test
+    void shouldThrowJsonExceptionAndDoesNotInteractWithSqsIfCannotMapRequestToJson() {
+        var objectMapper = mock(SerializationService.class);
+        helper =
+                new IPVCallbackHelper(
+                        accountInterventionService,
+                        auditService,
+                        authCodeResponseService,
+                        authorisationCodeService,
+                        cloudwatchMetricsService,
+                        configurationService,
+                        dynamoClientService,
+                        dynamoIdentityService,
+                        dynamoService,
+                        objectMapper,
+                        sessionService,
+                        sqsClient);
+        when(objectMapper.writeValueAsString(any())).thenThrow(new JsonException("json-exception"));
+
+        var exception =
+                assertThrows(
+                        JsonException.class,
+                        () ->
+                                helper.queueSPOTRequest(
+                                        new LogIds(),
+                                        "sector-identifier",
+                                        userProfile,
+                                        SUBJECT,
+                                        validUserIdentityUserInfo,
+                                        CLIENT_ID.getValue()),
+                        "Expected to throw JsonException");
+
+        assertThat(
+                logging.events(),
+                hasItem(withMessageContaining("Constructing SPOT request ready to queue")));
+        verifyNoInteractions(sqsClient);
+        assertEquals("json-exception", exception.getMessage());
+    }
+
+    @Test
+    void shouldSaveAdditionalIdentityClaimsToDynamo() {
+        helper.saveIdentityClaimsToDynamo(RP_PAIRWISE_SUBJECT, validUserIdentityUserInfo);
+
+        assertThat(
+                logging.events(),
+                hasItem(
+                        withMessageContaining(
+                                "Checking for additional identity claims to save to dynamo")));
+        assertThat(
+                logging.events(),
+                hasItem(withMessageContaining("Additional identity claims present: true")));
+        verify(dynamoIdentityService)
+                .saveIdentityClaims(
+                        "rp-pairwise-id",
+                        Map.of("https://vocab.account.gov.uk/v1/passport", "passport"),
+                        "P2",
+                        "core-identity");
+    }
+
+    private static ClientRegistry generateClientWithReturnCodes() {
+        return new ClientRegistry()
+                .withClientID(CLIENT_ID.getValue())
+                .withConsentRequired(false)
+                .withClientName("test-client")
+                .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
+                .withSectorIdentifierUri("https://test.com")
+                .withSubjectType("pairwise")
+                .withClaims(List.of("https://vocab.account.gov.uk/v1/returnCode"));
+    }
+
+    private static ClientRegistry generateClientWithoutReturnCodes() {
+        return new ClientRegistry()
+                .withClientID(CLIENT_ID.getValue())
+                .withConsentRequired(false)
+                .withClientName("test-client")
+                .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
+                .withSectorIdentifierUri("https://test.com")
+                .withSubjectType("pairwise");
+    }
+
+    private static UserProfile generateUserProfile() {
+        return new UserProfile()
+                .withEmail(TEST_EMAIL_ADDRESS)
+                .withEmailVerified(true)
+                .withPhoneNumber("012345678902")
+                .withPhoneNumberVerified(true)
+                .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
+                .withSubjectID(SUBJECT.getValue());
+    }
+
+    public static AuthenticationRequest generateAuthRequest(OIDCClaimsRequest oidcClaimsRequest) {
+        ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
+        Scope scope = new Scope();
+        Nonce nonce = new Nonce();
+        scope.add(OIDCScopeValue.OPENID);
+        scope.add("phone");
+        scope.add("email");
+        return new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
+                .state(RP_STATE)
+                .nonce(nonce)
+                .claims(oidcClaimsRequest)
+                .build();
+    }
+}

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -55,7 +55,6 @@ import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
-import uk.gov.di.orchestration.shared.helpers.SaltHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AwsSqsClient;
@@ -154,7 +153,7 @@ class IPVCallbackHandlerTest {
     private final UserProfile userProfile = generateUserProfile();
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
-                    SUBJECT.getValue(), "test.account.gov.uk", SaltHelper.generateNewSalt());
+                    SUBJECT.getValue(), "test.account.gov.uk", salt);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =
@@ -251,6 +250,7 @@ class IPVCallbackHandlerTest {
         when(configService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
         when(context.getAwsRequestId()).thenReturn(REQUEST_ID);
         when(cookieHelper.parseSessionCookie(anyMap())).thenCallRealMethod();
+        when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(salt);
         when(ipvCallbackHelper.getAccountInterventionStatus(any(), any()))
                 .thenReturn(new AccountInterventionStatus(false, false, false, false));
         when(ipvCallbackHelper.generateAuthenticationErrorResponse(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -236,7 +236,6 @@ class ProcessingIdentityHandlerTest {
                                 ENVIRONMENT,
                                 "Status",
                                 ProcessingIdentityStatus.COMPLETED.toString()));
-        verify(accountInterventionService).doAccountIntervention(aisResult);
     }
 
     @Test

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/ProcessAuthRequestException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/ProcessAuthRequestException.java
@@ -1,0 +1,21 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+import uk.gov.di.orchestration.shared.entity.ErrorResponse;
+
+public class ProcessAuthRequestException extends Exception {
+    final int statusCode;
+    final ErrorResponse errorResponse;
+
+    public ProcessAuthRequestException(int statusCode, ErrorResponse errorResponse) {
+        this.statusCode = statusCode;
+        this.errorResponse = errorResponse;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public ErrorResponse getErrorResponse() {
+        return errorResponse;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/entity/AuthCodeResponse.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/entity/AuthCodeResponse.java
@@ -1,0 +1,19 @@
+package uk.gov.di.orchestration.entity;
+
+import com.google.gson.annotations.Expose;
+import uk.gov.di.orchestration.shared.validation.Required;
+
+public class AuthCodeResponse {
+
+    @Expose @Required private String location;
+
+    public AuthCodeResponse() {}
+
+    public AuthCodeResponse(String location) {
+        this.location = location;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -19,7 +19,7 @@ import static uk.gov.di.orchestration.shared.domain.AccountInterventionsAuditabl
 
 public class AccountInterventionService {
 
-    private static final Logger LOGGER = LogManager.getLogger(AccountInterventionService.class);
+    private static final Logger LOG = LogManager.getLogger(AccountInterventionService.class);
     private final HttpClient httpClient;
     private final URI accountInterventionServiceURI;
     private final AuditService auditService;
@@ -97,7 +97,7 @@ public class AccountInterventionService {
             throw new AccountInterventionException(
                     "Problem communicating with Account Intervention Service", e);
         }
-        LOGGER.warn("Problem communicating with Account Intervention Service " + e);
+        LOG.warn("Problem communicating with Account Intervention Service " + e);
         return noInterventionResponse();
     }
 
@@ -123,6 +123,20 @@ public class AccountInterventionService {
         incrementCloudwatchMetrics(accountInterventionStatus);
 
         return accountInterventionStatus;
+    }
+
+    public void doAccountIntervention(AccountInterventionStatus accountInterventionStatus) {
+        if (accountInterventionStatus.blocked()) {
+            LOG.info("Account is blocked");
+            // TODO: (ATO-171) back channel logout + (ATO-170) redirect to blocked page
+        } else if (accountInterventionStatus.suspended()
+                || accountInterventionStatus.resetPassword()
+                || accountInterventionStatus.reproveIdentity()) {
+            LOG.info(
+                    "Account is suspended, requires a password reset, or requires identity to be reproved");
+            // TODO: (ATO-171) back channel logout + (ATO-170) redirect to suspended
+            // page
+        }
     }
 
     private void incrementCloudwatchMetrics(AccountInterventionStatus accountInterventionStatus) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -25,7 +25,6 @@ public class AccountInterventionService {
     private final AuditService auditService;
     private final boolean accountInterventionsCallEnabled;
     private final boolean accountInterventionsActionEnabled;
-    private final ConfigurationService configurationService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
 
     public AccountInterventionService(ConfigurationService configService) {
@@ -48,12 +47,11 @@ public class AccountInterventionService {
             HttpClient httpClient,
             CloudwatchMetricsService cloudwatchMetricsService,
             AuditService auditService) {
-        this.configurationService = configService;
         this.accountInterventionServiceURI = configService.getAccountInterventionServiceURI();
         this.accountInterventionsCallEnabled =
-                configurationService.isAccountInterventionServiceCallEnabled();
+                configService.isAccountInterventionServiceCallEnabled();
         this.accountInterventionsActionEnabled =
-                configurationService.isAccountInterventionServiceActionEnabled();
+                configService.isAccountInterventionServiceActionEnabled();
         this.httpClient = httpClient;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.auditService = auditService;
@@ -97,7 +95,7 @@ public class AccountInterventionService {
             throw new AccountInterventionException(
                     "Problem communicating with Account Intervention Service", e);
         }
-        LOG.warn("Problem communicating with Account Intervention Service " + e);
+        LOG.warn("Problem communicating with Account Intervention Service ", e);
         return noInterventionResponse();
     }
 
@@ -123,20 +121,6 @@ public class AccountInterventionService {
         incrementCloudwatchMetrics(accountInterventionStatus);
 
         return accountInterventionStatus;
-    }
-
-    public void doAccountIntervention(AccountInterventionStatus accountInterventionStatus) {
-        if (accountInterventionStatus.blocked()) {
-            LOG.info("Account is blocked");
-            // TODO: (ATO-171) back channel logout + (ATO-170) redirect to blocked page
-        } else if (accountInterventionStatus.suspended()
-                || accountInterventionStatus.resetPassword()
-                || accountInterventionStatus.reproveIdentity()) {
-            LOG.info(
-                    "Account is suspended, requires a password reset, or requires identity to be reproved");
-            // TODO: (ATO-171) back channel logout + (ATO-170) redirect to suspended
-            // page
-        }
     }
 
     private void incrementCloudwatchMetrics(AccountInterventionStatus accountInterventionStatus) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -1,0 +1,212 @@
+package uk.gov.di.orchestration.shared.services;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.entity.AuthCodeResponse;
+import uk.gov.di.orchestration.shared.domain.AuditableEvent;
+import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
+import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
+import uk.gov.di.orchestration.shared.entity.Session;
+import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
+import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
+import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
+import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
+import uk.gov.di.orchestration.shared.serialization.Json;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING;
+import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING_DOC_APP_JOURNEY;
+import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
+
+public class AuthCodeResponseGenerationService {
+    private static final Logger LOG = LogManager.getLogger(AuthCodeResponseGenerationService.class);
+
+    private final AuditService auditService;
+    private final CloudwatchMetricsService cloudwatchMetricsService;
+    private final ConfigurationService configurationService;
+    private final DynamoService dynamoService;
+    private final DynamoClientService dynamoClientService;
+
+    public AuthCodeResponseGenerationService(
+            AuditService auditService,
+            CloudwatchMetricsService cloudwatchMetricsService,
+            ConfigurationService configurationService,
+            DynamoService dynamoService,
+            DynamoClientService dynamoClientService) {
+        this.auditService = auditService;
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
+        this.configurationService = configurationService;
+        this.dynamoService = dynamoService;
+        this.dynamoClientService = dynamoClientService;
+    }
+
+    public AuthCodeResponseGenerationService(ConfigurationService configurationService) {
+        auditService = new AuditService(configurationService);
+        cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
+        this.configurationService = configurationService;
+        dynamoService = new DynamoService(configurationService);
+        dynamoClientService = new DynamoClientService(configurationService);
+    }
+
+    public AuthCodeResponseGenerationService() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public APIGatewayProxyResponseEvent generateAuthCodeResponse(
+            APIGatewayProxyRequestEvent input,
+            boolean isTestJourney,
+            boolean docAppJourney,
+            AuthenticationRequest authenticationRequest,
+            AuthorizationCode authCode,
+            Session session,
+            String clientSessionId,
+            ClientSession clientSession,
+            SessionService sessionService,
+            ClientID clientID,
+            AuthenticationSuccessResponse authenticationResponse,
+            AuditableEvent auditableEvent)
+            throws UserNotFoundException, ClientNotFoundException, Json.JsonException {
+
+        var dimensions =
+                getDimensions(session, clientSession, clientID, isTestJourney, docAppJourney);
+
+        var subjectId = AuditService.UNKNOWN;
+        var rpPairwiseId = AuditService.UNKNOWN;
+        String internalCommonPairwiseSubjectId;
+        if (docAppJourney) {
+            LOG.info("Session not saved for DocCheckingAppUser");
+            internalCommonPairwiseSubjectId = clientSession.getDocAppSubjectId().getValue();
+        } else {
+            processVectorOfTrust(clientSession, dimensions);
+            internalCommonPairwiseSubjectId = session.getInternalCommonSubjectIdentifier();
+            subjectId = getSubjectId(session);
+            rpPairwiseId = getRpPairwiseId(session, clientID);
+        }
+
+        auditService.submitAuditEvent(
+                auditableEvent,
+                clientSessionId,
+                session.getSessionId(),
+                clientID.getValue(),
+                internalCommonPairwiseSubjectId,
+                Objects.isNull(session.getEmailAddress())
+                        ? AuditService.UNKNOWN
+                        : session.getEmailAddress(),
+                IpAddressHelper.extractIpAddress(input),
+                AuditService.UNKNOWN,
+                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                pair("internalSubjectId", subjectId),
+                pair("isNewAccount", session.isNewAccount()),
+                pair("rpPairwiseId", rpPairwiseId),
+                pair("nonce", authenticationRequest.getNonce()),
+                pair("authCode", authCode));
+
+        cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
+        cloudwatchMetricsService.incrementSignInByClient(
+                session.isNewAccount(),
+                clientID.getValue(),
+                clientSession.getClientName(),
+                isTestJourney);
+        if (docAppJourney) {
+            sessionService.save(session.setNewAccount(EXISTING_DOC_APP_JOURNEY));
+        } else {
+            sessionService.save(session.setAuthenticated(true).setNewAccount(EXISTING));
+        }
+
+        LOG.info("Generating successful auth code response");
+        return generateApiGatewayProxyResponse(
+                200, new AuthCodeResponse(authenticationResponse.toURI().toString()));
+    }
+
+    private Map<String, String> getDimensions(
+            Session session,
+            ClientSession clientSession,
+            ClientID clientID,
+            boolean isTestJourney,
+            boolean docAppJourney) {
+        Map<String, String> dimensions =
+                new HashMap<>(
+                        Map.of(
+                                "Account",
+                                session.isNewAccount().name(),
+                                "Environment",
+                                configurationService.getEnvironment(),
+                                "Client",
+                                clientID.getValue(),
+                                "IsTest",
+                                Boolean.toString(isTestJourney),
+                                "IsDocApp",
+                                Boolean.toString(docAppJourney),
+                                "ClientName",
+                                clientSession.getClientName()));
+
+        if (Objects.nonNull(session.getVerifiedMfaMethodType())) {
+            dimensions.put("MfaMethod", session.getVerifiedMfaMethodType().getValue());
+        } else {
+            LOG.info(
+                    "No mfa method to set. User is either authenticated or signing in from a low level service");
+        }
+        return dimensions;
+    }
+
+    private void processVectorOfTrust(ClientSession clientSession, Map<String, String> dimensions) {
+        var mfaNotRequired =
+                clientSession
+                        .getEffectiveVectorOfTrust()
+                        .getCredentialTrustLevel()
+                        .equals(CredentialTrustLevel.LOW_LEVEL);
+        var levelOfConfidence = LevelOfConfidence.NONE.getValue();
+        if (clientSession.getEffectiveVectorOfTrust().containsLevelOfConfidence()) {
+            levelOfConfidence =
+                    clientSession.getEffectiveVectorOfTrust().getLevelOfConfidence().getValue();
+        }
+        dimensions.put("MfaRequired", mfaNotRequired ? "No" : "Yes");
+        dimensions.put("RequestedLevelOfConfidence", levelOfConfidence);
+    }
+
+    private String getSubjectId(Session session) throws UserNotFoundException {
+        var userProfile =
+                dynamoService
+                        .getUserProfileByEmailMaybe(session.getEmailAddress())
+                        .orElseThrow(
+                                () ->
+                                        new UserNotFoundException(
+                                                "Unable to find user with given email address"));
+        return Objects.isNull(session.getEmailAddress())
+                ? AuditService.UNKNOWN
+                : userProfile.getSubjectID();
+    }
+
+    private String getRpPairwiseId(Session session, ClientID clientID)
+            throws UserNotFoundException, ClientNotFoundException {
+        var userProfile =
+                dynamoService
+                        .getUserProfileByEmailMaybe(session.getEmailAddress())
+                        .orElseThrow(
+                                () ->
+                                        new UserNotFoundException(
+                                                "Unable to find user with given email address"));
+        var client =
+                dynamoClientService
+                        .getClient(clientID.getValue())
+                        .orElseThrow(() -> new ClientNotFoundException(clientID.getValue()));
+        return ClientSubjectHelper.getSubject(
+                        userProfile,
+                        client,
+                        dynamoService,
+                        configurationService.getInternalSectorUri())
+                .getValue();
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -2,16 +2,10 @@ package uk.gov.di.orchestration.shared.services;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.shared.domain.AuditableEvent;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
 import uk.gov.di.orchestration.shared.exceptions.AccountInterventionException;
-import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.io.IOException;
 import java.net.URI;
@@ -20,11 +14,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Map;
-import java.util.stream.Stream;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -35,7 +25,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.shared.domain.AccountInterventionsAuditableEvent.AIS_RESPONSE_RECEIVED;
-import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class AccountInterventionServiceTest {
     private final ConfigurationService config = mock(ConfigurationService.class);
@@ -44,7 +33,7 @@ class AccountInterventionServiceTest {
             mock(CloudwatchMetricsService.class);
     private final AuditService auditService = mock(AuditService.class);
 
-    private static String ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE =
+    private static final String ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE =
             """
             {
                 "intervention": {
@@ -65,8 +54,8 @@ class AccountInterventionServiceTest {
             }
             """;
 
-    private static String BASE_AIS_URL = "http://example.com/somepath/";
-    private static AuditContext someAuditContext =
+    private static final String BASE_AIS_URL = "http://example.com/somepath/";
+    private static final AuditContext someAuditContext =
             new AuditContext(
                     "some-client-session-id",
                     "some-session-id",
@@ -76,35 +65,6 @@ class AccountInterventionServiceTest {
                     "some-ip-address",
                     "some-phone-number",
                     "some-persistent-session-id");
-
-    @RegisterExtension
-    private final CaptureLoggingExtension logging =
-            new CaptureLoggingExtension(AccountInterventionService.class);
-
-    private static Stream<Arguments> accountInterventionStatuses() {
-        return Stream.of(
-                Arguments.of(
-                        new AccountInterventionStatus(true, false, false, false),
-                        "Account is blocked"),
-                Arguments.of(
-                        new AccountInterventionStatus(false, true, false, false),
-                        "Account is suspended, requires a password reset, or requires identity to be reproved"),
-                Arguments.of(
-                        new AccountInterventionStatus(false, true, true, false),
-                        "Account is suspended, requires a password reset, or requires identity to be reproved"),
-                Arguments.of(
-                        new AccountInterventionStatus(false, true, false, true),
-                        "Account is suspended, requires a password reset, or requires identity to be reproved"),
-                Arguments.of(
-                        new AccountInterventionStatus(false, true, true, true),
-                        "Account is suspended, requires a password reset, or requires identity to be reproved"),
-                Arguments.of(
-                        new AccountInterventionStatus(false, false, true, false),
-                        "Account is suspended, requires a password reset, or requires identity to be reproved"),
-                Arguments.of(
-                        new AccountInterventionStatus(false, false, false, true),
-                        "Account is suspended, requires a password reset, or requires identity to be reproved"));
-    }
 
     @BeforeEach
     void setup() throws URISyntaxException {
@@ -177,10 +137,10 @@ class AccountInterventionServiceTest {
 
         verifyNoInteractions(httpClient);
 
-        assertEquals(false, status.blocked());
-        assertEquals(false, status.suspended());
-        assertEquals(false, status.reproveIdentity());
-        assertEquals(false, status.resetPassword());
+        assertFalse(status.blocked());
+        assertFalse(status.suspended());
+        assertFalse(status.reproveIdentity());
+        assertFalse(status.resetPassword());
     }
 
     @Test
@@ -198,9 +158,7 @@ class AccountInterventionServiceTest {
 
         assertThrows(
                 AccountInterventionException.class,
-                () -> {
-                    accountInterventionService.getAccountStatus(internalPairwiseSubjectId);
-                });
+                () -> accountInterventionService.getAccountStatus(internalPairwiseSubjectId));
     }
 
     @Test
@@ -263,33 +221,6 @@ class AccountInterventionServiceTest {
 
         assertThrows(
                 AccountInterventionException.class,
-                () -> {
-                    accountInterventionService.getAccountStatus(internalPairwiseSubjectId, null);
-                });
-    }
-
-    @Test
-    void shouldNotPerformInterventionIfAccountInterventionStatusIndicatesNoInterventionRequired() {
-        var accountInterventionStatus = new AccountInterventionStatus(false, false, false, false);
-        var accountInterventionService =
-                new AccountInterventionService(
-                        config, httpClient, cloudwatchMetricsService, auditService);
-
-        accountInterventionService.doAccountIntervention(accountInterventionStatus);
-
-        assertThat(logging.events(), hasSize(0));
-    }
-
-    @ParameterizedTest
-    @MethodSource("accountInterventionStatuses")
-    void shouldPerformInterventionIfAccountInterventionStatusIndicatesToDoSo(
-            AccountInterventionStatus accountInterventionStatus, String expectedLogMessage) {
-        var accountInterventionService =
-                new AccountInterventionService(
-                        config, httpClient, cloudwatchMetricsService, auditService);
-
-        accountInterventionService.doAccountIntervention(accountInterventionStatus);
-
-        assertThat(logging.events(), hasItem(withMessageContaining(expectedLogMessage)));
+                () -> accountInterventionService.getAccountStatus(internalPairwiseSubjectId, null));
     }
 }


### PR DESCRIPTION
## What?

ATO-133:
- Persist return codes in DynamoDB; as it is storing the valid claims, returnCode exists there and shall be saved in the case that a return code is present

ATO-134:
- If there is an error returned from IPV, make AIS call then return ACCESS DENIED
- If does not match requested level of confidence (`userIdentityError`) then make AIS call then check if `returnCode` is present
- If `returnCode` is present, process the return code:
  - If clientRegistry does not contain `returnCode` or `returnCode` was not requested in the `authRequest`, bypass SPoT and return ACCESS DENIED
  - Else save identityClaims, generate authCode and returned RP
    - For generating the authCode, use similar process to the `AuthCodeHandler` to include all necessary logging etc (extract out to be used elsewhere)
