### PR TITLE
ATO-317: Add CloudWatch metric alarm for Account Intervention Service exceptions

### DIFF
--- a/ci/terraform/oidc/account-interventions-alerts.tf
+++ b/ci/terraform/oidc/account-interventions-alerts.tf
@@ -1,0 +1,31 @@
+data "aws_cloudwatch_log_group" "orchestration_redirect_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+  name  = replace("/aws/lambda/${var.environment}-orchestration-redirect-lambda", ".", "")
+}
+
+resource "aws_cloudwatch_log_metric_filter" "account_interventions_metric_filter" {
+  count          = var.use_localstack ? 0 : 1
+  name           = replace("${var.environment}-account-interventions-p1-errors", ".", "")
+  pattern        = "{($.AISException = 1)}"
+  log_group_name = data.aws_cloudwatch_log_group.orchestration_redirect_lambda_log_group[0].name
+
+  metric_transformation {
+    name      = replace("${var.environment}-account-interventions-error-count", ".", "")
+    namespace = "LambdaErrorsNamespace"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "account_interventions_p1_cloudwatch_alarm" {
+  count               = var.use_localstack ? 0 : 1
+  alarm_name          = replace("${var.environment}-P1-account-interventions-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.account_interventions_metric_filter[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.account_interventions_metric_filter[0].metric_transformation[0].namespace
+  period              = var.account_interventions_p1_alarm_error_time_period
+  statistic           = "Sum"
+  threshold           = var.account_interventions_p1_alarm_error_threshold
+  alarm_description   = "${var.account_interventions_p1_alarm_error_threshold} or more Account Interventions errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
+  alarm_actions       = [var.environment == "production" && var.account_intervention_service_abort_on_error ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : data.aws_sns_topic.slack_events.arn]
+}

--- a/ci/terraform/oidc/account-interventions-alerts.tf
+++ b/ci/terraform/oidc/account-interventions-alerts.tf
@@ -6,7 +6,7 @@ data "aws_cloudwatch_log_group" "orchestration_redirect_lambda_log_group" {
 resource "aws_cloudwatch_log_metric_filter" "account_interventions_metric_filter" {
   count          = var.use_localstack ? 0 : 1
   name           = replace("${var.environment}-account-interventions-p1-errors", ".", "")
-  pattern        = "{($.AISException = 1)}"
+  pattern        = "{($.${var.account_interventions_error_metric_name} = 1)}"
   log_group_name = data.aws_cloudwatch_log_group.orchestration_redirect_lambda_log_group[0].name
 
   metric_transformation {

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -32,6 +32,7 @@ module "authentication_callback" {
     ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled
     ACCOUNT_INTERVENTION_SERVICE_URI            = var.account_intervention_service_uri
     AUTHENTICATION_BACKEND_URI                  = "https://${local.di_auth_ext_api_id}-${local.vpce_id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
+    ACCOUNT_INTERVENTIONS_ERROR_METRIC_NAME     = var.account_interventions_error_metric_name
     DYNAMO_ENDPOINT                             = var.use_localstack ? var.lambda_dynamo_endpoint : null
     ENVIRONMENT                                 = var.environment
     IDENTITY_ENABLED                            = var.ipv_api_enabled

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -52,6 +52,12 @@ variable "doc_app_p1_alarm_error_time_period" {
   default     = 600
 }
 
+variable "account_interventions_error_metric_name" {
+  type        = string
+  description = "The name of the CloudWatch metric which counts Account Intervention Service errors"
+  default     = "AISException"
+}
+
 variable "account_interventions_p1_alarm_error_threshold" {
   type        = number
   description = "The number of Account Intervention Service errors raised before generating a Cloudwatch alarm"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -52,6 +52,18 @@ variable "doc_app_p1_alarm_error_time_period" {
   default     = 600
 }
 
+variable "account_interventions_p1_alarm_error_threshold" {
+  type        = number
+  description = "The number of Account Intervention Service errors raised before generating a Cloudwatch alarm"
+  default     = 20
+}
+
+variable "account_interventions_p1_alarm_error_time_period" {
+  type        = number
+  description = "The time period in seconds for when the Account Intervention Service errors need to occur"
+  default     = 600
+}
+
 variable "deployer_role_arn" {
   default     = null
   description = "The name of the AWS role to assume, leave blank when running locally"

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -133,7 +133,8 @@ public class AccountInterventionService {
 
     private AccountInterventionStatus handleException(Exception e) {
         cloudwatchMetricsService.incrementCounter(
-                "AISException", Map.of("Environment", configurationService.getEnvironment()));
+                configurationService.getAccountInterventionsErrorMetricName(),
+                Map.of("Environment", configurationService.getEnvironment()));
         if (accountInterventionsActionEnabled && acountInterventionsAbortOnError) {
             throw new AccountInterventionException(
                     "Problem communicating with Account Intervention Service", e);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -87,6 +87,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "5000"));
     }
 
+    public String getAccountInterventionsErrorMetricName() {
+        return System.getenv().getOrDefault("ACCOUNT_INTERVENTIONS_ERROR_METRIC_NAME", "");
+    }
+
     public String getAccountStatusBlockedURI() {
         return "/orch-frontend/not-available";
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -174,6 +174,7 @@ class AccountInterventionServiceTest {
 
         when(config.isAccountInterventionServiceActionEnabled()).thenReturn(true);
         when(config.abortOnAccountInterventionsErrorResponse()).thenReturn(true);
+        when(config.getAccountInterventionsErrorMetricName()).thenReturn("AISException");
 
         var internalPairwiseSubjectId = "some-internal-subject-id";
         var accountInterventionService =


### PR DESCRIPTION
## What?
- Alarm triggers a Pager Duty alarm only in production and when `account_intervention_service_abort_on_error == true`.
- Otherwise a slack alarm is generated.

## Why?

To quickly catch and resolve errors due to communicating with Account Intervention Service.

## Questions
Values for threshold and period have been reused from the other alarms. Is this reasonable?

## Testing

- Tested in sandpit (calling the Account Interventions stub) and alarm is correctly picking up AIS exceptions.
- Next test is in staging with a real error response from AIS.

