### PR TITLE
ATO-331: pass rp redirect uri to auth frontend

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -588,6 +588,7 @@ public class AuthorisationHandler
                             .jwtID(jwtID)
                             .claim("rp_client_id", client.getClientID())
                             .claim("rp_sector_host", rpSectorIdentifierHost)
+                            .claim("rp_redirect_uri", authenticationRequest.getRedirectionURI())
                             .claim("client_name", client.getClientName())
                             .claim("cookie_consent_shared", client.isCookieConsentShared())
                             .claim("consent_required", client.isConsentRequired())


### PR DESCRIPTION
## What?

Pass the RP redirect URI to the auth frontend

## Why?

Enables https://github.com/govuk-one-login/authentication-frontend/pull/1326
