### PR TITLE
AUT-1998: Add new journey type to ‘VerifyMfaCodeHandler’ for auth app codes

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -22,6 +22,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -76,7 +77,8 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
         }
 
         var authAppSecret =
-                codeRequest.getJourneyType().equals(JourneyType.SIGN_IN)
+                List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
+                                .contains(codeRequest.getJourneyType())
                         ? getMfaCredentialValue().orElse(null)
                         : codeRequest.getProfileInformation();
 
@@ -85,7 +87,8 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
             return Optional.of(ErrorResponse.ERROR_1043);
         }
 
-        if (!codeRequest.getJourneyType().equals(JourneyType.SIGN_IN)
+        if (!List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
+                        .contains(codeRequest.getJourneyType())
                 && !base32.isInAlphabet(codeRequest.getProfileInformation())) {
             return Optional.of(ErrorResponse.ERROR_1041);
         }
@@ -126,6 +129,7 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
                         true);
                 break;
             case SIGN_IN:
+            case PASSWORD_RESET_MFA:
                 clearAccountRecoveryBlockIfPresent(AUTH_APP, ipAddress, persistentSessionId);
         }
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -78,6 +78,10 @@ class AuthAppCodeProcessorTest {
         return Stream.of(
                 Arguments.of(JourneyType.SIGN_IN, null, CodeRequestType.AUTH_APP_SIGN_IN),
                 Arguments.of(
+                        JourneyType.PASSWORD_RESET_MFA,
+                        null,
+                        CodeRequestType.PW_RESET_MFA_AUTH_APP),
+                Arguments.of(
                         JourneyType.REGISTRATION,
                         AUTH_APP_SECRET,
                         CodeRequestType.AUTH_APP_REGISTRATION));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
@@ -13,6 +13,7 @@ public enum CodeRequestType {
     SMS_SIGN_IN(MFAMethodType.SMS, JourneyType.SIGN_IN),
     AUTH_APP_ACCOUNT_RECOVERY(MFAMethodType.AUTH_APP, JourneyType.ACCOUNT_RECOVERY),
     AUTH_APP_SIGN_IN(MFAMethodType.AUTH_APP, JourneyType.SIGN_IN),
+    PW_RESET_MFA_AUTH_APP(MFAMethodType.AUTH_APP, JourneyType.PASSWORD_RESET_MFA),
     AUTH_APP_REGISTRATION(MFAMethodType.AUTH_APP, JourneyType.REGISTRATION);
 
     private static final Map<CodeRequestTypeKey, CodeRequestType> codeRequestTypeMap =


### PR DESCRIPTION
## What?

New CodeRequestType added for the 2FA password reset journey using auth app notifications. 

The relevant processor was also enhanced to process requests for the 2FA password reset journey.

## Why?

We maintain separate 2FA attempts counters for each journey type so that the user has the correct number of attempts before they are locked out.

A new counter type is required for Password Reset 2FA Auth App.