### PR TITLE
AUT-2127: Create CheckReAuthUser handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckReauthUserRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckReauthUserRequest.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+
+public record CheckReauthUserRequest(@SerializedName("email") @Expose @Required String email) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -4,15 +4,103 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.frontendapi.entity.CheckReauthUserRequest;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
+import uk.gov.di.authentication.shared.services.*;
+import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1056;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
-public class CheckReAuthUserHandler
+public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOG = LogManager.getLogger(CheckReAuthUserHandler.class);
+
+    public CheckReAuthUserHandler(
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
+            AuthenticationService authenticationService) {
+        super(
+                CheckReauthUserRequest.class,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
+    }
+
+    public CheckReAuthUserHandler(ConfigurationService configurationService) {
+        super(CheckReauthUserRequest.class, configurationService);
+    }
+
+    public CheckReAuthUserHandler() {
+        this(ConfigurationService.getInstance());
+    }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        return generateApiGatewayProxyResponse(200, "Hello world");
+        return super.handleRequest(input, context);
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            CheckReauthUserRequest request,
+            UserContext userContext) {
+        LOG.info("Processing CheckReAuthUser request for email: {}", request.email());
+
+        return authenticationService
+                .getUserProfileByEmailMaybe(request.email())
+                .flatMap(userProfile -> verifyReAuthentication(userProfile, userContext))
+                .map(rpPairwiseId -> generateSuccessResponse())
+                .orElseGet(this::generateErrorResponse);
+    }
+
+    private Optional<String> verifyReAuthentication(
+            UserProfile userProfile, UserContext userContext) {
+        var client = userContext.getClient().orElseThrow();
+        var rpPairwiseId =
+                ClientSubjectHelper.getSubject(
+                                userProfile,
+                                client,
+                                authenticationService,
+                                configurationService.getInternalSectorUri())
+                        .getValue();
+        var internalPairwiseId =
+                ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                                userProfile,
+                                configurationService.getInternalSectorUri(),
+                                authenticationService)
+                        .getValue();
+
+        if (rpPairwiseId.equals(internalPairwiseId)) {
+            LOG.info("Successfully verified re-authentication");
+            return Optional.of(rpPairwiseId);
+        }
+
+        LOG.info("User re-authentication verification failed");
+        return Optional.empty();
+    }
+
+    private APIGatewayProxyResponseEvent generateSuccessResponse() {
+        LOG.info("Successfully processed CheckReAuthUser request");
+        return generateApiGatewayProxyResponse(200, "");
+    }
+
+    private APIGatewayProxyResponseEvent generateErrorResponse() {
+        LOG.info("User not found or no match");
+        return generateApiGatewayProxyErrorResponse(404, ERROR_1056);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -2,20 +2,140 @@ package uk.gov.di.authentication.frontendapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.frontendapi.entity.CheckReauthUserRequest;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.SaltHelper;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 
 class CheckReAuthUserHandlerTest {
-    @Test
-    void shouldReturn200ForSuccessfulRequest() {
-        var handler = new CheckReAuthUserHandler();
-        var context = mock(Context.class);
-        var event = new APIGatewayProxyRequestEvent();
 
-        var result = handler.handleRequest(event, context);
+    private static final String EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String TEST_SUBJECT_ID = "subject-id";
+    private static final String INTERNAL_SECTOR_URI = "http://www.example.com";
+
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final Context context = mock(Context.class);
+    private final SessionService sessionService = mock(SessionService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ClientService clientService = mock(ClientService.class);
+    private final Session session =
+            new Session(IdGenerator.generate()).setEmailAddress(EMAIL_ADDRESS);
+    private final UserContext userContext = mock(UserContext.class);
+    private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
+    private static final byte[] SALT = SaltHelper.generateNewSalt();
+
+    private CheckReAuthUserHandler handler;
+
+    @BeforeEach
+    public void setUp() {
+        when(context.getAwsRequestId()).thenReturn("aws-session-id");
+        when(sessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(session));
+
+        when(authenticationService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
+        when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
+        var userProfile = generateUserProfile();
+        userProfile.setSubjectID(TEST_SUBJECT_ID);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL_ADDRESS))
+                .thenReturn(Optional.of(userProfile));
+        handler =
+                new CheckReAuthUserHandler(
+                        configurationService,
+                        sessionService,
+                        clientSessionService,
+                        clientService,
+                        authenticationService);
+    }
+
+    @Test
+    void shouldReturn200ForSuccessfulReAuthRequest() {
+        var context = mock(Context.class);
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(getHeaders());
+        event.setBody(format("{ \"email\": \"%s\" }", EMAIL_ADDRESS));
+
+        when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
+        when(clientRegistry.getRedirectUrls()).thenReturn(List.of(INTERNAL_SECTOR_URI));
+
+        var result =
+                handler.handleRequestWithUserContext(
+                        event, context, new CheckReauthUserRequest(EMAIL_ADDRESS), userContext);
         assertEquals(200, result.getStatusCode());
-        assertEquals("Hello world", result.getBody());
+    }
+
+    @Test
+    void shouldReturn404ForWhenUserNotFound() {
+        var context = mock(Context.class);
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(getHeaders());
+        event.setBody(format("{ \"email\": \"%s\" }", EMAIL_ADDRESS));
+
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL_ADDRESS))
+                .thenReturn(Optional.empty());
+
+        var result =
+                handler.handleRequestWithUserContext(
+                        event, context, new CheckReauthUserRequest(EMAIL_ADDRESS), userContext);
+        assertEquals(404, result.getStatusCode());
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1056));
+    }
+
+    @Test
+    void shouldReturn404ForWhenUserDoesNotMatch() {
+        var context = mock(Context.class);
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(getHeaders());
+        event.setBody(format("{ \"email\": \"%s\" }", EMAIL_ADDRESS));
+
+        when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
+        when(clientRegistry.getRedirectUrls()).thenReturn(List.of("http://test.example.com"));
+
+        var result =
+                handler.handleRequestWithUserContext(
+                        event, context, new CheckReauthUserRequest(EMAIL_ADDRESS), userContext);
+        assertEquals(404, result.getStatusCode());
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1056));
+    }
+
+    private UserProfile generateUserProfile() {
+        return new UserProfile()
+                .withEmail(EMAIL_ADDRESS)
+                .withEmailVerified(true)
+                .withPhoneNumberVerified(true)
+                .withPublicSubjectID(new Subject().getValue())
+                .withSubjectID(TEST_SUBJECT_ID);
+    }
+
+    private Map<String, String> getHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Session-Id", session.getSessionId());
+        return headers;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -66,7 +66,8 @@ public enum ErrorResponse {
     ERROR_1052(1052, "Account Interventions API response Server Error"),
     ERROR_1053(1053, "Account Interventions API Bad Gateway"),
     ERROR_1054(1054, "Account Interventions API Gateway Timeout"),
-    ERROR_1055(1055, "Account Interventions API Unexpected Error");
+    ERROR_1055(1055, "Account Interventions API Unexpected Error"),
+    ERROR_1056(1056, "User not found or no match");
 
     private int code;
 


### PR DESCRIPTION
## What?

- Do a look up the user's profile via email in the input request
- Recalculate the RP pairwise ID, and compare pairwaise IDs of the signed-in user and user requesting re-authentication
- Return 200 http status code if there is a match, 400 http status code if no match or user not found

## Why?

To verify if re-authentication request is valid by comparing signed in user and user requesting re-authentication
