### PR TITLE
add part phone number to user exists api

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
@@ -18,6 +18,10 @@ public class CheckUserExistsResponse {
     @Expose
     private MFAMethodType mfaMethodType;
 
+    @SerializedName("phoneNumberLastThree")
+    @Expose
+    private String phoneNumberLastThree;
+
     public CheckUserExistsResponse() {}
 
     public CheckUserExistsResponse(
@@ -25,6 +29,17 @@ public class CheckUserExistsResponse {
         this.email = email;
         this.doesUserExist = doesUserExist;
         this.mfaMethodType = mfaMethodType;
+    }
+
+    public CheckUserExistsResponse(
+            String email,
+            boolean doesUserExist,
+            MFAMethodType mfaMethodType,
+            String phoneNumberLastThree) {
+        this.email = email;
+        this.doesUserExist = doesUserExist;
+        this.mfaMethodType = mfaMethodType;
+        this.phoneNumberLastThree = phoneNumberLastThree;
     }
 
     public String getEmail() {
@@ -37,5 +52,9 @@ public class CheckUserExistsResponse {
 
     public MFAMethodType getMfaMethodType() {
         return mfaMethodType;
+    }
+
+    public String getPhoneNumberLastThree() {
+        return phoneNumberLastThree;
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
@@ -158,7 +159,11 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                 var userCredentials =
                         authenticationService.getUserCredentialsFromEmail(emailAddress);
                 userMfaDetail =
-                        getUserMFADetail(userContext, userCredentials, isPhoneNumberVerified);
+                        getUserMFADetail(
+                                userContext,
+                                userCredentials,
+                                userProfile.get().getPhoneNumber(),
+                                isPhoneNumberVerified);
             } else {
                 auditableEvent = FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL;
             }
@@ -178,7 +183,10 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                     pair("rpPairwiseId", rpPairwiseId));
             CheckUserExistsResponse checkUserExistsResponse =
                     new CheckUserExistsResponse(
-                            emailAddress, userExists, userMfaDetail.getMfaMethodType());
+                            emailAddress,
+                            userExists,
+                            userMfaDetail.getMfaMethodType(),
+                            getLastDigitsOfPhoneNumber(userMfaDetail));
             sessionService.save(userContext.getSession());
 
             LOG.info("Successfully processed request");
@@ -187,6 +195,17 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
         } catch (JsonException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+        }
+    }
+
+    private String getLastDigitsOfPhoneNumber(UserMfaDetail userMfaDetail) {
+        if ((userMfaDetail.getPhoneNumber() != null && userMfaDetail.getPhoneNumber().isEmpty())
+                || !MFAMethodType.SMS.equals(userMfaDetail.getMfaMethodType())) {
+            return null;
+        } else {
+            return userMfaDetail
+                    .getPhoneNumber()
+                    .substring(userMfaDetail.getPhoneNumber().length() - 3);
         }
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -215,7 +215,11 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             var consentRequired = ConsentHelper.userHasNotGivenConsent(userContext);
 
             var userMfaDetail =
-                    getUserMFADetail(userContext, userCredentials, isPhoneNumberVerified);
+                    getUserMFADetail(
+                            userContext,
+                            userCredentials,
+                            userProfile.getPhoneNumber(),
+                            isPhoneNumberVerified);
 
             boolean isPasswordChangeRequired = isPasswordResetRequired(request.getPassword());
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -88,6 +88,7 @@ class CheckUserExistsHandlerTest {
     private final Session session = new Session(IdGenerator.generate());
     private static final String CLIENT_ID = "test-client-id";
     private static final String CLIENT_NAME = "test-client-name";
+    private static final String PHONE_NUMBER = "+44987654321";
     private static final Subject SUBJECT = new Subject();
     private static final String SECTOR_URI = "http://sector-identifier";
     private static final String PERSISTENT_SESSION_ID = "some-persistent-id-value";
@@ -127,6 +128,7 @@ class CheckUserExistsHandlerTest {
     void shouldReturn200IfUserExists() throws Json.JsonException {
         usingValidSession();
         var userProfile = generateUserProfile();
+        userProfile.setPhoneNumber(PHONE_NUMBER);
         when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT.array());
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL_ADDRESS))
                 .thenReturn(Optional.of(userProfile));
@@ -168,6 +170,7 @@ class CheckUserExistsHandlerTest {
         var checkUserExistsResponse =
                 objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
         assertEquals(EMAIL_ADDRESS, checkUserExistsResponse.getEmail());
+        assertEquals("321", checkUserExistsResponse.getPhoneNumberLastThree());
         assertEquals(MFAMethodType.SMS, checkUserExistsResponse.getMfaMethodType());
         assertTrue(checkUserExistsResponse.doesUserExist());
         var expectedRpPairwiseId =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -33,7 +33,9 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL;
@@ -66,7 +68,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         userStore.signUp(emailAddress, "password-1");
         if (MFAMethodType.SMS == mfaMethodType) {
             userStore.addMfaMethod(emailAddress, mfaMethodType, false, true, "credential");
-            userStore.addVerifiedPhoneNumber(emailAddress, "0987654321");
+            userStore.addVerifiedPhoneNumber(emailAddress, "+44987654321");
         } else {
             userStore.addMfaMethod(emailAddress, mfaMethodType, true, true, "credential");
         }
@@ -85,6 +87,13 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(checkUserExistsResponse.getEmail(), equalTo(emailAddress));
         assertThat(checkUserExistsResponse.getMfaMethodType(), equalTo(mfaMethodType));
         assertTrue(checkUserExistsResponse.doesUserExist());
+        if (MFAMethodType.SMS.equals(mfaMethodType)) {
+            assertThat(checkUserExistsResponse.getPhoneNumberLastThree(), equalTo("321"));
+        } else if (MFAMethodType.AUTH_APP.equals(mfaMethodType)) {
+            assertNull(checkUserExistsResponse.getPhoneNumberLastThree());
+        } else {
+            fail();
+        }
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CHECK_USER_KNOWN_EMAIL));
     }
 
@@ -110,6 +119,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(checkUserExistsResponse.getEmail(), equalTo(emailAddress));
         assertThat(checkUserExistsResponse.getMfaMethodType(), equalTo(MFAMethodType.NONE));
         assertFalse(checkUserExistsResponse.doesUserExist());
+        assertNull(checkUserExistsResponse.getPhoneNumberLastThree());
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CHECK_USER_NO_ACCOUNT_WITH_EMAIL));
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/entity/UserMfaDetail.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/UserMfaDetail.java
@@ -6,6 +6,7 @@ public class UserMfaDetail {
     protected boolean isMfaRequired;
     protected boolean mfaMethodVerified;
     protected MFAMethodType mfaMethodType;
+    protected String phoneNumber;
 
     public UserMfaDetail() {
         this.isMfaRequired = false;
@@ -14,10 +15,14 @@ public class UserMfaDetail {
     }
 
     public UserMfaDetail(
-            boolean isMfaRequired, boolean mfaMethodVerified, MFAMethodType mfaMethodType) {
+            boolean isMfaRequired,
+            boolean mfaMethodVerified,
+            MFAMethodType mfaMethodType,
+            String phoneNumber) {
         this.isMfaRequired = isMfaRequired;
         this.mfaMethodVerified = mfaMethodVerified;
         this.mfaMethodType = mfaMethodType;
+        this.phoneNumber = phoneNumber;
     }
 
     public boolean isMfaRequired() {
@@ -30,5 +35,9 @@ public class UserMfaDetail {
 
     public MFAMethodType getMfaMethodType() {
         return mfaMethodType;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
@@ -41,6 +41,7 @@ public class MfaHelper {
     public static UserMfaDetail getUserMFADetail(
             UserContext userContext,
             UserCredentials userCredentials,
+            String phoneNumber,
             boolean isPhoneNumberVerified) {
         var isMfaRequired = mfaRequired(userContext.getClientSession().getAuthRequestParams());
         var mfaMethodVerified = isPhoneNumberVerified;
@@ -53,6 +54,6 @@ public class MfaHelper {
         } else if (!isPhoneNumberVerified && mfaMethod.isPresent()) {
             mfaMethodType = MFAMethodType.valueOf(mfaMethod.get().getMfaMethodType());
         }
-        return new UserMfaDetail(isMfaRequired, mfaMethodVerified, mfaMethodType);
+        return new UserMfaDetail(isMfaRequired, mfaMethodVerified, mfaMethodType, phoneNumber);
     }
 }


### PR DESCRIPTION
## What?

Added the phoneNumberLastThree field to the CheckUserExists API response.

## Why?

Previously decided to user CheckUserExists API to present data for the new MFA PW reset journey as the user is not logged in before this journey so we require more information to proceed through the screens. This update adds the last 3 digits to API response so that the frontend can use it for the text 'We have sent a code to your phone number ending with XXX'.