### PR TITLE
ATO-171: Perform back-channel logout if account status is suspended or blocked

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -48,7 +48,7 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
         handler =
                 new AccountInterventionsHandler(
                         ACCOUNT_INTERVENTIONS_HANDLER_CONFIGURATION_SERVICE);
-        accountInterventionsStubExtension.init(setupUserAndRetrieveUserId());
+        accountInterventionsStubExtension.init(setupUserAndRetrieveUserId(), false, false);
         txmaAuditQueue.clear();
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/LogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/LogoutService.java
@@ -183,7 +183,10 @@ public class LogoutService {
         } else {
             throw new RuntimeException("Account status must be blocked or suspended");
         }
-        sessionId.ifPresent(t -> cloudwatchMetricsService.incrementLogout(clientId));
+        sessionId.ifPresent(
+                t ->
+                        cloudwatchMetricsService.incrementLogout(
+                                clientId, Optional.of(accountStatus)));
         return generateLogoutResponse(
                 ConstructUriHelper.buildURI(
                         configurationService.getOidcApiBaseURL().orElseThrow(), redirectUri),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/LogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/LogoutService.java
@@ -7,8 +7,10 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
+import uk.gov.di.orchestration.shared.helpers.ConstructUriHelper;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.services.AuditService;
@@ -62,6 +64,16 @@ public class LogoutService {
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.backChannelLogoutService = backChannelLogoutService;
+    }
+
+    public APIGatewayProxyResponseEvent handleAccountInterventionLogout(
+            Session session,
+            APIGatewayProxyRequestEvent input,
+            Optional<String> clientId,
+            Optional<String> sessionId,
+            AccountInterventionStatus accountStatus) {
+        destroySessions(session);
+        return generateAccountInterventionLogoutResponse(input, clientId, sessionId, accountStatus);
     }
 
     public void destroySessions(Session session) {
@@ -154,5 +166,31 @@ public class LogoutService {
 
         return generateApiGatewayProxyResponse(
                 302, "", Map.of(ResponseHeaders.LOCATION, uri.toString()), null);
+    }
+
+    private APIGatewayProxyResponseEvent generateAccountInterventionLogoutResponse(
+            APIGatewayProxyRequestEvent input,
+            Optional<String> clientId,
+            Optional<String> sessionId,
+            AccountInterventionStatus accountStatus) {
+        String redirectUri;
+        if (accountStatus.blocked()) {
+            redirectUri = configurationService.getAccountStatusBlockedURI();
+            LOG.info("Generating Account Intervention blocked logout response");
+        } else if (accountStatus.suspended()) {
+            redirectUri = configurationService.getAccountStatusSuspendedURI();
+            LOG.info("Generating Account Intervention suspended logout response");
+        } else {
+            throw new RuntimeException("Account status must be blocked or suspended");
+        }
+        sessionId.ifPresent(t -> cloudwatchMetricsService.incrementLogout(clientId));
+        return generateLogoutResponse(
+                ConstructUriHelper.buildURI(
+                        configurationService.getOidcApiBaseURL().orElseThrow(), redirectUri),
+                Optional.empty(),
+                Optional.empty(),
+                input,
+                clientId,
+                sessionId);
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
 import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
 import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
 import uk.gov.di.authentication.oidc.services.InitiateIPVAuthorisationService;
+import uk.gov.di.authentication.oidc.services.LogoutService;
 import uk.gov.di.orchestration.shared.conditions.IdentityHelper;
 import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 import uk.gov.di.orchestration.shared.entity.*;
@@ -64,6 +65,7 @@ class AuthenticationCallbackHandlerTest {
             mock(InitiateIPVAuthorisationService.class);
     private static final AccountInterventionService accountInterventionService =
             mock(AccountInterventionService.class);
+    private static final LogoutService logoutService = mock(LogoutService.class);
     private static final CookieHelper cookieHelper = mock(CookieHelper.class);
     private final ClientService clientService = mock(ClientService.class);
     private static final String TEST_FRONTEND_BASE_URL = "test.orchestration.frontend.url";
@@ -136,7 +138,8 @@ class AuthenticationCallbackHandlerTest {
                         authorisationCodeService,
                         clientService,
                         initiateIPVAuthorisationService,
-                        accountInterventionService);
+                        accountInterventionService,
+                        logoutService);
     }
 
     @Test
@@ -189,80 +192,6 @@ class AuthenticationCallbackHandlerTest {
                         eq(pair("rpPairwiseId", PAIRWISE_SUBJECT_ID.getValue())),
                         eq(pair("nonce", RP_NONCE)),
                         eq(pair("authCode", AUTH_CODE_RP_TO_ORCH.getValue())));
-    }
-
-    @Nested
-    class redirectToIPV {
-        private static MockedStatic<IdentityHelper> mockedIdentityHelper;
-
-        @BeforeAll
-        static void init() {
-            when(authorizationService.validateRequest(any(), any())).thenReturn(true);
-        }
-
-        @BeforeEach
-        void setup() throws UnsuccessfulCredentialResponseException {
-            mockedIdentityHelper = mockStatic(IdentityHelper.class);
-            when(IdentityHelper.identityRequired(anyMap(), anyBoolean(), anyBoolean()))
-                    .thenReturn(true);
-            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
-            when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
-                    .thenReturn(USER_INFO);
-            when(initiateIPVAuthorisationService.sendRequestToIPV(
-                            any(), any(), any(), any(), any(), any(), any(), any(), any()))
-                    .thenReturn(createIPVApiResponse());
-            usingValidSession();
-            usingValidClientSession();
-            usingValidClient();
-        }
-
-        @AfterEach
-        void afterEach() {
-            mockedIdentityHelper.close();
-        }
-
-        @Test
-        void shouldRedirectToIPVWhenIdentityRequired() {
-            var event = new APIGatewayProxyRequestEvent();
-            setValidHeadersAndQueryParameters(event);
-
-            var response = handler.handleRequest(event, null);
-
-            assertThat(response, hasStatus(302));
-
-            verify(cloudwatchMetricsService).incrementCounter(eq("AuthenticationCallback"), any());
-
-            verify(initiateIPVAuthorisationService)
-                    .sendRequestToIPV(
-                            any(), any(), any(), any(), any(), any(), any(), any(), any());
-        }
-
-        @Test
-        void shouldRedirectToIPVWithReproveIdentityWhenAccountInterventionsEnabled() {
-            when(configurationService.isAccountInterventionServiceEnabled()).thenReturn(true);
-            when(configurationService.isAccountInterventionServiceAuditEnabled()).thenReturn(true);
-            boolean reproveIdentity = true;
-            when(accountInterventionService.getAccountStatus(anyString()))
-                    .thenReturn(
-                            new AccountInterventionStatus(false, false, reproveIdentity, false));
-
-            var event = new APIGatewayProxyRequestEvent();
-            setValidHeadersAndQueryParameters(event);
-
-            handler.handleRequest(event, null);
-
-            verify(initiateIPVAuthorisationService)
-                    .sendRequestToIPV(
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            eq(reproveIdentity));
-        }
     }
 
     @Test
@@ -355,6 +284,174 @@ class AuthenticationCallbackHandlerTest {
                         OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED),
                 auditService);
         verifyNoInteractions(userInfoStorageService, cloudwatchMetricsService);
+    }
+
+    @Nested
+    class redirectToIPV {
+        private static MockedStatic<IdentityHelper> mockedIdentityHelper;
+
+        @BeforeAll
+        static void init() {
+            when(authorizationService.validateRequest(any(), any())).thenReturn(true);
+        }
+
+        @BeforeEach
+        void setup() throws UnsuccessfulCredentialResponseException {
+            mockedIdentityHelper = mockStatic(IdentityHelper.class);
+            when(IdentityHelper.identityRequired(anyMap(), anyBoolean(), anyBoolean()))
+                    .thenReturn(true);
+            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
+                    .thenReturn(USER_INFO);
+            when(initiateIPVAuthorisationService.sendRequestToIPV(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(createIPVApiResponse());
+            usingValidSession();
+            usingValidClientSession();
+            usingValidClient();
+        }
+
+        @AfterEach
+        void afterEach() {
+            mockedIdentityHelper.close();
+        }
+
+        @Test
+        void shouldRedirectToIPVWhenIdentityRequired() {
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            var response = handler.handleRequest(event, null);
+
+            assertThat(response, hasStatus(302));
+
+            verify(cloudwatchMetricsService).incrementCounter(eq("AuthenticationCallback"), any());
+
+            verify(initiateIPVAuthorisationService)
+                    .sendRequestToIPV(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
+        void shouldRedirectToIPVWithReproveIdentityWhenAccountInterventionsEnabled() {
+            when(configurationService.isAccountInterventionServiceEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceAuditEnabled()).thenReturn(true);
+            boolean reproveIdentity = true;
+            when(accountInterventionService.getAccountStatus(anyString()))
+                    .thenReturn(
+                            new AccountInterventionStatus(false, false, reproveIdentity, false));
+
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            handler.handleRequest(event, null);
+
+            verify(initiateIPVAuthorisationService)
+                    .sendRequestToIPV(
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            eq(reproveIdentity));
+        }
+    }
+
+    @Nested
+    class accountInterventions {
+        private static MockedStatic<IdentityHelper> mockedIdentityHelper;
+
+        @BeforeAll
+        static void init() {
+            when(authorizationService.validateRequest(any(), any())).thenReturn(true);
+        }
+
+        @BeforeEach
+        void setup() throws UnsuccessfulCredentialResponseException {
+            mockedIdentityHelper = mockStatic(IdentityHelper.class);
+            when(IdentityHelper.identityRequired(anyMap(), anyBoolean(), anyBoolean()))
+                    .thenReturn(false);
+            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
+                    .thenReturn(USER_INFO);
+            usingValidSession();
+            usingValidClientSession();
+            usingValidClient();
+        }
+
+        @AfterEach
+        void tearDown() {
+            mockedIdentityHelper.close();
+        }
+
+        @Test
+        void shouldPerformBackChannelLogoutWhenAccountStatusIsBlocked() {
+            AccountInterventionStatus accountStatus =
+                    new AccountInterventionStatus(true, false, false, false);
+            when(configurationService.isAccountInterventionServiceEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceAuditEnabled()).thenReturn(true);
+            when(accountInterventionService.getAccountStatus(any())).thenReturn(accountStatus);
+
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            handler.handleRequest(event, null);
+
+            verify(logoutService)
+                    .handleAccountInterventionLogout(
+                            session,
+                            event,
+                            Optional.of(CLIENT_ID.toString()),
+                            Optional.of(SESSION_ID.toString()),
+                            accountStatus);
+        }
+
+        @Test
+        void shouldPerformBackChannelLogoutWhenResetPasswordIsRequired() {
+            AccountInterventionStatus accountStatus =
+                    new AccountInterventionStatus(false, true, false, true);
+            when(configurationService.isAccountInterventionServiceEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceAuditEnabled()).thenReturn(true);
+            when(accountInterventionService.getAccountStatus(any())).thenReturn(accountStatus);
+
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            handler.handleRequest(event, null);
+
+            verify(logoutService)
+                    .handleAccountInterventionLogout(
+                            session,
+                            event,
+                            Optional.of(CLIENT_ID.toString()),
+                            Optional.of(SESSION_ID.toString()),
+                            accountStatus);
+        }
+
+        @Test
+        void shouldPerformBackChannelLogoutWhenNotOnIdentityJourneyAndAccountStatusIsSuspended() {
+            AccountInterventionStatus accountStatus =
+                    new AccountInterventionStatus(false, true, false, false);
+            when(configurationService.isAccountInterventionServiceEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceAuditEnabled()).thenReturn(true);
+            when(accountInterventionService.getAccountStatus(any())).thenReturn(accountStatus);
+
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            handler.handleRequest(event, null);
+
+            verify(logoutService)
+                    .handleAccountInterventionLogout(
+                            session,
+                            event,
+                            Optional.of(CLIENT_ID.toString()),
+                            Optional.of(SESSION_ID.toString()),
+                            accountStatus);
+        }
     }
 
     private APIGatewayProxyResponseEvent createIPVApiResponse() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/LogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/LogoutServiceTest.java
@@ -264,13 +264,14 @@ public class LogoutServiceTest {
     @Test
     void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsBlocked() {
         when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_API_BASE_URL));
+        var accountStatus = new AccountInterventionStatus(true, false, false, false);
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
                         session,
                         event,
                         Optional.of(CLIENT_ID),
                         Optional.of(SESSION_ID),
-                        new AccountInterventionStatus(true, false, false, false));
+                        accountStatus);
 
         verify(clientSessionService)
                 .deleteClientSessionFromRedis(session.getClientSessions().get(0));
@@ -286,7 +287,8 @@ public class LogoutServiceTest {
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID);
-        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
+        verify(cloudwatchMetricsService)
+                .incrementLogout(Optional.of(CLIENT_ID), Optional.of(accountStatus));
 
         assertThat(response, hasStatus(302));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(OIDC_API_BASE_URL));
@@ -295,13 +297,14 @@ public class LogoutServiceTest {
     @Test
     void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsSuspended() {
         when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_API_BASE_URL));
+        var accountStatus = new AccountInterventionStatus(false, true, false, false);
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
                         session,
                         event,
                         Optional.of(CLIENT_ID),
                         Optional.of(SESSION_ID),
-                        new AccountInterventionStatus(false, true, false, false));
+                        accountStatus);
 
         verify(clientSessionService)
                 .deleteClientSessionFromRedis(session.getClientSessions().get(0));
@@ -317,7 +320,8 @@ public class LogoutServiceTest {
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID);
-        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
+        verify(cloudwatchMetricsService)
+                .incrementLogout(Optional.of(CLIENT_ID), Optional.of(accountStatus));
 
         assertThat(response, hasStatus(302));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(OIDC_API_BASE_URL));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/LogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/LogoutServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.MockedStatic;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -46,6 +47,8 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -93,6 +96,8 @@ public class LogoutServiceTest {
     private static final String CLIENT_ID = "client-id";
     private static final Subject SUBJECT = new Subject();
     private static final String EMAIL = "joe.bloggs@test.com";
+
+    private static final String OIDC_API_BASE_URL = "https://oidc.test.account.gov.uk/";
 
     private SignedJWT signedIDToken;
     private Optional<String> audience;
@@ -257,6 +262,68 @@ public class LogoutServiceTest {
     }
 
     @Test
+    void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsBlocked() {
+        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_API_BASE_URL));
+        APIGatewayProxyResponseEvent response =
+                logoutService.handleAccountInterventionLogout(
+                        session,
+                        event,
+                        Optional.of(CLIENT_ID),
+                        Optional.of(SESSION_ID),
+                        new AccountInterventionStatus(true, false, false, false));
+
+        verify(clientSessionService)
+                .deleteClientSessionFromRedis(session.getClientSessions().get(0));
+        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(auditService)
+                .submitAuditEvent(
+                        OidcAuditableEvent.LOG_OUT_SUCCESS,
+                        AuditService.UNKNOWN,
+                        SESSION_ID,
+                        CLIENT_ID,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        IP_ADDRESS,
+                        AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID);
+        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
+
+        assertThat(response, hasStatus(302));
+        assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(OIDC_API_BASE_URL));
+    }
+
+    @Test
+    void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsSuspended() {
+        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_API_BASE_URL));
+        APIGatewayProxyResponseEvent response =
+                logoutService.handleAccountInterventionLogout(
+                        session,
+                        event,
+                        Optional.of(CLIENT_ID),
+                        Optional.of(SESSION_ID),
+                        new AccountInterventionStatus(false, true, false, false));
+
+        verify(clientSessionService)
+                .deleteClientSessionFromRedis(session.getClientSessions().get(0));
+        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(auditService)
+                .submitAuditEvent(
+                        OidcAuditableEvent.LOG_OUT_SUCCESS,
+                        AuditService.UNKNOWN,
+                        SESSION_ID,
+                        CLIENT_ID,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        IP_ADDRESS,
+                        AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID);
+        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
+
+        assertThat(response, hasStatus(302));
+        assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(OIDC_API_BASE_URL));
+    }
+
+    @Test
     public void shouldDeleteSessionFromRedisWhenNoCookieExists() {
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
         input.setQueryStringParameters(
@@ -300,6 +367,26 @@ public class LogoutServiceTest {
         verify(clientSessionService).deleteClientSessionFromRedis("client-session-id-2");
         verify(clientSessionService).deleteClientSessionFromRedis("client-session-id-3");
         verify(sessionService, times(1)).deleteSessionFromRedis(SESSION_ID);
+    }
+
+    @Test
+    void throwsWhenGenerateAccountInterventionLogoutResponseCalledInappropriately() {
+        AccountInterventionStatus status =
+                new AccountInterventionStatus(false, false, false, false);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                logoutService.handleAccountInterventionLogout(
+                                        session,
+                                        event,
+                                        Optional.of(CLIENT_ID),
+                                        Optional.of(SESSION_ID),
+                                        status),
+                        "Expected to throw exception");
+
+        assertEquals("Account status must be blocked or suspended", exception.getMessage());
     }
 
     private Session generateSession() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/domain/CloudwatchMetricDimensions.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/domain/CloudwatchMetricDimensions.java
@@ -7,7 +7,8 @@ public enum CloudwatchMetricDimensions {
     IS_TEST("IsTest"),
     REQUESTED_LEVEL_OF_CONFIDENCE("RequestedLevelOfConfidence"),
     MFA_REQUIRED("MfaRequired"),
-    CLIENT_NAME("ClientName");
+    CLIENT_NAME("ClientName"),
+    ACCOUNT_INTERVENTION_STATUS("AccountInterventionStatus");
 
     private String value;
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -56,7 +56,9 @@ public class AccountInterventionService {
 
         HttpRequest request =
                 HttpRequest.newBuilder()
-                        .uri(accountInterventionServiceURI.resolve(internalPairwiseSubjectId))
+                        .uri(
+                                accountInterventionServiceURI.resolve(
+                                        "/v1/ais/" + internalPairwiseSubjectId))
                         .GET()
                         .build();
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CloudwatchMetricsService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CloudwatchMetricsService.java
@@ -3,12 +3,14 @@ package uk.gov.di.orchestration.shared.services;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
 import uk.gov.di.orchestration.shared.entity.Session;
 
 import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.ACCOUNT;
+import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.ACCOUNT_INTERVENTION_STATUS;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.CLIENT;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.CLIENT_NAME;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
@@ -135,12 +137,29 @@ public class CloudwatchMetricsService {
     }
 
     public void incrementLogout(Optional<String> clientId) {
+        incrementLogout(clientId, Optional.empty());
+    }
+
+    public void incrementLogout(
+            Optional<String> clientId,
+            Optional<AccountInterventionStatus> accountInterventionStatus) {
+        String accountInterventionStr = "unknown";
+        if (accountInterventionStatus.isPresent()) {
+            if (accountInterventionStatus.get().blocked()) {
+                accountInterventionStr = "blocked";
+            }
+            if (accountInterventionStatus.get().suspended()) {
+                accountInterventionStr = "suspended";
+            }
+        }
         incrementCounter(
                 LOGOUT_SUCCESS.getValue(),
                 Map.of(
                         ENVIRONMENT.getValue(),
                         configurationService.getEnvironment(),
                         CLIENT.getValue(),
-                        clientId.orElse("unknown")));
+                        clientId.orElse("unknown"),
+                        ACCOUNT_INTERVENTION_STATUS.getValue(),
+                        accountInterventionStr));
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -91,6 +91,14 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals("true");
     }
 
+    public String getAccountStatusBlockedURI() {
+        return "/orch-frontend/not-available";
+    }
+
+    public String getAccountStatusSuspendedURI() {
+        return "/orch-frontend/unavailable";
+    }
+
     public long getAuthCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("AUTH_CODE_EXPIRY", "300"));
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -44,7 +44,7 @@ class AccountInterventionServiceTest {
             }
             """;
 
-    private static String BASE_AIS_URL = "http://example.com/somepath/";
+    private static String BASE_AIS_URL = "http://example.com/v1/ais/";
 
     @BeforeEach
     void setup() throws URISyntaxException {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountInterventionsStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountInterventionsStubExtension.java
@@ -12,7 +12,7 @@ public class AccountInterventionsStubExtension extends HttpStubExtension {
         super();
     }
 
-    public void init(String userId) {
+    public void init(String userId, boolean blocked, boolean suspended) {
         register(
                 "/v1/ais/" + userId,
                 200,
@@ -27,8 +27,12 @@ public class AccountInterventionsStubExtension extends HttpStubExtension {
                         + "    \"resetPasswordAt\": 1696875903456"
                         + "  },"
                         + "  \"state\": {"
-                        + "    \"blocked\": false,"
-                        + "    \"suspended\": false,"
+                        + "    \"blocked\": "
+                        + blocked
+                        + ","
+                        + "    \"suspended\": "
+                        + suspended
+                        + ","
                         + "    \"reproveIdentity\": false,"
                         + "    \"resetPassword\": false"
                         + "  }"


### PR DESCRIPTION
## What?

If the account status received from Account Interventions is `suspended` or `blocked`, destroy all sessions and redirect to account suspended/blocked page.

This PR does not handle destroying the Authentication frontend session.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3647
