### PR TITLE
Aut 2122/new journey type for reauth auth app

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -64,6 +64,12 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
                 CodeRequestType.getCodeRequestType(AUTH_APP, codeRequest.getJourneyType());
         var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
 
+        var nonRegistrationJourneyTypes =
+                List.of(
+                        JourneyType.SIGN_IN,
+                        JourneyType.PASSWORD_RESET_MFA,
+                        JourneyType.REAUTHENTICATE_MFA);
+
         if (isCodeBlockedForSession(codeBlockedKeyPrefix)) {
             LOG.info("Code blocked for session");
             return Optional.of(ErrorResponse.ERROR_1042);
@@ -77,8 +83,7 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
         }
 
         var authAppSecret =
-                List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
-                                .contains(codeRequest.getJourneyType())
+                nonRegistrationJourneyTypes.contains(codeRequest.getJourneyType())
                         ? getMfaCredentialValue().orElse(null)
                         : codeRequest.getProfileInformation();
 
@@ -87,8 +92,7 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
             return Optional.of(ErrorResponse.ERROR_1043);
         }
 
-        if (!List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
-                        .contains(codeRequest.getJourneyType())
+        if (!nonRegistrationJourneyTypes.contains(codeRequest.getJourneyType())
                 && !base32.isInAlphabet(codeRequest.getProfileInformation())) {
             return Optional.of(ErrorResponse.ERROR_1041);
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -388,7 +388,10 @@ class VerifyMfaCodeHandlerTest {
     }
 
     private static Stream<JourneyType> existingUserAuthAppJourneyTypes() {
-        return Stream.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA);
+        return Stream.of(
+                JourneyType.SIGN_IN,
+                JourneyType.PASSWORD_RESET_MFA,
+                JourneyType.REAUTHENTICATE_MFA);
     }
 
     @ParameterizedTest
@@ -432,7 +435,11 @@ class VerifyMfaCodeHandlerTest {
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.empty());
         var authAppSecret =
-                List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA).contains(journeyType)
+                List.of(
+                                        JourneyType.SIGN_IN,
+                                        JourneyType.PASSWORD_RESET_MFA,
+                                        JourneyType.REAUTHENTICATE_MFA)
+                                .contains(journeyType)
                         ? null
                         : AUTH_APP_SECRET;
         var codeRequest =
@@ -477,8 +484,9 @@ class VerifyMfaCodeHandlerTest {
                         JourneyType.ACCOUNT_RECOVERY, CodeRequestType.AUTH_APP_ACCOUNT_RECOVERY),
                 Arguments.of(JourneyType.REGISTRATION, CodeRequestType.AUTH_APP_REGISTRATION),
                 Arguments.of(JourneyType.SIGN_IN, CodeRequestType.AUTH_APP_SIGN_IN),
+                Arguments.of(JourneyType.PASSWORD_RESET_MFA, CodeRequestType.PW_RESET_MFA_AUTH_APP),
                 Arguments.of(
-                        JourneyType.PASSWORD_RESET_MFA, CodeRequestType.PW_RESET_MFA_AUTH_APP));
+                        JourneyType.REAUTHENTICATE_MFA, CodeRequestType.AUTH_APP_REAUTHENTICATION));
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -84,7 +84,11 @@ class AuthAppCodeProcessorTest {
                 Arguments.of(
                         JourneyType.REGISTRATION,
                         AUTH_APP_SECRET,
-                        CodeRequestType.AUTH_APP_REGISTRATION));
+                        CodeRequestType.AUTH_APP_REGISTRATION),
+                Arguments.of(
+                        JourneyType.REAUTHENTICATE_MFA,
+                        null,
+                        CodeRequestType.AUTH_APP_REAUTHENTICATION));
     }
 
     @ParameterizedTest

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
@@ -15,7 +15,8 @@ public enum CodeRequestType {
     AUTH_APP_SIGN_IN(MFAMethodType.AUTH_APP, JourneyType.SIGN_IN),
     PW_RESET_MFA_AUTH_APP(MFAMethodType.AUTH_APP, JourneyType.PASSWORD_RESET_MFA),
     AUTH_APP_REGISTRATION(MFAMethodType.AUTH_APP, JourneyType.REGISTRATION),
-    SMS_REAUTHENTICATION(MFAMethodType.SMS, JourneyType.REAUTHENTICATE_MFA);
+    SMS_REAUTHENTICATION(MFAMethodType.SMS, JourneyType.REAUTHENTICATE_MFA),
+    AUTH_APP_REAUTHENTICATION(MFAMethodType.AUTH_APP, JourneyType.REAUTHENTICATE_MFA);
 
     private static final Map<CodeRequestTypeKey, CodeRequestType> codeRequestTypeMap =
             new HashMap<>();


### PR DESCRIPTION
## What?

Adds a new journey type and code request type for reauthenticating with a two-factor mode of auth app.

This will ensure we have separate counters for the re-authentication journey, meaning that they cannot either request new codes more than the maximum limit, or enter the wrong code too many times.

## Why?

To support the new re-authentication journey, requiring users to re-authenticate during a journey.

## Related PRs

[Equivalent PR](https://github.com/govuk-one-login/authentication-api/pull/3720/files) that adds journey type for password reset (the current PR should look very similar to this)
[PR](https://github.com/govuk-one-login/authentication-api/pull/3738) that adds the a reauth journey for SMS

