### PR TITLE
ATO-250: Use VTR list from Client Session where required

### DIFF
--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -34,6 +34,7 @@ import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.NoSessionEntity;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
@@ -112,7 +113,8 @@ class DocAppCallbackHandlerTest {
     private final Session session = new Session(SESSION_ID).setEmailAddress(TEST_EMAIL_ADDRESS);
 
     private final ClientSession clientSession =
-            new ClientSession(generateAuthRequest().toParameters(), null, null, null);
+            new ClientSession(
+                    generateAuthRequest().toParameters(), null, (VectorOfTrust) null, null);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.User;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
@@ -102,7 +103,8 @@ class SignUpHandlerTest {
 
     private final Session session = new Session(IdGenerator.generate());
     private final ClientSession clientSession =
-            new ClientSession(generateAuthRequest().toParameters(), null, null, CLIENT_NAME);
+            new ClientSession(
+                    generateAuthRequest().toParameters(), null, (VectorOfTrust) null, CLIENT_NAME);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -410,7 +410,10 @@ class IPVCallbackHandlerTest {
                                         .add(ValidClaims.RETURN_CODE.getValue()));
         var clientSession =
                 new ClientSession(
-                        generateAuthRequest(claimsRequest).toParameters(), null, null, CLIENT_NAME);
+                        generateAuthRequest(claimsRequest).toParameters(),
+                        null,
+                        (VectorOfTrust) null,
+                        CLIENT_NAME);
 
         when(responseService.validateResponse(anyMap(), anyString())).thenReturn(Optional.empty());
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -323,7 +323,7 @@ public class AuthCodeHandler
         if (!orchestrationAuthorizationService.isClientRedirectUriValid(clientID, redirectUri)) {
             throw new ProcessAuthRequestException(400, ErrorResponse.ERROR_1016);
         }
-        VectorOfTrust requestedVectorOfTrust = clientSession.getEffectiveVectorOfTrust();
+        VectorOfTrust requestedVectorOfTrust = clientSession.getVtrWithLowestCredentialTrustLevel();
         if (isNull(session.getCurrentCredentialStrength())
                 || requestedVectorOfTrust
                                 .getCredentialTrustLevel()

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -377,7 +377,8 @@ public class AuthenticationCallbackHandler
 
                 LOG.info("Redirecting to: {} with state: {}", clientRedirectURI, state);
 
-                VectorOfTrust requestedVectorOfTrust = clientSession.getEffectiveVectorOfTrust();
+                VectorOfTrust requestedVectorOfTrust =
+                        clientSession.getVtrWithLowestCredentialTrustLevel();
                 if (isNull(userSession.getCurrentCredentialStrength())
                         || requestedVectorOfTrust
                                         .getCredentialTrustLevel()
@@ -483,15 +484,11 @@ public class AuthenticationCallbackHandler
             LOG.info(
                     "No mfa method to set. User is either authenticated or signing in from a low level service");
         }
-        var mfaRequired =
-                !clientSession
-                        .getEffectiveVectorOfTrust()
-                        .getCredentialTrustLevel()
-                        .equals(CredentialTrustLevel.LOW_LEVEL);
+        VectorOfTrust vtr = clientSession.getVtrWithLowestCredentialTrustLevel();
+        var mfaRequired = !vtr.getCredentialTrustLevel().equals(CredentialTrustLevel.LOW_LEVEL);
         var levelOfConfidence = LevelOfConfidence.NONE.getValue();
-        if (clientSession.getEffectiveVectorOfTrust().containsLevelOfConfidence()) {
-            levelOfConfidence =
-                    clientSession.getEffectiveVectorOfTrust().getLevelOfConfidence().getValue();
+        if (vtr.containsLevelOfConfidence()) {
+            levelOfConfidence = vtr.getLevelOfConfidence().getValue();
         }
         dimensions.put("MfaRequired", mfaRequired ? "Yes" : "No");
         dimensions.put("RequestedLevelOfConfidence", levelOfConfidence);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.RefreshTokenStore;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
@@ -228,16 +229,16 @@ public class TokenHandler
         if (authRequest.getNonce() != null) {
             additionalTokenClaims.put("nonce", authRequest.getNonce());
         }
-        String vot = clientSession.getEffectiveVectorOfTrust().retrieveVectorOfTrustForToken();
+        VectorOfTrust vtr = clientSession.getVtrWithLowestCredentialTrustLevel();
+        String vot = vtr.retrieveVectorOfTrustForToken();
 
         OIDCClaimsRequest claimsRequest = null;
-        if (Objects.nonNull(clientSession.getEffectiveVectorOfTrust().getLevelOfConfidence())
+        if (Objects.nonNull(vtr.getLevelOfConfidence())
                 && Objects.nonNull(authRequest.getOIDCClaims())) {
             claimsRequest = authRequest.getOIDCClaims();
         }
         var isConsentRequired =
-                clientRegistry.isConsentRequired()
-                        && !clientSession.getEffectiveVectorOfTrust().containsLevelOfConfidence();
+                clientRegistry.isConsentRequired() && !vtr.containsLevelOfConfidence();
         final OIDCClaimsRequest finalClaimsRequest = claimsRequest;
         OIDCTokenResponse tokenResponse;
         if (isDocCheckingAppUserWithSubjectId(clientSession)) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -272,6 +272,7 @@ class AuthCodeHandlerTest {
                         any(URI.class),
                         any(State.class)))
                 .thenReturn(authSuccessResponse);
+        when(clientSession.getVtrLocsAsCommaSeparatedString()).thenReturn("P0");
 
         var response = generateApiRequest();
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -570,7 +570,7 @@ class AuthCodeHandlerTest {
         when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(clientSession));
         when(vectorOfTrust.getCredentialTrustLevel()).thenReturn(requestedLevel);
-        when(clientSession.getEffectiveVectorOfTrust()).thenReturn(vectorOfTrust);
+        when(clientSession.getVtrWithLowestCredentialTrustLevel()).thenReturn(vectorOfTrust);
         when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
         when(clientSession.getClientName()).thenReturn(CLIENT_NAME);
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -470,7 +470,8 @@ class AuthorisationHandlerTest {
         void shouldRedirectToLoginWhenUserNeedsToBeUplifted() {
             session.setCurrentCredentialStrength(CredentialTrustLevel.LOW_LEVEL);
             withExistingSession(session);
-            when(clientSession.getEffectiveVectorOfTrust()).thenReturn(VectorOfTrust.getDefaults());
+            when(clientSession.getVtrWithLowestCredentialTrustLevel())
+                    .thenReturn(VectorOfTrust.getDefaults());
             when(userContext.getClientSession()).thenReturn(clientSession);
             when(userContext.getSession()).thenReturn(session);
             when(clientSession.getAuthRequestParams())

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/conditions/UpliftHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/conditions/UpliftHelper.java
@@ -16,7 +16,7 @@ public class UpliftHelper {
                         .getCurrentCredentialStrength()
                         .compareTo(
                                 context.getClientSession()
-                                        .getEffectiveVectorOfTrust()
+                                        .getVtrWithLowestCredentialTrustLevel()
                                         .getCredentialTrustLevel())
                 < 0);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
@@ -5,6 +5,7 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -65,6 +66,30 @@ public class ClientSession {
         this.effectiveVectorOfTrust = effectiveVectorOfTrust;
         this.vtrList.add(effectiveVectorOfTrust);
         return this;
+    }
+
+    public VectorOfTrust getVtrWithLowestCredentialTrustLevel() {
+        return this.vtrList.stream()
+                .filter(vot -> vot.getLevelOfConfidence() != null)
+                .min(
+                        Comparator.comparing(
+                                        VectorOfTrust::getLevelOfConfidence,
+                                        Comparator.nullsFirst(Comparator.naturalOrder()))
+                                .thenComparing(
+                                        VectorOfTrust::getCredentialTrustLevel,
+                                        Comparator.nullsFirst(Comparator.naturalOrder())))
+                .orElseGet(
+                        () ->
+                                this.vtrList.stream()
+                                        .min(
+                                                Comparator.comparing(
+                                                        VectorOfTrust::getCredentialTrustLevel,
+                                                        Comparator.nullsFirst(
+                                                                Comparator.naturalOrder())))
+                                        .orElseThrow(
+                                                () ->
+                                                        new IllegalArgumentException(
+                                                                "Invalid VTR attribute")));
     }
 
     public Subject getDocAppSubjectId() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
@@ -37,6 +37,18 @@ public class ClientSession {
         this.clientName = clientName;
     }
 
+    public ClientSession(
+            Map<String, List<String>> authRequestParams,
+            LocalDateTime creationDate,
+            List<VectorOfTrust> vtrList,
+            String clientName) {
+        this.authRequestParams = authRequestParams;
+        this.creationDate = creationDate;
+        this.vtrList = vtrList;
+        this.effectiveVectorOfTrust = getVtrWithLowestCredentialTrustLevel();
+        this.clientName = clientName;
+    }
+
     public ClientSession setIdTokenHint(String idTokenHint) {
         this.idTokenHint = idTokenHint;
         return this;
@@ -52,10 +64,6 @@ public class ClientSession {
 
     public LocalDateTime getCreationDate() {
         return creationDate;
-    }
-
-    public VectorOfTrust getEffectiveVectorOfTrust() {
-        return effectiveVectorOfTrust;
     }
 
     public List<VectorOfTrust> getVtrList() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
@@ -104,4 +104,20 @@ public class ClientSession {
     public String getClientName() {
         return clientName;
     }
+
+    public String getVtrLocsAsCommaSeparatedString() {
+        StringBuilder strBuilder = new StringBuilder();
+        for (VectorOfTrust vtr : this.vtrList) {
+            String loc =
+                    vtr.containsLevelOfConfidence()
+                            ? vtr.getLevelOfConfidence().getValue()
+                            : LevelOfConfidence.NONE.getValue();
+            strBuilder.append(loc).append(",");
+        }
+        if (strBuilder.length() > 0) {
+            strBuilder.setLength(strBuilder.length() - 1);
+            return strBuilder.toString();
+        }
+        return "";
+    }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -5,8 +5,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
-import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.Session;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
@@ -71,18 +71,11 @@ public class AuthCodeResponseGenerationService {
     }
 
     public void processVectorOfTrust(ClientSession clientSession, Map<String, String> dimensions) {
-        var mfaNotRequired =
-                clientSession
-                        .getEffectiveVectorOfTrust()
-                        .getCredentialTrustLevel()
-                        .equals(CredentialTrustLevel.LOW_LEVEL);
-        var levelOfConfidence = LevelOfConfidence.NONE.getValue();
-        if (clientSession.getEffectiveVectorOfTrust().containsLevelOfConfidence()) {
-            levelOfConfidence =
-                    clientSession.getEffectiveVectorOfTrust().getLevelOfConfidence().getValue();
-        }
+        VectorOfTrust vtr = clientSession.getVtrWithLowestCredentialTrustLevel();
+        var mfaNotRequired = vtr.getCredentialTrustLevel().equals(CredentialTrustLevel.LOW_LEVEL);
         dimensions.put("MfaRequired", mfaNotRequired ? "No" : "Yes");
-        dimensions.put("RequestedLevelOfConfidence", levelOfConfidence);
+        dimensions.put(
+                "RequestedLevelOfConfidence", clientSession.getVtrLocsAsCommaSeparatedString());
     }
 
     public String getSubjectId(Session session) throws UserNotFoundException {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/ClientSessionTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/ClientSessionTest.java
@@ -1,0 +1,171 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class ClientSessionTest {
+
+    private static final ClientID CLIENT_ID = new ClientID();
+    private static final URI REDIRECT_URI = URI.create("test-uri");
+    private static final String CLIENT_NAME = "some-client-name";
+
+    @ParameterizedTest
+    @MethodSource("lowestCtrTestCases")
+    void shouldCorrectlyFindVtrWithLowestCredentialTrustLevelFromList(
+            List<VectorOfTrust> vtrList, CredentialTrustLevel expectedCtl) {
+
+        ClientSession clientSession =
+                new ClientSession(
+                        generateAuthRequest().toParameters(),
+                        LocalDateTime.now(),
+                        vtrList,
+                        CLIENT_NAME);
+
+        var lowestVtr = clientSession.getVtrWithLowestCredentialTrustLevel();
+
+        assertThat(lowestVtr.getCredentialTrustLevel().getValue(), equalTo(expectedCtl.getValue()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("locsCssTestCases")
+    void shouldCorrectlyCreateVtrLevelsOfConfidenceAsCommaSeparatedString(
+            List<VectorOfTrust> vtrList, String expectedCss) {
+
+        ClientSession clientSession =
+                new ClientSession(
+                        generateAuthRequest().toParameters(),
+                        LocalDateTime.now(),
+                        vtrList,
+                        CLIENT_NAME);
+
+        var css = clientSession.getVtrLocsAsCommaSeparatedString();
+
+        assertThat(css, equalTo(expectedCss));
+    }
+
+    private static Stream<Arguments> lowestCtrTestCases() {
+        return Stream.of(
+                arguments(
+                        List.of(
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.LOW_LEVEL,
+                                        LevelOfConfidence.getDefault()),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.MEDIUM_LEVEL,
+                                        LevelOfConfidence.getDefault())),
+                        CredentialTrustLevel.LOW_LEVEL),
+                arguments(
+                        List.of(
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.LOW_LEVEL,
+                                        LevelOfConfidence.getDefault()),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.LOW_LEVEL,
+                                        LevelOfConfidence.getDefault())),
+                        CredentialTrustLevel.LOW_LEVEL),
+                arguments(
+                        List.of(
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.MEDIUM_LEVEL,
+                                        LevelOfConfidence.getDefault()),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.MEDIUM_LEVEL,
+                                        LevelOfConfidence.getDefault())),
+                        CredentialTrustLevel.MEDIUM_LEVEL),
+                arguments(
+                        List.of(
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.MEDIUM_LEVEL,
+                                        LevelOfConfidence.getDefault()),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.LOW_LEVEL,
+                                        LevelOfConfidence.getDefault()),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.MEDIUM_LEVEL,
+                                        LevelOfConfidence.getDefault()),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.MEDIUM_LEVEL,
+                                        LevelOfConfidence.getDefault())),
+                        CredentialTrustLevel.LOW_LEVEL),
+                arguments(
+                        List.of(
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.MEDIUM_LEVEL,
+                                        LevelOfConfidence.getDefault()),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.LOW_LEVEL,
+                                        LevelOfConfidence.getDefault()),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.LOW_LEVEL,
+                                        LevelOfConfidence.getDefault()),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.LOW_LEVEL,
+                                        LevelOfConfidence.getDefault())),
+                        CredentialTrustLevel.LOW_LEVEL));
+    }
+
+    private static Stream<Arguments> locsCssTestCases() {
+        return Stream.of(
+                arguments(
+                        List.of(
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.getDefault(),
+                                        LevelOfConfidence.HIGH_LEVEL)),
+                        "P3"),
+                arguments(
+                        List.of(
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.getDefault(),
+                                        LevelOfConfidence.getDefault()),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.getDefault(),
+                                        LevelOfConfidence.getDefault())),
+                        "P2,P2"),
+                arguments(
+                        List.of(
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.getDefault(),
+                                        LevelOfConfidence.LOW_LEVEL),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.getDefault(),
+                                        LevelOfConfidence.VERY_HIGH_LEVEL),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.getDefault(),
+                                        LevelOfConfidence.MEDIUM_LEVEL),
+                                VectorOfTrust.of(
+                                        CredentialTrustLevel.getDefault(),
+                                        LevelOfConfidence.LOW_LEVEL)),
+                        "P1,P4,P2,P1"));
+    }
+
+    public static AuthenticationRequest generateAuthRequest() {
+        ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
+        State state = new State();
+        Scope scope = new Scope();
+        Nonce nonce = new Nonce();
+        scope.add(OIDCScopeValue.OPENID);
+        scope.add("phone");
+        scope.add("email");
+        return new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
+                .state(state)
+                .nonce(nonce)
+                .build();
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSessionServiceTest.java
@@ -128,7 +128,7 @@ class ClientSessionServiceTest {
                 Map.of("authparam", List.of("v1", "v2")), clientSession.getAuthRequestParams());
         assertEquals(
                 VectorOfTrust.getDefaults().getCredentialTrustLevel(),
-                clientSession.getEffectiveVectorOfTrust().getCredentialTrustLevel());
+                clientSession.getVtrWithLowestCredentialTrustLevel().getCredentialTrustLevel());
         assertEquals("client-name", clientSession.getClientName());
     }
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationServiceTest.java
@@ -12,6 +12,7 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 
 import java.net.URI;
@@ -252,6 +253,6 @@ class NoSessionOrchestrationServiceTest {
                         .state(new State())
                         .nonce(new Nonce())
                         .build();
-        return new ClientSession(authRequest.toParameters(), null, null, null);
+        return new ClientSession(authRequest.toParameters(), null, (VectorOfTrust) null, null);
     }
 }


### PR DESCRIPTION
## What?

- Replace any usages of the old single VTR on `ClientSession` to the new list of VTRs.
- In the cases that our logic requires a single VTR, the VTR with the lowest credential trust value from the list is used.
- The VTR list is audited as a comma separated string.

## Why?

Currently we assume that we only receive a single VTR, but as part of the inherited identities work we need to be able to handle a list of VTRs.
