### PR TITLE
DOT-384: Enable support for client_secret_post token auth in integration

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -329,7 +329,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public boolean isClientSecretSupported() {
-        return List.of("build", "staging", "local").contains(getEnvironment());
+        return List.of("build", "staging", "local", "integration").contains(getEnvironment());
     }
 
     public boolean isIdentityEnabled() {


### PR DESCRIPTION
This will enable us to test client_secret_post support in the integration environment