### PR TITLE
ATO-66: Enable docapp decouple in build

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -75,7 +75,11 @@ module "authorize" {
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
-  security_group_ids = [
+  security_group_ids = var.authorize_protected_subnet_enabled ? [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+    local.authentication_egress_security_group_id,
+    ] : [
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
   ]

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -15,7 +15,7 @@ custom_doc_app_claim_enabled        = true
 ipv_no_session_response_enabled     = true
 doc_app_cri_data_v2_endpoint        = "credentials/issue"
 doc_app_use_cri_data_v2_endpoint    = true
-doc_app_decouple_enabled            = false
+doc_app_decouple_enabled            = true
 orch_client_id                      = "orchestrationAuth"
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----


### PR DESCRIPTION
## What?

Enable the docapp decouple in the build environment

## Why?

Testing in preparation for rollout