### PR TITLE
ATO-171: Attach policy to give orchestration-redirect lambda read access to user profile dynamo tables

### DIFF
--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -14,7 +14,8 @@ module "oidc_api_authentication_callback_role" {
     aws_iam_policy.orch_to_auth_kms_policy.arn,
     aws_iam_policy.authentication_callback_userinfo_encryption_key_kms_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn
+    local.client_registry_encryption_policy_arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn
   ]
 }
 


### PR DESCRIPTION
## What?

Give orchestration-redirect lambda permission to read user profile dynamo tables.

## Why?

Fixes deployment error: `.../staging-orchestration-redirect-lambda is not authorized to perform: dynamodb:DescribeTable on resource: .../staging-user-profile`

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3741 failed during deployment with the above error.
