### PR TITLE
ATO-159: Add performance testing stub to staging

### DIFF
--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -97,4 +97,24 @@ stub_rp_clients = [
     one_login_service = false
     service_type      = "MANDATORY"
   },
+  {
+    client_name = "relying-party-stub-staging-perf-test"
+    callback_urls = [
+      "https://perf-test-rp-staging.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://perf-test-rp-staging.build.stubs.account.gov.uk/signed-out",
+    ]
+    test_client                     = "1"
+    consent_required                = "0"
+    identity_verification_supported = "1"
+    client_type                     = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
+    one_login_service = false
+    service_type      = "MANDATORY"
+  },
 ]


### PR DESCRIPTION
## What?

Add performance testing stub to staging db
## Why?

To allow performance testers to use the stub