### PR TITLE
Ato 23/allow custom locs per rp

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
@@ -71,6 +71,10 @@ public class ClientRegistrationRequest {
     @Expose
     private String clientType = ClientType.WEB.getValue();
 
+    @SerializedName("accepted_levels_of_confidence")
+    @Expose
+    private List<String> clientLoCs = new ArrayList<>();
+
     public ClientRegistrationRequest() {}
 
     public ClientRegistrationRequest(
@@ -87,6 +91,38 @@ public class ClientRegistrationRequest {
             boolean identityVerificationRequired,
             List<String> claims,
             String clientType) {
+        this(
+                clientName,
+                redirectUris,
+                contacts,
+                publicKey,
+                scopes,
+                postLogoutRedirectUris,
+                backChannelLogoutUri,
+                serviceType,
+                sectorIdentifierUri,
+                subjectType,
+                identityVerificationRequired,
+                claims,
+                clientType,
+                null);
+    }
+
+    public ClientRegistrationRequest(
+            String clientName,
+            List<String> redirectUris,
+            List<String> contacts,
+            String publicKey,
+            List<String> scopes,
+            List<String> postLogoutRedirectUris,
+            String backChannelLogoutUri,
+            String serviceType,
+            String sectorIdentifierUri,
+            String subjectType,
+            boolean identityVerificationRequired,
+            List<String> claims,
+            String clientType,
+            List<String> clientLoCs) {
         this.clientName = clientName;
         this.redirectUris = redirectUris;
         this.contacts = contacts;
@@ -110,6 +146,9 @@ public class ClientRegistrationRequest {
             clientType = ClientType.WEB.getValue();
         }
         this.clientType = clientType;
+        if (Objects.nonNull(clientLoCs)) {
+            this.clientLoCs = clientLoCs;
+        }
     }
 
     public String getClientName() {
@@ -162,5 +201,9 @@ public class ClientRegistrationRequest {
 
     public String getClientType() {
         return clientType;
+    }
+
+    public List<String> getClientLoCs() {
+        return clientLoCs;
     }
 }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -125,7 +125,8 @@ public class ClientRegistrationHandler
                     clientRegistrationRequest.getClientType(),
                     clientRegistrationRequest.isIdentityVerificationRequired(),
                     null,
-                    ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
+                    ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
+                    clientRegistrationRequest.getClientLoCs());
 
             var clientRegistrationResponse =
                     new ClientRegistrationResponse(

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -5,6 +5,7 @@ import com.nimbusds.oauth2.sdk.client.RegistrationError;
 import com.nimbusds.openid.connect.sdk.SubjectType;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.orchestration.shared.entity.ClientType;
+import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.UpdateClientConfigRequest;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
@@ -40,6 +41,8 @@ public class ClientConfigValidationService {
             new ErrorObject("invalid_client_metadata", "Invalid Sector Identifier URI");
     public static final ErrorObject INVALID_CLIENT_TYPE =
             new ErrorObject("invalid_client_metadata", "Invalid Client Type");
+    public static final ErrorObject INVALID_CLIENT_LOCS =
+            new ErrorObject("invalid_client_metadata", "Invalid Accepted Levels of Confidence");
 
     public Optional<ErrorObject> validateClientRegistrationConfig(
             ClientRegistrationRequest registrationRequest) {
@@ -81,6 +84,9 @@ public class ClientConfigValidationService {
         if (Arrays.stream(ClientType.values())
                 .noneMatch(t -> t.getValue().equals(registrationRequest.getClientType()))) {
             return Optional.of(INVALID_CLIENT_TYPE);
+        }
+        if (!areClientLoCsValid(registrationRequest.getClientLoCs())) {
+            return Optional.of(INVALID_CLIENT_LOCS);
         }
         return Optional.empty();
     }
@@ -170,6 +176,16 @@ public class ClientConfigValidationService {
     private boolean areClaimsValid(List<String> claims) {
         for (String claim : claims) {
             if (ValidClaims.getAllValidClaims().stream().noneMatch(t -> t.equals(claim))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean areClientLoCsValid(List<String> clientLoCs) {
+        for (String clientLoC : clientLoCs) {
+            if (LevelOfConfidence.getAllSupportedLevelOfConfidenceValues().stream()
+                    .noneMatch(t -> t.equals(clientLoC))) {
                 return false;
             }
         }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -128,6 +128,11 @@ public class ClientConfigValidationService {
                 .orElse(true)) {
             return Optional.of(INVALID_CLIENT_TYPE);
         }
+        if (!Optional.ofNullable(updateRequest.getClientLoCs())
+                .map(this::areClientLoCsValid)
+                .orElse(true)) {
+            return Optional.of(INVALID_CLIENT_LOCS);
+        }
         return Optional.empty();
     }
 

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -122,7 +122,8 @@ class ClientRegistrationHandlerTest {
                         ClientType.WEB.getValue(),
                         false,
                         null,
-                        ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
+                        ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
+                        emptyList());
     }
 
     @Test
@@ -165,7 +166,8 @@ class ClientRegistrationHandlerTest {
                         ClientType.WEB.getValue(),
                         true,
                         null,
-                        ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
+                        ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
+                        emptyList());
     }
 
     @Test
@@ -200,7 +202,8 @@ class ClientRegistrationHandlerTest {
                         ClientType.WEB.getValue(),
                         false,
                         null,
-                        ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
+                        ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
+                        emptyList());
     }
 
     @Test

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.orchestration.shared.entity.ClientType;
+import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.UpdateClientConfigRequest;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 
@@ -210,7 +211,7 @@ class ClientConfigValidationServiceTest {
     }
 
     @Test
-    void shouldReturnErrorForInvalidCustomLoCsInRegistrationRequest() {
+    void shouldReturnErrorForInvalidClientLoCsInRegistrationRequest() {
         ClientRegistrationRequest regReq =
                 new ClientRegistrationRequest(
                         "",
@@ -226,7 +227,7 @@ class ClientConfigValidationServiceTest {
                         false,
                         emptyList(),
                         ClientType.WEB.getValue(),
-                        List.of("Not_an_accepted_LoC"));
+                        List.of("Unsupported_LoC"));
 
         Optional<ErrorObject> errorResponse =
                 validationService.validateClientRegistrationConfig(regReq);
@@ -272,7 +273,8 @@ class ClientConfigValidationServiceTest {
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
                                 "http://localhost/sector-id",
-                                ClientType.WEB.getValue()));
+                                ClientType.WEB.getValue(),
+                                List.of(LevelOfConfidence.MEDIUM_LEVEL.getValue())));
         assertThat(errorResponse, equalTo(Optional.empty()));
     }
 
@@ -294,7 +296,8 @@ class ClientConfigValidationServiceTest {
                                 singletonList("invalid-logout-uri"),
                                 String.valueOf(MANDATORY),
                                 null,
-                                ClientType.WEB.getValue()));
+                                ClientType.WEB.getValue(),
+                                List.of(LevelOfConfidence.MEDIUM_LEVEL.getValue())));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_POST_LOGOUT_URI)));
     }
 
@@ -309,7 +312,8 @@ class ClientConfigValidationServiceTest {
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
                                 null,
-                                ClientType.WEB.getValue()));
+                                ClientType.WEB.getValue(),
+                                List.of(LevelOfConfidence.MEDIUM_LEVEL.getValue())));
         assertThat(errorResponse, equalTo(Optional.of(RegistrationError.INVALID_REDIRECT_URI)));
     }
 
@@ -324,7 +328,8 @@ class ClientConfigValidationServiceTest {
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
                                 null,
-                                ClientType.WEB.getValue()));
+                                ClientType.WEB.getValue(),
+                                List.of(LevelOfConfidence.MEDIUM_LEVEL.getValue())));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_PUBLIC_KEY)));
     }
 
@@ -339,7 +344,8 @@ class ClientConfigValidationServiceTest {
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
                                 null,
-                                ClientType.WEB.getValue()));
+                                ClientType.WEB.getValue(),
+                                List.of(LevelOfConfidence.MEDIUM_LEVEL.getValue())));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_SCOPE)));
     }
 
@@ -354,8 +360,25 @@ class ClientConfigValidationServiceTest {
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
                                 null,
-                                "rubbish-client-type"));
+                                "rubbish-client-type",
+                                List.of(LevelOfConfidence.MEDIUM_LEVEL.getValue())));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_CLIENT_TYPE)));
+    }
+
+    @Test
+    void shouldReturnErrorForInvalidClientLoCsInUpdateRequest() {
+        Optional<ErrorObject> errorResponse =
+                validationService.validateClientUpdateConfig(
+                        generateClientUpdateRequest(
+                                singletonList("http://localhost:1000/redirect"),
+                                VALID_PUBLIC_CERT,
+                                List.of("openid", "email", "fax"),
+                                singletonList("http://localhost/post-redirect-logout"),
+                                String.valueOf(MANDATORY),
+                                null,
+                                ClientType.WEB.getValue(),
+                                List.of("Unsupported_LoC")));
+        assertThat(errorResponse, equalTo(Optional.of(INVALID_CLIENT_LOCS)));
     }
 
     private ClientRegistrationRequest generateClientRegRequest(
@@ -392,7 +415,8 @@ class ClientConfigValidationServiceTest {
             List<String> postLogoutUris,
             String serviceType,
             String sectorURI,
-            String clientType) {
+            String clientType,
+            List<String> clientLoCs) {
         UpdateClientConfigRequest configRequest = new UpdateClientConfigRequest();
         configRequest.setScopes(scopes);
         configRequest.setRedirectUris(redirectUri);
@@ -401,6 +425,7 @@ class ClientConfigValidationServiceTest {
         configRequest.setServiceType(serviceType);
         configRequest.setSectorIdentifierUri(sectorURI);
         configRequest.setClientType(clientType);
+        configRequest.setClientLoCs(clientLoCs);
         return configRequest;
     }
 }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService.INVALID_CLAIM;
+import static uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService.INVALID_CLIENT_LOCS;
 import static uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService.INVALID_CLIENT_TYPE;
 import static uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService.INVALID_POST_LOGOUT_URI;
 import static uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService.INVALID_PUBLIC_KEY;
@@ -206,6 +207,30 @@ class ClientConfigValidationServiceTest {
                                 emptyList(),
                                 "Mobile"));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_CLIENT_TYPE)));
+    }
+
+    @Test
+    void shouldReturnErrorForInvalidCustomLoCsInRegistrationRequest() {
+        ClientRegistrationRequest regReq =
+                new ClientRegistrationRequest(
+                        "",
+                        singletonList("http://localhost:1000/redirect"),
+                        singletonList("test-client@test.com"),
+                        VALID_PUBLIC_CERT,
+                        singletonList("openid"),
+                        singletonList("http://localhost/post-redirect-logout"),
+                        "http://example.com",
+                        String.valueOf(MANDATORY),
+                        "http://test.com",
+                        "public",
+                        false,
+                        emptyList(),
+                        ClientType.WEB.getValue(),
+                        List.of("Not_an_accepted_LoC"));
+
+        Optional<ErrorObject> errorResponse =
+                validationService.validateClientRegistrationConfig(regReq);
+        assertThat(errorResponse, equalTo(Optional.of(INVALID_CLIENT_LOCS)));
     }
 
     @ParameterizedTest

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
@@ -15,8 +15,9 @@ import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.sharedtest.basetest.DynamoTestConfiguration;
 
-import java.util.Collections;
 import java.util.List;
+
+import static java.util.Collections.emptyList;
 
 public class ClientStoreExtension extends DynamoExtension implements AfterEachCallback {
 
@@ -181,11 +182,12 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 sectorIdentifierUri,
                 subjectType,
                 consentRequired,
-                Collections.emptyList(),
+                emptyList(),
                 clientType.getValue(),
                 identityVerificationSupported,
                 clientSecret,
-                clientAuthMethod);
+                clientAuthMethod,
+                emptyList());
     }
 
     public void registerClient(
@@ -216,11 +218,12 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 sectorIdentifierUri,
                 subjectType,
                 consentRequired,
-                Collections.emptyList(),
+                emptyList(),
                 clientType.getValue(),
                 identityVerificationSupported,
                 null,
-                ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
+                ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
+                emptyList());
     }
 
     public void registerClient(
@@ -256,7 +259,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 clientType.getValue(),
                 identityVerificationSupported,
                 null,
-                ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
+                ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
+                emptyList());
     }
 
     public boolean clientExists(String clientID) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
@@ -36,6 +36,7 @@ public class ClientRegistry {
     private boolean oneLoginService = false;
     private String idTokenSigningAlgorithm = "ES256";
     private boolean smokeTest = false;
+    private List<String> clientLoCs = new ArrayList<>();
 
     public ClientRegistry() {}
 
@@ -374,6 +375,23 @@ public class ClientRegistry {
 
     public ClientRegistry withLandingPageUrl(String landingPageUrl) {
         this.landingPageUrl = landingPageUrl;
+        return this;
+    }
+
+    @DynamoDbAttribute("ClientLoCs")
+    public List<String> getClientLoCs() {
+        if (clientLoCs.isEmpty()) {
+            return LevelOfConfidence.getDefaultLevelOfConfidenceValues();
+        }
+        return clientLoCs;
+    }
+
+    public void setClientLoCs(List<String> clientLoCs) {
+        this.clientLoCs = clientLoCs;
+    }
+
+    public ClientRegistry withClientLoCs(List<String> clientLoCs) {
+        this.clientLoCs = clientLoCs;
         return this;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/LevelOfConfidence.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/LevelOfConfidence.java
@@ -6,6 +6,8 @@ import java.util.stream.Collectors;
 
 public enum LevelOfConfidence {
     NONE("P0", true),
+    HMRC1("PCl200", true),
+    HMRC2("PCl250", true),
     LOW_LEVEL("P1", false),
     MEDIUM_LEVEL("P2", true),
     HIGH_LEVEL("P3", false),
@@ -45,5 +47,19 @@ public enum LevelOfConfidence {
 
     public static LevelOfConfidence getDefault() {
         return MEDIUM_LEVEL;
+    }
+
+    public static List<String> getDefaultLevelOfConfidenceValues() {
+        List<LevelOfConfidence> defaults =
+                List.of(
+                        LevelOfConfidence.NONE,
+                        LevelOfConfidence.LOW_LEVEL,
+                        LevelOfConfidence.MEDIUM_LEVEL,
+                        LevelOfConfidence.HIGH_LEVEL,
+                        LevelOfConfidence.VERY_HIGH_LEVEL);
+        return defaults.stream()
+                .filter(LevelOfConfidence::isSupported)
+                .map(LevelOfConfidence::getValue)
+                .toList();
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
@@ -51,6 +51,10 @@ public class UpdateClientConfigRequest {
     @Expose
     private String clientType;
 
+    @SerializedName("accepted_levels_of_confidence")
+    @Expose
+    private List<String> clientLoCs;
+
     public UpdateClientConfigRequest() {}
 
     public String getClientId() {
@@ -95,6 +99,10 @@ public class UpdateClientConfigRequest {
 
     public String getClientType() {
         return clientType;
+    }
+
+    public List<String> getClientLoCs() {
+        return clientLoCs;
     }
 
     public UpdateClientConfigRequest setClientId(String clientId) {
@@ -145,6 +153,11 @@ public class UpdateClientConfigRequest {
 
     public UpdateClientConfigRequest setClientType(String clientType) {
         this.clientType = clientType;
+        return this;
+    }
+
+    public UpdateClientConfigRequest setClientLoCs(List<String> clientLoCs) {
+        this.clientLoCs = clientLoCs;
         return this;
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientService.java
@@ -28,7 +28,8 @@ public interface ClientService {
             String clientType,
             boolean identityVerificationSupported,
             String clientSecret,
-            String tokenAuthMethod);
+            String tokenAuthMethod,
+            List<String> clientLoCs);
 
     Optional<ClientRegistry> getClient(String clientId);
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
@@ -63,7 +63,8 @@ public class DynamoClientService implements ClientService {
             String clientType,
             boolean identityVerificationSupported,
             String clientSecret,
-            String tokenAuthMethod) {
+            String tokenAuthMethod,
+            List<String> clientLoCs) {
         var clientRegistry =
                 new ClientRegistry()
                         .withClientID(clientID)
@@ -84,6 +85,9 @@ public class DynamoClientService implements ClientService {
                         .withTokenAuthMethod(tokenAuthMethod);
         if (Objects.nonNull(clientSecret)) {
             clientRegistry.withClientSecret(Argon2EncoderHelper.argon2Hash(clientSecret));
+        }
+        if (Objects.nonNull(clientLoCs)) {
+            clientRegistry.withClientLoCs(clientLoCs);
         }
         dynamoClientRegistryTable.putItem(clientRegistry);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
@@ -110,6 +110,8 @@ public class DynamoClientService implements ClientService {
         Optional.ofNullable(updateRequest.getSectorIdentifierUri())
                 .ifPresent(clientRegistry::withSectorIdentifierUri);
         Optional.ofNullable(updateRequest.getClaims()).ifPresent(clientRegistry::withClaims);
+        Optional.ofNullable(updateRequest.getClientLoCs())
+                .ifPresent(clientRegistry::withClientLoCs);
         dynamoClientRegistryTable.putItem(clientRegistry);
         return clientRegistry;
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/ClientRegistryTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/ClientRegistryTest.java
@@ -1,0 +1,20 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+
+class ClientRegistryTest {
+
+    private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
+
+    @Test
+    void shouldReturnDefaultLoCsWhenRegistryEmpty() {
+        var clientRegistry = new ClientRegistry();
+        assertThat(
+                clientRegistry.getClientLoCs(),
+                equalTo(LevelOfConfidence.getDefaultLevelOfConfidenceValues()));
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/LevelOfConfidenceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/LevelOfConfidenceTest.java
@@ -5,13 +5,16 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LevelOfConfidenceTest {
 
@@ -50,13 +53,34 @@ class LevelOfConfidenceTest {
         List<String> allLevelOfConfidenceValues =
                 LevelOfConfidence.getAllSupportedLevelOfConfidenceValues();
 
-        assertThat(allLevelOfConfidenceValues.size(), equalTo(2));
+        assertTrue(
+                allLevelOfConfidenceValues.stream()
+                        .allMatch(
+                                cl ->
+                                        LevelOfConfidence.retrieveLevelOfConfidence(cl)
+                                                .isSupported()));
+        assertTrue(
+                Arrays.stream(LevelOfConfidence.values())
+                        .noneMatch(
+                                cl ->
+                                        !allLevelOfConfidenceValues.contains(cl.getValue())
+                                                && cl.isSupported()));
+    }
 
-        assertThat(allLevelOfConfidenceValues.get(0), equalTo(LevelOfConfidence.NONE.getValue()));
+    @Test
+    void shouldReturnOnlyDefaultLevelOfConfidenceValues() {
+        List<String> allLevelOfConfidenceValues =
+                LevelOfConfidence.getDefaultLevelOfConfidenceValues();
 
-        assertThat(
-                allLevelOfConfidenceValues.get(1),
-                equalTo(LevelOfConfidence.MEDIUM_LEVEL.getValue()));
+        assertTrue(
+                allLevelOfConfidenceValues.stream()
+                        .allMatch(
+                                cl ->
+                                        LevelOfConfidence.retrieveLevelOfConfidence(cl)
+                                                .isSupported()));
+        assertTrue(
+                allLevelOfConfidenceValues.stream()
+                        .allMatch(Pattern.compile("P[0-9]").asPredicate()));
     }
 
     private static Stream<Arguments> supportedLevelOfConfidence() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
@@ -6,6 +6,8 @@ import java.util.stream.Collectors;
 
 public enum LevelOfConfidence {
     NONE("P0", true),
+    HMRC1("PCl200", true),
+    HMRC2("PCl250", true),
     LOW_LEVEL("P1", false),
     MEDIUM_LEVEL("P2", true),
     HIGH_LEVEL("P3", false),
@@ -41,5 +43,19 @@ public enum LevelOfConfidence {
                 .filter(LevelOfConfidence::isSupported)
                 .map(LevelOfConfidence::getValue)
                 .collect(Collectors.toList());
+    }
+
+    public static List<String> getDefaultLevelOfConfidenceValues() {
+        List<LevelOfConfidence> defaults =
+                List.of(
+                        LevelOfConfidence.NONE,
+                        LevelOfConfidence.LOW_LEVEL,
+                        LevelOfConfidence.MEDIUM_LEVEL,
+                        LevelOfConfidence.HIGH_LEVEL,
+                        LevelOfConfidence.VERY_HIGH_LEVEL);
+        return defaults.stream()
+                .filter(LevelOfConfidence::isSupported)
+                .map(LevelOfConfidence::getValue)
+                .toList();
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
@@ -5,13 +5,16 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LevelOfConfidenceTest {
 
@@ -50,13 +53,34 @@ class LevelOfConfidenceTest {
         List<String> allLevelOfConfidenceValues =
                 LevelOfConfidence.getAllSupportedLevelOfConfidenceValues();
 
-        assertThat(allLevelOfConfidenceValues.size(), equalTo(2));
+        assertTrue(
+                allLevelOfConfidenceValues.stream()
+                        .allMatch(
+                                cl ->
+                                        LevelOfConfidence.retrieveLevelOfConfidence(cl)
+                                                .isSupported()));
+        assertTrue(
+                Arrays.stream(LevelOfConfidence.values())
+                        .noneMatch(
+                                cl ->
+                                        !allLevelOfConfidenceValues.contains(cl.getValue())
+                                                && cl.isSupported()));
+    }
 
-        assertThat(allLevelOfConfidenceValues.get(0), equalTo(LevelOfConfidence.NONE.getValue()));
+    @Test
+    void shouldReturnOnlyDefaultLevelOfConfidenceValues() {
+        List<String> allLevelOfConfidenceValues =
+                LevelOfConfidence.getDefaultLevelOfConfidenceValues();
 
-        assertThat(
-                allLevelOfConfidenceValues.get(1),
-                equalTo(LevelOfConfidence.MEDIUM_LEVEL.getValue()));
+        assertTrue(
+                allLevelOfConfidenceValues.stream()
+                        .allMatch(
+                                cl ->
+                                        LevelOfConfidence.retrieveLevelOfConfidence(cl)
+                                                .isSupported()));
+        assertTrue(
+                allLevelOfConfidenceValues.stream()
+                        .allMatch(Pattern.compile("P[0-9]").asPredicate()));
     }
 
     private static Stream<Arguments> supportedLevelOfConfidence() {


### PR DESCRIPTION
## What?

Update client registry (Java class) to have optional list of LoC and change code so it’s backwards compatible.
Needs to validate level of confidence being requested, as we will be accepting new levels. Different clients can request different levels.

## Why?

Part of HMRC migration

## Related PRs

[ATO-19](https://govukverify.atlassian.net/browse/ATO-19)


[ATO-19]: https://govukverify.atlassian.net/browse/ATO-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ