### PR TITLE
BAU: Exclude orchestration shared test from code coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -348,7 +348,7 @@ sonarqube {
         property "sonar.projectKey", "govuk-one-login_authentication-api"
         property "sonar.organization", "govuk-one-login"
         property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.coverage.exclusions", "**/shared-test/**"
+        property "sonar.coverage.exclusions", "**/shared-test/**,**/orchestration-shared-test/**"
     }
 }
 


### PR DESCRIPTION
## What?

Exclude orchestration shared test from code coverage

## Why?

This is all test helpers, not application code. It is not covered.

