### PR TITLE
BAU: Switch intervention and state object content in stub AIS response

### DIFF
--- a/interventions-api-stub/src/main/java/uk/gov/di/authentication/interventions/api/stub/entity/InterventionsApiStubResponse.java
+++ b/interventions-api-stub/src/main/java/uk/gov/di/authentication/interventions/api/stub/entity/InterventionsApiStubResponse.java
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName;
 
 public class InterventionsApiStubResponse {
 
-    public static class Interventions {
+    public static class State {
         @SerializedName("blocked")
         @Expose
         private Boolean blocked;
@@ -22,7 +22,7 @@ public class InterventionsApiStubResponse {
         @Expose
         private Boolean reproveIdentity;
 
-        public Interventions(AccountInterventionsStore accountInterventions) {
+        public State(AccountInterventionsStore accountInterventions) {
             this.blocked = accountInterventions.isBlocked();
             this.reproveIdentity = accountInterventions.isReproveIdentity();
             this.suspended = accountInterventions.isSuspended();
@@ -30,7 +30,7 @@ public class InterventionsApiStubResponse {
         }
     }
 
-    public class State {
+    public class Intervention {
 
         @SerializedName("updatedAt")
         @Expose
@@ -56,7 +56,7 @@ public class InterventionsApiStubResponse {
         @Expose
         private Long resetPasswordAt;
 
-        public State() {
+        public Intervention() {
             this.updatedAt = 1696969322935L;
             this.appliedAt = 1696869005821L;
             this.sentAt = 1696869003456L;
@@ -67,15 +67,15 @@ public class InterventionsApiStubResponse {
     }
 
     @Expose
-    @SerializedName("intervention")
-    private Interventions interventions;
-
-    @Expose
     @SerializedName("state")
     private State state;
 
+    @Expose
+    @SerializedName("intervention")
+    private Intervention intervention;
+
     public InterventionsApiStubResponse(AccountInterventionsStore accountInterventions) {
-        this.state = new State();
-        this.interventions = new Interventions(accountInterventions);
+        this.intervention = new Intervention();
+        this.state = new State(accountInterventions);
     }
 }

--- a/interventions-api-stub/src/test/java/uk/gov/di/authentication/interventions/api/stub/lambda/AccountInterventionsApiStubHandlerTest.java
+++ b/interventions-api-stub/src/test/java/uk/gov/di/authentication/interventions/api/stub/lambda/AccountInterventionsApiStubHandlerTest.java
@@ -43,12 +43,12 @@ class AccountInterventionsApiStubHandlerTest {
 
         var result = handler.handleRequest(event, context);
         assertEquals(200, result.getStatusCode());
-        var interventionBlock =
-                "{\"blocked\":true,\"resetPassword\":true,\"suspended\":true,\"reproveIdentity\":true}";
         var stateBlock =
+                "{\"blocked\":true,\"resetPassword\":true,\"suspended\":true,\"reproveIdentity\":true}";
+        var interventionBlock =
                 "{\"updatedAt\":1696969322935,\"appliedAt\":1696869005821,\"sentAt\":1696869003456,\"description\":\"AIS_USER_PASSWORD_RESET_AND_IDENTITY_VERIFIED\",\"reprovedIdentityAt\":1696969322935,\"resetPasswordAt\":1696875903456}";
         var expectedJson =
-                format("{\"intervention\":%s,\"state\":%s}", interventionBlock, stateBlock);
+                format("{\"state\":%s,\"intervention\":%s}", stateBlock, interventionBlock);
         assertEquals(expectedJson, result.getBody());
     }
 


### PR DESCRIPTION
## What?
- Switch intervention and state object content in stub AIS response

## Why?
- Current setup holds intervention fields in state object in JSON and vice versa
- This cannot be correctly parsed by Account Interventions handler
