### PR TITLE
INCIDEN-576: Add tests to check all handlers have handleRequest method

### DIFF
--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/DynatraceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/DynatraceTest.java
@@ -1,0 +1,12 @@
+package uk.gov.di.accountmanagement;
+
+import org.junit.jupiter.api.Test;
+
+import static uk.gov.di.authentication.sharedtest.helper.DynatraceHelper.assertHandlersHaveOwnHandleRequestMethods;
+
+public class DynatraceTest {
+    @Test
+    void allHandlersHaveOwnHandleRequestMethod() {
+        assertHandlersHaveOwnHandleRequestMethods("uk.gov.di.accountmanagement.lambda");
+    }
+}

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/DynatraceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/DynatraceTest.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.external;
+
+import org.junit.jupiter.api.Test;
+
+import static uk.gov.di.authentication.sharedtest.helper.DynatraceHelper.assertHandlersHaveOwnHandleRequestMethods;
+
+public class DynatraceTest {
+    @Test
+    void allHandlersHaveOwnHandleRequestMethod() {
+        assertHandlersHaveOwnHandleRequestMethods("uk.gov.di.authentication.external.lambda");
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,8 @@ subprojects {
                 "org.mockito:mockito-core:5.8.0",
                 "org.awaitility:awaitility:4.2.0",
                 "com.approvaltests:approvaltests:22.3.2",
-                configurations.hamcrest
+                configurations.hamcrest,
+                "org.reflections:reflections:0.10.2"
 
         test_runtime "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/DynatraceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/DynatraceTest.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.clientregistry;
+
+import org.junit.jupiter.api.Test;
+
+import static uk.gov.di.orchestration.sharedtest.helper.DynatraceHelper.assertHandlersHaveOwnHandleRequestMethods;
+
+public class DynatraceTest {
+    @Test
+    void allHandlersHaveOwnHandleRequestMethod() {
+        assertHandlersHaveOwnHandleRequestMethods("uk.gov.di.authentication.clientregistry.lambda");
+    }
+}

--- a/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/DynatraceTest.java
+++ b/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/DynatraceTest.java
@@ -1,0 +1,13 @@
+package uk.gov.di.authentication.deliveryreceiptsapi;
+
+import org.junit.jupiter.api.Test;
+
+import static uk.gov.di.authentication.sharedtest.helper.DynatraceHelper.assertHandlersHaveOwnHandleRequestMethods;
+
+public class DynatraceTest {
+    @Test
+    void allHandlersHaveOwnHandleRequestMethod() {
+        assertHandlersHaveOwnHandleRequestMethods(
+                "uk.gov.di.authentication.deliveryreceiptsapi.lambda");
+    }
+}

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/DynatraceTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/DynatraceTest.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.app;
+
+import org.junit.jupiter.api.Test;
+
+import static uk.gov.di.orchestration.sharedtest.helper.DynatraceHelper.assertHandlersHaveOwnHandleRequestMethods;
+
+public class DynatraceTest {
+    @Test
+    void allHandlersHaveOwnHandleRequestMethod() {
+        assertHandlersHaveOwnHandleRequestMethods("uk.gov.di.authentication.app.lambda");
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -55,6 +55,12 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
     }
 
     @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        return super.handleRequest(input, context);
+    }
+
+    @Override
     public APIGatewayProxyResponseEvent handleRequestWithUserContext(
             APIGatewayProxyRequestEvent input,
             Context context,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/DynatraceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/DynatraceTest.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.frontendapi;
+
+import org.junit.jupiter.api.Test;
+
+import static uk.gov.di.authentication.sharedtest.helper.DynatraceHelper.assertHandlersHaveOwnHandleRequestMethods;
+
+public class DynatraceTest {
+    @Test
+    void allHandlersHaveOwnHandleRequestMethod() {
+        assertHandlersHaveOwnHandleRequestMethods("uk.gov.di.authentication.frontendapi.lambda");
+    }
+}

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/DynatraceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/DynatraceTest.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.ipv;
+
+import org.junit.jupiter.api.Test;
+
+import static uk.gov.di.orchestration.sharedtest.helper.DynatraceHelper.assertHandlersHaveOwnHandleRequestMethods;
+
+public class DynatraceTest {
+    @Test
+    void allHandlersHaveOwnHandleRequestMethod() {
+        assertHandlersHaveOwnHandleRequestMethods("uk.gov.di.authentication.ipv.lambda");
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/DynatraceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/DynatraceTest.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.oidc;
+
+import org.junit.jupiter.api.Test;
+
+import static uk.gov.di.orchestration.sharedtest.helper.DynatraceHelper.assertHandlersHaveOwnHandleRequestMethods;
+
+public class DynatraceTest {
+    @Test
+    void allHandlersHaveOwnHandleRequestMethod() {
+        assertHandlersHaveOwnHandleRequestMethods("uk.gov.di.authentication.oidc.lambda");
+    }
+}

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/DynatraceHelper.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/DynatraceHelper.java
@@ -1,0 +1,36 @@
+package uk.gov.di.orchestration.sharedtest.helper;
+
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.reflections.Reflections;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.reflections.scanners.Scanners.SubTypes;
+
+public class DynatraceHelper {
+    private static final ClassLoader loader = ClassLoader.getSystemClassLoader();
+
+    public static void assertHandlersHaveOwnHandleRequestMethods(String packageName) {
+        getHandlers(packageName).forEach(DynatraceHelper::assertHasOwnHandleRequestMethod);
+    }
+
+    private static Stream<String> getHandlers(String packageName) {
+        return new Reflections(packageName).get(SubTypes.of(RequestHandler.class)).stream();
+    }
+
+    private static void assertHasOwnHandleRequestMethod(String className) {
+        try {
+            var methods = loader.loadClass(className).getDeclaredMethods();
+            var handleRequestMethods =
+                    Arrays.stream(methods).filter(m -> "handleRequest".equals(m.getName())).count();
+            assertTrue(
+                    handleRequestMethods > 0,
+                    className
+                            + " does not define a handleRequest method, which is required for Dynatrace");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/DynatraceHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/DynatraceHelper.java
@@ -1,0 +1,36 @@
+package uk.gov.di.authentication.sharedtest.helper;
+
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.reflections.Reflections;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.reflections.scanners.Scanners.SubTypes;
+
+public class DynatraceHelper {
+    private static final ClassLoader loader = ClassLoader.getSystemClassLoader();
+
+    public static void assertHandlersHaveOwnHandleRequestMethods(String packageName) {
+        getHandlers(packageName).forEach(DynatraceHelper::assertHasOwnHandleRequestMethod);
+    }
+
+    private static Stream<String> getHandlers(String packageName) {
+        return new Reflections(packageName).get(SubTypes.of(RequestHandler.class)).stream();
+    }
+
+    private static void assertHasOwnHandleRequestMethod(String className) {
+        try {
+            var methods = loader.loadClass(className).getDeclaredMethods();
+            var handleRequestMethods =
+                    Arrays.stream(methods).filter(m -> "handleRequest".equals(m.getName())).count();
+            assertTrue(
+                    handleRequestMethods > 0,
+                    className
+                            + " does not define a handleRequest method, which is required for Dynatrace");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## What?
- Add tests to ensure all lambda handlers define their own handleRequest method
- Fix AccountInterventionsHandler

## Why?
We had an incident on Tuesday when this method was removed from a handler. This causes dynatrace to hang, which means all functions time out at 30 seconds. This dramatically increases cold starts, and means we lose observability.
