### PR TITLE
AUT-1326: Remove code that sets password hint version

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/Features.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/Features.java
@@ -1,28 +1,9 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
-
 public class Features {
-
-    @SerializedName("updatePasswordHintTextVersion")
-    @Expose
-    private String updatePasswordHintTextVersion;
-
-    public String getUpdatePasswordHintTextVersion() {
-        return updatePasswordHintTextVersion;
-    }
-
-    public void setUpdatePasswordHintTextVersion(String updatePasswordHintTextVersion) {
-        this.updatePasswordHintTextVersion = updatePasswordHintTextVersion;
-    }
 
     @Override
     public String toString() {
-        return "Features{"
-                + "updatePasswordHintTextVersion='"
-                + updatePasswordHintTextVersion
-                + '\''
-                + '}';
+        return "Features{}";
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import static java.util.function.Predicate.not;
 import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.COOKIE_CONSENT;
 import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.GA;
-import static uk.gov.di.authentication.frontendapi.features.FeatureStrategies.fiftyFiftyStrategy;
 
 public class StartService {
 
@@ -246,7 +245,6 @@ public class StartService {
 
     public Features getSessionFeatures() {
         Features features = new Features();
-        features.setUpdatePasswordHintTextVersion(fiftyFiftyStrategy() ? "1" : "2");
         return features;
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -146,7 +146,6 @@ class StartHandlerTest {
         when(startService.buildUserStartInfo(userContext, cookieConsentValue, gaTrackingId, true))
                 .thenReturn(userStartInfo);
         Features features = new Features();
-        features.setUpdatePasswordHintTextVersion("1");
         when(startService.getSessionFeatures()).thenReturn(features);
         when(configurationService.isExtendedFeatureFlagsEnabled()).thenReturn(isFeaturesEnabled);
         usingValidClientSession();
@@ -188,7 +187,6 @@ class StartHandlerTest {
         assertThat(response.getUser().getGaCrossDomainTrackingId(), equalTo(gaTrackingId));
         if (isFeaturesEnabled) {
             assertThat(response.getFeatures(), not(equalTo(null)));
-            assertThat(response.getFeatures().getUpdatePasswordHintTextVersion(), equalTo("1"));
         } else {
             assertThat(response.getFeatures(), equalTo(null));
         }


### PR DESCRIPTION
## What?

Remove code that sets password hint version but retain the `Feature` class so that we have the facility to run these kind of experiments in future. 

## Why?

The related code within `authentication-frontend` has been removed so there is now no need to set and provide this.

## Related PRs

* https://github.com/govuk-one-login/authentication-frontend/pull/1257
