### PR TITLE
AUT-2217: add subject to session for auth app MFA PW reset journey

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
@@ -1,0 +1,42 @@
+package uk.gov.di.authentication.frontendapi.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+public class SessionHelper {
+    private static final Logger LOG = LogManager.getLogger(VerifyMfaCodeHandler.class);
+
+    public static void updateSessionWithSubject(
+            UserContext userContext,
+            AuthenticationService authenticationService,
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            Session session) {
+        LOG.info("Calculating internal common subject identifier");
+        UserProfile userProfile =
+                userContext.getUserProfile().isPresent()
+                        ? userContext.getUserProfile().get()
+                        : authenticationService.getUserProfileByEmail(session.getEmailAddress());
+        var internalCommonSubjectIdentifier =
+                session.getInternalCommonSubjectIdentifier() != null
+                        ? session.getInternalCommonSubjectIdentifier()
+                        : ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                                        userProfile,
+                                        configurationService.getInternalSectorUri(),
+                                        authenticationService)
+                                .getValue();
+        LOG.info("Setting internal common subject identifier in user session");
+        sessionService.save(
+                userContext
+                        .getSession()
+                        .setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier));
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
+import uk.gov.di.authentication.frontendapi.helpers.SessionHelper;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
@@ -16,9 +17,7 @@ import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
-import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
-import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
@@ -153,26 +152,12 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
             }
             if (codeRequestType.equals(CodeRequestType.PW_RESET_MFA_SMS)) {
-                LOG.info("Calculating internal common subject identifier");
-                UserProfile userProfile =
-                        userContext.getUserProfile().isPresent()
-                                ? userContext.getUserProfile().get()
-                                : authenticationService.getUserProfileByEmail(
-                                        session.getEmailAddress());
-                var internalCommonSubjectIdentifier =
-                        session.getInternalCommonSubjectIdentifier() != null
-                                ? session.getInternalCommonSubjectIdentifier()
-                                : ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                                                userProfile,
-                                                configurationService.getInternalSectorUri(),
-                                                authenticationService)
-                                        .getValue();
-                LOG.info("Setting internal common subject identifier in user session");
-                sessionService.save(
-                        userContext
-                                .getSession()
-                                .setInternalCommonSubjectIdentifier(
-                                        internalCommonSubjectIdentifier));
+                SessionHelper.updateSessionWithSubject(
+                        userContext,
+                        authenticationService,
+                        configurationService,
+                        sessionService,
+                        session);
             }
             processSuccessfulCodeRequest(session, codeRequest, input, userContext);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.helpers.SessionHelper;
 import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessor;
 import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessorFactory;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
@@ -131,7 +132,14 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             if (errorResponse.filter(ErrorResponse.ERROR_1041::equals).isPresent()) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1041);
             }
-
+            if (JourneyType.PASSWORD_RESET_MFA.equals(codeRequest.getJourneyType())) {
+                SessionHelper.updateSessionWithSubject(
+                        userContext,
+                        authenticationService,
+                        configurationService,
+                        sessionService,
+                        session);
+            }
             processCodeSession(
                     errorResponse, session, input, userContext, codeRequest, mfaCodeProcessor);
 


### PR DESCRIPTION
## What?

Code added to retrieve subject identifier and update the session with it exists for the verify code handler (sms code verification). This code has been moved to a helper and is now also being used in the verify mfa code handler (auth app code verification).

## Why?

The UI is unable to request auth code verification due to API failure with 1001 error returned. The issue is expected to be around the session not having a subject as experienced previously with SMS verification before user logs in.
