### PR TITLE
BAU: Reduce Account Interventions Service call timeout from 5 second to 1 second

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -494,7 +494,7 @@ variable "account_intervention_service_uri" {
 }
 
 variable "account_intervention_service_call_timeout" {
-  default     = 5000
+  default     = 1000
   type        = number
   description = "The HTTP Client connection timeout for requests to Account Intervention Service (in milliseconds)."
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -84,7 +84,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public long getAccountInterventionServiceCallTimeout() {
         return Long.parseLong(
-                System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "5000"));
+                System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "1000"));
     }
 
     public String getAccountStatusBlockedURI() {


### PR DESCRIPTION
## What?

Reduce Account Interventions Service call timeout from 5 second to 1 second

## Why?

It should not take longer than 1s to receive a response from AIS. Orchestration should wait as little time as possible.
