### PR TITLE
ATO-236: Millisecond timestamp for txma audit

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/audit/TxmaAuditEvent.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/audit/TxmaAuditEvent.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
 public class TxmaAuditEvent {
 
     @Expose private final long timestamp;
+    @Expose private final long eventTimestampMs;
 
     @Expose private final String eventName;
 
@@ -26,15 +27,18 @@ public class TxmaAuditEvent {
     @Expose private Map<String, Object> restricted;
     @Expose private Map<String, Object> extensions;
 
-    public TxmaAuditEvent(String eventName, long timestamp) {
+    public TxmaAuditEvent(String eventName, long timestamp, long eventTimestampMs) {
         this.eventName = eventName;
         this.timestamp = timestamp;
+        this.eventTimestampMs = eventTimestampMs;
     }
 
     public static TxmaAuditEvent auditEventWithTime(
             AuditableEvent eventName, Supplier<Date> dateSupplier) {
         return new TxmaAuditEvent(
-                "AUTH_" + eventName.toString(), dateSupplier.get().toInstant().getEpochSecond());
+                "AUTH_" + eventName.toString(),
+                dateSupplier.get().toInstant().getEpochSecond(),
+                dateSupplier.get().toInstant().toEpochMilli());
     }
 
     public static TxmaAuditEvent auditEvent(AuditableEvent event) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/audit/TxmaAuditEventTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/audit/TxmaAuditEventTest.java
@@ -36,6 +36,9 @@ class TxmaAuditEventTest {
         assertThat(
                 payload,
                 hasNumericFieldWithValue("timestamp", is(now.toInstant().getEpochSecond())));
+        assertThat(
+                payload,
+                hasNumericFieldWithValue("event_timestamp_ms", is(now.toInstant().toEpochMilli())));
     }
 
     @Test


### PR DESCRIPTION
## What?

Include an addition timestamp field `event_timestamp_ms` giving txma a millisecond timestamp

## Why?

HMRC requirement