### PR TITLE
ATO-220: Set correct public keys

### DIFF
--- a/ci/terraform/auth-external-api/integration.tfvars
+++ b/ci/terraform/auth-external-api/integration.tfvars
@@ -10,5 +10,5 @@ endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 orch_client_id                  = "orchestrationAuth"
-orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5Px78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ=="
+orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzzwKLypUL89WVaeTbfBZu0Fws8T7ppx89XLVfgXIoCs2P//N5qdghvzgNIgVehQ7CkzyorO/lnRlWPfjCG4Oxw=="
 support_auth_orch_split         = true

--- a/ci/terraform/auth-external-api/production.tfvars
+++ b/ci/terraform/auth-external-api/production.tfvars
@@ -11,4 +11,4 @@ endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 orch_client_id                  = "orchestrationAuth"
-orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5Px78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ=="
+orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5iJXSuxgbfM6ADQVtNNDi7ED5ly5+3VZPbjHv+v0AjQ5Ps+avkXWKwOeScG9sS0cDf0utEXi3fN3cEraa9WuKQ=="

--- a/ci/terraform/auth-external-api/staging.tfvars
+++ b/ci/terraform/auth-external-api/staging.tfvars
@@ -10,9 +10,4 @@ endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 orch_client_id                  = "orchestrationAuth"
-orch_to_auth_public_signing_key = <<-EOT
------BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5PP1PZmhiuHR57ZEfZXARt9/uiG+
-KKF+S7us4zEEEmEXZFR1H+kWP5RrLHQy9esxsul9X7V4pygDTY1I6QbMGg==
------END PUBLIC KEY-----
-EOT
+orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5PP1PZmhiuHR57ZEfZXARt9/uiG+KKF+S7us4zEEEmEXZFR1H+kWP5RrLHQy9esxsul9X7V4pygDTY1I6QbMGg=="


### PR DESCRIPTION
## What?

Set the correct public keys for the pair orch uses to sign requests to auth post-split. Previously all copies of the sandpit key.
Copied from the KMS console.

Build done previously.
