### PR TITLE
ATO-316: Manually set connection timeout for request to Account Intervention Service

### DIFF
--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -51,6 +51,7 @@ module "authentication_callback" {
     OIDC_API_BASE_URL                           = local.api_base_url
     FRONTEND_BASE_URL                           = "https://${local.frontend_fqdn}/"
     ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR = var.account_intervention_service_abort_on_error
+    ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
   }
 
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler::handleRequest"

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -40,6 +40,7 @@ module "ipv-callback" {
     ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled
     ACCOUNT_INTERVENTION_SERVICE_URI            = var.account_intervention_service_uri
     ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR = var.account_intervention_service_abort_on_error
+    ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
     IPV_AUDIENCE                                = var.ipv_audience
     IPV_AUTHORISATION_CALLBACK_URI              = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_CLIENT_ID                 = var.ipv_authorisation_client_id

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -39,8 +39,9 @@ module "processing-identity" {
     ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED = var.account_intervention_service_action_enabled
     ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled
     ACCOUNT_INTERVENTION_SERVICE_URI            = var.account_intervention_service_uri
-    FRONTEND_BASE_URL                           = "https://${local.frontend_fqdn}/"
     ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR = var.account_intervention_service_abort_on_error
+    ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
+    FRONTEND_BASE_URL                           = "https://${local.frontend_fqdn}/"
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.ProcessingIdentityHandler::handleRequest"
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -493,6 +493,12 @@ variable "account_intervention_service_uri" {
   type    = string
 }
 
+variable "account_intervention_service_call_timeout" {
+  default     = 5000
+  type        = number
+  description = "The HTTP Client connection timeout for requests to Account Intervention Service (in milliseconds)."
+}
+
 variable "orch_redirect_uri" {
   type        = string
   description = "The redirect URI set by Orchestration in the OAuth2 authorize request to Authentication"

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -14,6 +14,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -37,7 +38,11 @@ public class AccountInterventionService {
     public AccountInterventionService(ConfigurationService configService) {
         this(
                 configService,
-                HttpClient.newHttpClient(),
+                HttpClient.newBuilder()
+                        .connectTimeout(
+                                Duration.ofMillis(
+                                        configService.getAccountInterventionServiceCallTimeout()))
+                        .build(),
                 new CloudwatchMetricsService(),
                 new AuditService(configService));
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -82,6 +82,11 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return URI.create(System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_URI", ""));
     }
 
+    public long getAccountInterventionServiceCallTimeout() {
+        return Long.parseLong(
+                System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "5000"));
+    }
+
     public String getAccountStatusBlockedURI() {
         return "/orch-frontend/not-available";
     }


### PR DESCRIPTION
## What?

Configure timeout for requests to AIS as an environment variable with a default value of 5 seconds.

## Why?

AIS should take no longer than 5 seconds to respond.
An environment variable is used to allow for experimentation in different envs.

## Testing
Will require testing in staging to ensure the timeout functions correctly and that 5 seconds is an acceptable initial value.
