### PR TITLE
AUT-1988: Fixup internal pairwise ID generation

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -165,7 +166,7 @@ public class TokenHandler
                             ? AuditService.UNKNOWN
                             : ClientSubjectHelper.calculatePairwiseIdentifier(
                                     subjectID,
-                                    configurationService.getInternalSectorUri(),
+                                    URI.create(configurationService.getInternalSectorUri()),
                                     SdkBytes.fromByteBuffer(userProfile.getSalt()).asByteArray());
 
             auditService.submitAuditEvent(

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
@@ -206,7 +206,7 @@ class TokenHandlerTest {
         String internalPairwiseId =
                 ClientSubjectHelper.calculatePairwiseIdentifier(
                         SUBJECT_ID,
-                        "https://test-backend.com",
+                        "test-backend.com",
                         SdkBytes.fromByteBuffer(ByteBuffer.allocateDirect(12345)).asByteArray());
         APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
         String formData = "code=" + VALID_AUTH_CODE + "&client_id=" + CLIENT_ID;

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -36,6 +36,7 @@ module "auth_token" {
     AUTHENTICATION_BACKEND_URI                = "https://${aws_api_gateway_rest_api.di_auth_ext_api.id}-${data.aws_vpc_endpoint.auth_api_vpc_endpoint.id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
     ORCH_TO_AUTH_TOKEN_SIGNING_PUBLIC_KEY     = var.orch_to_auth_public_signing_key
     SUPPORT_AUTH_ORCH_SPLIT                   = var.support_auth_orch_split
+    INTERNAl_SECTOR_URI                       = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.external.lambda.TokenHandler::handleRequest"
   handler_runtime       = "java17"


### PR DESCRIPTION
## What?

- Make internal sector uri available via env vars
- Use host only to generate ID

## Why?

- Previously failed with a null pointer exception
- Would not have generated the correct ID

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3597
