### PR TITLE
ATO-255: restrict codeowners for the duration of the deployment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/auth-team @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads @govuk-one-login/orchestration-team
+* @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads


### PR DESCRIPTION
## What?

Restrict the codeowners file to just the leads groups

## Why?

To avoid incompatible changes during the release of phase 1 of the auth orch split
