### PR TITLE
ATO-231: Enabling api gateway integration

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -611,7 +611,7 @@ resource "aws_api_gateway_method" "orch_frontend_proxy_method" {
 
 data "aws_cloudformation_stack" "orch_frontend_stack" {
   count = var.orch_frontend_api_gateway_integration_enabled ? 1 : 0
-  name  = "${var.environment}-orch-frontend"
+  name  = replace("${var.environment}-orch-f-deploy", "authdev1", "dev")
 }
 
 locals {

--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -47,6 +47,6 @@ orch_client_id = "orchestrationAuth"
 
 support_auth_orch_split = false
 
-orch_frontend_api_gateway_integration_enabled = false
+orch_frontend_api_gateway_integration_enabled = true
 
 orch_redirect_uri = "https://oidc.authdev1.sandpit.account.gov.uk/orchestration-redirect"


### PR DESCRIPTION
- Linking "authdev1" cloudformation stack to "dev"

## What?

Set `orch_frontend_api_gateway_integration_enabled = true`

## Why?

This will allow us to redirect /orch-frontend/* requests to the orch frontend load-balancer.

## Related PRs

[ATO-186](https://govukverify.atlassian.net/jira/software/c/projects/ATO/boards/390?selectedIssue=ATO-186)


[ATO-186]: https://govukverify.atlassian.net/browse/ATO-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ