### PR TITLE
ATO-151: re-add exported subnet value

### DIFF
--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -27,6 +27,10 @@ output "authentication_oidc_redis_security_group_id" {
   value = aws_security_group.allow_access_to_oidc_redis.id
 }
 
+output "authentication_subnet_ids" {
+  value = local.private_subnet_ids
+}
+
 output "authentication_private_subnet_ids" {
   value = local.private_subnet_ids
 }


### PR DESCRIPTION
## What?

Re-add the old exported name of the subnet

## Why?
This is used by the experian check, defined in another repo

