### PR TITLE
Aut 2146/create email check sqs

### DIFF
--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -11,7 +11,8 @@ module "account_management_api_send_notification_role" {
     aws_iam_policy.parameter_policy.arn,
     module.account_management_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.user_profile_encryption_policy_arn
+    local.user_profile_encryption_policy_arn,
+    local.pending_email_check_queue_access_policy_arn
   ]
 }
 

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -15,10 +15,11 @@ data "terraform_remote_state" "shared" {
 }
 
 locals {
-  lambda_code_signing_configuration_arn   = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
-  account_modifiers_encryption_policy_arn = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
-  common_passwords_encryption_policy_arn  = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
-  client_registry_encryption_policy_arn   = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
-  user_profile_encryption_policy_arn      = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
-  pending_email_check_queue_id            = data.terraform_remote_state.shared.outputs.pending_email_check_queue_id
+  lambda_code_signing_configuration_arn       = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
+  account_modifiers_encryption_policy_arn     = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
+  common_passwords_encryption_policy_arn      = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
+  client_registry_encryption_policy_arn       = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
+  user_profile_encryption_policy_arn          = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
+  pending_email_check_queue_id                = data.terraform_remote_state.shared.outputs.pending_email_check_queue_id
+  pending_email_check_queue_access_policy_arn = data.terraform_remote_state.shared.outputs.pending_email_check_queue_access_policy_arn
 }

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -20,4 +20,5 @@ locals {
   common_passwords_encryption_policy_arn  = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
   client_registry_encryption_policy_arn   = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
   user_profile_encryption_policy_arn      = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
+  pending_email_check_queue_id            = data.terraform_remote_state.shared.outputs.pending_email_check_queue_id
 }

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -72,6 +72,11 @@ output "pending_email_check_queue_encryption_key_arn" {
   value       = aws_kms_key.pending_email_check_queue_encryption_key.arn
 }
 
+output "pending_email_check_queue_access_policy_arn" {
+  description = "the ARN of the IAM policy that allows write access to the pending email check queue"
+  value       = aws_iam_policy.pending_email_check_queue_access_policy.arn
+}
+
 output "email_lambda_iam_role_arn" {
   value = aws_iam_role.email_lambda_iam_role.arn
 }

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -63,6 +63,10 @@ output "sqs_lambda_iam_role_name" {
   value = aws_iam_role.sqs_lambda_iam_role.name
 }
 
+output "pending_email_check_queue_id" {
+  value = aws_sqs_queue.pending_email_check_queue.id
+}
+
 output "email_lambda_iam_role_arn" {
   value = aws_iam_role.email_lambda_iam_role.arn
 }

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -67,6 +67,11 @@ output "pending_email_check_queue_id" {
   value = aws_sqs_queue.pending_email_check_queue.id
 }
 
+output "pending_email_check_queue_encryption_key_arn" {
+  description = "the ARN of the KMS key used to encrypt payloads in the pending email check queue"
+  value       = aws_kms_key.pending_email_check_queue_encryption_key.arn
+}
+
 output "email_lambda_iam_role_arn" {
   value = aws_iam_role.email_lambda_iam_role.arn
 }

--- a/ci/terraform/shared/sqs-policy.tf
+++ b/ci/terraform/shared/sqs-policy.tf
@@ -1,0 +1,27 @@
+data "aws_iam_policy_document" "pending_email_check_queue_subscription_policy_document" {
+  statement {
+    effect = "Allow"
+
+    sid = "AllowReadDeleteAccessToPendingEmailCheckQueue"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.auth_check_account_id}:root"]
+    }
+    actions = [
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:ReceiveMessage",
+    ]
+    resources = [
+      aws_sqs_queue.pending_email_check_queue.arn,
+    ]
+  }
+}
+
+resource "aws_sqs_queue_policy" "pending_email_check_queue_subscription" {
+  queue_url = aws_sqs_queue.pending_email_check_queue.id
+
+  policy = data.aws_iam_policy_document.pending_email_check_queue_subscription_policy_document.json
+}

--- a/ci/terraform/shared/sqs.tf
+++ b/ci/terraform/shared/sqs.tf
@@ -5,7 +5,7 @@ resource "aws_sqs_queue" "pending_email_check_queue" {
   message_retention_seconds = 1209600
   receive_wait_time_seconds = 10
 
-  kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
+  kms_master_key_id                 = var.use_localstack ? null : aws_kms_key.pending_email_check_queue_encryption_key.arn
   kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
 
   redrive_policy = jsonencode({
@@ -19,10 +19,11 @@ resource "aws_sqs_queue" "pending_email_check_queue" {
 resource "aws_sqs_queue" "pending_email_check_dead_letter_queue" {
   name = "${var.environment}-pending-email-check-dlq"
 
-  kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
+  kms_master_key_id                 = var.use_localstack ? null : aws_kms_key.pending_email_check_queue_encryption_key.arn
   kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
 
   message_retention_seconds = 1209600
 
   tags = local.default_tags
 }
+

--- a/ci/terraform/shared/sqs.tf
+++ b/ci/terraform/shared/sqs.tf
@@ -27,3 +27,34 @@ resource "aws_sqs_queue" "pending_email_check_dead_letter_queue" {
   tags = local.default_tags
 }
 
+data "aws_iam_policy_document" "pending_email_queue_access_policy_document" {
+  version   = "2012-10-17"
+  policy_id = "${var.environment}-pending-email-check-queue-access-policy"
+
+  statement {
+    effect    = "Allow"
+    sid       = "AllowWriteAccessToPendingEmailCheckQueue"
+    actions   = ["sqs:SendMessage", ]
+    resources = [aws_sqs_queue.pending_email_check_queue.arn]
+  }
+
+  statement {
+    effect = "Allow"
+    sid    = "AllowAccessToKeyForEncryptingPayloads"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
+    ]
+    resources = [
+      aws_kms_key.pending_email_check_queue_encryption_key.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "pending_email_check_queue_access_policy" {
+  name_prefix = "pending-email-queue-access-"
+  path        = "/${var.environment}/"
+  description = "IAM Policy for write access to the pending email queue"
+
+  policy = data.aws_iam_policy_document.pending_email_queue_access_policy_document.json
+}

--- a/ci/terraform/shared/sqs.tf
+++ b/ci/terraform/shared/sqs.tf
@@ -8,5 +8,21 @@ resource "aws_sqs_queue" "pending_email_check_queue" {
   kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
   kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
 
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.pending_email_check_dead_letter_queue.arn
+    maxReceiveCount     = 1
+  })
+
+  tags = local.default_tags
+}
+
+resource "aws_sqs_queue" "pending_email_check_dead_letter_queue" {
+  name = "${var.environment}-pending-email-check-dlq"
+
+  kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
+  kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
+
+  message_retention_seconds = 1209600
+
   tags = local.default_tags
 }

--- a/ci/terraform/shared/sqs.tf
+++ b/ci/terraform/shared/sqs.tf
@@ -1,0 +1,12 @@
+resource "aws_sqs_queue" "pending_email_check_queue" {
+  name                      = "${var.environment}-pending-email-check-queue"
+  delay_seconds             = 10
+  max_message_size          = 2048
+  message_retention_seconds = 1209600
+  receive_wait_time_seconds = 10
+
+  kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
+  kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
+
+  tags = local.default_tags
+}

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -156,3 +156,8 @@ variable "enable_user_profile_stream" {
   type        = bool
   description = "Whether the User Profile DynamoDB table should have streaming turned on (this is consumed by Experian Phone Check lambda in a separate repo)"
 }
+
+variable "auth_check_account_id" {
+  type        = string
+  description = "Account id of the auth check aws account"
+}


### PR DESCRIPTION
## What?

Adds sqs queue and dead letter queue to request an email check. This will be written to from the frontend as well as the account management api, and read from the email checking lambda.

Also adds an access policy for the account management api.

## Why?

Support email checking as part of sign up / email changes.

## TODO before merge

- [x] Create the relevant account ids in secrets in each of the relevant aws accounts
