### PR TITLE
Revert "BAU: Remove leftover waf rule for sandpit blocking requests from localhost

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -374,7 +374,7 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
         }
 
         dynamic "rule_action_override" {
-          for_each = var.environment != "production" ? ["1"] : []
+          for_each = var.environment != "production" || var.environment != "sandpit" ? ["1"] : []
           content {
             name = "EC2MetaDataSSRF_BODY"
             action_to_use {


### PR DESCRIPTION
This reverts commit 28bfc8a62de5b47cd0e8283b586b2478ac5782f2.

## What?

Revert changes to WAF rules around localhost

## Why?

We suspect these are causing prod smoke test failures

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3677
