### PR TITLE
Aut 2148/create email check dynamo

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -472,3 +472,38 @@ resource "aws_dynamodb_table" "authentication_callback_userinfo" {
 
   tags = local.default_tags
 }
+
+resource "aws_dynamodb_table" "email-check-result" {
+  name         = "${var.environment}-email-check-result"
+  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
+
+  hash_key = "Email"
+
+  read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+  write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  attribute {
+    name = "Email"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.email_check_result_encryption_key.arn
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  tags = local.default_tags
+}

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -619,3 +619,27 @@ resource "aws_kms_key" "user_profile_table_encryption_key" {
   })
   tags = local.default_tags
 }
+
+resource "aws_kms_key" "email_check_result_encryption_key" {
+  description              = "KMS encryption key for email check result table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.services;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
@@ -17,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DynamoEmailCheckResultServiceIntegrationTest {
 
     private static String email = "test.user@example.com";
-    private static String status = "some-status";
+    private static EmailCheckResultStatus status = EmailCheckResultStatus.PENDING;
 
     DynamoEmailCheckResultService dynamoEmailCheckResultService =
             new DynamoEmailCheckResultService(ConfigurationService.getInstance());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
@@ -1,0 +1,42 @@
+package uk.gov.di.authentication.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
+import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
+
+import java.time.temporal.ChronoUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DynamoEmailCheckResultServiceIntegrationTest {
+
+    private static String email = "test.user@example.com";
+    private static String status = "some-status";
+
+    DynamoEmailCheckResultService dynamoEmailCheckResultService =
+            new DynamoEmailCheckResultService(ConfigurationService.getInstance());
+
+    @RegisterExtension
+    protected static final EmailCheckResultExtension emailCheckResultExtension =
+            new EmailCheckResultExtension();
+
+    @Test
+    void shouldSaveAndReadAnEmailCheckResult() {
+        dynamoEmailCheckResultService.saveEmailCheckResult(email, status, unixTimePlusNDays(1));
+
+        var result = dynamoEmailCheckResultService.getEmailCheckStore(email);
+
+        assertTrue(result.isPresent());
+        assertThat(result.get().getEmail(), equalTo(email));
+        assertThat(result.get().getStatus(), equalTo(status));
+    }
+
+    private long unixTimePlusNDays(Integer numberOfDays) {
+        return NowHelper.nowPlus(numberOfDays, ChronoUnit.DAYS).toInstant().getEpochSecond();
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
@@ -11,6 +11,7 @@ import java.time.temporal.ChronoUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DynamoEmailCheckResultServiceIntegrationTest {
@@ -34,6 +35,17 @@ class DynamoEmailCheckResultServiceIntegrationTest {
         assertTrue(result.isPresent());
         assertThat(result.get().getEmail(), equalTo(email));
         assertThat(result.get().getStatus(), equalTo(status));
+    }
+
+    @Test
+    void shouldNotReturnAnEmailCheckResultWhenTimeToLiveHasExpired() {
+        long unixTimeInThePast =
+                NowHelper.nowPlus(-1, ChronoUnit.DAYS).toInstant().getEpochSecond();
+        dynamoEmailCheckResultService.saveEmailCheckResult(email, status, unixTimeInThePast);
+
+        var result = dynamoEmailCheckResultService.getEmailCheckStore(email);
+
+        assertFalse(result.isPresent());
     }
 
     private long unixTimePlusNDays(Integer numberOfDays) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/EmailCheckResultExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/EmailCheckResultExtension.java
@@ -1,0 +1,53 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+
+public class EmailCheckResultExtension extends DynamoExtension implements AfterEachCallback {
+
+    public static final String EMAIL_CHECK_RESULT_TABLE = "local-email-check-result";
+
+    private static final String EMAIL_FIELD = "Email";
+
+    public EmailCheckResultExtension() {
+        createInstance();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, EMAIL_CHECK_RESULT_TABLE, EMAIL_FIELD);
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(EMAIL_CHECK_RESULT_TABLE)) {
+            createEmailCheckResultTable();
+        }
+    }
+
+    private void createEmailCheckResultTable() {
+        CreateTableRequest request =
+                CreateTableRequest.builder()
+                        .tableName(EMAIL_CHECK_RESULT_TABLE)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.HASH)
+                                        .attributeName(EMAIL_FIELD)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(EMAIL_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .build();
+
+        dynamoDB.createTable(request);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultStatus.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultStatus.java
@@ -1,0 +1,17 @@
+package uk.gov.di.authentication.shared.entity;
+
+public enum EmailCheckResultStatus {
+    PENDING("PENDING"),
+    ALLOW("ALLOW"),
+    DENY("DENY");
+
+    private String value;
+
+    EmailCheckResultStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultStore.java
@@ -1,0 +1,60 @@
+package uk.gov.di.authentication.shared.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class EmailCheckResultStore {
+
+    public static final String ATTRIBUTE_EMAIL = "Email";
+    public static final String ATTRIBUTE_STATUS = "Status";
+    public static final String ATTRIBUTE_TIME_TO_EXIST = "TimeToExist";
+
+    private String email;
+    private String status;
+    private long timeToExist;
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute(ATTRIBUTE_EMAIL)
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public EmailCheckResultStore withEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_STATUS)
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public EmailCheckResultStore withStatus(String status) {
+        this.status = status;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_TIME_TO_EXIST)
+    public long getTimeToExist() {
+        return timeToExist;
+    }
+
+    public void setTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+    }
+
+    public EmailCheckResultStore withTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+        return this;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultStore.java
@@ -12,7 +12,7 @@ public class EmailCheckResultStore {
     public static final String ATTRIBUTE_TIME_TO_EXIST = "TimeToExist";
 
     private String email;
-    private String status;
+    private EmailCheckResultStatus status;
     private long timeToExist;
 
     @DynamoDbPartitionKey
@@ -31,15 +31,15 @@ public class EmailCheckResultStore {
     }
 
     @DynamoDbAttribute(ATTRIBUTE_STATUS)
-    public String getStatus() {
+    public EmailCheckResultStatus getStatus() {
         return status;
     }
 
-    public void setStatus(String status) {
+    public void setStatus(EmailCheckResultStatus status) {
         this.status = status;
     }
 
-    public EmailCheckResultStore withStatus(String status) {
+    public EmailCheckResultStore withStatus(EmailCheckResultStatus status) {
         this.status = status;
         return this;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoEmailCheckResultService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoEmailCheckResultService.java
@@ -1,0 +1,25 @@
+package uk.gov.di.authentication.shared.services;
+
+import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
+
+import java.util.Optional;
+
+public class DynamoEmailCheckResultService extends BaseDynamoService<EmailCheckResultStore> {
+
+    public DynamoEmailCheckResultService(ConfigurationService configurationService) {
+        super(EmailCheckResultStore.class, "email-check-result", configurationService);
+    }
+
+    public Optional<EmailCheckResultStore> getEmailCheckStore(String email) {
+        return get(email);
+    }
+
+    public void saveEmailCheckResult(String email, String status, Long timeToExist) {
+        var emailCheckResult =
+                new EmailCheckResultStore()
+                        .withEmail(email)
+                        .withStatus(status)
+                        .withTimeToExist(timeToExist);
+        put(emailCheckResult);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoEmailCheckResultService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoEmailCheckResultService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.services;
 
+import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
@@ -16,7 +17,8 @@ public class DynamoEmailCheckResultService extends BaseDynamoService<EmailCheckR
                 .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
     }
 
-    public void saveEmailCheckResult(String email, String status, Long timeToExist) {
+    public void saveEmailCheckResult(
+            String email, EmailCheckResultStatus status, Long timeToExist) {
         var emailCheckResult =
                 new EmailCheckResultStore()
                         .withEmail(email)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoEmailCheckResultService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoEmailCheckResultService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.shared.services;
 
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 
 import java.util.Optional;
 
@@ -11,7 +12,8 @@ public class DynamoEmailCheckResultService extends BaseDynamoService<EmailCheckR
     }
 
     public Optional<EmailCheckResultStore> getEmailCheckStore(String email) {
-        return get(email);
+        return get(email)
+                .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
     }
 
     public void saveEmailCheckResult(String email, String status, Long timeToExist) {


### PR DESCRIPTION
## What?

Adds a dynamo table for storing an email check result, consisting of an email address, a status and a time to live.

Also adds read and write functionality (not yet used).

## Why?

Part of the infrastructure and code that will be needed for adding the email checks - see the [epic ticket](https://govukverify.atlassian.net/jira/software/c/projects/AUT/boards/477?assignee=620a44d9a715c600691222f8&selectedIssue=AUT-2144) for the full architecture diagram.