### PR TITLE
ATO-248: Update vtr validation

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
@@ -74,7 +74,9 @@ class RequestObjectToAuthRequestHelperTest {
         var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
-                getClaimsSetBuilder(scope).claim("vtr", List.of("P2.Cl.Cm", "Cl.Cm")).build();
+                getClaimsSetBuilder(scope)
+                        .claim("vtr", List.of("P2.Cl.Cm", "PCL250.Cl.Cm"))
+                        .build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
         var authRequest =
                 new AuthenticationRequest.Builder(
@@ -102,7 +104,7 @@ class RequestObjectToAuthRequestHelperTest {
         assertThat(transformedAuthRequest.getRequestObject(), equalTo(signedJWT));
         assertThat(
                 transformedAuthRequest.getCustomParameter("vtr"),
-                equalTo(List.of("[\"P2.Cl.Cm\",\"Cl.Cm\"]")));
+                equalTo(List.of("[\"P2.Cl.Cm\",\"PCL250.Cl.Cm\"]")));
     }
 
     @Test

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/VectorOfTrust.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/VectorOfTrust.java
@@ -147,6 +147,18 @@ public class VectorOfTrust {
             vtrList.add(vot);
         }
 
+        var identityVectorsCount =
+                vtrList.stream()
+                        .filter(
+                                vtr ->
+                                        Objects.nonNull(vtr.getLevelOfConfidence())
+                                                && !vtr.getLevelOfConfidence().equals(NONE))
+                        .count();
+        if (identityVectorsCount != 0 && identityVectorsCount < vtrList.size()) {
+            throw new IllegalArgumentException(
+                    "VTR cannot contain both identity and non-identity vectors");
+        }
+
         return vtrList;
     }
 


### PR DESCRIPTION
## What?

Update vtr validation to account for the new list format. 

## Why?

- Vtrs must contain either all identity vectors (have P-values) or all non-identity vectors (do not have P-values)

