### PR TITLE
AUT-2268: Update existing experian phone checker lambda to consume the new sqs events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,6 +295,7 @@ task oidcTerraform (type: Terraform) {
             environment "FRONTEND_API_KEY", json.frontend_api_key.value
             environment "EVENTS_SNS_TOPIC_ARN", json.events_sns_topic_arn.value
             environment "EMAIL_QUEUE_URL", json.email_queue.value
+            environment "EXPERIAN_PHONE_CHECKER_QUEUE_URL", json.experian_phone_checker_queue.value
         }
         allprojects.findAll {it.name == "account-management-integration-tests"}.first().tasks.getByName("test") {
             environment "EVENTS_SNS_TOPIC_ARN", json.events_sns_topic_arn.value

--- a/ci/terraform/oidc/experian_phone_checker.tf
+++ b/ci/terraform/oidc/experian_phone_checker.tf
@@ -1,0 +1,218 @@
+module "experian_phone_checker_sqs_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "experian-phone-checker-shared-sqs"
+  vpc_arn     = local.authentication_vpc_arn
+}
+
+resource "aws_sqs_queue" "experian_phone_checker_queue" {
+  name                       = "${var.environment}-experian-phone-checker-queue"
+  max_message_size           = 2048
+  message_retention_seconds  = 60
+  visibility_timeout_seconds = 180
+
+  kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
+  kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.experian_phone_checker_dead_letter_queue.arn
+    maxReceiveCount     = 3
+  })
+
+  tags = local.default_tags
+}
+
+
+resource "aws_sqs_queue" "experian_phone_checker_dead_letter_queue" {
+  name          = "${var.environment}-experian_phone_checker-dlq"
+  delay_seconds = 300
+
+  kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
+  kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
+
+  message_retention_seconds = 3600 * 6
+
+  tags = local.default_tags
+}
+
+data "aws_iam_policy_document" "experian_phone_checker_queue_policy_document" {
+  statement {
+    sid    = "SendSQS"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [module.frontend_api_verify_mfa_code_role.arn]
+    }
+
+    actions = [
+      "sqs:SendMessage",
+      "sqs:ChangeMessageVisibility",
+      "sqs:GetQueueAttributes",
+    ]
+
+    resources = [
+      aws_sqs_queue.experian_phone_checker_queue.arn
+    ]
+  }
+
+  statement {
+    sid    = "ReceiveSQS"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [module.experian_phone_checker_sqs_role.arn]
+    }
+
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+    ]
+
+    resources = [
+      aws_sqs_queue.experian_phone_checker_queue.arn
+    ]
+  }
+
+  depends_on = [
+    module.experian_phone_checker_sqs_role,
+    module.frontend_api_verify_mfa_code_role,
+  ]
+}
+
+data "aws_iam_policy_document" "experian_phone_checker_dl_queue_policy_document" {
+  statement {
+    sid    = "SendAndReceive"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root", module.experian_phone_checker_sqs_role.arn]
+    }
+
+    actions = [
+      "sqs:SendMessage",
+      "sqs:ReceiveMessage",
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+    ]
+
+    resources = [aws_sqs_queue.experian_phone_checker_dead_letter_queue.arn]
+  }
+
+  depends_on = [
+    module.experian_phone_checker_sqs_role,
+  ]
+}
+
+resource "aws_sqs_queue_policy" "experian_phone_checker_dl_queue_policy" {
+  depends_on = [
+    data.aws_iam_policy_document.experian_phone_checker_dl_queue_policy_document,
+  ]
+
+  queue_url = aws_sqs_queue.experian_phone_checker_dead_letter_queue.id
+  policy    = data.aws_iam_policy_document.experian_phone_checker_dl_queue_policy_document.json
+}
+
+resource "aws_sqs_queue_policy" "experian_phone_checker_queue_policy" {
+  depends_on = [
+    data.aws_iam_policy_document.email_queue_policy_document,
+  ]
+
+  queue_url = aws_sqs_queue.experian_phone_checker_queue.id
+  policy    = data.aws_iam_policy_document.experian_phone_checker_queue_policy_document.json
+}
+
+resource "aws_lambda_function" "experian_phone_checker_sqs_lambda" {
+  function_name = "${var.environment}-experian-phone-checker-sqs-lambda"
+  role          = module.experian_phone_checker_sqs_role.arn
+  handler       = "uk.gov.di.authentication.contraindicators.experianphonecheck.lambda.ExperianPhoneCheckSQSHandler::handleRequest"
+  timeout       = 30
+  memory_size   = 512
+  runtime       = "java17"
+  publish       = true
+
+  s3_bucket         = aws_s3_bucket.source_bucket.bucket
+  s3_key            = aws_s3_object.frontend_api_release_zip.key
+  s3_object_version = aws_s3_object.frontend_api_release_zip.version_id
+
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  vpc_config {
+    security_group_ids = [local.authentication_egress_security_group_id]
+    subnet_ids         = local.authentication_private_subnet_ids
+  }
+  environment {
+    variables = merge(var.notify_template_map, {
+      JAVA_TOOL_OPTIONS = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+    })
+  }
+  kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
+
+  tags = local.default_tags
+
+  depends_on = [
+    module.experian_phone_checker_sqs_role,
+  ]
+}
+
+resource "aws_lambda_alias" "experian_sqs_lambda_active" {
+  name             = "${aws_lambda_function.experian_phone_checker_sqs_lambda.function_name}-active"
+  description      = "Alias pointing at active version of Lambda"
+  function_name    = aws_lambda_function.experian_phone_checker_sqs_lambda.arn
+  function_version = aws_lambda_function.experian_phone_checker_sqs_lambda.version
+}
+
+resource "aws_lambda_event_source_mapping" "experian_lambda_sqs_mapping" {
+  event_source_arn = aws_sqs_queue.experian_phone_checker_queue.arn
+  function_name    = aws_lambda_function.experian_phone_checker_sqs_lambda.arn
+
+  depends_on = [
+    aws_sqs_queue.experian_phone_checker_queue,
+    aws_sqs_queue_policy.experian_phone_checker_queue_policy,
+    aws_lambda_function.experian_phone_checker_sqs_lambda,
+    module.experian_phone_checker_sqs_role
+  ]
+}
+
+resource "aws_lambda_event_source_mapping" "experian_dlq_lambda_sqs_mapping" {
+  event_source_arn = aws_sqs_queue.experian_phone_checker_dead_letter_queue.arn
+  function_name    = aws_lambda_function.experian_phone_checker_sqs_lambda.arn
+
+  depends_on = [
+    aws_sqs_queue.experian_phone_checker_dead_letter_queue,
+    aws_sqs_queue_policy.experian_phone_checker_dl_queue_policy,
+    aws_lambda_function.experian_phone_checker_sqs_lambda,
+    module.experian_phone_checker_sqs_role
+  ]
+}
+
+resource "aws_cloudwatch_log_group" "experian_sqs_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+
+  name              = "/aws/lambda/${aws_lambda_function.experian_phone_checker_sqs_lambda.function_name}"
+  tags              = local.default_tags
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
+
+  depends_on = [
+    aws_lambda_function.experian_phone_checker_sqs_lambda
+  ]
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "experian_sqs_lambda_log_subscription" {
+  count = length(var.logging_endpoint_arns)
+
+  name            = "${aws_lambda_function.experian_phone_checker_sqs_lambda.function_name}-log-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.sqs_lambda_log_group[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}

--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -31,6 +31,10 @@ output "email_queue" {
   value = aws_sqs_queue.email_queue.id
 }
 
+output "experian_phone_checker_queue" {
+  value = aws_sqs_queue.experian_phone_checker_queue.id
+}
+
 output "analytics_cookie_domain" {
   value = local.service_domain
 }

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -259,6 +259,11 @@ variable "test_clients_enabled" {
   default = "false"
 }
 
+variable "phone_checker_with_reply" {
+  type    = string
+  default = "false"
+}
+
 variable "client_registry_api_enabled" {
   default = true
 }

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -40,6 +40,7 @@ module "verify_mfa_code" {
     TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP = var.test_client_verify_phone_number_otp
     TEST_CLIENTS_ENABLED                = var.test_clients_enabled
     INTERNAl_SECTOR_URI                 = var.internal_sector_uri
+    EXPERIAN_PHONE_CHECKER_QUEUE_URL    = aws_sqs_queue.experian_phone_checker_queue.id
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler::handleRequest"
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/PhoneNumberRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/PhoneNumberRequest.java
@@ -1,0 +1,60 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+
+public class PhoneNumberRequest {
+    @Expose
+    @SerializedName("phoneNumberVerified")
+    private boolean phoneNumberVerified;
+
+    @Expose
+    @SerializedName("phoneNumber")
+    private String phoneNumber;
+
+    @Expose
+    @SerializedName("updatedPhoneNumber")
+    private boolean updatedPhoneNumber;
+
+    @Expose
+    @SerializedName("journeyType")
+    private JourneyType journeyType;
+
+    @Expose
+    @SerializedName("internalCommonSubjectIdentifier")
+    private String internalCommonSubjectIdentifier;
+
+    public PhoneNumberRequest(
+            boolean phoneNumberVerified,
+            String phoneNumber,
+            boolean updatedPhoneNumber,
+            JourneyType journeyType,
+            String internalCommonSubjectIdentifier) {
+        this.phoneNumberVerified = phoneNumberVerified;
+        this.phoneNumber = phoneNumber;
+        this.updatedPhoneNumber = updatedPhoneNumber;
+        this.journeyType = journeyType;
+        this.internalCommonSubjectIdentifier = internalCommonSubjectIdentifier;
+    }
+
+    public boolean isPhoneNumberVerified() {
+        return phoneNumberVerified;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public boolean isUpdatedPhoneNumber() {
+        return updatedPhoneNumber;
+    }
+
+    public JourneyType getJourneyType() {
+        return journeyType;
+    }
+
+    public String getInternalCommonSubjectIdentifier() {
+        return internalCommonSubjectIdentifier;
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
@@ -8,6 +8,7 @@ import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
@@ -24,6 +25,7 @@ class MfaCodeProcessorFactoryTest {
     private final AuditService auditService = mock(AuditService.class);
     private final UserContext userContext = mock(UserContext.class);
     private final Session session = mock(Session.class);
+    private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final DynamoAccountModifiersService accountModifiersService =
             mock(DynamoAccountModifiersService.class);
     private final MfaCodeProcessorFactory mfaCodeProcessorFactory =
@@ -61,6 +63,7 @@ class MfaCodeProcessorFactoryTest {
     void whenMfaMethodGeneratesPhoneNumberCodeProcessor() {
         when(session.getEmailAddress()).thenReturn("test@test.com");
         when(userContext.getSession()).thenReturn(session);
+        when(configurationService.getAwsRegion()).thenReturn("eu-west-2");
         var mfaCodeProcessor =
                 mfaCodeProcessorFactory.getMfaCodeProcessor(
                         MFAMethodType.SMS,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -258,6 +258,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("EMAIL_QUEUE_URL");
     }
 
+    public String getExperianPhoneCheckerQueueUri() {
+        return System.getenv("EXPERIAN_PHONE_CHECKER_QUEUE_URL");
+    }
+
     public String getSpotQueueUri() {
         return System.getenv("SPOT_QUEUE_URL");
     }
@@ -536,6 +540,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public boolean isTestClientsEnabled() {
         return System.getenv().getOrDefault("TEST_CLIENTS_ENABLED", "false").equals("true");
+    }
+
+    public boolean isPhoneCheckerWithReplyEnabled() {
+        return System.getenv().getOrDefault("PHONE_CHECKER_WITH_RETRY", "false").equals("true");
     }
 
     public String getSyntheticsUsers() {


### PR DESCRIPTION
## What?

Updating the experian phone checker lambda to send a phone check request the sqs queue. A feature swtich has been implemented for this.

## Why?

When the Experian Phone Checker service (owned by Experian) has an outage then checks against phone numbers fail and do not happen.  There is no failure or DLQ for the transactions, so we have no way of trying to run them again.  The service has failed a few times recently which generates alerts that we have to deal with, but we are unable to recover the transactions.

## Related PRs
AUT-2103: https://govukverify.atlassian.net/jira/software/c/projects/AUT/boards/477?assignee=712020%3A83ea1983-6d9e-47b3-9dab-b7bf994a488b&assignee=712020%3Ad3baca0d-e361-43cf-9972-bc82fc554739&selectedIssue=AUT-2103
