### PR TITLE
AUT-2195 AUT-2196 /get-mfa-methods stub - skeleton and dummy response

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/GetMfaMethodsRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/GetMfaMethodsRequest.java
@@ -1,0 +1,17 @@
+package uk.gov.di.accountmanagement.entity;
+
+import com.google.gson.annotations.Expose;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public class GetMfaMethodsRequest {
+
+    @Expose @Required private String email;
+
+    public GetMfaMethodsRequest(String email) {
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/MFAMethodsListResponse.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/MFAMethodsListResponse.java
@@ -1,0 +1,8 @@
+package uk.gov.di.accountmanagement.entity;
+
+import com.google.gson.annotations.Expose;
+import uk.gov.di.authentication.shared.validation.Required;
+
+import java.util.List;
+
+public record MFAMethodsListResponse(@Expose @Required List<MFARecord> mfaRecordList) {}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/MFARecord.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/MFARecord.java
@@ -1,0 +1,11 @@
+package uk.gov.di.accountmanagement.entity;
+
+import com.google.gson.annotations.Expose;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public record MFARecord(
+        @Expose @Required String mfaIdentifier,
+        @Expose @Required String priorityIdentifier,
+        @Expose @Required String mfaMethodType,
+        @Expose @Required String endpoint,
+        @Expose @Required boolean methodVerified) {}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
@@ -1,0 +1,52 @@
+package uk.gov.di.accountmanagement.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.accountmanagement.entity.MFAMethodsListResponse;
+import uk.gov.di.accountmanagement.entity.MFARecord;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.SerializationService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+
+public class GetMfaMethodsHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final Json objectMapper = SerializationService.getInstance();
+    private static final Logger LOG = LogManager.getLogger(GetMfaMethodsHandler.class);
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+
+        String sessionId =
+                RequestHeaderHelper.getHeaderValueOrElse(input.getHeaders(), SESSION_ID_HEADER, "");
+        attachSessionIdToLogs(sessionId);
+
+        LOG.info("GetMFAMethodsHandler received request");
+
+        List<MFARecord> list = new ArrayList<>();
+
+        list.add(new MFARecord("1", "PRIMARY", "test1", "EP", true));
+        list.add(new MFARecord("2", "SECONDARY", "test2", "EP", true));
+
+        MFAMethodsListResponse response = new MFAMethodsListResponse(list);
+        try {
+            return generateApiGatewayProxyResponse(200, objectMapper.writeValueAsString(response));
+        } catch (Json.JsonException | IllegalArgumentException ex) {
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1056);
+        }
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
@@ -1,0 +1,20 @@
+package uk.gov.di.accountmanagement.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class GetMfaMethodsHandlerTest {
+    @Test
+    void shouldReturn200ForSuccessfulRequest() {
+        var handler = new GetMfaMethodsHandler();
+        var context = mock(Context.class);
+        var event = new APIGatewayProxyRequestEvent();
+
+        var result = handler.handleRequest(event, context);
+        assertEquals(200, result.getStatusCode());
+    }
+}

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/GetMfaMethodsListIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/GetMfaMethodsListIntegrationTest.java
@@ -1,0 +1,61 @@
+package uk.gov.di.accountmanagement.api;
+
+import com.nimbusds.jose.JOSEException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.accountmanagement.entity.GetMfaMethodsRequest;
+import uk.gov.di.accountmanagement.lambda.GetMfaMethodsHandler;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+
+import java.security.NoSuchAlgorithmException;
+import java.text.ParseException;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+public class GetMfaMethodsListIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    private static final String USER_EMAIL = "test@email.com";
+
+    private static final String USER_PASSWORD = "Password123!";
+
+    private String SESSION_ID;
+
+    @BeforeEach
+    void setup() throws JOSEException, NoSuchAlgorithmException, Json.JsonException {
+        var configuration =
+                new IntegrationTestConfigurationService(
+                        auditTopic,
+                        notificationsQueue,
+                        auditSigningKey,
+                        tokenSigner,
+                        ipvPrivateKeyJwtSigner,
+                        spotQueue,
+                        docAppPrivateKeyJwtSigner,
+                        configurationParameters) {
+
+                    @Override
+                    public String getTxmaAuditQueueUrl() {
+                        return txmaAuditQueue.getQueueUrl();
+                    }
+                };
+        String subjectId = "new-subject";
+        SESSION_ID = redis.createUnauthenticatedSessionWithEmail(USER_EMAIL);
+
+        handler = new GetMfaMethodsHandler();
+    }
+
+    @Test
+    void shouldCallMFAInforAndReturn200() throws Json.JsonException, ParseException {
+        var response =
+                makeRequest(
+                        Optional.of(new GetMfaMethodsRequest(USER_EMAIL)),
+                        constructFrontendHeaders(SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(200));
+    }
+}

--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -139,6 +139,7 @@ resource "aws_api_gateway_deployment" "deployment" {
       module.update_phone_number.method_trigger_value,
       module.send_otp_notification.integration_trigger_value,
       module.send_otp_notification.method_trigger_value,
+      local.deploy_get_mfa_methods_count == 1 ? module.get-mfa-methods.integration_trigger_value : null,
       aws_lambda_alias.authorizer_alias.function_version
     ]))
   }

--- a/ci/terraform/account-management/get-mfa-methods.tf
+++ b/ci/terraform/account-management/get-mfa-methods.tf
@@ -1,0 +1,64 @@
+module "account_management_api_get_mfa_methods" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "account-management-api-get_mfa_methods"
+  vpc_arn     = local.vpc_arn
+  count       = local.deploy_get_mfa_methods_count
+
+  policies_to_attach = [
+    aws_iam_policy.dynamo_am_user_read_access_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.parameter_policy.arn,
+    module.account_management_txma_audit.access_policy_arn,
+    local.user_profile_encryption_policy_arn
+  ]
+}
+
+module "get-mfa-methods" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "get-mfa-methods"
+  path_part       = "get-mfa-methods"
+  endpoint_method = ["POST"]
+  handler_environment_variables = {
+    ENVIRONMENT          = var.environment
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
+    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY            = local.redis_key
+    TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+  }
+  handler_function_name = "uk.gov.di.accountmanagement.lambda.GetMfaMethodsHandler::handleRequest"
+
+  authorizer_id    = aws_api_gateway_authorizer.di_account_management_api.id
+  rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+
+  memory_size                 = lookup(var.performance_tuning, "get-mfa-methods", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "get-mfa-methods", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "get-mfa-methods", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "get-mfa-methods", local.default_performance_parameters).scaling_trigger
+
+  source_bucket           = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file         = aws_s3_object.account_management_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn = local.vpc_arn
+  security_group_ids = [
+    local.allow_aws_service_access_security_group_id,
+    aws_security_group.allow_access_to_am_redis.id,
+  ]
+  subnet_id                              = local.private_subnet_ids
+  environment                            = var.environment
+  lambda_role_arn                        = module.account_management_api_update_phone_number_role.arn
+  use_localstack                         = var.use_localstack
+  default_tags                           = local.default_tags
+  logging_endpoint_arns                  = var.logging_endpoint_arns
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
+  count                                  = local.deploy_get_mfa_methods_count
+}

--- a/ci/terraform/account-management/site.tf
+++ b/ci/terraform/account-management/site.tf
@@ -50,6 +50,7 @@ locals {
   }
 
   request_tracing_allowed = contains(["build", "sandpit"], var.environment)
+  deploy_get_mfa_methods_count = contains(["build", "sandpit"], var.environment) ? 1 : 0
 
   access_logging_template = jsonencode({
     requestId                    = "$context.requestId"

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -66,7 +66,8 @@ public enum ErrorResponse {
     ERROR_1052(1052, "Account Interventions API response Server Error"),
     ERROR_1053(1053, "Account Interventions API Bad Gateway"),
     ERROR_1054(1054, "Account Interventions API Gateway Timeout"),
-    ERROR_1055(1055, "Account Interventions API Unexpected Error");
+    ERROR_1055(1055, "Account Interventions API Unexpected Error"),
+    ERROR_1056(1056, "MFA Method(s) not found for the provided parameters");
 
     private int code;
 


### PR DESCRIPTION
## What?

Skeleton and dummy response/tests for AUT-2195 and AUT-2196 - get-mfa-methods call. 

Should not be deployed past build and sandpit. Final shape of API call and spec WIP.

Deployed to sandpit. 

## Why?

Skeleton in place to fill out when we have final agreement on API Spec.
