### PR TITLE
ATO-310: Add metric for failed AIS call

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -26,6 +26,7 @@ public class AccountInterventionService {
     private final boolean accountInterventionsCallEnabled;
     private final boolean accountInterventionsActionEnabled;
     private final CloudwatchMetricsService cloudwatchMetricsService;
+    private final ConfigurationService configurationService;
 
     public AccountInterventionService(ConfigurationService configService) {
         this(
@@ -55,6 +56,7 @@ public class AccountInterventionService {
         this.httpClient = httpClient;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.auditService = auditService;
+        this.configurationService = configService;
     }
 
     public AccountInterventionStatus getAccountStatus(String internalPairwiseSubjectId)
@@ -91,6 +93,8 @@ public class AccountInterventionService {
     }
 
     private AccountInterventionStatus handleException(Exception e) {
+        cloudwatchMetricsService.incrementCounter(
+                "AISCallFailure", Map.of("Environment", configurationService.getEnvironment()));
         if (accountInterventionsActionEnabled) {
             throw new AccountInterventionException(
                     "Problem communicating with Account Intervention Service", e);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -65,12 +65,14 @@ class AccountInterventionServiceTest {
                     "some-ip-address",
                     "some-phone-number",
                     "some-persistent-session-id");
+    private static final String ENVIRONMENT = "test-environment";
 
     @BeforeEach
     void setup() throws URISyntaxException {
         when(config.getAccountInterventionServiceURI()).thenReturn(new URI(BASE_AIS_URL));
         when(config.isAccountInterventionServiceCallEnabled()).thenReturn(true);
         when(config.isAccountInterventionServiceActionEnabled()).thenReturn(false);
+        when(config.getEnvironment()).thenReturn(ENVIRONMENT);
     }
 
     @Test
@@ -160,6 +162,9 @@ class AccountInterventionServiceTest {
         assertThrows(
                 AccountInterventionException.class,
                 () -> accountInterventionService.getAccountStatus(internalPairwiseSubjectId));
+
+        verify(cloudwatchMetricsService)
+                .incrementCounter("AISCallFailure", Map.of("Environment", ENVIRONMENT));
     }
 
     @Test


### PR DESCRIPTION
## What?

Add metric for failed AIS call
## Why?

So we can track when AIS calls are unsuccesful
