### PR TITLE
AUT-2318: audit event and user feedback on 5th failed login attempt

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -178,7 +178,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                 } else {
                     codeStorageService.increaseIncorrectPasswordCount(request.getEmail());
                 }
-
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
                         userContext.getClientSessionId(),
@@ -194,6 +193,27 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                                 "incorrectPasswordCount",
                                 codeStorageService.getIncorrectPasswordCount(request.getEmail())),
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
+
+                if (incorrectPasswordCount + 1 >= configurationService.getMaxPasswordRetries()) {
+                    LOG.info("User has now exceeded max password retries");
+
+                    auditService.submitAuditEvent(
+                            FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
+                            userContext.getClientSessionId(),
+                            userContext.getSession().getSessionId(),
+                            clientId,
+                            internalCommonSubjectIdentifier.getValue(),
+                            userProfile.getEmail(),
+                            IpAddressHelper.extractIpAddress(input),
+                            userProfile.getPhoneNumber(),
+                            persistentSessionId,
+                            pair("internalSubjectId", userProfile.getSubjectID()),
+                            pair(
+                                    "attemptNoFailedAt",
+                                    configurationService.getMaxPasswordRetries()));
+
+                    return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1028);
+                }
 
                 return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
             }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -694,7 +694,7 @@ class LoginHandlerTest {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
-        when(codeStorageService.getIncorrectPasswordCountReauthJourney(EMAIL)).thenReturn(5);
+        when(codeStorageService.getIncorrectPasswordCountReauthJourney(EMAIL)).thenReturn(4);
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
         usingDefaultVectorOfTrust();


### PR DESCRIPTION
## What?

The application will record the first instance of the AUTH_ACCOUNT_TEMPORARILY_LOCKED event on the login attempt where the user is locked out and not the subsequent attempt.

## Why?

During investigation of https://govukverify.atlassian.net/browse/AUT-2316  it was found that there was less than 15 minutes between events AUTH_ACCOUNT_TEMPORARILY_LOCKED and  AUTH_LOG_IN_SUCCESS which lead to the belief that the 15 minute timeout was not working as expected. 

The application only records the AUTH_ACCOUNT_TEMPORARILY_LOCKED event if the user makes a subsequent attempt after being locked out so the lockout actually started on the last instance of AUTH_INVALID_CREDENTIALS prior to this.