### PR TITLE
AUT-1958: Increase rate limit staging (frontend API)

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -253,7 +253,7 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_frontend_api" {
     name     = "${var.environment}-frontend-waf-rate-based-rule"
     statement {
       rate_based_statement {
-        limit              = 7200
+        limit              = var.environment == "staging" ? 10000000 : 7200
         aggregate_key_type = "IP"
       }
     }


### PR DESCRIPTION
## What?
- Increase rate limit for the Frontend API in Staging environment

## Why?
- Required for performance testing

## Related PRs
- Accompanies relaxation of limits on accessing the frontend app (in that case for GDS IP addresses only) in the frontend repo: https://github.com/govuk-one-login/authentication-frontend/pull/1278
