### PR TITLE
BAU: use 'sonar' task instead of 'sonarqube'

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -318,4 +318,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew testCodeCoverageReport sonarqube -x test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck
+        run: ./gradlew testCodeCoverageReport sonar -x test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck


### PR DESCRIPTION

## What?

use 'sonar' task instead of 'sonarqube'

## Why?

'sonarqube' is deprecated.

