### PR TITLE
AUT-1847: Setting tfvars to point to account interventions API in build

### DIFF
--- a/ci/terraform/interventions-api-stub/build.tfvars
+++ b/ci/terraform/interventions-api-stub/build.tfvars
@@ -1,5 +1,6 @@
 interventions_api_stub_release_zip_file = "./artifacts/interventions-api-stub.zip"
 shared_state_bucket                     = "digital-identity-dev-tfstate"
+account_intervention_service_uri        = "https://ip433hxp5m.execute-api.eu-west-2.amazonaws.com/build"
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/interventions-api-stub/variables.tf
+++ b/ci/terraform/interventions-api-stub/variables.tf
@@ -53,6 +53,11 @@ variable "endpoint_memory_size" {
   type    = number
 }
 
+variable "account_intervention_service_uri" {
+  default = "undefined"
+  type    = string
+}
+
 variable "interventions_api_stub_release_zip_file" {
   default     = "../../../interventions-api-stub/build/distributions/interventions-api-stub.zip"
   description = "Location of the Lambda ZIP file - defaults to build output folder when built locally"

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -8,6 +8,7 @@ logging_endpoint_arns                = []
 shared_state_bucket                  = "digital-identity-dev-tfstate"
 test_clients_enabled                 = true
 internal_sector_uri                  = "https://identity.build.account.gov.uk"
+account_intervention_service_uri     = "https://ip433hxp5m.execute-api.eu-west-2.amazonaws.com/build"
 
 
 auth_frontend_public_encryption_key = <<-EOT


### PR DESCRIPTION
## What?

Setting account_interventions_api_uri to point at the API gateway for build-di-interventions-api-stub.

This is a WIP.

## Why?

This is to test end to end user journey manually
