### PR TITLE
ATO-176: Fix AIS URI

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -106,7 +106,9 @@ public class AccountInterventionService {
                 HttpRequest.newBuilder()
                         .uri(
                                 accountInterventionServiceURI.resolve(
-                                        "/v1/ais/" + internalPairwiseSubjectId))
+                                        accountInterventionServiceURI.getPath()
+                                                + "/v1/ais/"
+                                                + internalPairwiseSubjectId))
                         .GET()
                         .build();
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -54,7 +54,7 @@ class AccountInterventionServiceTest {
             }
             """;
 
-    private static String BASE_AIS_URL = "http://example.com/v1/ais/";
+    private static String BASE_AIS_URL = "http://example.com/environment";
     private static AuditContext someAuditContext =
             new AuditContext(
                     "some-client-session-id",
@@ -92,7 +92,8 @@ class AccountInterventionServiceTest {
         verify(httpClient).send(httpRequestCaptor.capture(), any());
         var requestUri = httpRequestCaptor.getValue();
 
-        assertEquals(BASE_AIS_URL + internalPairwiseSubjectId, requestUri.uri().toString());
+        assertEquals(
+                BASE_AIS_URL + "/v1/ais/" + internalPairwiseSubjectId, requestUri.uri().toString());
     }
 
     @Test


### PR DESCRIPTION
## What
Fix how the AIS URI is resolved so that no part of the path is stripped.

## Why
Previously the call to AIS was stripping the environment part of the path, ie. giving
`https://some.uri.com/abc/id` instead of `https://some.uri.com/environment/abc/id`

