### PR TITLE
ATO-176: Remove AIS URI in build

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -19,7 +19,6 @@ doc_app_use_cri_data_v2_endpoint          = true
 doc_app_decouple_enabled                  = true
 orch_client_id                            = "orchestrationAuth"
 account_intervention_service_call_enabled = true
-account_intervention_service_uri          = "https://ip433hxp5m.execute-api.eu-west-2.amazonaws.com/build"
 auth_frontend_public_encryption_key       = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApLJWOHz7uHLinSJr8XM0


### PR DESCRIPTION
## What?

Remove AIS URI in build

## Why?

Remove line as it is incorrect and stored in a secret instead.

