### PR TITLE
Update Stub Handler Response

### DIFF
--- a/interventions-api-stub/src/test/java/uk/gov/di/authentication/interventions/api/stub/lambda/AccountInterventionsApiStubHandlerTest.java
+++ b/interventions-api-stub/src/test/java/uk/gov/di/authentication/interventions/api/stub/lambda/AccountInterventionsApiStubHandlerTest.java
@@ -53,7 +53,7 @@ class AccountInterventionsApiStubHandlerTest {
     }
 
     @Test
-    void shouldReturn404WhenThePairwiseIdDoesNotExistInTheDatabase() {
+    void shouldReturn200WhenThePairwiseIdDoesNotExistInTheDatabase() {
         var handler = new AccountInterventionsApiStubHandler(accountInterventionsDbService);
         when(accountInterventionsDbService.getAccountInterventions(PAIRWISE_ID))
                 .thenReturn(Optional.empty());
@@ -62,6 +62,6 @@ class AccountInterventionsApiStubHandlerTest {
         event.setPathParameters(Map.of(PATH_PARAM_NAME_IN_API_GW, PAIRWISE_ID));
 
         var result = handler.handleRequest(event, context);
-        assertEquals(404, result.getStatusCode());
+        assertEquals(200, result.getStatusCode());
     }
 }


### PR DESCRIPTION
## What?

Updated stub handler to return 200 response in event of no matching account being found by account interventions service.

## Why?

It was returning 404 when spec requires 200 for this case.
