### PR TITLE
ATO-NONE: Tidy test to use common method

### DIFF
--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -775,29 +775,8 @@ class IPVCallbackHandlerTest {
 
         assertDoesRedirectToFrontendErrorPage(event, "error");
 
-        verify(auditService)
-                .submitAuditEvent(
-                        IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        CLIENT_ID.getValue(),
-                        expectedCommonSubject,
-                        TEST_EMAIL_ADDRESS,
-                        AuditService.UNKNOWN,
-                        userProfile.getPhoneNumber(),
-                        PERSISTENT_SESSION_ID);
-
-        verify(auditService)
-                .submitAuditEvent(
-                        IPVAuditableEvent.IPV_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        CLIENT_ID.getValue(),
-                        expectedCommonSubject,
-                        TEST_EMAIL_ADDRESS,
-                        AuditService.UNKNOWN,
-                        userProfile.getPhoneNumber(),
-                        PERSISTENT_SESSION_ID);
+        verifyAuditEvent(IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED);
+        verifyAuditEvent(IPVAuditableEvent.IPV_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED);
 
         verifyNoMoreInteractions(auditService);
         verifyNoInteractions(dynamoIdentityService);


### PR DESCRIPTION
Tidy test to use an existing common method and remove unnecessary code, making it more readable
