### PR TITLE
ATO-159: Fix production urls in tf for stub clients

### DIFF
--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -41,10 +41,10 @@ stub_rp_clients = [
   {
     client_name = "relying-party-stub-production"
     callback_urls = [
-      "https://rp-production.stubs.account.gov.uk/oidc/authorization-code/callback",
+      "https://rp.stubs.account.gov.uk/oidc/authorization-code/callback",
     ]
     logout_urls = [
-      "https://rp-production.stubs.account.gov.uk/signed-out",
+      "https://rp.stubs.account.gov.uk/signed-out",
     ]
     test_client                     = "0"
     consent_required                = "0"
@@ -61,10 +61,10 @@ stub_rp_clients = [
   {
     client_name = "relying-party-stub-production-app"
     callback_urls = [
-      "https://doc-app-rp-production.stubs.account.gov.uk/oidc/authorization-code/callback",
+      "https://doc-app-rp.stubs.account.gov.uk/oidc/authorization-code/callback",
     ]
     logout_urls = [
-      "https://doc-app-rp-production.stubs.account.gov.uk/signed-out",
+      "https://doc-app-rp.stubs.account.gov.uk/signed-out",
     ]
     test_client                     = "1"
     consent_required                = "0"


### PR DESCRIPTION
## What?

Fix prod urls in terraform for stub clients
## Why?

They were incorrect originally

