### PR TITLE
ATO-135: Add Return Code claim to integration tests and auditing

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -66,6 +66,7 @@ import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.ADDRESS
 import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.CORE_IDENTITY_CLAIM;
 import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.DRIVING_PERMIT;
 import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.PASSPORT_CLAIM;
+import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.RETURN_CODE;
 import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.SOCIAL_SECURITY_RECORD;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -198,7 +199,9 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         ValidClaims.DRIVING_PERMIT.getValue(),
                         DRIVING_PERMIT,
                         ValidClaims.SOCIAL_SECURITY_RECORD.getValue(),
-                        SOCIAL_SECURITY_RECORD),
+                        SOCIAL_SECURITY_RECORD,
+                        ValidClaims.RETURN_CODE.getValue(),
+                        RETURN_CODE),
                 180,
                 true);
 
@@ -219,15 +222,18 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var socialSecurityRecordClaim =
                 (JSONArray)
                         userInfoResponse.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue());
+        var returnCodeClaim =
+                (JSONArray) userInfoResponse.getClaim(ValidClaims.RETURN_CODE.getValue());
         assertThat(((JSONObject) addressClaim.get(0)).size(), equalTo(7));
         assertThat(((JSONObject) passportClaim.get(0)).size(), equalTo(2));
         assertThat(((JSONObject) drivingPermitClaim.get(0)).size(), equalTo(6));
         assertThat(((JSONObject) socialSecurityRecordClaim.get(0)).size(), equalTo(1));
+        assertThat(((JSONObject) returnCodeClaim.get(0)).size(), equalTo(1));
 
         assertThat(
                 userInfoResponse.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
                 equalTo(signedCredential.serialize()));
-        assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(10));
+        assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(11));
 
         assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(USER_INFO_RETURNED));
     }
@@ -428,7 +434,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .add(ValidClaims.ADDRESS.getValue())
                         .add(ValidClaims.PASSPORT.getValue())
                         .add(ValidClaims.DRIVING_PERMIT.getValue())
-                        .add(ValidClaims.SOCIAL_SECURITY_RECORD.getValue());
+                        .add(ValidClaims.SOCIAL_SECURITY_RECORD.getValue())
+                        .add(ValidClaims.RETURN_CODE.getValue());
         var oidcValidClaimsRequest =
                 new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         var claimsSet =

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -126,14 +126,11 @@ public class UserInfoHandler
 
         LOG.info("Successfully processed UserInfo request. Sending back UserInfo response");
 
-        var returnCodeClaim = userInfo.getJSONArrayClaim(ValidClaims.RETURN_CODE.getValue());
+        var returnCodeClaim = userInfo.getClaim(ValidClaims.RETURN_CODE.getValue());
         var metadataPairs = new AuditService.MetadataPair[] {};
 
-        if (returnCodeClaim != null && !returnCodeClaim.isEmpty()) {
-            metadataPairs =
-                    new AuditService.MetadataPair[] {
-                        pair("return-code", returnCodeClaim.toJSONString())
-                    };
+        if (returnCodeClaim != null) {
+            metadataPairs = new AuditService.MetadataPair[] {pair("return-code", returnCodeClaim)};
         }
 
         auditService.submitAuditEvent(


### PR DESCRIPTION
_This PR was co-authored by Isaac Au_

## What?

- Audit the Return Code claim when it is available.
- Add Return Code claim to existing integration tests.

Note that as Return Code is an additional claim, the functionality to include Return Code in the user info response is already handled.

Testing in sandpit will be done once all tickets in the [ATO-112 epic](https://govukverify.atlassian.net/browse/ATO-112) are ready.

## Why?

RPs have requested more information about failures after we redirect back.
