### PR TITLE
ATO-177: Audit calls to the Account Intervention Services (Re-apply)

### DIFF
--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -27,26 +27,26 @@ module "authentication_callback" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ACCOUNT_INTERVENTION_SERVICE_AUDIT_ENABLED = var.account_intervention_service_audit_enabled
-    ACCOUNT_INTERVENTION_SERVICE_ENABLED       = var.account_intervention_service_enabled
-    ACCOUNT_INTERVENTION_SERVICE_URI           = var.account_intervention_service_uri
-    AUTHENTICATION_BACKEND_URI                 = "https://${local.di_auth_ext_api_id}-${local.vpce_id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
-    DYNAMO_ENDPOINT                            = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    ENVIRONMENT                                = var.environment
-    IDENTITY_ENABLED                           = var.ipv_api_enabled
-    INTERNAl_SECTOR_URI                        = var.internal_sector_uri
-    IPV_AUDIENCE                               = var.ipv_audience
-    IPV_AUTHORISATION_CALLBACK_URI             = var.ipv_authorisation_callback_uri
-    IPV_AUTHORISATION_CLIENT_ID                = var.ipv_authorisation_client_id
-    IPV_AUTHORISATION_URI                      = var.ipv_authorisation_uri
-    IPV_TOKEN_SIGNING_KEY_ALIAS                = local.ipv_token_auth_key_alias_name
-    LOCALSTACK_ENDPOINT                        = var.use_localstack ? var.localstack_endpoint : null
-    LOGIN_URI                                  = "https://${local.frontend_fqdn}/"
-    ORCH_CLIENT_ID                             = var.orch_client_id
-    ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS       = local.orch_to_auth_signing_key_alias_name
-    REDIS_KEY                                  = local.redis_key
-    SUPPORT_AUTH_ORCH_SPLIT                    = var.support_auth_orch_split
-    TXMA_AUDIT_QUEUE_URL                       = module.oidc_txma_audit.queue_url
+    ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED = var.account_intervention_service_action_enabled
+    ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled
+    ACCOUNT_INTERVENTION_SERVICE_URI            = var.account_intervention_service_uri
+    AUTHENTICATION_BACKEND_URI                  = "https://${local.di_auth_ext_api_id}-${local.vpce_id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
+    DYNAMO_ENDPOINT                             = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT                                 = var.environment
+    IDENTITY_ENABLED                            = var.ipv_api_enabled
+    INTERNAl_SECTOR_URI                         = var.internal_sector_uri
+    IPV_AUDIENCE                                = var.ipv_audience
+    IPV_AUTHORISATION_CALLBACK_URI              = var.ipv_authorisation_callback_uri
+    IPV_AUTHORISATION_CLIENT_ID                 = var.ipv_authorisation_client_id
+    IPV_AUTHORISATION_URI                       = var.ipv_authorisation_uri
+    IPV_TOKEN_SIGNING_KEY_ALIAS                 = local.ipv_token_auth_key_alias_name
+    LOCALSTACK_ENDPOINT                         = var.use_localstack ? var.localstack_endpoint : null
+    LOGIN_URI                                   = "https://${local.frontend_fqdn}/"
+    ORCH_CLIENT_ID                              = var.orch_client_id
+    ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS        = local.orch_to_auth_signing_key_alias_name
+    REDIS_KEY                                   = local.redis_key
+    SUPPORT_AUTH_ORCH_SPLIT                     = var.support_auth_orch_split
+    TXMA_AUDIT_QUEUE_URL                        = module.oidc_txma_audit.queue_url
   }
 
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler::handleRequest"

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -29,16 +29,16 @@ module "processing-identity" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DYNAMO_ENDPOINT                            = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TXMA_AUDIT_QUEUE_URL                       = module.oidc_txma_audit.queue_url
-    ENVIRONMENT                                = var.environment
-    HEADERS_CASE_INSENSITIVE                   = var.use_localstack ? "true" : "false"
-    LOCALSTACK_ENDPOINT                        = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY                                  = local.redis_key
-    INTERNAl_SECTOR_URI                        = var.internal_sector_uri
-    ACCOUNT_INTERVENTION_SERVICE_AUDIT_ENABLED = var.account_intervention_service_audit_enabled
-    ACCOUNT_INTERVENTION_SERVICE_ENABLED       = var.account_intervention_service_enabled
-    ACCOUNT_INTERVENTION_SERVICE_URI           = var.account_intervention_service_uri
+    DYNAMO_ENDPOINT                             = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TXMA_AUDIT_QUEUE_URL                        = module.oidc_txma_audit.queue_url
+    ENVIRONMENT                                 = var.environment
+    HEADERS_CASE_INSENSITIVE                    = var.use_localstack ? "true" : "false"
+    LOCALSTACK_ENDPOINT                         = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                                   = local.redis_key
+    INTERNAl_SECTOR_URI                         = var.internal_sector_uri
+    ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED = var.account_intervention_service_action_enabled
+    ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled
+    ACCOUNT_INTERVENTION_SERVICE_URI            = var.account_intervention_service_uri
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.ProcessingIdentityHandler::handleRequest"
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -469,12 +469,12 @@ variable "orch_frontend_api_gateway_integration_enabled" {
   default     = false
 }
 
-variable "account_intervention_service_audit_enabled" {
+variable "account_intervention_service_action_enabled" {
   default = false
   type    = bool
 }
 
-variable "account_intervention_service_enabled" {
+variable "account_intervention_service_call_enabled" {
   default = false
   type    = bool
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -141,8 +141,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             LOG.info(
                     "Generating ProcessingIdentityResponse with ProcessingIdentityStatus: {}",
                     processingStatus);
-            if (processingStatus == ProcessingIdentityStatus.COMPLETED
-                    && configurationService.isAccountInterventionServiceAuditEnabled()) {
+            if (processingStatus == ProcessingIdentityStatus.COMPLETED) {
                 checkAccountInterventionService(pairwiseSubject.getValue());
             }
             return generateApiGatewayProxyResponse(
@@ -167,7 +166,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                                 accountInterventionService.getAccountStatus(
                                         internalPairwiseSubjectId));
 
-        if (configurationService.isAccountInterventionServiceEnabled()) {
+        if (configurationService.isAccountInterventionServiceActionEnabled()) {
             if (aisResult.blocked()) {
                 // TODO: back channel logout + redirect to blocked page
                 LOG.info("Account is blocked");

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -9,6 +9,7 @@ import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityRequest;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityResponse;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityStatus;
+import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
@@ -123,25 +124,29 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             configurationService.getEnvironment(),
                             "Status",
                             processingStatus.toString()));
+
+            var auditContext =
+                    new AuditContext(
+                            userContext.getClientSessionId(),
+                            userContext.getSession().getSessionId(),
+                            userContext.getClient().get().getClientID(),
+                            AuditService.UNKNOWN,
+                            userContext
+                                    .getUserProfile()
+                                    .map(UserProfile::getEmail)
+                                    .orElse(AuditService.UNKNOWN),
+                            IpAddressHelper.extractIpAddress(input),
+                            AuditService.UNKNOWN,
+                            PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+
             auditService.submitAuditEvent(
-                    IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST,
-                    userContext.getClientSessionId(),
-                    userContext.getSession().getSessionId(),
-                    userContext.getClient().get().getClientID(),
-                    AuditService.UNKNOWN,
-                    userContext
-                            .getUserProfile()
-                            .map(UserProfile::getEmail)
-                            .orElse(AuditService.UNKNOWN),
-                    IpAddressHelper.extractIpAddress(input),
-                    AuditService.UNKNOWN,
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST, auditContext);
             sessionService.save(userContext.getSession());
             LOG.info(
                     "Generating ProcessingIdentityResponse with ProcessingIdentityStatus: {}",
                     processingStatus);
             if (processingStatus == ProcessingIdentityStatus.COMPLETED) {
-                checkAccountInterventionService(pairwiseSubject.getValue());
+                checkAccountInterventionService(pairwiseSubject.getValue(), auditContext);
             }
             return generateApiGatewayProxyResponse(
                     200, new ProcessingIdentityResponse(processingStatus));
@@ -157,13 +162,14 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
         }
     }
 
-    private void checkAccountInterventionService(String internalPairwiseSubjectId) {
+    private void checkAccountInterventionService(
+            String internalPairwiseSubjectId, AuditContext auditContext) {
         var aisResult =
                 segmentedFunctionCall(
                         "AIS: getAccountStatus",
                         () ->
                                 accountInterventionService.getAccountStatus(
-                                        internalPairwiseSubjectId));
+                                        internalPairwiseSubjectId, auditContext));
 
         if (configurationService.isAccountInterventionServiceActionEnabled()) {
             if (aisResult.blocked()) {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
-import static java.net.http.HttpClient.newHttpClient;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
@@ -50,7 +49,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
         this.accountInterventionService =
                 new AccountInterventionService(
-                        configurationService, newHttpClient(), cloudwatchMetricsService);
+                        configurationService, cloudwatchMetricsService, auditService);
     }
 
     public ProcessingIdentityHandler() {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -183,7 +183,8 @@ public class IPVAuthorisationService {
                         .claim("response_type", ResponseType.CODE.toString())
                         .claim("scope", scope.toString())
                         .claim("vtr", vtr);
-        if (configurationService.isAccountInterventionServiceEnabled() && reproveIdentity != null) {
+        if (configurationService.isAccountInterventionServiceActionEnabled()
+                && reproveIdentity != null) {
             claimsBuilder.claim("reprove_identity", reproveIdentity);
         }
         if (Objects.nonNull(claims)) {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -199,7 +199,7 @@ class ProcessingIdentityHandlerTest {
 
     @Test
     void
-            shouldMakeAndAuditAISCallIfAccountInterventionServiceAuditIsEnabledAndProcessingStatusIsCOMPLETED()
+            shouldActionAISCallIfAccountInterventionServiceActionIsEnabledAndProcessingStatusIsCOMPLETED()
                     throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
@@ -212,7 +212,7 @@ class ProcessingIdentityHandlerTest {
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
         when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
-        when(accountInterventionService.getAccountStatus(anyString()))
+        when(accountInterventionService.getAccountStatus(anyString(), any()))
                 .thenReturn(new AccountInterventionStatus(false, false, false, false));
 
         var result = handler.handleRequest(event, context);
@@ -253,7 +253,7 @@ class ProcessingIdentityHandlerTest {
                 .thenReturn(Optional.of(getClientSession()));
         when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
         when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
-        when(accountInterventionService.getAccountStatus(anyString())).thenReturn(aisResult);
+        when(accountInterventionService.getAccountStatus(anyString(), any())).thenReturn(aisResult);
 
         var result = handler.handleRequest(event, context);
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -211,7 +211,7 @@ class ProcessingIdentityHandlerTest {
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
-        when(configurationService.isAccountInterventionServiceAuditEnabled()).thenReturn(true);
+        when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
         when(accountInterventionService.getAccountStatus(anyString()))
                 .thenReturn(new AccountInterventionStatus(false, false, false, false));
 
@@ -251,8 +251,8 @@ class ProcessingIdentityHandlerTest {
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
-        when(configurationService.isAccountInterventionServiceAuditEnabled()).thenReturn(true);
-        when(configurationService.isAccountInterventionServiceEnabled()).thenReturn(true);
+        when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
+        when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
         when(accountInterventionService.getAccountStatus(anyString())).thenReturn(aisResult);
 
         var result = handler.handleRequest(event, context);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -222,7 +222,8 @@ class IPVAuthorisationServiceTest {
                             .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
                             .build();
             when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(signResult);
-            when(configurationService.isAccountInterventionServiceEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
         }
 
         @Test
@@ -323,9 +324,10 @@ class IPVAuthorisationServiceTest {
         }
 
         @Test
-        void shouldNotConstructJWTWithReproveIdentityClaimIfAccountInterventionsFlagDisabled()
+        void shouldNotConstructJWTWithReproveIdentityClaimIfAccountInterventionsActionFlagDisabled()
                 throws JOSEException, ParseException {
-            when(configurationService.isAccountInterventionServiceEnabled()).thenReturn(false);
+            when(configurationService.isAccountInterventionServiceActionEnabled())
+                    .thenReturn(false);
             EncryptedJWT encryptedJWT;
 
             try (var mockIdGenerator = mockStatic(IdGenerator.class)) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -303,14 +303,14 @@ public class AuthenticationCallbackHandler
 
                 cloudwatchMetricsService.incrementCounter("AuthenticationCallback", dimensions);
 
-                Boolean reproveIdentity = null;
-                if (configurationService.isAccountInterventionServiceEnabled()
-                        && configurationService.isAccountInterventionServiceAuditEnabled()) {
-                    var accountStatus =
-                            accountInterventionService.getAccountStatus(
-                                    userInfo.getSubject().getValue());
-                    reproveIdentity = accountStatus.reproveIdentity();
-                }
+                var accountStatus =
+                        accountInterventionService.getAccountStatus(
+                                userInfo.getSubject().getValue());
+
+                Boolean reproveIdentity =
+                        configurationService.isAccountInterventionServiceActionEnabled()
+                                ? accountStatus.reproveIdentity()
+                                : null;
 
                 if (identityRequired) {
                     return initiateIPVAuthorisationService.sendRequestToIPV(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -24,6 +24,7 @@ import uk.gov.di.authentication.oidc.exceptions.AuthenticationCallbackException;
 import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
 import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
 import uk.gov.di.authentication.oidc.services.InitiateIPVAuthorisationService;
+import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
@@ -302,9 +303,24 @@ public class AuthenticationCallbackHandler
 
                 cloudwatchMetricsService.incrementCounter("AuthenticationCallback", dimensions);
 
+                var auditContext =
+                        new AuditContext(
+                                clientSessionId,
+                                userSession.getSessionId(),
+                                clientId,
+                                userInfo.getSubject().getValue(),
+                                Objects.isNull(userSession.getEmailAddress())
+                                        ? AuditService.UNKNOWN
+                                        : userSession.getEmailAddress(),
+                                IpAddressHelper.extractIpAddress(input),
+                                Objects.isNull(userInfo.getPhoneNumber())
+                                        ? AuditService.UNKNOWN
+                                        : userInfo.getPhoneNumber(),
+                                persistentSessionId);
+
                 var accountStatus =
                         accountInterventionService.getAccountStatus(
-                                userInfo.getSubject().getValue());
+                                userInfo.getSubject().getValue(), auditContext);
 
                 Boolean reproveIdentity =
                         configurationService.isAccountInterventionServiceActionEnabled()

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.GET;
-import static java.net.http.HttpClient.newHttpClient;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static uk.gov.di.orchestration.shared.conditions.IdentityHelper.identityRequired;
@@ -105,7 +104,7 @@ public class AuthenticationCallbackHandler
                         cloudwatchMetricsService);
         this.accountInterventionService =
                 new AccountInterventionService(
-                        configurationService, newHttpClient(), cloudwatchMetricsService);
+                        configurationService, cloudwatchMetricsService, auditService);
     }
 
     public AuthenticationCallbackHandler(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -104,8 +104,8 @@ class AuthenticationCallbackHandlerTest {
         when(configurationService.getLoginURI()).thenReturn(URI.create(TEST_FRONTEND_BASE_URL));
         when(configurationService.getAuthenticationBackendURI())
                 .thenReturn(URI.create(TEST_AUTH_BACKEND_BASE_URL));
-        when(configurationService.isAccountInterventionServiceEnabled()).thenReturn(false);
-        when(configurationService.isAccountInterventionServiceAuditEnabled()).thenReturn(false);
+        when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(false);
+        when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(false);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
                         CLIENT_SESSION_ID, TEST_EMAIL_ADDRESS, clientSession))
                 .thenReturn(AUTH_CODE_RP_TO_ORCH);
@@ -239,8 +239,8 @@ class AuthenticationCallbackHandlerTest {
 
         @Test
         void shouldRedirectToIPVWithReproveIdentityWhenAccountInterventionsEnabled() {
-            when(configurationService.isAccountInterventionServiceEnabled()).thenReturn(true);
-            when(configurationService.isAccountInterventionServiceAuditEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
             boolean reproveIdentity = true;
             when(accountInterventionService.getAccountStatus(anyString()))
                     .thenReturn(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -242,9 +242,8 @@ class AuthenticationCallbackHandlerTest {
             when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
             when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
             boolean reproveIdentity = true;
-            when(accountInterventionService.getAccountStatus(anyString()))
-                    .thenReturn(
-                            new AccountInterventionStatus(false, false, reproveIdentity, false));
+            when(accountInterventionService.getAccountStatus(anyString(), any()))
+                    .thenReturn(new AccountInterventionStatus(false, true, reproveIdentity, false));
 
             var event = new APIGatewayProxyRequestEvent();
             setValidHeadersAndQueryParameters(event);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/audit/AuditContext.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/audit/AuditContext.java
@@ -1,0 +1,172 @@
+package uk.gov.di.orchestration.audit;
+
+import uk.gov.di.orchestration.shared.services.AuditService;
+
+import java.util.Objects;
+
+public final class AuditContext {
+    private String clientSessionId;
+    private String sessionId;
+    private String clientId;
+    private String subjectId;
+    private String email;
+    private String ipAddress;
+    private String phoneNumber;
+    private String persistentSessionId;
+    private AuditService.MetadataPair[] metadataPairs;
+
+    public AuditContext(
+            String clientSessionId,
+            String sessionId,
+            String clientId,
+            String subjectId,
+            String email,
+            String ipAddress,
+            String phoneNumber,
+            String persistentSessionId,
+            AuditService.MetadataPair... metadataPairs) {
+        this.clientSessionId = clientSessionId;
+        this.sessionId = sessionId;
+        this.clientId = clientId;
+        this.subjectId = subjectId;
+        this.email = email;
+        this.ipAddress = ipAddress;
+        this.phoneNumber = phoneNumber;
+        this.persistentSessionId = persistentSessionId;
+        this.metadataPairs = metadataPairs;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
+    public void setClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getSubjectId() {
+        return subjectId;
+    }
+
+    public void setSubjectId(String subjectId) {
+        this.subjectId = subjectId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getPersistentSessionId() {
+        return persistentSessionId;
+    }
+
+    public void setPersistentSessionId(String persistentSessionId) {
+        this.persistentSessionId = persistentSessionId;
+    }
+
+    public AuditService.MetadataPair[] getMetadataPairs() {
+        return metadataPairs;
+    }
+
+    public void setMetadataPairs(AuditService.MetadataPair[] metadataPairs) {
+        this.metadataPairs = metadataPairs;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (AuditContext) obj;
+        return Objects.equals(this.clientSessionId, that.clientSessionId)
+                && Objects.equals(this.sessionId, that.sessionId)
+                && Objects.equals(this.clientId, that.clientId)
+                && Objects.equals(this.subjectId, that.subjectId)
+                && Objects.equals(this.email, that.email)
+                && Objects.equals(this.ipAddress, that.ipAddress)
+                && Objects.equals(this.phoneNumber, that.phoneNumber)
+                && Objects.equals(this.persistentSessionId, that.persistentSessionId)
+                && Objects.equals(this.metadataPairs, that.metadataPairs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                clientSessionId,
+                sessionId,
+                clientId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                metadataPairs);
+    }
+
+    @Override
+    public String toString() {
+        return "AuditContext["
+                + "clientSessionId="
+                + clientSessionId
+                + ", "
+                + "sessionId="
+                + sessionId
+                + ", "
+                + "clientId="
+                + clientId
+                + ", "
+                + "subjectId="
+                + subjectId
+                + ", "
+                + "email="
+                + email
+                + ", "
+                + "ipAddress="
+                + ipAddress
+                + ", "
+                + "phoneNumber="
+                + phoneNumber
+                + ", "
+                + "persistentSessionId="
+                + persistentSessionId
+                + ", "
+                + "metadataPairs="
+                + metadataPairs
+                + ']';
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/domain/AccountInterventionsAuditableEvent.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/domain/AccountInterventionsAuditableEvent.java
@@ -1,0 +1,9 @@
+package uk.gov.di.orchestration.shared.domain;
+
+public enum AccountInterventionsAuditableEvent implements AuditableEvent {
+    AIS_RESPONSE_RECEIVED;
+
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/AccountInterventionException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/AccountInterventionException.java
@@ -1,6 +1,11 @@
 package uk.gov.di.orchestration.shared.exceptions;
 
 public class AccountInterventionException extends RuntimeException {
+
+    public AccountInterventionException(String message) {
+        super(message);
+    }
+
     public AccountInterventionException(String message, Exception cause) {
         super(message, cause);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.orchestration.shared.services;
 
+import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 import uk.gov.di.orchestration.shared.helpers.PhoneNumberHelper;
@@ -37,6 +38,36 @@ public class AuditService {
                         configurationService.getAwsRegion(),
                         configurationService.getTxmaAuditQueueUrl(),
                         configurationService.getLocalstackEndpointUri());
+    }
+
+    public void submitAuditEvent(AuditableEvent event, AuditContext auditContext) {
+        var user =
+                TxmaAuditUser.user()
+                        .withUserId(auditContext.getSubjectId())
+                        .withPhone(auditContext.getPhoneNumber())
+                        .withEmail(auditContext.getEmail())
+                        .withIpAddress(auditContext.getIpAddress())
+                        .withSessionId(auditContext.getSessionId())
+                        .withPersistentSessionId(auditContext.getPersistentSessionId())
+                        .withGovukSigninJourneyId(auditContext.getClientSessionId());
+
+        var txmaAuditEvent =
+                auditEventWithTime(event, () -> Date.from(clock.instant()))
+                        .withClientId(auditContext.getClientId())
+                        .withComponentId(configurationService.getOidcApiBaseURL().orElse("UNKNOWN"))
+                        .withUser(user);
+
+        Arrays.stream(auditContext.getMetadataPairs())
+                .forEach(pair -> txmaAuditEvent.addExtension(pair.getKey(), pair.getValue()));
+
+        Optional.ofNullable(auditContext.getPhoneNumber())
+                .filter(not(String::isBlank))
+                .flatMap(PhoneNumberHelper::maybeGetCountry)
+                .ifPresent(
+                        country ->
+                                txmaAuditEvent.addExtension("phone_number_country_code", country));
+
+        txmaQueueClient.send(txmaAuditEvent.serialize());
     }
 
     public void submitAuditEvent(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -62,9 +62,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public boolean isAccountInterventionServiceActionEnabled() {
-        return System.getenv()
-                .getOrDefault("ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED", "false")
-                .equals("true");
+        return isAccountInterventionServiceCallEnabled()
+                && System.getenv()
+                        .getOrDefault("ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED", "false")
+                        .equals("true");
     }
 
     public boolean isAccountInterventionServiceCallEnabled() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -61,15 +61,15 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("ACCESS_TOKEN_EXPIRY", "180"));
     }
 
-    public boolean isAccountInterventionServiceAuditEnabled() {
+    public boolean isAccountInterventionServiceActionEnabled() {
         return System.getenv()
-                .getOrDefault("ACCOUNT_INTERVENTION_SERVICE_AUDIT_ENABLED", "false")
+                .getOrDefault("ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED", "false")
                 .equals("true");
     }
 
-    public boolean isAccountInterventionServiceEnabled() {
+    public boolean isAccountInterventionServiceCallEnabled() {
         return System.getenv()
-                .getOrDefault("ACCOUNT_INTERVENTION_SERVICE_ENABLED", "false")
+                .getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED", "false")
                 .equals("true");
     }
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -164,7 +164,8 @@ class AccountInterventionServiceTest {
     }
 
     @Test
-    void shouldSendAuditEventWhenServiceCallAndActionEnabled() throws IOException, InterruptedException {
+    void shouldSendAuditEventWhenServiceCallAndActionEnabled()
+            throws IOException, InterruptedException {
 
         when(config.isAccountInterventionServiceActionEnabled()).thenReturn(true);
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -49,7 +49,7 @@ class AccountInterventionServiceTest {
     @BeforeEach
     void setup() throws URISyntaxException {
         when(config.getAccountInterventionServiceURI()).thenReturn(new URI(BASE_AIS_URL));
-        when(config.isAccountInterventionServiceEnabled()).thenReturn(true);
+        when(config.isAccountInterventionServiceCallEnabled()).thenReturn(true);
     }
 
     @Test

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -3,6 +3,8 @@ package uk.gov.di.orchestration.shared.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 import uk.gov.di.orchestration.shared.exceptions.AccountInterventionException;
 
 import java.io.IOException;
@@ -13,15 +15,23 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.shared.domain.AccountInterventionsAuditableEvent.AIS_RESPONSE_RECEIVED;
 
 class AccountInterventionServiceTest {
     private final ConfigurationService config = mock(ConfigurationService.class);
     private final HttpClient httpClient = mock(HttpClient.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
+    private final AuditService auditService = mock(AuditService.class);
 
     private static String ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE =
             """
@@ -45,11 +55,22 @@ class AccountInterventionServiceTest {
             """;
 
     private static String BASE_AIS_URL = "http://example.com/somepath/";
+    private static AuditContext someAuditContext =
+            new AuditContext(
+                    "some-client-session-id",
+                    "some-session-id",
+                    "some-client-id",
+                    "some-subject-id",
+                    "some-email",
+                    "some-ip-address",
+                    "some-phone-number",
+                    "some-persistent-session-id");
 
     @BeforeEach
     void setup() throws URISyntaxException {
         when(config.getAccountInterventionServiceURI()).thenReturn(new URI(BASE_AIS_URL));
         when(config.isAccountInterventionServiceCallEnabled()).thenReturn(true);
+        when(config.isAccountInterventionServiceActionEnabled()).thenReturn(false);
     }
 
     @Test
@@ -57,7 +78,9 @@ class AccountInterventionServiceTest {
             throws IOException, InterruptedException {
 
         var internalPairwiseSubjectId = "some-internal-subject-id";
-        var ais = new AccountInterventionService(config, httpClient, cloudwatchMetricsService);
+        var ais =
+                new AccountInterventionService(
+                        config, httpClient, cloudwatchMetricsService, auditService);
         var httpResponse = mock(HttpResponse.class);
         var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
 
@@ -77,7 +100,8 @@ class AccountInterventionServiceTest {
 
         var internalPairwiseSubjectId = "some-internal-subject-id";
         var accountInterventionService =
-                new AccountInterventionService(config, httpClient, cloudwatchMetricsService);
+                new AccountInterventionService(
+                        config, httpClient, cloudwatchMetricsService, auditService);
         var httpResponse = mock(HttpResponse.class);
 
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
@@ -101,12 +125,34 @@ class AccountInterventionServiceTest {
     }
 
     @Test
+    void shouldReturnAccountStatusAllClearWhenDisabled() {
+
+        when(config.isAccountInterventionServiceCallEnabled()).thenReturn(false);
+
+        var internalPairwiseSubjectId = "some-internal-subject-id";
+        var ais =
+                new AccountInterventionService(
+                        config, httpClient, cloudwatchMetricsService, auditService);
+        var status = ais.getAccountStatus(internalPairwiseSubjectId);
+
+        verifyNoInteractions(httpClient);
+
+        assertEquals(false, status.blocked());
+        assertEquals(false, status.suspended());
+        assertEquals(false, status.reproveIdentity());
+        assertEquals(false, status.resetPassword());
+    }
+
+    @Test
     void shouldThrowAccountInterventionExceptionWhenExceptionThrownByHttpClient()
             throws IOException, InterruptedException {
 
+        when(config.isAccountInterventionServiceActionEnabled()).thenReturn(true);
+
         var internalPairwiseSubjectId = "some-internal-subject-id";
         var accountInterventionService =
-                new AccountInterventionService(config, httpClient, cloudwatchMetricsService);
+                new AccountInterventionService(
+                        config, httpClient, cloudwatchMetricsService, auditService);
 
         when(httpClient.send(any(), any())).thenThrow(new IOException("Test IO Exception"));
 
@@ -114,6 +160,70 @@ class AccountInterventionServiceTest {
                 AccountInterventionException.class,
                 () -> {
                     accountInterventionService.getAccountStatus(internalPairwiseSubjectId);
+                });
+    }
+
+    @Test
+    void shouldSendAuditEventWhenServiceCallAndActionEnabled() throws IOException, InterruptedException {
+
+        when(config.isAccountInterventionServiceActionEnabled()).thenReturn(true);
+
+        var internalPairwiseSubjectId = "some-internal-subject-id";
+        var accountInterventionService =
+                new AccountInterventionService(
+                        config, httpClient, cloudwatchMetricsService, auditService);
+        var httpResponse = mock(HttpResponse.class);
+        var auditEventNameCaptor = ArgumentCaptor.forClass(AuditableEvent.class);
+        var auditContextCaptor = ArgumentCaptor.forClass(AuditContext.class);
+
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        when(httpResponse.body()).thenReturn(ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE);
+
+        accountInterventionService.getAccountStatus(internalPairwiseSubjectId, someAuditContext);
+
+        verify(auditService)
+                .submitAuditEvent(auditEventNameCaptor.capture(), auditContextCaptor.capture());
+        assertEquals(AIS_RESPONSE_RECEIVED, auditEventNameCaptor.getValue());
+        assertEquals(someAuditContext, auditContextCaptor.getValue());
+    }
+
+    @Test
+    void shouldNotSendAuditEventWhenServiceEnabledAndActionDisabled()
+            throws IOException, InterruptedException {
+
+        var internalPairwiseSubjectId = "some-internal-subject-id";
+        var accountInterventionService =
+                new AccountInterventionService(
+                        config, httpClient, cloudwatchMetricsService, auditService);
+        var httpResponse = mock(HttpResponse.class);
+
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        when(httpResponse.body()).thenReturn(ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE);
+
+        accountInterventionService.getAccountStatus(internalPairwiseSubjectId, someAuditContext);
+
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNullAuditContextSuppliedAndActionEnabled()
+            throws IOException, InterruptedException {
+
+        when(config.isAccountInterventionServiceActionEnabled()).thenReturn(true);
+
+        var internalPairwiseSubjectId = "some-internal-subject-id";
+        var accountInterventionService =
+                new AccountInterventionService(
+                        config, httpClient, cloudwatchMetricsService, auditService);
+        var httpResponse = mock(HttpResponse.class);
+
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        when(httpResponse.body()).thenReturn(ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE);
+
+        assertThrows(
+                AccountInterventionException.class,
+                () -> {
+                    accountInterventionService.getAccountStatus(internalPairwiseSubjectId, null);
                 });
     }
 }


### PR DESCRIPTION
### What?
Call the AuditService when we get a response from the AccountInterventionService.

Introduce an AuditContext object to carry information required for the audit event sent to TXMA. There is a significant overlap with the data contained in this object and TxmaAuditUser, however they are used for differnet things. The TxmaAuditUser is used to construct the user section of a TxmaAuditEvent, and therefor must match that exactly. The AuditContext is intended to represent the data that we understand about the user and this request that can be shared by multiple events. To make this useful in more places, more work should be done to understand event specific information, added as metadata pairs. Further work on that is out of scope for this ticket.

Added a new AccountInterventionsAuditableEvent to carry the AuditableEvent, since this is shared.

Update the AuthenticationCallbackHandler and ProcessingIdentityHandler calls to the AccountInterventionService to provide an audit context.

### Why?
Required for ATO-43

Reapplies previous ATO-177 PR (https://github.com/govuk-one-login/authentication-api/pull/3682) with fix for problem reverted with https://github.com/govuk-one-login/authentication-api/pull/3697