### PR TITLE
ATO-342: Update AIS logic to permit users to continue to Auth only services

### DIFF
--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountInterventionsStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountInterventionsStubExtension.java
@@ -56,7 +56,12 @@ public class AccountInterventionsStubExtension extends HttpStubExtension {
                         + "}");
     }
 
-    public void initWithBlockedOrSuspended(String userId, boolean blocked, boolean suspended) {
+    public void initWithAccountStatus(
+            String userId,
+            boolean blocked,
+            boolean suspended,
+            boolean reproveIdentity,
+            boolean resetPassword) {
         register(
                 "/v1/ais/" + userId,
                 200,
@@ -66,7 +71,7 @@ public class AccountInterventionsStubExtension extends HttpStubExtension {
                         + "    \"updatedAt\": 1696969322935,"
                         + "    \"appliedAt\": 1696869005821,"
                         + "    \"sentAt\": 1696869003456,"
-                        + "    \"description\": \"AIS_USER_PASSWORD_RESET_AND_IDENTITY_VERIFIED\","
+                        + "    \"description\": \"EXAMPLE_DESCRIPTION\","
                         + "    \"reprovedIdentityAt\": 1696969322935,"
                         + "    \"resetPasswordAt\": 1696875903456"
                         + "  },"
@@ -77,8 +82,11 @@ public class AccountInterventionsStubExtension extends HttpStubExtension {
                         + "    \"suspended\": "
                         + suspended
                         + ","
-                        + "    \"reproveIdentity\": false,"
-                        + "    \"resetPassword\": false"
+                        + "    \"reproveIdentity\": "
+                        + reproveIdentity
+                        + ","
+                        + "    \"resetPassword\": "
+                        + resetPassword
                         + "  }"
                         + "}");
     }


### PR DESCRIPTION
## What?

When on an auth-only journey, and Account Intervention Service responds with `blocked = false`, `suspended = true`, `resetPassword = false`, `reproveIdentity = true`, continue to RP (without requesting user to reprove identity).

## Why?

Updated requirement: see [slack thread](https://gds.slack.com/archives/C04N83W7V2N/p1706545004908939)

