### PR TITLE
AUT-1858: Force deployment of account-interventions endpoint if switched on

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -79,6 +79,8 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.orch_auth_code.method_trigger_value,
       module.identity_progress.integration_trigger_value,
       module.identity_progress.method_trigger_value,
+      local.deploy_account_interventions_count == 1 ? module.account_interventions[0].integration_trigger_value : null,
+      local.deploy_account_interventions_count == 1 ? module.account_interventions[0].method_trigger_value : null,
       local.account_modifiers_encryption_policy_arn,
     ]))
   }


### PR DESCRIPTION

## What?

Force deployment of account-interventions endpoint if switched on

## Why?

The endpoint is being created but not deployed at the moment.

## Related PRs

#3818
