### PR TITLE
ATO-NONE: Add cloudwatch metrics to AIS

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -46,10 +46,11 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
     public ProcessingIdentityHandler(ConfigurationService configurationService) {
         super(ProcessingIdentityRequest.class, configurationService);
         this.dynamoIdentityService = new DynamoIdentityService(configurationService);
-        this.accountInterventionService =
-                new AccountInterventionService(configurationService, newHttpClient());
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
+        this.accountInterventionService =
+                new AccountInterventionService(
+                        configurationService, newHttpClient(), cloudwatchMetricsService);
     }
 
     public ProcessingIdentityHandler() {
@@ -165,14 +166,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                         () ->
                                 accountInterventionService.getAccountStatus(
                                         internalPairwiseSubjectId));
-
-        cloudwatchMetricsService.incrementCounter(
-                "AISResult",
-                Map.of(
-                        "blocked", String.valueOf(aisResult.blocked()),
-                        "suspended", String.valueOf(aisResult.suspended()),
-                        "resetPassword", String.valueOf(aisResult.resetPassword()),
-                        "reproveIdentity", String.valueOf(aisResult.reproveIdentity())));
 
         if (configurationService.isAccountInterventionServiceEnabled()) {
             if (aisResult.blocked()) {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -232,14 +232,6 @@ class ProcessingIdentityHandlerTest {
                                 ENVIRONMENT,
                                 "Status",
                                 ProcessingIdentityStatus.COMPLETED.toString()));
-        verify(cloudwatchMetricsService)
-                .incrementCounter(
-                        "AISResult",
-                        Map.of(
-                                "blocked", "false",
-                                "suspended", "false",
-                                "resetPassword", "false",
-                                "reproveIdentity", "false"));
     }
 
     @ParameterizedTest
@@ -280,14 +272,6 @@ class ProcessingIdentityHandlerTest {
                                 ENVIRONMENT,
                                 "Status",
                                 ProcessingIdentityStatus.COMPLETED.toString()));
-        verify(cloudwatchMetricsService)
-                .incrementCounter(
-                        "AISResult",
-                        Map.of(
-                                "blocked", String.valueOf(aisResult.blocked()),
-                                "suspended", String.valueOf(aisResult.suspended()),
-                                "resetPassword", String.valueOf(aisResult.resetPassword()),
-                                "reproveIdentity", String.valueOf(aisResult.reproveIdentity())));
 
         assertThat(outputStreamCaptor.toString(), containsString(expectedLogMessage));
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -103,7 +103,8 @@ public class AuthenticationCallbackHandler
                                 configurationService, redisConnectionService, kmsConnectionService),
                         cloudwatchMetricsService);
         this.accountInterventionService =
-                new AccountInterventionService(configurationService, newHttpClient());
+                new AccountInterventionService(
+                        configurationService, newHttpClient(), cloudwatchMetricsService);
     }
 
     public AuthenticationCallbackHandler(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -247,7 +247,7 @@ class AuthenticationCallbackHandlerTest {
             when(configurationService.isAccountInterventionServiceEnabled()).thenReturn(true);
             when(configurationService.isAccountInterventionServiceAuditEnabled()).thenReturn(true);
             boolean reproveIdentity = true;
-            when(accountInterventionService.getAccountStatus(any()))
+            when(accountInterventionService.getAccountStatus(anyString()))
                     .thenReturn(
                             new AccountInterventionStatus(false, false, reproveIdentity, false));
 


### PR DESCRIPTION
## What?

- Add cloudwatch metrics to AIS as is called in each place it is used
- Remove URISyntaxException as cannot be thrown from that body
- 
## Why?

Want cloudwatch metrics whenever AIS is called so putting it into the service makes sense
