### PR TITLE
AUT-2113: Add reauthenticate param to buildUserStartInfo

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -124,12 +124,15 @@ public class StartHandler
             var gaTrackingId =
                     startService.getGATrackingId(
                             userContext.getClientSession().getAuthRequestParams());
+            var reauthenticate = false;
+
             var userStartInfo =
                     startService.buildUserStartInfo(
                             userContext,
                             cookieConsent,
                             gaTrackingId,
-                            configurationService.isIdentityEnabled());
+                            configurationService.isIdentityEnabled(),
+                            reauthenticate);
             var clientSessionId =
                     getHeaderValueFromHeaders(
                             input.getHeaders(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -46,6 +46,8 @@ public class StartHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(StartHandler.class);
+
+    protected static final String REAUTHENTICATE_HEADER = "Reauthenticate";
     private final ClientSessionService clientSessionService;
     private final SessionService sessionService;
     private final AuditService auditService;
@@ -124,8 +126,13 @@ public class StartHandler
             var gaTrackingId =
                     startService.getGATrackingId(
                             userContext.getClientSession().getAuthRequestParams());
-            var reauthenticate = false;
-
+            var reauthenticateHeader =
+                    getHeaderValueFromHeaders(
+                            input.getHeaders(),
+                            REAUTHENTICATE_HEADER,
+                            configurationService.getHeadersCaseInsensitive());
+            var reauthenticate =
+                    reauthenticateHeader != null && reauthenticateHeader.equals("true");
             var userStartInfo =
                     startService.buildUserStartInfo(
                             userContext,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -148,7 +148,8 @@ public class StartService {
             UserContext userContext,
             String cookieConsent,
             String gaTrackingId,
-            boolean identityEnabled) {
+            boolean identityEnabled,
+            boolean reauthenticate) {
         var uplift = false;
         var identityRequired = false;
         var consentRequired = false;
@@ -170,7 +171,10 @@ public class StartService {
             mfaMethodType = MFAMethodType.AUTH_APP;
         }
 
-        var userIsAuthenticated = !docCheckingAppUser && userContext.getSession().isAuthenticated();
+        var userIsAuthenticated =
+                !docCheckingAppUser
+                        && userContext.getSession().isAuthenticated()
+                        && !reauthenticate;
 
         LOG.info(
                 "Found UserStartInfo for Authenticated: {} ConsentRequired: {} UpliftRequired: {} IdentityRequired: {}. CookieConsent: {}. GATrackingId: {}. DocCheckingAppUser: {}",

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -143,7 +143,8 @@ class StartHandlerTest {
         when(startService.getGATrackingId(anyMap())).thenReturn(gaTrackingId);
         when(startService.getCookieConsentValue(anyMap(), anyString()))
                 .thenReturn(cookieConsentValue);
-        when(startService.buildUserStartInfo(userContext, cookieConsentValue, gaTrackingId, true))
+        when(startService.buildUserStartInfo(
+                        userContext, cookieConsentValue, gaTrackingId, true, false))
                 .thenReturn(userStartInfo);
         Features features = new Features();
         when(startService.getSessionFeatures()).thenReturn(features);
@@ -225,7 +226,7 @@ class StartHandlerTest {
                                 false));
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
-        when(startService.buildUserStartInfo(userContext, null, null, true))
+        when(startService.buildUserStartInfo(userContext, null, null, true, false))
                 .thenReturn(userStartInfo);
         usingValidDocAppClientSession();
         usingValidSession();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -65,6 +65,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandler.REAUTHENTICATE_HEADER;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
@@ -271,6 +272,81 @@ class StartHandlerTest {
                         AuditService.UNKNOWN,
                         PERSISTENT_ID,
                         pair("internalSubjectId", AuditService.UNKNOWN));
+    }
+
+    @Test
+    void shouldReturn200WithAuthenticatedFalseWhenAReauthenticationJourney()
+            throws ParseException, Json.JsonException {
+        when(userContext.getClientSession()).thenReturn(clientSession);
+        when(startService.validateSession(session, CLIENT_SESSION_ID)).thenReturn(session);
+        when(startService.buildUserContext(session, clientSession)).thenReturn(userContext);
+        when(startService.buildClientStartInfo(userContext)).thenReturn(getClientStartInfo());
+        when(startService.getGATrackingId(anyMap())).thenReturn(null);
+        when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
+        when(startService.buildUserStartInfo(userContext, null, null, true, true))
+                .thenReturn(new UserStartInfo(false, false, false, false, null, null, false, null));
+        usingValidSession();
+        usingValidClientSession();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
+        headers.put(SESSION_ID_HEADER, SESSION_ID);
+        headers.put(REAUTHENTICATE_HEADER, "true");
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(headers);
+        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(200));
+
+        var response = objectMapper.readValue(result.getBody(), StartResponse.class);
+
+        assertFalse(response.getUser().isAuthenticated());
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.START_INFO_FOUND,
+                        CLIENT_SESSION_ID,
+                        SESSION_ID,
+                        TEST_CLIENT_ID,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        "123.123.123.123",
+                        AuditService.UNKNOWN,
+                        PERSISTENT_ID,
+                        pair("internalSubjectId", AuditService.UNKNOWN));
+    }
+
+    @Test
+    void shouldReturn200WithAuthenticatedTrueWhenReauthenticateHeaderNotSetToTrue()
+            throws ParseException, Json.JsonException {
+        when(userContext.getClientSession()).thenReturn(clientSession);
+        when(startService.validateSession(session, CLIENT_SESSION_ID)).thenReturn(session);
+        when(startService.buildUserContext(session, clientSession)).thenReturn(userContext);
+        when(startService.buildClientStartInfo(userContext)).thenReturn(getClientStartInfo());
+        when(startService.getGATrackingId(anyMap())).thenReturn(null);
+        when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
+        when(startService.buildUserStartInfo(userContext, null, null, true, false))
+                .thenReturn(new UserStartInfo(false, false, false, true, null, null, false, null));
+        usingValidSession();
+        usingValidClientSession();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
+        headers.put(SESSION_ID_HEADER, SESSION_ID);
+        headers.put(REAUTHENTICATE_HEADER, "false");
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(headers);
+        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(200));
+
+        var response = objectMapper.readValue(result.getBody(), StartResponse.class);
+
+        assertTrue(response.getUser().isAuthenticated());
     }
 
     @Test


### PR DESCRIPTION
If this param is set to true, then the user is returned as not authenticated. This will form part of the reauthentication flow.

## Related PRs
https://github.com/govuk-one-login/authentication-frontend/pull/1253

