### PR TITLE
AUT-1844: Added Zero Args Constructor For Account Interventions Handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -49,6 +49,10 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         this.accountInterventionsService = accountInterventionsService;
     }
 
+    public AccountInterventionsHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
     public AccountInterventionsHandler(ConfigurationService configurationService) {
         super(AccountInterventionsRequest.class, configurationService);
         accountInterventionsService = new AccountInterventionsService();


### PR DESCRIPTION
## What?

Added zero args constructor to the Account Interventions Handler.

## Why?

A zero args constructor is required to instantiate the handler class.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3593
