### PR TITLE
ATO-249: Add field to store a list of VTRs in ClientSession

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.Expose;
 import com.nimbusds.oauth2.sdk.id.Subject;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -17,6 +18,8 @@ public class ClientSession {
 
     @Expose private VectorOfTrust effectiveVectorOfTrust;
 
+    @Expose private List<VectorOfTrust> vtrList = new ArrayList<>();
+
     @Expose private Subject docAppSubjectId;
 
     @Expose private String clientName;
@@ -29,6 +32,7 @@ public class ClientSession {
         this.authRequestParams = authRequestParams;
         this.creationDate = creationDate;
         this.effectiveVectorOfTrust = effectiveVectorOfTrust;
+        this.vtrList.add(effectiveVectorOfTrust);
         this.clientName = clientName;
     }
 
@@ -53,8 +57,13 @@ public class ClientSession {
         return effectiveVectorOfTrust;
     }
 
+    public List<VectorOfTrust> getVtrList() {
+        return vtrList;
+    }
+
     public ClientSession setEffectiveVectorOfTrust(VectorOfTrust effectiveVectorOfTrust) {
         this.effectiveVectorOfTrust = effectiveVectorOfTrust;
+        this.vtrList.add(effectiveVectorOfTrust);
         return this;
     }
 


### PR DESCRIPTION
## What?

Add `vtrList` field to `ClientSession` class and initialise it using the existing `effectiveVectorOfTrust` field.

## Why?

The assumption that we are only returning one VTR is changing, and this is the first step to allowing multiple VTRs to be returned. This is a result of the inherit identities work.