### PR TITLE
AUT-1847: Log AIS service errors as errors

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -101,7 +101,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                             accountInterventionsInboundResponse.state().suspended());
             return generateApiGatewayProxyResponse(200, accountInterventionsResponse, true);
         } catch (UnsuccessfulAccountInterventionsResponseException e) {
-            LOG.debug(
+            LOG.error(
                     "Error in Account Interventions response HttpCode: {}, ErrorMessage: {}.",
                     e.getHttpCode(),
                     e.getMessage());


### PR DESCRIPTION
## What?

Log AIS service errors as errors.

## Why?

Currently unable to see errors returned from the stub in the logs.
These messages should be logged as 'error'.
