### PR TITLE
ATO-334: Add additional error handling in Account Intervention Service

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -128,7 +128,7 @@ public class AccountInterventionService {
 
     private AccountInterventionStatus handleException(Exception e) {
         cloudwatchMetricsService.incrementCounter(
-                "AISCallFailure", Map.of("Environment", configurationService.getEnvironment()));
+                "AISException", Map.of("Environment", configurationService.getEnvironment()));
         if (accountInterventionsActionEnabled && acountInterventionsAbortOnError) {
             throw new AccountInterventionException(
                     "Problem communicating with Account Intervention Service", e);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -111,6 +111,7 @@ class AccountInterventionServiceTest {
 
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
         when(httpResponse.body()).thenReturn(ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE);
+        when(httpResponse.statusCode()).thenReturn(200);
 
         var status = accountInterventionService.getAccountStatus(internalPairwiseSubjectId);
 
@@ -186,7 +187,7 @@ class AccountInterventionServiceTest {
                 () -> accountInterventionService.getAccountStatus(internalPairwiseSubjectId));
 
         verify(cloudwatchMetricsService)
-                .incrementCounter("AISCallFailure", Map.of("Environment", ENVIRONMENT));
+                .incrementCounter("AISException", Map.of("Environment", ENVIRONMENT));
     }
 
     @Test
@@ -205,6 +206,7 @@ class AccountInterventionServiceTest {
 
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
         when(httpResponse.body()).thenReturn(ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE);
+        when(httpResponse.statusCode()).thenReturn(200);
 
         accountInterventionService.getAccountStatus(internalPairwiseSubjectId, someAuditContext);
 


### PR DESCRIPTION
## What?

Improve coverage of error handling when making requests to and serialising the response from Account Intervention Service.

Refactor Account Intervention Service to improve readability.

Rename CloudWatch metric from `AISCallFailure` to `AISException` to better reflect it's usage.

## Why?

In order to properly test the AIS connection timeout (https://github.com/govuk-one-login/authentication-api/pull/3862), additional error handling is required.

## Related PRs

This work branched off https://github.com/govuk-one-login/authentication-api/pull/3850 and so will be merged into ATO-315.
