### PR TITLE
AUT-1858: Remove 'depends on' for account interventions lambda

### DIFF
--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -65,10 +65,4 @@ module "account_interventions" {
 
   use_localstack = var.use_localstack
   count          = local.deploy_account_interventions_count
-
-  depends_on = [
-    aws_api_gateway_rest_api.di_authentication_frontend_api,
-    aws_api_gateway_resource.connect_resource,
-    aws_api_gateway_resource.wellknown_resource,
-  ]
 }


### PR DESCRIPTION

## What?

Remove depends on for account interventions lambda.

## Why?

The endpoint is being created but not deployed.
The code deleted is relevant only for endpoints in the oidc api, not the frontend api.

In staging the frontend call to the api is resulting in a '403 error', suggesting the api is not deployed.  In the console the endpoint is not part of the deployed stage.

https://repost.aws/knowledge-center/api-gateway-authentication-token-errors