### PR TITLE
ATO-66: Enable Doc App decouple enabled flag for build

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -15,7 +15,7 @@ custom_doc_app_claim_enabled        = true
 ipv_no_session_response_enabled     = true
 doc_app_cri_data_v2_endpoint        = "credentials/issue"
 doc_app_use_cri_data_v2_endpoint    = true
-doc_app_decouple_enabled            = false
+doc_app_decouple_enabled            = true
 orch_client_id                      = "orchestrationAuth"
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----


### PR DESCRIPTION
## What?

Enable Doc App decouple enabled flag for build

## Why?

To ensure everything is working as expected by performing a journey.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3506
https://github.com/govuk-one-login/authentication-api/pull/3508