### PR TITLE
ATO-251: Tidy and tag deprecated code

### DIFF
--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -34,7 +34,6 @@ import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.NoSessionEntity;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
-import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
@@ -57,6 +56,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -113,8 +113,7 @@ class DocAppCallbackHandlerTest {
     private final Session session = new Session(SESSION_ID).setEmailAddress(TEST_EMAIL_ADDRESS);
 
     private final ClientSession clientSession =
-            new ClientSession(
-                    generateAuthRequest().toParameters(), null, (VectorOfTrust) null, null);
+            new ClientSession(generateAuthRequest().toParameters(), null, emptyList(), null);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -119,12 +120,12 @@ public class IpvTokenTest {
 
     private final ClientSession clientSession =
             new ClientSession(
-                            generateAuthRequest(new OIDCClaimsRequest()).toParameters(),
-                            null,
+                    generateAuthRequest(new OIDCClaimsRequest()).toParameters(),
+                    null,
+                    List.of(
                             new VectorOfTrust(CredentialTrustLevel.LOW_LEVEL),
-                            CLIENT_NAME)
-                    .setEffectiveVectorOfTrust(
-                            new VectorOfTrust(CredentialTrustLevel.MEDIUM_LEVEL));
+                            new VectorOfTrust(CredentialTrustLevel.MEDIUM_LEVEL)),
+                    CLIENT_NAME);
 
     private final String ACCESS_TOKEN_FIELD = "access_token";
     private final String TOKEN_TYPE_FIELD = "token_type";

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvUserIdentityTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvUserIdentityTest.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -119,12 +120,12 @@ public class IpvUserIdentityTest {
 
     private final ClientSession clientSession =
             new ClientSession(
-                            generateAuthRequest(new OIDCClaimsRequest()).toParameters(),
-                            null,
+                    generateAuthRequest(new OIDCClaimsRequest()).toParameters(),
+                    null,
+                    List.of(
                             new VectorOfTrust(CredentialTrustLevel.LOW_LEVEL),
-                            CLIENT_NAME)
-                    .setEffectiveVectorOfTrust(
-                            new VectorOfTrust(CredentialTrustLevel.MEDIUM_LEVEL));
+                            new VectorOfTrust(CredentialTrustLevel.MEDIUM_LEVEL)),
+                    CLIENT_NAME);
 
     private AccessToken accessToken;
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
@@ -49,7 +49,6 @@ import java.util.Map;
 import java.util.Optional;
 
 public class OrchestrationAuthorizationService {
-
     public static final String VTR_PARAM = "vtr";
     public static final String AUTHENTICATION_STATE_STORAGE_PREFIX = "auth-state:";
     private static final JWSAlgorithm SIGNING_ALGORITHM = JWSAlgorithm.ES256;
@@ -197,10 +196,6 @@ public class OrchestrationAuthorizationService {
             URI redirectUri, State state, ResponseMode responseMode, ErrorObject errorObject) {
         LOG.info("Generating Authentication Error Response");
         return new AuthenticationErrorResponse(redirectUri, errorObject, state, responseMode);
-    }
-
-    public VectorOfTrust getEffectiveVectorOfTrust(AuthenticationRequest authenticationRequest) {
-        return VectorOfTrust.orderVtrList(getVtrList(authenticationRequest)).get(0);
     }
 
     public List<VectorOfTrust> getVtrList(AuthenticationRequest authenticationRequest) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
@@ -244,11 +244,6 @@ class OrchestrationAuthorizationServiceTest {
     }
 
     private ClientRegistry generateClientRegistry(
-            String redirectURI, String clientID, List<String> scopes) {
-        return generateClientRegistry(redirectURI, clientID, scopes, false);
-    }
-
-    private ClientRegistry generateClientRegistry(
             String redirectURI, String clientID, List<String> scopes, boolean testClient) {
         return new ClientRegistry()
                 .withRedirectUrls(singletonList(redirectURI))

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
@@ -4,7 +4,6 @@ import com.google.gson.annotations.Expose;
 import com.nimbusds.oauth2.sdk.id.Subject;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -16,25 +15,19 @@ public class ClientSession {
 
     @Expose private LocalDateTime creationDate;
 
-    @Expose private VectorOfTrust effectiveVectorOfTrust;
+    /**
+     * @deprecated ClientSession is to use vtrList and no longer use effectiveVectorOfTrust. Must be
+     *     retained until Authentication no longer depend on this field.
+     */
+    @Deprecated(forRemoval = true)
+    @Expose
+    private VectorOfTrust effectiveVectorOfTrust;
 
-    @Expose private List<VectorOfTrust> vtrList = new ArrayList<>();
+    @Expose private List<VectorOfTrust> vtrList;
 
     @Expose private Subject docAppSubjectId;
 
     @Expose private String clientName;
-
-    public ClientSession(
-            Map<String, List<String>> authRequestParams,
-            LocalDateTime creationDate,
-            VectorOfTrust effectiveVectorOfTrust,
-            String clientName) {
-        this.authRequestParams = authRequestParams;
-        this.creationDate = creationDate;
-        this.effectiveVectorOfTrust = effectiveVectorOfTrust;
-        this.vtrList.add(effectiveVectorOfTrust);
-        this.clientName = clientName;
-    }
 
     public ClientSession(
             Map<String, List<String>> authRequestParams,
@@ -69,12 +62,6 @@ public class ClientSession {
 
     public List<VectorOfTrust> getVtrList() {
         return vtrList;
-    }
-
-    public ClientSession setEffectiveVectorOfTrust(VectorOfTrust effectiveVectorOfTrust) {
-        this.effectiveVectorOfTrust = effectiveVectorOfTrust;
-        this.vtrList.add(effectiveVectorOfTrust);
-        return this;
     }
 
     public Subject getDocAppSubjectId() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSessionService.java
@@ -51,15 +51,6 @@ public class ClientSessionService {
     public ClientSession generateClientSession(
             Map<String, List<String>> authRequestParams,
             LocalDateTime creationDate,
-            VectorOfTrust effectiveVectorOfTrust,
-            String clientName) {
-        return new ClientSession(
-                authRequestParams, creationDate, List.of(effectiveVectorOfTrust), clientName);
-    }
-
-    public ClientSession generateClientSession(
-            Map<String, List<String>> authRequestParams,
-            LocalDateTime creationDate,
             List<VectorOfTrust> vtrList,
             String clientName) {
         return new ClientSession(authRequestParams, creationDate, vtrList, clientName);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelperTest.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -177,7 +178,7 @@ class DocAppUserHelperTest {
                 new ClientSession(
                         authRequest.toParameters(),
                         LocalDateTime.now(),
-                        VectorOfTrust.getDefaults(),
+                        List.of(VectorOfTrust.getDefaults()),
                         CLIENT_NAME);
         subject.ifPresent(clientSession::setDocAppSubjectId);
         var clientRegistry =

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSessionServiceTest.java
@@ -137,7 +137,7 @@ class ClientSessionServiceTest {
                 new ClientSession(
                         Map.of("authparam", List.of("v1", "v2")),
                         LocalDateTime.now(),
-                        VectorOfTrust.getDefaults(),
+                        List.of(VectorOfTrust.getDefaults()),
                         "client-name"));
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationServiceTest.java
@@ -12,7 +12,6 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
-import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 
 import java.net.URI;
@@ -20,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -253,6 +253,6 @@ class NoSessionOrchestrationServiceTest {
                         .state(new State())
                         .nonce(new Nonce())
                         .build();
-        return new ClientSession(authRequest.toParameters(), null, (VectorOfTrust) null, null);
+        return new ClientSession(authRequest.toParameters(), null, emptyList(), null);
     }
 }


### PR DESCRIPTION
## What?

Remove instances of `effectiveVectorOfTrust` and tag deprecated field

## Why?

To remove dead code and mark code for deletion for when auth no longer depends on it

## Related PRs
https://github.com/govuk-one-login/authentication-api/pull/3887
https://github.com/govuk-one-login/authentication-api/pull/3889
https://github.com/govuk-one-login/authentication-api/pull/3897
