### PR TITLE
AUT-2310: increase lockout for failed password/mfa code attempts

### DIFF
--- a/ci/terraform/account-management/authdev1.tfvars
+++ b/ci/terraform/account-management/authdev1.tfvars
@@ -12,7 +12,7 @@ endpoint_memory_size   = 1536
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 
-blocked_email_duration                    = 30
+lockout_duration                          = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
 

--- a/ci/terraform/account-management/authdev2.tfvars
+++ b/ci/terraform/account-management/authdev2.tfvars
@@ -12,7 +12,7 @@ endpoint_memory_size   = 1536
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 
-blocked_email_duration                    = 30
+lockout_duration                          = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
 

--- a/ci/terraform/account-management/build-overrides.tfvars
+++ b/ci/terraform/account-management/build-overrides.tfvars
@@ -9,7 +9,7 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
-blocked_email_duration                    = 30
+lockout_duration                          = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
 

--- a/ci/terraform/account-management/sandpit.tfvars
+++ b/ci/terraform/account-management/sandpit.tfvars
@@ -12,7 +12,7 @@ endpoint_memory_size   = 1536
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 
-blocked_email_duration                    = 30
+lockout_duration                          = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
 

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -33,7 +33,7 @@ module "send_otp_notification" {
     LOCALSTACK_ENDPOINT                    = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                              = local.redis_key
     TXMA_AUDIT_QUEUE_URL                   = module.account_management_txma_audit.queue_url
-    BLOCKED_EMAIL_DURATION                 = var.blocked_email_duration
+    LOCKOUT_DURATION                       = var.lockout_duration
     DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
     EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
     INTERNAl_SECTOR_URI                    = var.internal_sector_uri

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -195,7 +195,7 @@ variable "txma_account_id" {
   type    = string
 }
 
-variable "blocked_email_duration" {
+variable "lockout_duration" {
   type    = number
   default = 900
 }

--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -40,7 +40,8 @@ lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 endpoint_memory_size   = 1536
 
-blocked_email_duration                    = 30
+
+lockout_duration                          = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
 

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -40,7 +40,7 @@ lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 endpoint_memory_size   = 1536
 
-blocked_email_duration                    = 30
+lockout_duration                          = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
 

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -35,8 +35,9 @@ dqhoDR3/THktb4KThc+U5EOWCWpH4OIAetYtjFChnkR8kU05Ol9zfdR08uO0RxMk
 -----END PUBLIC KEY-----
 EOT
 
-blocked_email_duration = 30
-otp_code_ttl_duration  = 120
+
+lockout_duration      = 30
+otp_code_ttl_duration = 120
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -29,6 +29,7 @@ module "check_reauth_user" {
     TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI  = var.internal_sector_uri
     REDIS_KEY            = local.redis_key
+    LOCKOUT_DURATION     = var.lockout_duration
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.CheckReAuthUserHandler::handleRequest"

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -39,6 +39,7 @@ module "login" {
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
     INTERNAl_SECTOR_URI      = var.internal_sector_uri
+    LOCKOUT_DURATION         = var.lockout_duration
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.LoginHandler::handleRequest"
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -27,7 +27,7 @@ module "mfa" {
 
   handler_environment_variables = {
     ENVIRONMENT                            = var.environment
-    BLOCKED_EMAIL_DURATION                 = var.blocked_email_duration
+    LOCKOUT_DURATION                       = var.lockout_duration
     DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
     EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
     EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -25,17 +25,17 @@ module "reset-password-request" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT            = var.environment
-    FRONTEND_BASE_URL      = "https://${local.frontend_fqdn}/"
-    RESET_PASSWORD_ROUTE   = var.reset_password_route
-    BLOCKED_EMAIL_DURATION = var.blocked_email_duration
-    SQS_ENDPOINT           = var.use_localstack ? "http://localhost:45678/" : null
-    EMAIL_QUEUE_URL        = aws_sqs_queue.email_queue.id
-    TXMA_AUDIT_QUEUE_URL   = module.oidc_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT    = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY              = local.redis_key
-    DYNAMO_ENDPOINT        = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    INTERNAl_SECTOR_URI    = var.internal_sector_uri
+    ENVIRONMENT          = var.environment
+    FRONTEND_BASE_URL    = "https://${local.frontend_fqdn}/"
+    RESET_PASSWORD_ROUTE = var.reset_password_route
+    LOCKOUT_DURATION     = var.lockout_duration
+    SQS_ENDPOINT         = var.use_localstack ? "http://localhost:45678/" : null
+    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
+    TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY            = local.redis_key
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    INTERNAl_SECTOR_URI  = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ResetPasswordRequestHandler::handleRequest"
 

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -39,7 +39,8 @@ lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 endpoint_memory_size   = 1536
 
-blocked_email_duration                    = 30
+
+lockout_duration                          = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -29,7 +29,7 @@ module "send_notification" {
 
   handler_environment_variables = {
     ENVIRONMENT                            = var.environment
-    BLOCKED_EMAIL_DURATION                 = var.blocked_email_duration
+    LOCKOUT_DURATION                       = var.lockout_duration
     EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id
     PENDING_EMAIL_CHECK_QUEUE_URL          = local.pending_email_check_queue_id
     SUPPORT_EMAIL_CHECK_ENABLED            = var.support_email_check_enabled

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -210,7 +210,7 @@ variable "reset_password_route" {
   default = "reset-password?code="
 }
 
-variable "blocked_email_duration" {
+variable "lockout_duration" {
   type    = number
   default = 900
 }

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -30,7 +30,7 @@ module "verify_code" {
 
   handler_environment_variables = {
     ENVIRONMENT                         = var.environment
-    BLOCKED_EMAIL_DURATION              = var.blocked_email_duration
+    LOCKOUT_DURATION                    = var.lockout_duration
     TXMA_AUDIT_QUEUE_URL                = module.oidc_txma_audit.queue_url
     LOCALSTACK_ENDPOINT                 = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                           = local.redis_key

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -30,7 +30,7 @@ module "verify_mfa_code" {
 
   handler_environment_variables = {
     ENVIRONMENT                         = var.environment
-    BLOCKED_EMAIL_DURATION              = var.blocked_email_duration
+    LOCKOUT_DURATION                    = var.lockout_duration
     TXMA_AUDIT_QUEUE_URL                = module.oidc_txma_audit.queue_url
     LOCALSTACK_ENDPOINT                 = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                           = local.redis_key

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -277,9 +277,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     "User has requested too many OTP codes. Setting block with prefix: {}",
                     newCodeRequestBlockPrefix);
             codeStorageService.saveBlockedForEmail(
-                    email,
-                    newCodeRequestBlockPrefix,
-                    configurationService.getBlockedEmailDuration());
+                    email, newCodeRequestBlockPrefix, configurationService.getLockoutDuration());
             LOG.info("Resetting code request count");
             sessionService.save(
                     session.resetCodeRequestCount(NotificationType.MFA_SMS, journeyType));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -198,7 +198,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
             codeStorageService.saveBlockedForEmail(
                     userContext.getSession().getEmailAddress(),
                     codeRequestBlockedKeyPrefix,
-                    configurationService.getBlockedEmailDuration());
+                    configurationService.getLockoutDuration());
             sessionService.save(userContext.getSession().resetPasswordResetCount());
             return Optional.of(ErrorResponse.ERROR_1022);
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -357,9 +357,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                     "User has requested too many OTP codes. Setting block with prefix: {}",
                     newCodeRequestBlockPrefix);
             codeStorageService.saveBlockedForEmail(
-                    email,
-                    newCodeRequestBlockPrefix,
-                    configurationService.getBlockedEmailDuration());
+                    email, newCodeRequestBlockPrefix, configurationService.getLockoutDuration());
 
             LOG.info("Resetting code request count");
             sessionService.save(session.resetCodeRequestCount(notificationType, journeyType));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -185,7 +185,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         codeStorageService.saveBlockedForEmail(
                 session.getEmailAddress(),
                 codeBlockPrefix,
-                configurationService.getBlockedEmailDuration());
+                configurationService.getLockoutDuration());
         LOG.info("Email is blocked");
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -258,7 +258,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         }
 
         codeStorageService.saveBlockedForEmail(
-                emailAddress, codeBlockedKeyPrefix, configurationService.getBlockedEmailDuration());
+                emailAddress, codeBlockedKeyPrefix, configurationService.getLockoutDuration());
 
         if (mfaMethodType == MFAMethodType.SMS) {
             codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -86,7 +86,7 @@ public class MfaHandlerTest {
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String CODE = "123456";
     private static final long CODE_EXPIRY_TIME = 900;
-    private static final long BLOCKED_EMAIL_DURATION = 799;
+    private static final long LOCKOUT_DURATION = 799;
     private static final String TEST_CLIENT_ID = "test-client-id";
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
@@ -389,7 +389,7 @@ public class MfaHandlerTest {
                 .thenReturn(Optional.of(PHONE_NUMBER));
 
         usingValidSession();
-        when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
+        when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         session.incrementCodeRequestCount(NotificationType.VERIFY_EMAIL, JourneyType.REGISTRATION);
         session.incrementCodeRequestCount(NotificationType.VERIFY_EMAIL, JourneyType.REGISTRATION);
         session.incrementCodeRequestCount(NotificationType.VERIFY_EMAIL, JourneyType.REGISTRATION);
@@ -418,7 +418,7 @@ public class MfaHandlerTest {
 
         usingValidSession();
 
-        when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
+        when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
 
         CodeRequestType codeRequestTypeForBlockedOtpRequestType =
                 CodeRequestType.getCodeRequestType(
@@ -447,7 +447,7 @@ public class MfaHandlerTest {
     @MethodSource("smsJourneyTypes")
     void shouldReturn400IfUserHasReachedTheSmsSignInCodeRequestLimit(JourneyType journeyType) {
         usingValidSession();
-        when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
+        when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         session.incrementCodeRequestCount(MFA_SMS, journeyType);
         session.incrementCodeRequestCount(MFA_SMS, journeyType);
         session.incrementCodeRequestCount(MFA_SMS, journeyType);
@@ -477,7 +477,7 @@ public class MfaHandlerTest {
                 .saveBlockedForEmail(
                         TEST_EMAIL_ADDRESS,
                         CODE_REQUEST_BLOCKED_KEY_PREFIX + codeRequestType,
-                        BLOCKED_EMAIL_DURATION);
+                        LOCKOUT_DURATION);
 
         verify(auditService)
                 .submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -84,7 +84,7 @@ class ResetPasswordRequestHandlerTest {
     private static final String PERSISTENT_ID = "some-persistent-id-value";
     private static final long CODE_EXPIRY_TIME = 900;
     private static final String TEST_CLIENT_ID = "test-client-id";
-    private static final long BLOCKED_EMAIL_DURATION = 799;
+    private static final long LOCKOUT_DURATION = 799;
     private static final Json objectMapper = SerializationService.getInstance();
     private static final String PHONE_NUMBER = "01234567890";
     private static final AuditService.MetadataPair PASSWORD_RESET_COUNTER =
@@ -336,7 +336,7 @@ class ResetPasswordRequestHandlerTest {
         Subject subject = new Subject("subject_1");
         String sessionId = "1233455677";
         when(authenticationService.getSubjectFromEmail(TEST_EMAIL_ADDRESS)).thenReturn(subject);
-        when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
+        when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         Session session = mock(Session.class);
         when(session.getEmailAddress()).thenReturn(TEST_EMAIL_ADDRESS);
         when(session.getSessionId()).thenReturn(sessionId);
@@ -359,7 +359,7 @@ class ResetPasswordRequestHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1022));
         verify(codeStorageService)
                 .saveBlockedForEmail(
-                        TEST_EMAIL_ADDRESS, codeRequestBlockedKeyPrefix, BLOCKED_EMAIL_DURATION);
+                        TEST_EMAIL_ADDRESS, codeRequestBlockedKeyPrefix, LOCKOUT_DURATION);
         verify(session).resetPasswordResetCount();
         verifyNoInteractions(awsSqsClient);
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -101,7 +101,7 @@ class SendNotificationHandlerTest {
     private static final String TEST_PHONE_NUMBER = "07755551084";
     private static final String TEST_SIX_DIGIT_CODE = "123456";
     private static final long CODE_EXPIRY_TIME = 900;
-    private static final long BLOCKED_EMAIL_DURATION = 799;
+    private static final long LOCKOUT_DURATION = 799;
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     new Subject().getValue(), "test.account.gov.uk", SaltHelper.generateNewSalt());
@@ -175,7 +175,7 @@ class SendNotificationHandlerTest {
         when(configurationService.isEmailCheckEnabled()).thenReturn(true);
         when(configurationService.getEmailAccountCreationOtpCodeExpiry())
                 .thenReturn(CODE_EXPIRY_TIME);
-        when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
+        when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(configurationService.getEnvironment()).thenReturn("unit-test");
@@ -708,7 +708,7 @@ class SendNotificationHandlerTest {
                 .saveBlockedForEmail(
                         TEST_EMAIL_ADDRESS,
                         CODE_REQUEST_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_REGISTRATION,
-                        BLOCKED_EMAIL_DURATION);
+                        LOCKOUT_DURATION);
         verify(codeStorageService, never())
                 .saveOtpCode(
                         TEST_EMAIL_ADDRESS, TEST_SIX_DIGIT_CODE, CODE_EXPIRY_TIME, VERIFY_EMAIL);
@@ -746,7 +746,7 @@ class SendNotificationHandlerTest {
                 .saveBlockedForEmail(
                         TEST_EMAIL_ADDRESS,
                         CODE_REQUEST_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_ACCOUNT_RECOVERY,
-                        BLOCKED_EMAIL_DURATION);
+                        LOCKOUT_DURATION);
         verify(codeStorageService, never())
                 .saveOtpCode(
                         TEST_EMAIL_ADDRESS,
@@ -788,7 +788,7 @@ class SendNotificationHandlerTest {
                 .saveBlockedForEmail(
                         TEST_EMAIL_ADDRESS,
                         CODE_REQUEST_BLOCKED_KEY_PREFIX + CodeRequestType.SMS_REGISTRATION,
-                        BLOCKED_EMAIL_DURATION);
+                        LOCKOUT_DURATION);
         verify(codeStorageService, never())
                 .saveOtpCode(
                         TEST_EMAIL_ADDRESS,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -132,7 +132,7 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(withAuthenticationRequest().toParameters());
 
         when(userProfile.getSubjectID()).thenReturn(SUBJECT_ID);
-        when(configurationService.getBlockedEmailDuration()).thenReturn(900L);
+        when(configurationService.getLockoutDuration()).thenReturn(900L);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(clientSession));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -80,8 +80,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("AUTH_CODE_EXPIRY", "300"));
     }
 
-    public long getBlockedEmailDuration() {
-        return Long.parseLong(System.getenv().getOrDefault("BLOCKED_EMAIL_DURATION", "900"));
+    public long getLockoutDuration() {
+        return Long.parseLong(System.getenv().getOrDefault("LOCKOUT_DURATION", "900"));
     }
 
     public int getBulkUserEmailBatchQueryLimit() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.shared.services;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -25,10 +26,16 @@ class CodeStorageServiceTest {
             "f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a";
     private static final String CODE = "123456";
     private static final String SUBJECT = "some-subject";
+    private static final long CODE_EXPIRY_TIME = 900;
+    private static final long AUTH_CODE_EXPIRY_TIME = 300;
+    private static final String CODE_BLOCKED_VALUE = "blocked";
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
+
+    private static final ConfigurationService configurationService =
+            mock(ConfigurationService.class);
     private final CodeStorageService codeStorageService =
-            new CodeStorageService(redisConnectionService);
+            new CodeStorageService(configurationService, redisConnectionService);
 
     enum RedisKeys {
         INCORRECT_MFA_COUNTER("multiple-incorrect-mfa-codes:"),
@@ -60,9 +67,10 @@ class CodeStorageServiceTest {
         }
     }
 
-    private static final long CODE_EXPIRY_TIME = 900;
-    private static final long AUTH_CODE_EXPIRY_TIME = 300;
-    private static final String CODE_BLOCKED_VALUE = "blocked";
+    @BeforeAll
+    static void init() {
+        when(configurationService.getLockoutDuration()).thenReturn(CODE_EXPIRY_TIME);
+    }
 
     @Test
     void shouldCallRedisWithValidEmailCodeAndHashedEmail() {


### PR DESCRIPTION
## What?

Timeout after entering incorrect password/code (or requesting too many codes) is being increased from 15 minutes to 2 hours. Hardcoded timeouts have been removed and now depend on environment variables only. A feature flag has also been added so functionality can be tested before go/no go decision.

## Why?

Timeout increase needed across signup, login, pw reset and account recovery journeys. These timeouts need to cover all applicable scenarios where a user can exceed the password / mfa code (email, sms, auth app) retry attempt limits. These scenarios are covered in sub-stories of [AUT-1951](https://govukverify.atlassian.net/browse/AUT-1951)

[AUT-1951]: https://govukverify.atlassian.net/browse/AUT-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ