### PR TITLE
AUT-1858: Turn on Account Interventions In Staging

### DIFF
--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -58,7 +58,7 @@ locals {
   }
 
   request_tracing_allowed            = contains(["build", "sandpit"], var.environment)
-  deploy_account_interventions_count = contains(["build", "sandpit"], var.environment) ? 1 : 0
+  deploy_account_interventions_count = contains(["build", "sandpit", "staging"], var.environment) ? 1 : 0
   deploy_reauth_user_count           = contains(["build", "sandpit"], var.environment) ? 1 : 0
 
   access_logging_template = jsonencode({


### PR DESCRIPTION
## What?

Turned on account interventions in staging.

## Why?

Account Interventions lambda need to be deployed in staging environment to integrate with AIS API


