### PR TITLE
BAU: Set consent required to constant value of 'false' in new client registry entries

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -120,7 +120,7 @@ public class ClientRegistrationHandler
                     clientRegistrationRequest.getServiceType(),
                     sanitiseUrl(clientRegistrationRequest.getSectorIdentifierUri()),
                     clientRegistrationRequest.getSubjectType(),
-                    !clientRegistrationRequest.isIdentityVerificationRequired(),
+                    false,
                     clientRegistrationRequest.getClaims(),
                     clientRegistrationRequest.getClientType(),
                     clientRegistrationRequest.isIdentityVerificationRequired(),

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -56,6 +56,7 @@ class ClientRegistrationHandlerTest {
     private static final List<String> REDIRECT_URIS = List.of("http://localhost:8080/redirect-uri");
     private static final List<String> CONTACTS = List.of("joe.bloggs@test.com");
     private static final String SERVICE_TYPE = String.valueOf(MANDATORY);
+    private static final boolean CONSENT_REQUIRED_FIXED_VALUE = false;
     private final String clientId = IdGenerator.generate();
     private final Context context = mock(Context.class);
     private final ClientService clientService = mock(ClientService.class);
@@ -116,7 +117,7 @@ class ClientRegistrationHandlerTest {
                         SERVICE_TYPE,
                         SECTOR_IDENTIFIER,
                         SUBJECT_TYPE,
-                        true,
+                        CONSENT_REQUIRED_FIXED_VALUE,
                         emptyList(),
                         ClientType.WEB.getValue(),
                         false,
@@ -159,7 +160,7 @@ class ClientRegistrationHandlerTest {
                         SERVICE_TYPE,
                         SECTOR_IDENTIFIER,
                         SUBJECT_TYPE,
-                        false,
+                        CONSENT_REQUIRED_FIXED_VALUE,
                         emptyList(),
                         ClientType.WEB.getValue(),
                         true,
@@ -194,7 +195,7 @@ class ClientRegistrationHandlerTest {
                         SERVICE_TYPE,
                         SECTOR_IDENTIFIER,
                         SUBJECT_TYPE,
-                        true,
+                        CONSENT_REQUIRED_FIXED_VALUE,
                         emptyList(),
                         ClientType.WEB.getValue(),
                         false,


### PR DESCRIPTION
## What?
- Set consent required to constant value of 'false' in new client registry entries

## Why?
- Consent required in client registry reflects a time when the programme thought it would have to rely on user consent to share data
- However, the data sharing no longer relies on this mechanism to obtain consent
- This value can therefore be set to 'false' for all new client
