### PR TITLE
ATO-151: Allow egress to the authorize lambda when it is in the protected subnet

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -75,7 +75,11 @@ module "authorize" {
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
-  security_group_ids = [
+  security_group_ids = var.authorize_protected_subnet_enabled ? [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+    local.authentication_egress_security_group_id,
+    ] : [
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]


### PR DESCRIPTION
When in the protected subnet, egress is restricted by the network firewall. Therefore we can safely enable the open egress security group.
