### PR TITLE
AUT-2206 Milliseconds event timestamps for audit events

### DIFF
--- a/shared/src/main/java/uk/gov/di/audit/TxmaAuditEvent.java
+++ b/shared/src/main/java/uk/gov/di/audit/TxmaAuditEvent.java
@@ -14,6 +14,8 @@ public class TxmaAuditEvent {
 
     @Expose private final long timestamp;
 
+    @Expose private final long eventTimestampMs;
+
     @Expose private final String eventName;
 
     @Expose private String clientId;
@@ -26,15 +28,18 @@ public class TxmaAuditEvent {
     @Expose private Map<String, Object> restricted;
     @Expose private Map<String, Object> extensions;
 
-    public TxmaAuditEvent(String eventName, long timestamp) {
+    public TxmaAuditEvent(String eventName, long timestamp, long eventTimestampMs) {
         this.eventName = eventName;
         this.timestamp = timestamp;
+        this.eventTimestampMs = eventTimestampMs;
     }
 
     public static TxmaAuditEvent auditEventWithTime(
             AuditableEvent eventName, Supplier<Date> dateSupplier) {
         return new TxmaAuditEvent(
-                "AUTH_" + eventName.toString(), dateSupplier.get().toInstant().getEpochSecond());
+                "AUTH_" + eventName.toString(),
+                dateSupplier.get().toInstant().getEpochSecond(),
+                dateSupplier.get().toInstant().toEpochMilli());
     }
 
     public static TxmaAuditEvent auditEvent(AuditableEvent event) {

--- a/shared/src/test/java/uk/gov/di/audit/TxmaAuditEventTest.java
+++ b/shared/src/test/java/uk/gov/di/audit/TxmaAuditEventTest.java
@@ -36,6 +36,9 @@ class TxmaAuditEventTest {
         assertThat(
                 payload,
                 hasNumericFieldWithValue("timestamp", is(now.toInstant().getEpochSecond())));
+        assertThat(
+                payload,
+                hasNumericFieldWithValue("event_timestamp_ms", is(now.toInstant().toEpochMilli())));
     }
 
     @Test


### PR DESCRIPTION
## What?

Include Millisecond timestamp field as part of audit event

## Why?

TXMA Audit events require a millisecond timestamp be sent through.

## Related PRs

Mirrors the change made on the orch side: https://github.com/govuk-one-login/authentication-api/pull/3706/files
