### PR TITLE
ATO-176: Fix improper string comparison

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/LogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/LogoutService.java
@@ -178,7 +178,7 @@ public class LogoutService {
         // Temporarily redirect to auth frontend (in staging and production) instead of orch
         // frontend, while orch frontend is not deployed in these envs.
         String env = configurationService.getEnvironment();
-        if (env == "staging" || env == "production") {
+        if (env.equals("staging") || env.equals("production")) {
             baseRedirectUrl = configurationService.getFrontendBaseUrl();
             if (accountStatus.blocked()) {
                 redirectPath = "/unavailable-permanent";

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/LogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/LogoutServiceTest.java
@@ -99,6 +99,8 @@ public class LogoutServiceTest {
 
     private static final String OIDC_API_BASE_URL = "https://oidc.test.account.gov.uk/";
 
+    private static final String ENVIRONMENT = "test";
+
     private SignedJWT signedIDToken;
     private Optional<String> audience;
     private Session session;
@@ -115,6 +117,7 @@ public class LogoutServiceTest {
         when(configurationService.getDefaultLogoutURI()).thenReturn(DEFAULT_LOGOUT_URI);
         when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
         when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_API_BASE_URL));
+        when(configurationService.getEnvironment()).thenReturn(ENVIRONMENT);
         logoutService =
                 new LogoutService(
                         configurationService,


### PR DESCRIPTION
## What?

Change how strings are compared which controls whether to redirect to auth or orch frontend.

## Why?

`==` compares memory addresses whereas `.equals()` compares content (the intended functionality)

## Related PRs

PR containing original change: https://github.com/govuk-one-login/authentication-api/pull/3820
