### PR TITLE
ATO-282: Extend auth user info ttl to 6 hours

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
@@ -17,7 +17,7 @@ public class AuthenticationUserInfoStorageService
                 AuthenticationUserInfo.class,
                 "authentication-callback-userinfo",
                 configurationService);
-        this.timeToExist = configurationService.getSessionExpiry();
+        this.timeToExist = 21600L; // 6 hours
     }
 
     public void addAuthenticationUserInfoData(String subjectID, UserInfo userInfo) {


### PR DESCRIPTION
## What?
The Auth user info response is currently stored for one hour in a dynamo table. Increase this to 6 hours.

## Why?
LITE (one of the RPs) use refresh tokens. We want to keep those working in mostly the same way after the split.
