### PR TITLE
AUT-2273: Add terraform to deploy email check result writer lambda

### DIFF
--- a/ci/terraform/shared/kms-policies.tf
+++ b/ci/terraform/shared/kms-policies.tf
@@ -152,3 +152,25 @@ data "aws_iam_policy_document" "user_profile_encryption_key_policy_document" {
     ]
   }
 }
+
+resource "aws_iam_policy" "email_check_results_encryption_key_kms_policy" {
+  name        = "${var.environment}-email-check-results-table-encryption-key-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS encryption of the email check results table"
+
+  policy = data.aws_iam_policy_document.email_check_results_encryption_key_kms_policy_document.json
+}
+
+data "aws_iam_policy_document" "email_check_results_encryption_key_kms_policy_document" {
+  statement {
+    sid    = "AllowAccessToEmailCheckResultsTableKmsEncryptionKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      aws_kms_key.email_check_result_encryption_key.arn
+    ]
+  }
+}

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -240,3 +240,7 @@ output "user_credentials_encryption_policy_arn" {
 output "user_profile_encryption_policy_arn" {
   value = aws_iam_policy.user_profile_encryption_key_kms_policy.arn
 }
+
+output "email_check_results_encryption_policy_arn" {
+  value = aws_iam_policy.email_check_results_encryption_key_kms_policy.arn
+}

--- a/ci/terraform/utils/email_check_results_writer_dynamo_access.tf
+++ b/ci/terraform/utils/email_check_results_writer_dynamo_access.tf
@@ -1,0 +1,27 @@
+data "aws_dynamodb_table" "email_check_results_table" {
+  name = "${var.environment}-email-check-result"
+}
+
+data "aws_iam_policy_document" "email_check_results_writer_dynamo_write_access" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+
+    resources = [
+      data.aws_dynamodb_table.email_check_results_table.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "email_check_results_writer_dynamo_write_access" {
+  name_prefix = "dynamo-access-policy"
+  description = "IAM policy managing write access for the Email Check Results Writer lambda to the Email Check Results table"
+
+  policy = data.aws_iam_policy_document.email_check_results_writer_dynamo_write_access.json
+}

--- a/ci/terraform/utils/email_check_results_writer_lambda.tf
+++ b/ci/terraform/utils/email_check_results_writer_lambda.tf
@@ -1,0 +1,104 @@
+resource "aws_lambda_event_source_mapping" "lambda_sqs_mapping" {
+  event_source_arn = var.email_check_results_sqs_queue_arn
+  function_name    = aws_lambda_function.email_check_results_writer_lambda.arn
+
+  depends_on = [
+    aws_lambda_function.email_check_results_writer_lambda,
+    aws_iam_policy.email_check_queue_policy,
+  ]
+}
+
+module "email_check_results_writer_role" {
+  source = "../modules/lambda-role"
+
+  environment = var.environment
+  role_name   = "email-check-results-writer"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.email_check_results_writer_dynamo_write_access.arn,
+    aws_iam_policy.email_check_queue_policy.arn,
+    aws_iam_policy.email_check_sqs_kms_decrypt_policy.arn,
+    local.email_check_results_encryption_policy_arn,
+  ]
+}
+
+resource "aws_lambda_function" "email_check_results_writer_lambda" {
+  #checkov:skip=CKV_AWS_116:No DLQ is required for this lambda, as it is SQS driven, and the SQS has a DLQ
+  function_name                  = "${var.environment}-email-check-writer"
+  role                           = module.email_check_results_writer_role.arn
+  handler                        = "uk.gov.di.authentication.utils.lambda.EmailCheckResultWriterHandler::handleRequest"
+  timeout                        = 30
+  memory_size                    = 512
+  runtime                        = "java17"
+  publish                        = true
+  reserved_concurrent_executions = 1000
+
+  s3_bucket         = aws_s3_object.utils_release_zip.bucket
+  s3_key            = aws_s3_object.utils_release_zip.key
+  s3_object_version = aws_s3_object.utils_release_zip.version_id
+
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  vpc_config {
+    security_group_ids = [local.authentication_egress_security_group_id]
+    subnet_ids         = local.authentication_private_subnet_ids
+  }
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  environment {
+    variables = {
+      JAVA_TOOL_OPTIONS = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+      ENVIRONMENT       = var.environment
+    }
+  }
+  kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+
+  tags = local.default_tags
+}
+
+resource "aws_lambda_alias" "email_check_results_writer_lambda" {
+  name             = replace("${var.environment}-${aws_lambda_function.email_check_results_writer_lambda.function_name}-lambda-active", ".", "")
+  description      = "Alias pointing at active version of Lambda"
+  function_name    = aws_lambda_function.email_check_results_writer_lambda.arn
+  function_version = aws_lambda_function.email_check_results_writer_lambda.version
+}
+
+resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrency_config" {
+  count = var.email_check_results_writer_provisioned_concurrency == 0 ? 0 : 1
+
+  function_name = aws_lambda_function.email_check_results_writer_lambda.function_name
+  qualifier     = aws_lambda_alias.email_check_results_writer_lambda.name
+
+  provisioned_concurrent_executions = var.email_check_results_writer_provisioned_concurrency
+}
+
+resource "aws_cloudwatch_log_group" "lambda_log_group" {
+  name       = "/aws/lambda/${aws_lambda_function.email_check_results_writer_lambda.function_name}"
+  tags       = local.default_tags
+  kms_key_id = local.cloudwatch_encryption_key_arn
+  #checkov:skip=CKV_AWS_338:Cloudwatch logs do not need to be retained for a year, as they are shipped elsewhere (Splunk)
+  retention_in_days = var.cloudwatch_log_retention
+
+  depends_on = [
+    aws_lambda_function.email_check_results_writer_lambda
+  ]
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
+  count           = length(var.logging_endpoint_arns)
+  name            = "${aws_lambda_function.email_check_results_writer_lambda.function_name}-log-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.lambda_log_group.name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}
+
+
+

--- a/ci/terraform/utils/email_check_results_writer_sqs_permissions.tf
+++ b/ci/terraform/utils/email_check_results_writer_sqs_permissions.tf
@@ -1,0 +1,49 @@
+### Permissions for Lambda to access SQS (including decrpyting messages)
+resource "aws_iam_policy" "email_check_queue_policy" {
+  depends_on = [
+    data.aws_iam_policy_document.email_check_result_queue_policy_document,
+  ]
+
+  policy = data.aws_iam_policy_document.email_check_result_queue_policy_document.json
+}
+
+data "aws_iam_policy_document" "email_check_result_queue_policy_document" {
+  statement {
+    sid    = "ReceiveSQS"
+    effect = "Allow"
+
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:ChangeMessageVisibility",
+    ]
+
+    resources = [
+      var.email_check_results_sqs_queue_arn
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "email_check_sqs_kms_decrypt_policy_document" {
+  statement {
+    actions   = ["kms:Decrypt"]
+    resources = [var.email_check_results_sqs_queue_encryption_key_arn]
+  }
+}
+
+resource "aws_iam_policy" "email_check_sqs_kms_decrypt_policy" {
+  name        = "LambdaExecutionPolicy"
+  description = "Policy for email check writer to decrypt email check results SQS messages (which are server-side encrypted with a customer managed key)"
+  policy      = data.aws_iam_policy_document.email_check_sqs_kms_decrypt_policy_document.json
+}
+
+### Permissions for SQS to trigger Lambda
+resource "aws_lambda_permission" "allow_sqs_invoke" {
+  statement_id  = "SQSInvokeFunction"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.email_check_results_writer_lambda.function_name
+
+  principal  = "sqs.amazonaws.com"
+  source_arn = var.email_check_results_sqs_queue_arn
+}

--- a/ci/terraform/utils/shared.tf
+++ b/ci/terraform/utils/shared.tf
@@ -9,15 +9,16 @@ data "terraform_remote_state" "shared" {
 }
 
 locals {
-  cloudwatch_encryption_key_arn            = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
-  bulk_user_email_table_encryption_key_arn = data.terraform_remote_state.shared.outputs.bulk_user_email_table_encryption_key_arn
-  lambda_env_vars_encryption_kms_key_arn   = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
-  lambda_code_signing_configuration_arn    = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
-  authentication_vpc_arn                   = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
-  authentication_private_subnet_ids        = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
-  authentication_security_group_id         = data.terraform_remote_state.shared.outputs.authentication_security_group_id
-  authentication_egress_security_group_id  = data.terraform_remote_state.shared.outputs.authentication_egress_security_group_id
-  user_profile_encryption_policy_arn       = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
+  cloudwatch_encryption_key_arn             = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  bulk_user_email_table_encryption_key_arn  = data.terraform_remote_state.shared.outputs.bulk_user_email_table_encryption_key_arn
+  lambda_env_vars_encryption_kms_key_arn    = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
+  lambda_code_signing_configuration_arn     = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
+  authentication_vpc_arn                    = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
+  authentication_private_subnet_ids         = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
+  authentication_security_group_id          = data.terraform_remote_state.shared.outputs.authentication_security_group_id
+  authentication_egress_security_group_id   = data.terraform_remote_state.shared.outputs.authentication_egress_security_group_id
+  user_profile_encryption_policy_arn        = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
+  email_check_results_encryption_policy_arn = data.terraform_remote_state.shared.outputs.email_check_results_encryption_policy_arn
   default_performance_parameters = {
     memory  = 1024,
     timeout = 900,

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -170,3 +170,17 @@ variable "internal_sector_uri" {
   type    = string
   default = "undefined"
 }
+
+variable "email_check_results_writer_provisioned_concurrency" {
+  description = "Provisioned concurrency for the email check results writer"
+  type        = number
+  default     = 1
+}
+
+variable "email_check_results_sqs_queue_arn" {
+  description = "ARN of the SQS email results check queue"
+}
+
+variable "email_check_results_sqs_queue_encryption_key_arn" {
+  description = "ARN of the CMK used for server side encryption on the SQS email results check queue"
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/EmailCheckResultWriterIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/EmailCheckResultWriterIntegrationTest.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.annotations.NotNull;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
-import uk.gov.di.authentication.shared.lambda.EmailCheckResultWriterHandler;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
+import uk.gov.di.authentication.utils.lambda.EmailCheckResultWriterHandler;
 
 import java.util.List;
 

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
@@ -1,4 +1,4 @@
-package uk.gov.di.authentication.shared.lambda;
+package uk.gov.di.authentication.utils.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandlerTest.java
@@ -1,12 +1,12 @@
-package uk.gov.di.authentication.shared.lambda;
+package uk.gov.di.authentication.utils.lambda;
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.annotations.NotNull;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 


### PR DESCRIPTION
## What?
- Add terraform to deploy email check result writer lambda

## Note on secrets

As a prerequisite for the pipeline to deploy this successfully, we have populated a number of secrets:
- /deploy/sandpit/email_check_results_sqs_queue_arn
- /deploy/sandpit/email_check_results_sqs_queue_encryption_key_arn
- /deploy/build/email_check_results_sqs_queue_arn
- /deploy/build/email_check_results_sqs_queue_encryption_key_arn
- /deploy/staging/email_check_results_sqs_queue_arn
- /deploy/staging/email_check_results_sqs_queue_encryption_key_arn
- /deploy/integration/email_check_results_sqs_queue_arn
- /deploy/integration/email_check_results_sqs_queue_encryption_key_arn
- /deploy/production/email_check_results_sqs_queue_arn
- /deploy/production/email_check_results_sqs_queue_encryption_key_arn

## Why?
- This will record the results of a counter fraud check of emails (implementation details of that check are in a separate private repository)
- The results of that check can be used to block certain user journeys in case of a negative result (not currently implemented)

## Related PRs
- Deploys this lambda: https://github.com/govuk-one-login/authentication-api/pull/3894
