### PR TITLE
AUT-2340: Add `isEmailCheckEnabled` flag to authentication `ConfigurationService`

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -161,6 +161,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("SUPPORT_AUTH_ORCH_SPLIT", "false").equals("true");
     }
 
+    public boolean isEmailCheckEnabled() {
+        return System.getenv().getOrDefault("SUPPORT_EMAIL_CHECK_ENABLED", "false").equals("true");
+    }
+
     public boolean isBulkUserEmailEmailSendingEnabled() {
         return System.getenv()
                 .getOrDefault("BULK_USER_EMAIL_EMAIL_SENDING_ENABLED", "false")


### PR DESCRIPTION
## What?

Adds an `isEmailCheckEnabled` flag, backed by `SUPPORT_EMAIL_CHECK_ENABLED` to the authentication `ConfigurationService`.

## Why?

This allows the bypassing of the email checking logic in stable environments while the feature is being developed.

## Related PRs

This will be used by:
- https://github.com/govuk-one-login/authentication-api/pull/3912
- https://github.com/govuk-one-login/authentication-api/pull/3891

