### PR TITLE
ATO-208: Fix client types for sandpit stubs

### DIFF
--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -17,7 +17,7 @@ stub_rp_clients = [
     ]
     test_client                     = "0"
     consent_required                = "0"
-    client_type                     = "WEB"
+    client_type                     = "web"
     identity_verification_supported = "0"
     scopes = [
       "openid",

--- a/ci/terraform/shared/authdev2.tfvars
+++ b/ci/terraform/shared/authdev2.tfvars
@@ -17,7 +17,7 @@ stub_rp_clients = [
     ]
     test_client                     = "0"
     consent_required                = "0"
-    client_type                     = "WEB"
+    client_type                     = "web"
     identity_verification_supported = "0"
     scopes = [
       "openid",

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -17,7 +17,7 @@ stub_rp_clients = [
     ]
     test_client                     = "0"
     consent_required                = "0"
-    client_type                     = "WEB"
+    client_type                     = "web"
     identity_verification_supported = "0"
     scopes = [
       "openid",


### PR DESCRIPTION
## What?

Change the casing of client types from WEB to web for sandpit stubs
## Why?

The correct casing is lower case - the upper case fail validation on the request object flow

