### PR TITLE
ATO-208: Generate reauthentication claim

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -17,7 +17,8 @@ module "oidc_authorize_role" {
     aws_iam_policy.auth_public_encryption_key_parameter_policy.arn,
     local.client_registry_encryption_policy_arn,
     local.doc_app_credential_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.oidc_token_kms_signing_policy.arn
   ]
 }
 
@@ -56,6 +57,7 @@ module "authorize" {
     DYNAMO_ENDPOINT                      = var.use_localstack ? var.lambda_dynamo_endpoint : null
     CUSTOM_DOC_APP_CLAIM_ENABLED         = var.custom_doc_app_claim_enabled
     ORCH_REDIRECT_URI                    = var.orch_redirect_uri
+    TOKEN_SIGNING_KEY_ALIAS              = local.id_token_signing_key_alias_name
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
   rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
@@ -20,6 +20,8 @@ import java.text.ParseException;
 import java.util.List;
 import java.util.Objects;
 
+import static com.nimbusds.openid.connect.sdk.Prompt.Type.parse;
+
 public class RequestObjectToAuthRequestHelper {
     private static final Json objectMapper = SerializationService.getInstance();
 
@@ -65,6 +67,13 @@ public class RequestObjectToAuthRequestHelper {
             }
             if (Objects.nonNull(jwtClaimsSet.getClaim("rp_sid"))) {
                 builder.customParameter("rp_sid", jwtClaimsSet.getClaim("rp_sid").toString());
+            }
+            if (Objects.nonNull(jwtClaimsSet.getClaim("prompt"))) {
+                builder.prompt(parse(jwtClaimsSet.getStringClaim("prompt")));
+            }
+            if (Objects.nonNull(jwtClaimsSet.getClaim("id_token_hint"))) {
+                builder.customParameter(
+                        "id_token_hint", jwtClaimsSet.getStringClaim("id_token_hint"));
             }
             return builder.build();
         } catch (ParseException | com.nimbusds.oauth2.sdk.ParseException | Json.JsonException e) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -782,7 +782,7 @@ public class AuthorisationHandler
     }
 
     private String getReauthenticateClaim(AuthenticationRequest authenticationRequest) {
-        var isTokenSignatureValid =
+        boolean isTokenSignatureValid =
                 segmentedFunctionCall(
                         "isTokenSignatureValid",
                         () ->


### PR DESCRIPTION
## What?

When the login prompt and id token are set, id token is valid and for the correct rp, we should send a reauthenticate claim equal to the rp pairwise id
## Why?

To allow auth to reauthenticate the user
