### PR TITLE
BAU: Use default deploy targets when only '-p' is passed to sandpit deploy scripts

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Fix script formatting
+ee2a12fb178b8c7ecd95265088f473112f1dade8

--- a/deploy-authdevs.sh
+++ b/deploy-authdevs.sh
@@ -1,27 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-###Export The di-Auth-devlopment account profile below 
 export AWS_PROFILE=di-auth-dev
 
-envvalue=( "authdev1" "authdev2"  )
+envvalue=("authdev1" "authdev2")
 
 select word in "${envvalue[@]}"; do
-    if [[ -z "$word" ]]; then
-        printf '"%s" is not a valid choice\n' "$REPLY" >&2
-    else
-        user_in="$(( REPLY - 1 ))"
-        break
-    fi
+  if [[ -z "$word" ]]; then
+    printf '"%s" is not a valid choice\n' "$REPLY" >&2
+  else
+    user_in="$((REPLY - 1))"
+    break
+  fi
 done
 
-for (( i = 0; i < ${#envvalue[@]}; ++i )); do
-    if (( i == user_in )); then
-        printf 'You picked "%s"\n' "${envvalue[$i]}"
-        export env=${envvalue[$i]}
-        printf "deploying in enviorment %s\n" "$env"
-        read -r -p "Press enter to continue or ctr c to abort"
-    fi
+for ((i = 0; i < ${#envvalue[@]}; ++i)); do
+  if ((i == user_in)); then
+    printf 'You picked "%s"\n' "${envvalue[$i]}"
+    export env=${envvalue[$i]}
+    printf "deploying in environment %s\n" "$env"
+    read -r -p "Press enter to continue or ctrl+c to abort"
+  fi
 done
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
@@ -143,7 +142,6 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
-
 
 if [[ $BUILD == "1" ]]; then
   echo "Building deployment artefacts ... "

--- a/deploy-authdevs.sh
+++ b/deploy-authdevs.sh
@@ -79,7 +79,8 @@ TEST_SERVICES=0
 CLEAN=""
 RUN_SHELL=0
 TERRAFORM_OPTS="-auto-approve"
-if [[ $# == 0 ]]; then
+
+if [[ $# == 0 ]] || [[ $* == "-p" ]]; then
   AM=1
   AUTH_EXTERNAL_API=1
   BUILD=1
@@ -87,6 +88,7 @@ if [[ $# == 0 ]]; then
   INTERVENTIONS=1
   SHARED=1
 fi
+
 while [[ $# -gt 0 ]]; do
   case $1 in
   -a | --account-management)

--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -57,7 +57,8 @@ TEST_SERVICES=0
 CLEAN=""
 RUN_SHELL=0
 TERRAFORM_OPTS="-auto-approve"
-if [[ $# == 0 ]]; then
+
+if [[ $# == 0 ]] || [[ $* == "-p" ]]; then
   AM=1
   AUTH_EXTERNAL_API=1
   BUILD=1
@@ -65,6 +66,7 @@ if [[ $# == 0 ]]; then
   INTERVENTIONS=1
   SHARED=1
 fi
+
 while [[ $# -gt 0 ]]; do
   case $1 in
   -a | --account-management)


### PR DESCRIPTION
## What?

When `deploy-xx.sh -p` is run, it will now use the default targets.

Additionally, fix formatting in `deploy-authdevs.sh`, and exclude the formatting commit from git blame as-per
https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/

## Why?

Previously, we just checked if no arguments were passed. It'd be nice to be able to specify prompt and use the defaults.
