### PR TITLE
Revert "ATO-255: restrict codeowners for the duration of the deployment"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads
+* @govuk-one-login/auth-team @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads @govuk-one-login/orchestration-team


### PR DESCRIPTION
This reverts commit 7c9ad5de86f7b615119e8df0d4b347b7e5d4496c.

## What?

Phase 1 deployment is complete; restore original codeowners