### PR TITLE
AUT-2149: Add email check result handler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/EmailCheckResultWriterIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/EmailCheckResultWriterIntegrationTest.java
@@ -1,0 +1,74 @@
+package uk.gov.di.authentication.api;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.annotations.NotNull;
+import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
+import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
+import uk.gov.di.authentication.shared.lambda.EmailCheckResultWriterHandler;
+import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
+import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class EmailCheckResultWriterIntegrationTest extends HandlerIntegrationTest<SQSEvent, Void> {
+    private static final String TEST_MSG_EMAIL = "test@test.com";
+    private static final long TEST_MSG_TIME_TO_EXIST = 4073717403L;
+    private static final String TEST_MSG_REF_NUMBER = "123456-abc1234def5678";
+    DynamoEmailCheckResultService dynamoEmailCheckResultService =
+            new DynamoEmailCheckResultService(TEST_CONFIGURATION_SERVICE);
+
+    @RegisterExtension
+    protected static final EmailCheckResultExtension emailCheckResultExtension =
+            new EmailCheckResultExtension();
+
+    @BeforeEach
+    void setup() {
+        handler = new EmailCheckResultWriterHandler(TEST_CONFIGURATION_SERVICE);
+    }
+
+    @Test
+    void shouldSaveSqsContentToEmailCheckResultStoreWhenReceivingAValidSqsEvent() {
+        var emailCheckResultStatus = EmailCheckResultStatus.ALLOW;
+        SQSEvent event = getSqsEventWithSingleMessage(true, emailCheckResultStatus);
+
+        handler.handleRequest(event, mock(Context.class));
+
+        EmailCheckResultStore dbEntry =
+                dynamoEmailCheckResultService.getEmailCheckStore(TEST_MSG_EMAIL).get();
+        assertEquals(TEST_MSG_EMAIL, dbEntry.getEmail());
+        assertEquals(emailCheckResultStatus, dbEntry.getStatus());
+        assertEquals(TEST_MSG_REF_NUMBER, dbEntry.getReferenceNumber());
+        assertEquals(TEST_MSG_TIME_TO_EXIST, dbEntry.getTimeToExist());
+    }
+
+    @NotNull
+    private static SQSEvent getSqsEventWithSingleMessage(
+            boolean doesMessageContainRequiredFields, EmailCheckResultStatus status) {
+        SQSEvent event = new SQSEvent();
+        SQSEvent.SQSMessage sqsMessage = new SQSEvent.SQSMessage();
+
+        if (doesMessageContainRequiredFields) {
+            sqsMessage.setBody(
+                    String.format(
+                            "{ \"Email\": \"%s\", \"Status\": \"%s\", \"TimeToExist\": \"%d\", \"ReferenceNumber\": \"%s\" }",
+                            TEST_MSG_EMAIL,
+                            status.toString(),
+                            TEST_MSG_TIME_TO_EXIST,
+                            TEST_MSG_REF_NUMBER));
+        } else {
+            sqsMessage.setBody(("{}"));
+        }
+
+        List<SQSEvent.SQSMessage> records = List.of(sqsMessage);
+        event.setRecords(records);
+        return event;
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoEmailCheckResultServiceIntegrationTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DynamoEmailCheckResultServiceIntegrationTest {
 
     private static String email = "test.user@example.com";
+    private static String referenceNumber = "test-reference";
     private static EmailCheckResultStatus status = EmailCheckResultStatus.PENDING;
 
     DynamoEmailCheckResultService dynamoEmailCheckResultService =
@@ -29,20 +30,23 @@ class DynamoEmailCheckResultServiceIntegrationTest {
 
     @Test
     void shouldSaveAndReadAnEmailCheckResult() {
-        dynamoEmailCheckResultService.saveEmailCheckResult(email, status, unixTimePlusNDays(1));
+        dynamoEmailCheckResultService.saveEmailCheckResult(
+                email, status, unixTimePlusNDays(1), referenceNumber);
 
         var result = dynamoEmailCheckResultService.getEmailCheckStore(email);
 
         assertTrue(result.isPresent());
         assertThat(result.get().getEmail(), equalTo(email));
         assertThat(result.get().getStatus(), equalTo(status));
+        assertThat(result.get().getReferenceNumber(), equalTo(referenceNumber));
     }
 
     @Test
     void shouldNotReturnAnEmailCheckResultWhenTimeToLiveHasExpired() {
         long unixTimeInThePast =
                 NowHelper.nowPlus(-1, ChronoUnit.DAYS).toInstant().getEpochSecond();
-        dynamoEmailCheckResultService.saveEmailCheckResult(email, status, unixTimeInThePast);
+        dynamoEmailCheckResultService.saveEmailCheckResult(
+                email, status, unixTimeInThePast, referenceNumber);
 
         var result = dynamoEmailCheckResultService.getEmailCheckStore(email);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultSqsMessage.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultSqsMessage.java
@@ -1,0 +1,54 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public class EmailCheckResultSqsMessage {
+    @Expose
+    @SerializedName("Email")
+    @Required
+    private String email;
+
+    @Expose
+    @SerializedName("Status")
+    @Required
+    private EmailCheckResultStatus emailCheckResultStatus;
+
+    @Expose
+    @SerializedName("TimeToExist")
+    @Required
+    private long timeToExist;
+
+    @Expose
+    @SerializedName("ReferenceNumber")
+    @Required
+    private String referenceNumber;
+
+    public EmailCheckResultSqsMessage(
+            String email,
+            EmailCheckResultStatus emailCheckResultStatus,
+            long timeToExist,
+            String referenceNumber) {
+        this.email = email;
+        this.emailCheckResultStatus = emailCheckResultStatus;
+        this.timeToExist = timeToExist;
+        this.referenceNumber = referenceNumber;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public EmailCheckResultStatus getEmailCheckResultStatus() {
+        return emailCheckResultStatus;
+    }
+
+    public long getTimeToExist() {
+        return timeToExist;
+    }
+
+    public String getReferenceNumber() {
+        return referenceNumber;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultSqsMessage.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultSqsMessage.java
@@ -4,51 +4,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.validation.Required;
 
-public class EmailCheckResultSqsMessage {
-    @Expose
-    @SerializedName("Email")
-    @Required
-    private String email;
-
-    @Expose
-    @SerializedName("Status")
-    @Required
-    private EmailCheckResultStatus emailCheckResultStatus;
-
-    @Expose
-    @SerializedName("TimeToExist")
-    @Required
-    private long timeToExist;
-
-    @Expose
-    @SerializedName("ReferenceNumber")
-    @Required
-    private String referenceNumber;
-
-    public EmailCheckResultSqsMessage(
-            String email,
-            EmailCheckResultStatus emailCheckResultStatus,
-            long timeToExist,
-            String referenceNumber) {
-        this.email = email;
-        this.emailCheckResultStatus = emailCheckResultStatus;
-        this.timeToExist = timeToExist;
-        this.referenceNumber = referenceNumber;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public EmailCheckResultStatus getEmailCheckResultStatus() {
-        return emailCheckResultStatus;
-    }
-
-    public long getTimeToExist() {
-        return timeToExist;
-    }
-
-    public String getReferenceNumber() {
-        return referenceNumber;
-    }
-}
+public record EmailCheckResultSqsMessage(
+        @Expose @SerializedName("Email") @Required String email,
+        @Expose @SerializedName("Status") @Required EmailCheckResultStatus emailCheckResultStatus,
+        @Expose @SerializedName("TimeToExist") @Required long timeToExist,
+        @Expose @SerializedName("ReferenceNumber") @Required String referenceNumber) {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultStore.java
@@ -10,10 +10,12 @@ public class EmailCheckResultStore {
     public static final String ATTRIBUTE_EMAIL = "Email";
     public static final String ATTRIBUTE_STATUS = "Status";
     public static final String ATTRIBUTE_TIME_TO_EXIST = "TimeToExist";
+    public static final String ATTRIBUTE_REFERENCE_NUMBER = "ReferenceNumber";
 
     private String email;
     private EmailCheckResultStatus status;
     private long timeToExist;
+    private String referenceNumber;
 
     @DynamoDbPartitionKey
     @DynamoDbAttribute(ATTRIBUTE_EMAIL)
@@ -55,6 +57,20 @@ public class EmailCheckResultStore {
 
     public EmailCheckResultStore withTimeToExist(long timeToExist) {
         this.timeToExist = timeToExist;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_REFERENCE_NUMBER)
+    public String getReferenceNumber() {
+        return referenceNumber;
+    }
+
+    public void setReferenceNumber(String referenceNumber) {
+        this.referenceNumber = referenceNumber;
+    }
+
+    public EmailCheckResultStore withReferenceNumber(String referenceNumber) {
+        this.referenceNumber = referenceNumber;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/EmailCheckResultWriterHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/EmailCheckResultWriterHandler.java
@@ -1,0 +1,75 @@
+package uk.gov.di.authentication.shared.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.EmailCheckResultSqsMessage;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.serialization.Json.JsonException;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+
+public class EmailCheckResultWriterHandler implements RequestHandler<SQSEvent, Void> {
+
+    private static final Logger LOG = LogManager.getLogger(EmailCheckResultWriterHandler.class);
+    private final Json objectMapper = SerializationService.getInstance();
+    private final DynamoEmailCheckResultService db;
+
+    public EmailCheckResultWriterHandler(DynamoEmailCheckResultService databaseService) {
+        this.db = databaseService;
+    }
+
+    public EmailCheckResultWriterHandler(ConfigurationService configService) {
+        this.db = new DynamoEmailCheckResultService(configService);
+    }
+
+    public EmailCheckResultWriterHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    @Override
+    public Void handleRequest(SQSEvent event, Context context) {
+        return segmentedFunctionCall(
+                "shared-api::" + getClass().getSimpleName(),
+                () -> emailCheckResultWriterHandler(event));
+    }
+
+    public Void emailCheckResultWriterHandler(SQSEvent event) {
+        LOG.info(
+                "EmailCheckResultWriterHandler has been invoked with {} record(s)",
+                event.getRecords().size());
+        for (SQSMessage msg : event.getRecords()) {
+            try {
+                LOG.info("Message received from SQS queue");
+                EmailCheckResultSqsMessage emailCheckResult =
+                        objectMapper.readValue(msg.getBody(), EmailCheckResultSqsMessage.class);
+
+                db.saveEmailCheckResult(
+                        emailCheckResult.getEmail(),
+                        emailCheckResult.getEmailCheckResultStatus(),
+                        emailCheckResult.getTimeToExist(),
+                        emailCheckResult.getReferenceNumber());
+
+                LOG.info(
+                        "Message for email check reference {} written to database",
+                        emailCheckResult.getReferenceNumber());
+
+            } catch (JsonException e) {
+                LOG.error("Error when mapping message from queue to a EmailCheckResultSqsMessage");
+                throw new RuntimeException(
+                        "Error when mapping message from queue to a EmailCheckResultSqsMessage", e);
+            } catch (Exception e) {
+                LOG.error("An unexpected error occurred in the EmailCheckResultWriterHandler", e);
+                throw new RuntimeException(
+                        "An unexpected error occurred in the EmailCheckResultWriterHandler", e);
+            }
+        }
+        return null;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/EmailCheckResultWriterHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/EmailCheckResultWriterHandler.java
@@ -51,14 +51,14 @@ public class EmailCheckResultWriterHandler implements RequestHandler<SQSEvent, V
                         objectMapper.readValue(msg.getBody(), EmailCheckResultSqsMessage.class);
 
                 db.saveEmailCheckResult(
-                        emailCheckResult.getEmail(),
-                        emailCheckResult.getEmailCheckResultStatus(),
-                        emailCheckResult.getTimeToExist(),
-                        emailCheckResult.getReferenceNumber());
+                        emailCheckResult.email(),
+                        emailCheckResult.emailCheckResultStatus(),
+                        emailCheckResult.timeToExist(),
+                        emailCheckResult.referenceNumber());
 
                 LOG.info(
                         "Message for email check reference {} written to database",
-                        emailCheckResult.getReferenceNumber());
+                        emailCheckResult.referenceNumber());
 
             } catch (JsonException e) {
                 LOG.error("Error when mapping message from queue to a EmailCheckResultSqsMessage");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoEmailCheckResultService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoEmailCheckResultService.java
@@ -18,12 +18,13 @@ public class DynamoEmailCheckResultService extends BaseDynamoService<EmailCheckR
     }
 
     public void saveEmailCheckResult(
-            String email, EmailCheckResultStatus status, Long timeToExist) {
+            String email, EmailCheckResultStatus status, Long timeToExist, String referenceNumber) {
         var emailCheckResult =
                 new EmailCheckResultStore()
                         .withEmail(email)
                         .withStatus(status)
-                        .withTimeToExist(timeToExist);
+                        .withTimeToExist(timeToExist)
+                        .withReferenceNumber(referenceNumber);
         put(emailCheckResult);
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/lambda/EmailCheckResultWriterHandlerTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/lambda/EmailCheckResultWriterHandlerTest.java
@@ -1,0 +1,104 @@
+package uk.gov.di.authentication.shared.lambda;
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
+import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class EmailCheckResultWriterHandlerTest {
+    private static final String TEST_MSG_EMAIL = "test@test.com";
+    private static final long TEST_MSG_TIME_TO_EXIST = 1706870420L;
+    private static final String TEST_MSG_REF_NUMBER = "123456-abc1234def5678";
+    private static DynamoEmailCheckResultService dbMock;
+    private static ArgumentCaptor<String> emailCaptor;
+    private static ArgumentCaptor<EmailCheckResultStatus> statusCaptor;
+    private static ArgumentCaptor<Long> timeToExistCaptor;
+    private static ArgumentCaptor<String> referenceNumberCaptor;
+    private EmailCheckResultWriterHandler handler;
+
+    @BeforeAll
+    static void init() {
+        dbMock = mock(DynamoEmailCheckResultService.class);
+        emailCaptor = ArgumentCaptor.forClass(String.class);
+        statusCaptor = ArgumentCaptor.forClass(EmailCheckResultStatus.class);
+        timeToExistCaptor = ArgumentCaptor.forClass(Long.class);
+        referenceNumberCaptor = ArgumentCaptor.forClass(String.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        handler = new EmailCheckResultWriterHandler(dbMock);
+    }
+
+    @Test
+    void shouldProcessValidSQSEventWithSingleMessageAndSaveToDatabase() {
+        var emailCheckResultStatus = EmailCheckResultStatus.ALLOW;
+        SQSEvent event = getSqsEventWithSingleMessage(true, emailCheckResultStatus);
+
+        handler.emailCheckResultWriterHandler(event);
+
+        verify(dbMock)
+                .saveEmailCheckResult(
+                        emailCaptor.capture(), statusCaptor.capture(),
+                        timeToExistCaptor.capture(), referenceNumberCaptor.capture());
+
+        assertEquals(TEST_MSG_EMAIL, emailCaptor.getValue());
+        assertEquals(emailCheckResultStatus, statusCaptor.getValue());
+        assertEquals(TEST_MSG_TIME_TO_EXIST, timeToExistCaptor.getValue());
+        assertEquals(TEST_MSG_REF_NUMBER, referenceNumberCaptor.getValue());
+    }
+
+    @Test
+    void shouldRethrowRuntimeErrorOnSQSEventWithSingleInvalidMessage() {
+        SQSEvent event = getSqsEventWithSingleMessage(false);
+
+        RuntimeException thrown =
+                assertThrows(
+                        RuntimeException.class, () -> handler.emailCheckResultWriterHandler(event));
+
+        assertEquals(
+                "Error when mapping message from queue to a EmailCheckResultSqsMessage",
+                thrown.getMessage());
+    }
+
+    @NotNull
+    private static SQSEvent getSqsEventWithSingleMessage(boolean doesMessageContainRequiredFields) {
+        return getSqsEventWithSingleMessage(
+                doesMessageContainRequiredFields, EmailCheckResultStatus.ALLOW);
+    }
+
+    @NotNull
+    private static SQSEvent getSqsEventWithSingleMessage(
+            boolean doesMessageContainRequiredFields, EmailCheckResultStatus status) {
+        SQSEvent event = new SQSEvent();
+        SQSMessage sqsMessage = new SQSMessage();
+
+        if (doesMessageContainRequiredFields) {
+            sqsMessage.setBody(
+                    String.format(
+                            "{ \"Email\": \"%s\", \"Status\": \"%s\", \"TimeToExist\": \"%d\", \"ReferenceNumber\": \"%s\" }",
+                            TEST_MSG_EMAIL,
+                            status.toString(),
+                            TEST_MSG_TIME_TO_EXIST,
+                            TEST_MSG_REF_NUMBER));
+        } else {
+            sqsMessage.setBody(("{}"));
+        }
+
+        List<SQSMessage> records = List.of(sqsMessage);
+        event.setRecords(records);
+        return event;
+    }
+}


### PR DESCRIPTION
## What?
- Add email check result handler 
- Also add a field to the expected SQS and Dynamo store as agreed schema changed since initial work was done on that (see "Related PRs")
- This extra field will allow us to trace a request from the point that it is triggered all the way through to the result storage
- Note: the extra DB field is kept separate in the first commit. Subsequent work to implement the handler (the main focus of the Jira ticket) is in the second commit

## Why?
- This will record the results of a counter fraud check of emails (implementation details of that check are in a separate private repository)
- The results of that check can be used to block certain user journeys in case of a negative result (not currently implemented)

## Related PRs
- As noted above, the work of this PR has been augmented to add a further field reflecting a constant reference number: https://github.com/govuk-one-login/authentication-api/pull/3826
