### PR TITLE
ATO-27: Handle non-medium identities

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -316,8 +316,9 @@ public class IPVCallbackHandler
                     AuditService.UNKNOWN,
                     userProfile.getPhoneNumber(),
                     persistentId);
+            var vtrList = clientSession.getVtrList();
             var userIdentityError =
-                    ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo);
+                    ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, vtrList);
             if (userIdentityError.isPresent()) {
                 var accountInterventionStatus =
                         ipvCallbackHelper.getAccountInterventionStatus(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/LevelOfConfidence.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/LevelOfConfidence.java
@@ -27,10 +27,10 @@ public enum LevelOfConfidence {
         return supported;
     }
 
-    public static LevelOfConfidence retrieveLevelOfConfidence(String vrtSet) {
+    public static LevelOfConfidence retrieveLevelOfConfidence(String vtrSet) {
         return Arrays.stream(values())
                 .filter(LevelOfConfidence::isSupported)
-                .filter(tl -> vrtSet.equals(tl.getValue()))
+                .filter(tl -> vtrSet.equals(tl.getValue()))
                 .findFirst()
                 .orElseThrow(
                         () -> new IllegalArgumentException("Invalid LevelOfConfidence provided"));
@@ -41,5 +41,9 @@ public enum LevelOfConfidence {
                 .filter(LevelOfConfidence::isSupported)
                 .map(LevelOfConfidence::getValue)
                 .collect(Collectors.toList());
+    }
+
+    public static LevelOfConfidence getDefault() {
+        return MEDIUM_LEVEL;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/VectorOfTrust.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/VectorOfTrust.java
@@ -76,7 +76,7 @@ public class VectorOfTrust {
     }
 
     public static VectorOfTrust getDefaults() {
-        return new VectorOfTrust(CredentialTrustLevel.getDefault());
+        return VectorOfTrust.of(CredentialTrustLevel.getDefault(), LevelOfConfidence.getDefault());
     }
 
     public String retrieveVectorOfTrustForToken() {
@@ -174,7 +174,7 @@ public class VectorOfTrust {
         return Objects.hash(credentialTrustLevel, levelOfConfidence);
     }
 
-    static VectorOfTrust of(
+    public static VectorOfTrust of(
             CredentialTrustLevel credentialTrustLevel, LevelOfConfidence levelOfConfidence) {
         return new VectorOfTrust(credentialTrustLevel, Optional.ofNullable(levelOfConfidence));
     }


### PR DESCRIPTION
## What?

Handle non-medium identities

## Why?

To allow non-medium ID users to be passed back to the RP

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3755
