### PR TITLE
AUT-2139: expose MfaMethodType in CheckUserExists API response

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 
 public class CheckUserExistsResponse {
 
@@ -13,11 +14,17 @@ public class CheckUserExistsResponse {
     @Expose
     private boolean doesUserExist;
 
+    @SerializedName("mfaMethodType")
+    @Expose
+    private MFAMethodType mfaMethodType;
+
     public CheckUserExistsResponse() {}
 
-    public CheckUserExistsResponse(String email, boolean doesUserExist) {
+    public CheckUserExistsResponse(
+            String email, boolean doesUserExist, MFAMethodType mfaMethodType) {
         this.email = email;
         this.doesUserExist = doesUserExist;
+        this.mfaMethodType = mfaMethodType;
     }
 
     public String getEmail() {
@@ -26,5 +33,9 @@ public class CheckUserExistsResponse {
 
     public boolean doesUserExist() {
         return doesUserExist;
+    }
+
+    public MFAMethodType getMfaMethodType() {
+        return mfaMethodType;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/entity/UserMfaDetail.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/UserMfaDetail.java
@@ -1,0 +1,34 @@
+package uk.gov.di.authentication.entity;
+
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
+
+public class UserMfaDetail {
+    protected boolean isMfaRequired;
+    protected boolean mfaMethodVerified;
+    protected MFAMethodType mfaMethodType;
+
+    public UserMfaDetail() {
+        this.isMfaRequired = false;
+        this.mfaMethodVerified = false;
+        this.mfaMethodType = MFAMethodType.NONE;
+    }
+
+    public UserMfaDetail(
+            boolean isMfaRequired, boolean mfaMethodVerified, MFAMethodType mfaMethodType) {
+        this.isMfaRequired = isMfaRequired;
+        this.mfaMethodVerified = mfaMethodVerified;
+        this.mfaMethodType = mfaMethodType;
+    }
+
+    public boolean isMfaRequired() {
+        return isMfaRequired;
+    }
+
+    public boolean isMfaMethodVerified() {
+        return mfaMethodVerified;
+    }
+
+    public MFAMethodType getMfaMethodType() {
+        return mfaMethodType;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
@@ -2,9 +2,12 @@ package uk.gov.di.authentication.shared.conditions;
 
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import uk.gov.di.authentication.entity.UserMfaDetail;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.List;
 import java.util.Map;
@@ -33,5 +36,23 @@ public class MfaHelper {
         return Optional.ofNullable(userCredentials.getMfaMethods())
                 .flatMap(
                         mfaMethods -> mfaMethods.stream().filter(MFAMethod::isEnabled).findFirst());
+    }
+
+    public static UserMfaDetail getUserMFADetail(
+            UserContext userContext,
+            UserCredentials userCredentials,
+            boolean isPhoneNumberVerified) {
+        var isMfaRequired = mfaRequired(userContext.getClientSession().getAuthRequestParams());
+        var mfaMethodVerified = isPhoneNumberVerified;
+
+        var mfaMethod = getPrimaryMFAMethod(userCredentials);
+        var mfaMethodType = MFAMethodType.SMS;
+        if (mfaMethod.filter(MFAMethod::isMethodVerified).isPresent()) {
+            mfaMethodVerified = true;
+            mfaMethodType = MFAMethodType.valueOf(mfaMethod.get().getMfaMethodType());
+        } else if (!isPhoneNumberVerified && mfaMethod.isPresent()) {
+            mfaMethodType = MFAMethodType.valueOf(mfaMethod.get().getMfaMethodType());
+        }
+        return new UserMfaDetail(isMfaRequired, mfaMethodVerified, mfaMethodType);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java
@@ -125,8 +125,9 @@ public class UserCredentials {
         return mfaMethods;
     }
 
-    public void withMfaMethods(List<MFAMethod> mfaMethods) {
+    public UserCredentials withMfaMethods(List<MFAMethod> mfaMethods) {
         this.mfaMethods = mfaMethods;
+        return this;
     }
 
     public UserCredentials setMfaMethod(MFAMethod mfaMethod) {


### PR DESCRIPTION
## What?

[JIRA link](https://govukverify.atlassian.net/browse/AUT-2139)

We need to pass the users MFA type to the ui during password reset so the end user can navigate to the relevant MFA screen (auth app / sms).

## Why?

User will not be logged in so the user context at this stage will not contain the required information, we need to expose the mfa type of the user prior to login so we can complete the password reset user journey.