### PR TITLE
BAU: Switch state and interventions JSON 'shape'

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/Intervention.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/Intervention.java
@@ -4,9 +4,7 @@ import com.google.gson.annotations.Expose;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 
 public record Intervention(
-        @Expose @Required String updatedAt,
-        @Expose @Required String appliedAt,
-        @Expose @Required String sentAt,
-        @Expose @Required String description,
-        @Expose @Required String reprovedIdentityAt,
-        @Expose @Required String resetPasswordAt) {}
+        @Expose @Required boolean blocked,
+        @Expose @Required boolean suspended,
+        @Expose @Required boolean reproveIdentity,
+        @Expose @Required boolean resetPassword) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/State.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/State.java
@@ -4,7 +4,9 @@ import com.google.gson.annotations.Expose;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 
 public record State(
-        @Expose @Required boolean blocked,
-        @Expose @Required boolean suspended,
-        @Expose @Required boolean reproveIdentity,
-        @Expose @Required boolean resetPassword) {}
+        @Expose @Required String updatedAt,
+        @Expose @Required String appliedAt,
+        @Expose @Required String sentAt,
+        @Expose @Required String description,
+        @Expose @Required String reprovedIdentityAt,
+        @Expose @Required String resetPasswordAt) {}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -328,14 +328,14 @@ public class AccountInterventionsHandlerTest {
     private AccountInterventionsInboundResponse generateAccountInterventionResponse(
             boolean blocked, boolean suspended, boolean reproveIdentity, boolean resetPassword) {
         return new AccountInterventionsInboundResponse(
-                new Intervention(
+                new Intervention(blocked, suspended, reproveIdentity, resetPassword),
+                new State(
                         "1696969322935",
                         "1696869005821",
                         "1696869003456",
                         "AIS_USER_PASSWORD_RESET_AND_IDENTITY_VERIFIED",
                         "1696969322935",
-                        "1696875903456"),
-                new State(blocked, suspended, reproveIdentity, resetPassword));
+                        "1696875903456"));
     }
 
     private Map<String, String> getHeaders() {


### PR DESCRIPTION
## What?
- Switch state and interventions JSON 'shape' 

## Why?
- State POJO reflected contents of "interventions" JSON field coming back from Account Interventions Service (or stub)
- And vice versa for Interventions POJO and "state" field
- This should help the account interventions handler to parse the JSON from AIS correctly
