### PR TITLE
Ato 270/authcodehandler throwing exception in prod

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -42,6 +42,7 @@ import static java.util.Map.entry;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.INVALID_CODE_SENT;
+import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1002;
 import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.NONE;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
@@ -110,6 +111,16 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             Context context,
             VerifyMfaCodeRequest codeRequest,
             UserContext userContext) {
+
+        if (!CodeRequestType.isValidCodeRequestType(
+                codeRequest.getMfaMethodType(), codeRequest.getJourneyType())) {
+            LOG.warn(
+                    "Invalid MFA Type '{}' for journey '{}'",
+                    codeRequest.getMfaMethodType(),
+                    codeRequest.getJourneyType());
+            return generateApiGatewayProxyErrorResponse(400, ERROR_1002);
+        }
+
         LOG.info("Invoking verify MFA code handler");
         try {
             var session = userContext.getSession();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -548,6 +548,12 @@ class VerifyMfaCodeHandlerTest {
                         : AUTH_APP_SECRET;
         var codeRequest =
                 new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, journeyType, authAppSecret);
+
+        if (!CodeRequestType.isValidCodeRequestType(
+                codeRequest.getMfaMethodType(), codeRequest.getJourneyType())) {
+            return;
+        }
+
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -591,6 +597,10 @@ class VerifyMfaCodeHandlerTest {
         var codeRequest =
                 new VerifyMfaCodeRequest(
                         MFAMethodType.AUTH_APP, CODE, journeyType, profileInformation);
+        if (!CodeRequestType.isValidCodeRequestType(
+                codeRequest.getMfaMethodType(), codeRequest.getJourneyType())) {
+            return;
+        }
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -712,6 +722,10 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1037));
         var codeRequest =
                 new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, journeyType, PHONE_NUMBER);
+        if (!CodeRequestType.isValidCodeRequestType(
+                codeRequest.getMfaMethodType(), codeRequest.getJourneyType())) {
+            return;
+        }
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -750,6 +764,9 @@ class VerifyMfaCodeHandlerTest {
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.of(ErrorResponse.ERROR_1041));
         session.setNewAccount(Session.AccountState.NEW);
         session.setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
+        if (!CodeRequestType.isValidCodeRequestType(MFAMethodType.AUTH_APP, journeyType)) {
+            return;
+        }
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -927,6 +927,23 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
     }
 
+    @Test
+    void shouldReturn400WhenInvalidMFAJourneyCombination() {
+        setUpAuthAppRequest(JourneyType.PASSWORD_RESET);
+        var code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.SMS, code, JourneyType.PASSWORD_RESET);
+
+        var response =
+                makeRequest(
+                        Optional.of(codeRequest),
+                        constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1002));
+    }
+
     private void setUpTest(String sessionId, Scope scope) throws Json.JsonException {
         userStore.addUnverifiedUser(EMAIL_ADDRESS, USER_PASSWORD);
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.shared.entity;
 
+import uk.gov.di.authentication.shared.exceptions.CodeRequestTypeNotFoundException;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,6 +40,12 @@ public enum CodeRequestType {
         this.journeyType = journeyType;
     }
 
+    public static boolean isValidCodeRequestType(
+            MFAMethodType mfaMethodType, JourneyType journeyType) {
+        CodeRequestTypeKey key = new CodeRequestTypeKey(mfaMethodType, journeyType);
+        return codeRequestTypeMap.containsKey(key);
+    }
+
     public static CodeRequestType getCodeRequestType(
             NotificationType notificationType, JourneyType journeyType) {
         return getCodeRequestType(notificationType.getMfaMethodType(), journeyType);
@@ -45,6 +53,13 @@ public enum CodeRequestType {
 
     public static CodeRequestType getCodeRequestType(
             MFAMethodType mfaMethodType, JourneyType journeyType) {
+        if (!isValidCodeRequestType(mfaMethodType, journeyType)) {
+            throw new CodeRequestTypeNotFoundException(
+                    String.format(
+                            "CodeRequestType not found for MFA Type and Journey Type: [%s , %s]",
+                            mfaMethodType.getValue(), journeyType.getValue()));
+        }
+
         CodeRequestTypeKey key = new CodeRequestTypeKey(mfaMethodType, journeyType);
         return codeRequestTypeMap.get(key);
     }
@@ -53,7 +68,7 @@ public enum CodeRequestType {
         return mfaMethodType;
     }
 
-    private JourneyType getJourneyType() {
+    public JourneyType getJourneyType() {
         return journeyType;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -109,6 +109,9 @@ public class Session {
     }
 
     public int getCodeRequestCount(CodeRequestType requestType) {
+        if (requestType == null) {
+            throw new IllegalArgumentException("CodeRequestType cannot be null");
+        }
         LOG.info("CodeRequest count: {}", codeRequestCountMap);
         return codeRequestCountMap.getOrDefault(requestType, 0);
     }
@@ -120,7 +123,6 @@ public class Session {
         int currentCount = getCodeRequestCount(requestType);
         codeRequestCountMap.put(requestType, currentCount + 1);
         LOG.info("CodeRequest count incremented: {}", codeRequestCountMap);
-
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/CodeRequestTypeNotFoundException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/CodeRequestTypeNotFoundException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class CodeRequestTypeNotFoundException extends RuntimeException {
+    public CodeRequestTypeNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/CodeRequestTypeTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/CodeRequestTypeTest.java
@@ -1,0 +1,17 @@
+package uk.gov.di.authentication.shared.entity;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.exceptions.CodeRequestTypeNotFoundException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
+
+class CodeRequestTypeTest {
+
+    @Test
+    void invalidNotificationTypeJourneyComboShouldThrowError() {
+        assertThrows(
+                CodeRequestTypeNotFoundException.class,
+                () -> CodeRequestType.getCodeRequestType(VERIFY_EMAIL, JourneyType.SIGN_IN));
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/SessionTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/SessionTest.java
@@ -1,0 +1,35 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.SaltHelper;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
+
+class SessionTest {
+    private final String expectedCommonSubject =
+            ClientSubjectHelper.calculatePairwiseIdentifier(
+                    new Subject().getValue(), "test.account.gov.uk", SaltHelper.generateNewSalt());
+    private final Session session =
+            new Session(IdGenerator.generate())
+                    .setEmailAddress("joe.bloggs@test.com")
+                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+
+    @RegisterExtension
+    private final CaptureLoggingExtension logging = new CaptureLoggingExtension(Session.class);
+
+    @Test
+    void invalidNotificationJourneyComboShouldNotAddNullValuesToSession() {
+        try {
+            session.incrementCodeRequestCount(VERIFY_EMAIL, JourneyType.SIGN_IN);
+            assertThat(session.getCodeRequestCount(null), equalTo(0));
+        } catch (Exception e) {
+        }
+    }
+}


### PR DESCRIPTION
## What?

Prevent null data from being added to the client registry when invalid MFA and Journey combination sent.

## Why?

This is causing `com.google.gson.JsonSyntaxException: duplicate key: null: java.lang.RuntimeException` in production. 
See: https://gds.slack.com/archives/C060UE8NSP4/p1704990806624429

## Related PRs

[ATO-212](https://govukverify.atlassian.net/browse/ATO-212)


[ATO-212]: https://govukverify.atlassian.net/browse/ATO-212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ