### PR TITLE
ATO-171: Perform back-channel logout if account status is suspended or blocked (v2)

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -57,7 +57,7 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
         handler =
                 new AccountInterventionsHandler(
                         ACCOUNT_INTERVENTIONS_HANDLER_CONFIGURATION_SERVICE);
-        accountInterventionsStubExtension.init(
+        accountInterventionsStubExtension.initWithBlockedUserId(
                 setupUserAndRetrieveUserId(TEST_EMAIL_ADDRESS),
                 setupUserAndRetrieveUserId(TEST_EMAIL_ADDRESS_PERMANENTLY_BLOCKED_USER));
         txmaAuditQueue.clear();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
 import uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler;
 import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
+import uk.gov.di.authentication.sharedtest.extensions.AccountInterventionsStubExtension;
 import uk.gov.di.orchestration.shared.entity.AuthenticationUserInfo;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ClientType;
@@ -58,6 +59,8 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
@@ -79,6 +82,10 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     protected final AuthenticationCallbackUserInfoStoreExtension userInfoStoreExtension =
             new AuthenticationCallbackUserInfoStoreExtension(180);
 
+    @RegisterExtension
+    public final AccountInterventionsStubExtension accountInterventionApiStub =
+            new AccountInterventionsStubExtension();
+
     protected final ConfigurationService configurationService =
             new AuthenticationCallbackHandlerIntegrationTest.TestConfigurationService(
                     authExternalApiStub,
@@ -88,7 +95,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                     tokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
-                    docAppPrivateKeyJwtSigner);
+                    docAppPrivateKeyJwtSigner,
+                    accountInterventionApiStub);
 
     private static final String CLIENT_ID = "test-client-id";
     private static final String CLIENT_NAME = "test-client-name";
@@ -97,6 +105,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     private static final Subject SUBJECT_ID = new Subject();
 
     private static final String IPV_CLIENT_ID = "ipv-client-id";
+    private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final KeyPair keyPair = generateRsaKeyPair();
     private static final String publicKey =
             "-----BEGIN PUBLIC KEY-----\n"
@@ -111,6 +120,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
             setupTest();
             setupSession();
             setupClientRegWithoutIdentityVerificationSupported();
+            accountInterventionApiStub.initWithBlockedOrSuspended(
+                    SUBJECT_ID.getValue(), false, false);
         }
 
         @Test
@@ -245,10 +256,12 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
             setupTest();
             setupSession();
             setupClientRegWithIdentityVerificationSupported();
+            accountInterventionApiStub.initWithBlockedOrSuspended(
+                    SUBJECT_ID.getValue(), false, false);
         }
 
         @Test
-        void shouldRedirectToIPVWhenIdentityRequired() throws Json.JsonException {
+        void shouldRedirectToIPVWhenIdentityRequired() {
             var response =
                     makeRequest(
                             Optional.empty(),
@@ -276,6 +289,94 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         private void setupClientRegWithIdentityVerificationSupported() {
             setupClientReg(true);
+        }
+    }
+
+    @Nested
+    class AccountInterventionJourney {
+
+        @BeforeEach()
+        void accountInterventionSetup() throws Json.JsonException {
+            setupTest();
+            setupSession();
+            setupClientRegWithoutIdentityVerificationSupported();
+        }
+
+        @Test
+        void shouldLogoutAndRedirectToBlockedPageWhenAccountIsBlocked() throws Json.JsonException {
+            accountInterventionApiStub.initWithBlockedOrSuspended(
+                    SUBJECT_ID.getValue(), true, false);
+
+            var session = redis.getSession(SESSION_ID);
+            assertNotNull(session);
+
+            var response =
+                    makeRequest(
+                            Optional.of(TEST_EMAIL_ADDRESS),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            constructQueryStringParameters());
+
+            assertThat(response, hasStatus(302));
+            assertThrows(
+                    uk.gov.di.orchestration.shared.serialization.Json.JsonException.class,
+                    () -> redis.getSession(SESSION_ID));
+
+            URI redirectLocationHeader =
+                    URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
+
+            assertThat(
+                    redirectLocationHeader.toString(),
+                    containsString(configurationService.getAccountStatusBlockedURI().toString()));
+
+            assertTxmaAuditEventsReceived(
+                    txmaAuditQueue,
+                    List.of(
+                            OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                            OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                            OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
+                            OidcAuditableEvent.LOG_OUT_SUCCESS));
+        }
+
+        @Test
+        void shouldLogoutAndRedirectToSuspendedPageWhenAccountIsSuspended()
+                throws Json.JsonException {
+            accountInterventionApiStub.initWithBlockedOrSuspended(
+                    SUBJECT_ID.getValue(), false, true);
+
+            var session = redis.getSession(SESSION_ID);
+            assertNotNull(session);
+
+            var response =
+                    makeRequest(
+                            Optional.of(TEST_EMAIL_ADDRESS),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            constructQueryStringParameters());
+
+            assertThat(response, hasStatus(302));
+            assertThrows(
+                    uk.gov.di.orchestration.shared.serialization.Json.JsonException.class,
+                    () -> redis.getSession(SESSION_ID));
+
+            URI redirectLocationHeader =
+                    URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
+
+            assertThat(
+                    redirectLocationHeader.toString(),
+                    containsString(configurationService.getAccountStatusSuspendedURI().toString()));
+
+            assertTxmaAuditEventsReceived(
+                    txmaAuditQueue,
+                    List.of(
+                            OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                            OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                            OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
+                            OidcAuditableEvent.LOG_OUT_SUCCESS));
+        }
+
+        private void setupClientRegWithoutIdentityVerificationSupported() {
+            setupClientReg(false);
         }
     }
 
@@ -357,6 +458,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     protected static class TestConfigurationService extends IntegrationTestConfigurationService {
 
         private final AuthExternalApiStubExtension authExternalApiStub;
+        private final AccountInterventionsStubExtension accountInterventionApiStub;
 
         public TestConfigurationService(
                 AuthExternalApiStubExtension authExternalApiStub,
@@ -366,7 +468,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                 TokenSigningExtension tokenSigningKey,
                 TokenSigningExtension ipvPrivateKeyJwtSigner,
                 SqsQueueExtension spotQueue,
-                TokenSigningExtension docAppPrivateKeyJwtSigner) {
+                TokenSigningExtension docAppPrivateKeyJwtSigner,
+                AccountInterventionsStubExtension accountInterventionsStubExtension) {
             super(
                     auditEventTopic,
                     notificationQueue,
@@ -377,6 +480,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                     docAppPrivateKeyJwtSigner,
                     configurationParameters);
             this.authExternalApiStub = authExternalApiStub;
+            this.accountInterventionApiStub = accountInterventionsStubExtension;
         }
 
         @Override
@@ -434,7 +538,25 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         @Override
         public URI getAccountInterventionServiceURI() {
-            return URI.create("https://authorize-account-intervention");
+            try {
+                return new URIBuilder()
+                        .setHost("localhost")
+                        .setPort(accountInterventionApiStub.getHttpPort())
+                        .setScheme("http")
+                        .build();
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public boolean isAccountInterventionServiceCallEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean isAccountInterventionServiceActionEnabled() {
+            return true;
         }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
 import uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler;
 import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
 import uk.gov.di.authentication.sharedtest.extensions.AccountInterventionsStubExtension;
+import uk.gov.di.orchestration.shared.domain.AccountInterventionsAuditableEvent;
 import uk.gov.di.orchestration.shared.entity.AuthenticationUserInfo;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ClientType;
@@ -151,6 +152,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                             OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
                             OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                             OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
+                            AccountInterventionsAuditableEvent.AIS_RESPONSE_RECEIVED,
                             OidcAuditableEvent.AUTH_CODE_ISSUED));
 
             Optional<AuthenticationUserInfo> userInfoDbEntry =
@@ -282,6 +284,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                     txmaAuditQueue,
                     List.of(
                             OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                            AccountInterventionsAuditableEvent.AIS_RESPONSE_RECEIVED,
                             OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                             OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
                             IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED));
@@ -333,6 +336,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                     txmaAuditQueue,
                     List.of(
                             OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                            AccountInterventionsAuditableEvent.AIS_RESPONSE_RECEIVED,
                             OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                             OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
                             OidcAuditableEvent.LOG_OUT_SUCCESS));
@@ -370,6 +374,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                     txmaAuditQueue,
                     List.of(
                             OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                            AccountInterventionsAuditableEvent.AIS_RESPONSE_RECEIVED,
                             OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                             OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
                             OidcAuditableEvent.LOG_OUT_SUCCESS));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/LogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/LogoutService.java
@@ -183,7 +183,10 @@ public class LogoutService {
         } else {
             throw new RuntimeException("Account status must be blocked or suspended");
         }
-        sessionId.ifPresent(t -> cloudwatchMetricsService.incrementLogout(clientId));
+        sessionId.ifPresent(
+                t ->
+                        cloudwatchMetricsService.incrementLogout(
+                                clientId, Optional.of(accountStatus)));
         return generateLogoutResponse(
                 ConstructUriHelper.buildURI(
                         configurationService.getOidcApiBaseURL().orElseThrow(), redirectUri),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/LogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/LogoutService.java
@@ -7,8 +7,10 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
+import uk.gov.di.orchestration.shared.helpers.ConstructUriHelper;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.services.AuditService;
@@ -62,6 +64,16 @@ public class LogoutService {
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.backChannelLogoutService = backChannelLogoutService;
+    }
+
+    public APIGatewayProxyResponseEvent handleAccountInterventionLogout(
+            Session session,
+            APIGatewayProxyRequestEvent input,
+            Optional<String> clientId,
+            Optional<String> sessionId,
+            AccountInterventionStatus accountStatus) {
+        destroySessions(session);
+        return generateAccountInterventionLogoutResponse(input, clientId, sessionId, accountStatus);
     }
 
     public void destroySessions(Session session) {
@@ -154,5 +166,31 @@ public class LogoutService {
 
         return generateApiGatewayProxyResponse(
                 302, "", Map.of(ResponseHeaders.LOCATION, uri.toString()), null);
+    }
+
+    private APIGatewayProxyResponseEvent generateAccountInterventionLogoutResponse(
+            APIGatewayProxyRequestEvent input,
+            Optional<String> clientId,
+            Optional<String> sessionId,
+            AccountInterventionStatus accountStatus) {
+        String redirectUri;
+        if (accountStatus.blocked()) {
+            redirectUri = configurationService.getAccountStatusBlockedURI();
+            LOG.info("Generating Account Intervention blocked logout response");
+        } else if (accountStatus.suspended()) {
+            redirectUri = configurationService.getAccountStatusSuspendedURI();
+            LOG.info("Generating Account Intervention suspended logout response");
+        } else {
+            throw new RuntimeException("Account status must be blocked or suspended");
+        }
+        sessionId.ifPresent(t -> cloudwatchMetricsService.incrementLogout(clientId));
+        return generateLogoutResponse(
+                ConstructUriHelper.buildURI(
+                        configurationService.getOidcApiBaseURL().orElseThrow(), redirectUri),
+                Optional.empty(),
+                Optional.empty(),
+                input,
+                clientId,
+                sessionId);
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
 import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
 import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
 import uk.gov.di.authentication.oidc.services.InitiateIPVAuthorisationService;
+import uk.gov.di.authentication.oidc.services.LogoutService;
 import uk.gov.di.orchestration.shared.conditions.IdentityHelper;
 import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 import uk.gov.di.orchestration.shared.entity.*;
@@ -64,6 +65,7 @@ class AuthenticationCallbackHandlerTest {
             mock(InitiateIPVAuthorisationService.class);
     private static final AccountInterventionService accountInterventionService =
             mock(AccountInterventionService.class);
+    private static final LogoutService logoutService = mock(LogoutService.class);
     private static final CookieHelper cookieHelper = mock(CookieHelper.class);
     private final ClientService clientService = mock(ClientService.class);
     private static final String TEST_FRONTEND_BASE_URL = "test.orchestration.frontend.url";
@@ -137,7 +139,8 @@ class AuthenticationCallbackHandlerTest {
                         authorisationCodeService,
                         clientService,
                         initiateIPVAuthorisationService,
-                        accountInterventionService);
+                        accountInterventionService,
+                        logoutService);
     }
 
     @Test
@@ -197,79 +200,6 @@ class AuthenticationCallbackHandlerTest {
                         eq(pair("rpPairwiseId", PAIRWISE_SUBJECT_ID.getValue())),
                         eq(pair("nonce", RP_NONCE)),
                         eq(pair("authCode", AUTH_CODE_RP_TO_ORCH.getValue())));
-    }
-
-    @Nested
-    class redirectToIPV {
-        private static MockedStatic<IdentityHelper> mockedIdentityHelper;
-
-        @BeforeAll
-        static void init() {
-            when(authorizationService.validateRequest(any(), any())).thenReturn(true);
-        }
-
-        @BeforeEach
-        void setup() throws UnsuccessfulCredentialResponseException {
-            mockedIdentityHelper = mockStatic(IdentityHelper.class);
-            when(IdentityHelper.identityRequired(anyMap(), anyBoolean(), anyBoolean()))
-                    .thenReturn(true);
-            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
-            when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
-                    .thenReturn(USER_INFO);
-            when(initiateIPVAuthorisationService.sendRequestToIPV(
-                            any(), any(), any(), any(), any(), any(), any(), any(), any()))
-                    .thenReturn(createIPVApiResponse());
-            usingValidSession();
-            usingValidClientSession();
-            usingValidClient();
-        }
-
-        @AfterEach
-        void afterEach() {
-            mockedIdentityHelper.close();
-        }
-
-        @Test
-        void shouldRedirectToIPVWhenIdentityRequired() {
-            var event = new APIGatewayProxyRequestEvent();
-            setValidHeadersAndQueryParameters(event);
-
-            var response = handler.handleRequest(event, null);
-
-            assertThat(response, hasStatus(302));
-
-            verify(cloudwatchMetricsService).incrementCounter(eq("AuthenticationCallback"), any());
-
-            verify(initiateIPVAuthorisationService)
-                    .sendRequestToIPV(
-                            any(), any(), any(), any(), any(), any(), any(), any(), any());
-        }
-
-        @Test
-        void shouldRedirectToIPVWithReproveIdentityWhenAccountInterventionsEnabled() {
-            when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
-            when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
-            boolean reproveIdentity = true;
-            when(accountInterventionService.getAccountStatus(anyString(), any()))
-                    .thenReturn(new AccountInterventionStatus(false, true, reproveIdentity, false));
-
-            var event = new APIGatewayProxyRequestEvent();
-            setValidHeadersAndQueryParameters(event);
-
-            handler.handleRequest(event, null);
-
-            verify(initiateIPVAuthorisationService)
-                    .sendRequestToIPV(
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            eq(reproveIdentity));
-        }
     }
 
     @Test
@@ -362,6 +292,174 @@ class AuthenticationCallbackHandlerTest {
                         OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED),
                 auditService);
         verifyNoInteractions(userInfoStorageService, cloudwatchMetricsService);
+    }
+
+    @Nested
+    class redirectToIPV {
+        private static MockedStatic<IdentityHelper> mockedIdentityHelper;
+
+        @BeforeAll
+        static void init() {
+            when(authorizationService.validateRequest(any(), any())).thenReturn(true);
+        }
+
+        @BeforeEach
+        void setup() throws UnsuccessfulCredentialResponseException {
+            mockedIdentityHelper = mockStatic(IdentityHelper.class);
+            when(IdentityHelper.identityRequired(anyMap(), anyBoolean(), anyBoolean()))
+                    .thenReturn(true);
+            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
+                    .thenReturn(USER_INFO);
+            when(initiateIPVAuthorisationService.sendRequestToIPV(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(createIPVApiResponse());
+            usingValidSession();
+            usingValidClientSession();
+            usingValidClient();
+        }
+
+        @AfterEach
+        void afterEach() {
+            mockedIdentityHelper.close();
+        }
+
+        @Test
+        void shouldRedirectToIPVWhenIdentityRequired() {
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            var response = handler.handleRequest(event, null);
+
+            assertThat(response, hasStatus(302));
+
+            verify(cloudwatchMetricsService).incrementCounter(eq("AuthenticationCallback"), any());
+
+            verify(initiateIPVAuthorisationService)
+                    .sendRequestToIPV(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
+        void shouldRedirectToIPVWithReproveIdentityWhenAccountInterventionsEnabled() {
+            when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
+            boolean reproveIdentity = true;
+            when(accountInterventionService.getAccountStatus(anyString()))
+                    .thenReturn(
+                            new AccountInterventionStatus(false, false, reproveIdentity, false));
+
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            handler.handleRequest(event, null);
+
+            verify(initiateIPVAuthorisationService)
+                    .sendRequestToIPV(
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            eq(reproveIdentity));
+        }
+    }
+
+    @Nested
+    class accountInterventions {
+        private static MockedStatic<IdentityHelper> mockedIdentityHelper;
+
+        @BeforeAll
+        static void init() {
+            when(authorizationService.validateRequest(any(), any())).thenReturn(true);
+        }
+
+        @BeforeEach
+        void setup() throws UnsuccessfulCredentialResponseException {
+            mockedIdentityHelper = mockStatic(IdentityHelper.class);
+            when(IdentityHelper.identityRequired(anyMap(), anyBoolean(), anyBoolean()))
+                    .thenReturn(false);
+            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
+                    .thenReturn(USER_INFO);
+            usingValidSession();
+            usingValidClientSession();
+            usingValidClient();
+        }
+
+        @AfterEach
+        void tearDown() {
+            mockedIdentityHelper.close();
+        }
+
+        @Test
+        void shouldPerformBackChannelLogoutWhenAccountStatusIsBlocked() {
+            AccountInterventionStatus accountStatus =
+                    new AccountInterventionStatus(true, false, false, false);
+            when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
+            when(accountInterventionService.getAccountStatus(any())).thenReturn(accountStatus);
+
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            handler.handleRequest(event, null);
+
+            verify(logoutService)
+                    .handleAccountInterventionLogout(
+                            session,
+                            event,
+                            Optional.of(CLIENT_ID.toString()),
+                            Optional.of(SESSION_ID.toString()),
+                            accountStatus);
+        }
+
+        @Test
+        void shouldPerformBackChannelLogoutWhenResetPasswordIsRequired() {
+            AccountInterventionStatus accountStatus =
+                    new AccountInterventionStatus(false, true, false, true);
+            when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
+            when(accountInterventionService.getAccountStatus(any())).thenReturn(accountStatus);
+
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            handler.handleRequest(event, null);
+
+            verify(logoutService)
+                    .handleAccountInterventionLogout(
+                            session,
+                            event,
+                            Optional.of(CLIENT_ID.toString()),
+                            Optional.of(SESSION_ID.toString()),
+                            accountStatus);
+        }
+
+        @Test
+        void shouldPerformBackChannelLogoutWhenNotOnIdentityJourneyAndAccountStatusIsSuspended() {
+            AccountInterventionStatus accountStatus =
+                    new AccountInterventionStatus(false, true, false, false);
+            when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
+            when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
+            when(accountInterventionService.getAccountStatus(any())).thenReturn(accountStatus);
+
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            handler.handleRequest(event, null);
+
+            verify(logoutService)
+                    .handleAccountInterventionLogout(
+                            session,
+                            event,
+                            Optional.of(CLIENT_ID.toString()),
+                            Optional.of(SESSION_ID.toString()),
+                            accountStatus);
+        }
     }
 
     private APIGatewayProxyResponseEvent createIPVApiResponse() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -350,7 +350,7 @@ class AuthenticationCallbackHandlerTest {
             when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
             when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
             boolean reproveIdentity = true;
-            when(accountInterventionService.getAccountStatus(anyString()))
+            when(accountInterventionService.getAccountStatus(anyString(), any()))
                     .thenReturn(
                             new AccountInterventionStatus(false, false, reproveIdentity, false));
 
@@ -375,7 +375,7 @@ class AuthenticationCallbackHandlerTest {
         @Test
         void shouldRedirectToIPVWhenAccountStatusIsSuspended() {
             boolean reproveIdentity = true;
-            when(accountInterventionService.getAccountStatus(anyString()))
+            when(accountInterventionService.getAccountStatus(anyString(), any()))
                     .thenReturn(new AccountInterventionStatus(false, true, reproveIdentity, false));
 
             var event = new APIGatewayProxyRequestEvent();
@@ -400,7 +400,8 @@ class AuthenticationCallbackHandlerTest {
         void shouldNotRedirectToIPVWhenAccountStatusIsBlocked() {
             AccountInterventionStatus accountStatus =
                     new AccountInterventionStatus(true, false, false, false);
-            when(accountInterventionService.getAccountStatus(any())).thenReturn(accountStatus);
+            when(accountInterventionService.getAccountStatus(anyString(), any()))
+                    .thenReturn(accountStatus);
 
             var event = new APIGatewayProxyRequestEvent();
             setValidHeadersAndQueryParameters(event);
@@ -460,7 +461,8 @@ class AuthenticationCallbackHandlerTest {
                     new AccountInterventionStatus(true, false, false, false);
             when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
             when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
-            when(accountInterventionService.getAccountStatus(any())).thenReturn(accountStatus);
+            when(accountInterventionService.getAccountStatus(anyString(), any()))
+                    .thenReturn(accountStatus);
 
             var event = new APIGatewayProxyRequestEvent();
             setValidHeadersAndQueryParameters(event);
@@ -482,7 +484,8 @@ class AuthenticationCallbackHandlerTest {
                     new AccountInterventionStatus(false, true, false, true);
             when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
             when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
-            when(accountInterventionService.getAccountStatus(any())).thenReturn(accountStatus);
+            when(accountInterventionService.getAccountStatus(anyString(), any()))
+                    .thenReturn(accountStatus);
 
             var event = new APIGatewayProxyRequestEvent();
             setValidHeadersAndQueryParameters(event);
@@ -504,7 +507,8 @@ class AuthenticationCallbackHandlerTest {
                     new AccountInterventionStatus(false, true, false, false);
             when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
             when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
-            when(accountInterventionService.getAccountStatus(any())).thenReturn(accountStatus);
+            when(accountInterventionService.getAccountStatus(anyString(), any()))
+                    .thenReturn(accountStatus);
 
             var event = new APIGatewayProxyRequestEvent();
             setValidHeadersAndQueryParameters(event);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/LogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/LogoutServiceTest.java
@@ -264,13 +264,14 @@ public class LogoutServiceTest {
     @Test
     void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsBlocked() {
         when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_API_BASE_URL));
+        var accountStatus = new AccountInterventionStatus(true, false, false, false);
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
                         session,
                         event,
                         Optional.of(CLIENT_ID),
                         Optional.of(SESSION_ID),
-                        new AccountInterventionStatus(true, false, false, false));
+                        accountStatus);
 
         verify(clientSessionService)
                 .deleteClientSessionFromRedis(session.getClientSessions().get(0));
@@ -286,7 +287,8 @@ public class LogoutServiceTest {
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID);
-        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
+        verify(cloudwatchMetricsService)
+                .incrementLogout(Optional.of(CLIENT_ID), Optional.of(accountStatus));
 
         assertThat(response, hasStatus(302));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(OIDC_API_BASE_URL));
@@ -295,13 +297,14 @@ public class LogoutServiceTest {
     @Test
     void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsSuspended() {
         when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_API_BASE_URL));
+        var accountStatus = new AccountInterventionStatus(false, true, false, false);
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
                         session,
                         event,
                         Optional.of(CLIENT_ID),
                         Optional.of(SESSION_ID),
-                        new AccountInterventionStatus(false, true, false, false));
+                        accountStatus);
 
         verify(clientSessionService)
                 .deleteClientSessionFromRedis(session.getClientSessions().get(0));
@@ -317,7 +320,8 @@ public class LogoutServiceTest {
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID);
-        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
+        verify(cloudwatchMetricsService)
+                .incrementLogout(Optional.of(CLIENT_ID), Optional.of(accountStatus));
 
         assertThat(response, hasStatus(302));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(OIDC_API_BASE_URL));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/LogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/LogoutServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.MockedStatic;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -46,6 +47,8 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -93,6 +96,8 @@ public class LogoutServiceTest {
     private static final String CLIENT_ID = "client-id";
     private static final Subject SUBJECT = new Subject();
     private static final String EMAIL = "joe.bloggs@test.com";
+
+    private static final String OIDC_API_BASE_URL = "https://oidc.test.account.gov.uk/";
 
     private SignedJWT signedIDToken;
     private Optional<String> audience;
@@ -257,6 +262,68 @@ public class LogoutServiceTest {
     }
 
     @Test
+    void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsBlocked() {
+        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_API_BASE_URL));
+        APIGatewayProxyResponseEvent response =
+                logoutService.handleAccountInterventionLogout(
+                        session,
+                        event,
+                        Optional.of(CLIENT_ID),
+                        Optional.of(SESSION_ID),
+                        new AccountInterventionStatus(true, false, false, false));
+
+        verify(clientSessionService)
+                .deleteClientSessionFromRedis(session.getClientSessions().get(0));
+        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(auditService)
+                .submitAuditEvent(
+                        OidcAuditableEvent.LOG_OUT_SUCCESS,
+                        AuditService.UNKNOWN,
+                        SESSION_ID,
+                        CLIENT_ID,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        IP_ADDRESS,
+                        AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID);
+        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
+
+        assertThat(response, hasStatus(302));
+        assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(OIDC_API_BASE_URL));
+    }
+
+    @Test
+    void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsSuspended() {
+        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_API_BASE_URL));
+        APIGatewayProxyResponseEvent response =
+                logoutService.handleAccountInterventionLogout(
+                        session,
+                        event,
+                        Optional.of(CLIENT_ID),
+                        Optional.of(SESSION_ID),
+                        new AccountInterventionStatus(false, true, false, false));
+
+        verify(clientSessionService)
+                .deleteClientSessionFromRedis(session.getClientSessions().get(0));
+        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(auditService)
+                .submitAuditEvent(
+                        OidcAuditableEvent.LOG_OUT_SUCCESS,
+                        AuditService.UNKNOWN,
+                        SESSION_ID,
+                        CLIENT_ID,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        IP_ADDRESS,
+                        AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID);
+        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
+
+        assertThat(response, hasStatus(302));
+        assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(OIDC_API_BASE_URL));
+    }
+
+    @Test
     public void shouldDeleteSessionFromRedisWhenNoCookieExists() {
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
         input.setQueryStringParameters(
@@ -300,6 +367,26 @@ public class LogoutServiceTest {
         verify(clientSessionService).deleteClientSessionFromRedis("client-session-id-2");
         verify(clientSessionService).deleteClientSessionFromRedis("client-session-id-3");
         verify(sessionService, times(1)).deleteSessionFromRedis(SESSION_ID);
+    }
+
+    @Test
+    void throwsWhenGenerateAccountInterventionLogoutResponseCalledInappropriately() {
+        AccountInterventionStatus status =
+                new AccountInterventionStatus(false, false, false, false);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                logoutService.handleAccountInterventionLogout(
+                                        session,
+                                        event,
+                                        Optional.of(CLIENT_ID),
+                                        Optional.of(SESSION_ID),
+                                        status),
+                        "Expected to throw exception");
+
+        assertEquals("Account status must be blocked or suspended", exception.getMessage());
     }
 
     private Session generateSession() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/domain/CloudwatchMetricDimensions.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/domain/CloudwatchMetricDimensions.java
@@ -7,7 +7,8 @@ public enum CloudwatchMetricDimensions {
     IS_TEST("IsTest"),
     REQUESTED_LEVEL_OF_CONFIDENCE("RequestedLevelOfConfidence"),
     MFA_REQUIRED("MfaRequired"),
-    CLIENT_NAME("ClientName");
+    CLIENT_NAME("ClientName"),
+    ACCOUNT_INTERVENTION_STATUS("AccountInterventionStatus");
 
     private String value;
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -104,7 +104,9 @@ public class AccountInterventionService {
 
         HttpRequest request =
                 HttpRequest.newBuilder()
-                        .uri(accountInterventionServiceURI.resolve(internalPairwiseSubjectId))
+                        .uri(
+                                accountInterventionServiceURI.resolve(
+                                        "/v1/ais/" + internalPairwiseSubjectId))
                         .GET()
                         .build();
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CloudwatchMetricsService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CloudwatchMetricsService.java
@@ -3,12 +3,14 @@ package uk.gov.di.orchestration.shared.services;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
 import uk.gov.di.orchestration.shared.entity.Session;
 
 import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.ACCOUNT;
+import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.ACCOUNT_INTERVENTION_STATUS;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.CLIENT;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.CLIENT_NAME;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
@@ -135,12 +137,29 @@ public class CloudwatchMetricsService {
     }
 
     public void incrementLogout(Optional<String> clientId) {
+        incrementLogout(clientId, Optional.empty());
+    }
+
+    public void incrementLogout(
+            Optional<String> clientId,
+            Optional<AccountInterventionStatus> accountInterventionStatus) {
+        String accountInterventionStr = "unknown";
+        if (accountInterventionStatus.isPresent()) {
+            if (accountInterventionStatus.get().blocked()) {
+                accountInterventionStr = "blocked";
+            }
+            if (accountInterventionStatus.get().suspended()) {
+                accountInterventionStr = "suspended";
+            }
+        }
         incrementCounter(
                 LOGOUT_SUCCESS.getValue(),
                 Map.of(
                         ENVIRONMENT.getValue(),
                         configurationService.getEnvironment(),
                         CLIENT.getValue(),
-                        clientId.orElse("unknown")));
+                        clientId.orElse("unknown"),
+                        ACCOUNT_INTERVENTION_STATUS.getValue(),
+                        accountInterventionStr));
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -92,6 +92,14 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals("true");
     }
 
+    public String getAccountStatusBlockedURI() {
+        return "/orch-frontend/not-available";
+    }
+
+    public String getAccountStatusSuspendedURI() {
+        return "/orch-frontend/unavailable";
+    }
+
     public long getAuthCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("AUTH_CODE_EXPIRY", "300"));
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -54,8 +54,8 @@ class AccountInterventionServiceTest {
             }
             """;
 
-    private static final String BASE_AIS_URL = "http://example.com/somepath/";
-    private static final AuditContext someAuditContext =
+    private static String BASE_AIS_URL = "http://example.com/v1/ais/";
+    private static AuditContext someAuditContext =
             new AuditContext(
                     "some-client-session-id",
                     "some-session-id",

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountInterventionsStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountInterventionsStubExtension.java
@@ -12,7 +12,7 @@ public class AccountInterventionsStubExtension extends HttpStubExtension {
         super();
     }
 
-    public void init(String nonBlockedUserId, String blockedUserId) {
+    public void initWithBlockedUserId(String nonBlockedUserId, String blockedUserId) {
         register(
                 "/v1/ais/" + nonBlockedUserId,
                 200,
@@ -50,6 +50,33 @@ public class AccountInterventionsStubExtension extends HttpStubExtension {
                         + "  \"state\": {"
                         + "    \"blocked\": true,"
                         + "    \"suspended\": false,"
+                        + "    \"reproveIdentity\": false,"
+                        + "    \"resetPassword\": false"
+                        + "  }"
+                        + "}");
+    }
+
+    public void initWithBlockedOrSuspended(String userId, boolean blocked, boolean suspended) {
+        register(
+                "/v1/ais/" + userId,
+                200,
+                "application/json",
+                "{"
+                        + "  \"intervention\": {"
+                        + "    \"updatedAt\": 1696969322935,"
+                        + "    \"appliedAt\": 1696869005821,"
+                        + "    \"sentAt\": 1696869003456,"
+                        + "    \"description\": \"AIS_USER_PASSWORD_RESET_AND_IDENTITY_VERIFIED\","
+                        + "    \"reprovedIdentityAt\": 1696969322935,"
+                        + "    \"resetPasswordAt\": 1696875903456"
+                        + "  },"
+                        + "  \"state\": {"
+                        + "    \"blocked\": "
+                        + blocked
+                        + ","
+                        + "    \"suspended\": "
+                        + suspended
+                        + ","
                         + "    \"reproveIdentity\": false,"
                         + "    \"resetPassword\": false"
                         + "  }"


### PR DESCRIPTION
## What?

If the account status received from Account Interventions is `suspended` or `blocked`, destroy all sessions and redirect to account suspended/blocked page.

This PR does not handle destroying the Authentication frontend session.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3647
