### PR TITLE
ATO-347: Encapsulate account intervention logic

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -248,17 +248,17 @@ public class IPVCallbackHandler
                             persistentId);
 
             if (errorObject.isPresent()) {
-                var accountInterventionStatus =
+                var accountInterventionState =
                         segmentedFunctionCall(
-                                "AIS: getAccountStatus",
+                                "AIS: getAccountState",
                                 () ->
-                                        this.accountInterventionService.getAccountStatus(
+                                        this.accountInterventionService.getAccountState(
                                                 internalPairwiseSubjectId, auditContext));
                 if (configurationService.isAccountInterventionServiceActionEnabled()
-                        && (accountInterventionStatus.blocked()
-                                || accountInterventionStatus.suspended())) {
+                        && (accountInterventionState.blocked()
+                                || accountInterventionState.suspended())) {
                     return logoutService.handleAccountInterventionLogout(
-                            session, input, clientId, accountInterventionStatus);
+                            session, input, clientId, accountInterventionState);
                 }
 
                 return ipvCallbackHelper.generateAuthenticationErrorResponse(
@@ -339,17 +339,17 @@ public class IPVCallbackHandler
             var userIdentityError =
                     ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, vtrList);
             if (userIdentityError.isPresent()) {
-                var accountInterventionStatus =
+                var accountInterventionState =
                         segmentedFunctionCall(
-                                "AIS: getAccountStatus",
+                                "AIS: getAccountState",
                                 () ->
-                                        this.accountInterventionService.getAccountStatus(
+                                        this.accountInterventionService.getAccountState(
                                                 internalPairwiseSubjectId, auditContext));
                 if (configurationService.isAccountInterventionServiceActionEnabled()
-                        && (accountInterventionStatus.blocked()
-                                || accountInterventionStatus.suspended())) {
+                        && (accountInterventionState.blocked()
+                                || accountInterventionState.suspended())) {
                     return logoutService.handleAccountInterventionLogout(
-                            session, input, clientId, accountInterventionStatus);
+                            session, input, clientId, accountInterventionState);
                 }
 
                 var returnCode = userIdentityUserInfo.getClaim(RETURN_CODE.getValue());

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -11,7 +11,7 @@ import uk.gov.di.authentication.ipv.entity.ProcessingIdentityRequest;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityResponse;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityStatus;
 import uk.gov.di.orchestration.audit.AuditContext;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
@@ -165,9 +165,9 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             if (processingStatus == ProcessingIdentityStatus.COMPLETED) {
                 var aisResult =
                         segmentedFunctionCall(
-                                "AIS: getAccountStatus",
+                                "AIS: getAccountState",
                                 () ->
-                                        accountInterventionService.getAccountStatus(
+                                        accountInterventionService.getAccountState(
                                                 internalPairwiseSubjectId, auditContext));
                 if (configurationService.isAccountInterventionServiceActionEnabled()
                         && (aisResult.suspended() || aisResult.blocked())) {
@@ -192,7 +192,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             APIGatewayProxyRequestEvent input,
             UserContext userContext,
             ClientRegistry client,
-            AccountInterventionStatus aisResult)
+            AccountInterventionState aisResult)
             throws Json.JsonException {
         var logoutResult =
                 logoutService.handleAccountInterventionLogout(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -25,7 +25,7 @@ import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.IpvCallbackException;
 import uk.gov.di.authentication.ipv.entity.LogIds;
 import uk.gov.di.orchestration.audit.AuditContext;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
@@ -157,11 +157,11 @@ class IPVCallbackHelperTest {
                         SerializationService.getInstance(),
                         sessionService,
                         sqsClient);
-        when(accountInterventionService.getAccountStatus(INTERNAL_PAIRWISE_ID, auditContext))
-                .thenReturn(new AccountInterventionStatus(false, false, false, false));
-        when(accountInterventionService.getAccountStatus(
+        when(accountInterventionService.getAccountState(INTERNAL_PAIRWISE_ID, auditContext))
+                .thenReturn(new AccountInterventionState(false, false, false, false));
+        when(accountInterventionService.getAccountState(
                         INTERNAL_PAIRWISE_ID_WITH_INTERVENTION, auditContext))
-                .thenReturn(new AccountInterventionStatus(false, true, false, false));
+                .thenReturn(new AccountInterventionState(false, true, false, false));
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
                         anyString(), anyString(), any(ClientSession.class)))
                 .thenReturn(AUTH_CODE);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -40,7 +40,7 @@ import uk.gov.di.authentication.ipv.helpers.IPVCallbackHelper;
 import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.ipv.services.IPVTokenService;
 import uk.gov.di.orchestration.audit.AuditContext;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
@@ -269,8 +269,8 @@ class IPVCallbackHandlerTest {
         when(context.getAwsRequestId()).thenReturn(REQUEST_ID);
         when(cookieHelper.parseSessionCookie(anyMap())).thenCallRealMethod();
         when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(salt);
-        when(accountInterventionService.getAccountStatus(any(), any()))
-                .thenReturn(new AccountInterventionStatus(false, false, false, false));
+        when(accountInterventionService.getAccountState(any(), any()))
+                .thenReturn(new AccountInterventionState(false, false, false, false));
         when(ipvCallbackHelper.generateAuthenticationErrorResponse(
                         any(), any(), anyBoolean(), anyString(), anyString()))
                 .thenReturn(
@@ -331,7 +331,7 @@ class IPVCallbackHandlerTest {
                                 userProfile, configService.getInternalSectorUri(), dynamoService)
                         .getValue();
         verify(accountInterventionService)
-                .getAccountStatus(eq(expectedInternalPairwiseSubjectId), any(AuditContext.class));
+                .getAccountState(eq(expectedInternalPairwiseSubjectId), any(AuditContext.class));
     }
 
     @ParameterizedTest
@@ -678,7 +678,7 @@ class IPVCallbackHandlerTest {
         assertEquals(
                 accessDeniedURI.toString(), response.getHeaders().get(ResponseHeaders.LOCATION));
         verify(accountInterventionService)
-                .getAccountStatus(eq(expectedInternalPairwiseSubjectId), any(AuditContext.class));
+                .getAccountState(eq(expectedInternalPairwiseSubjectId), any(AuditContext.class));
 
         verifyNoInteractions(ipvTokenService);
         verifyNoInteractions(dynamoIdentityService);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -229,8 +229,6 @@ class ProcessingIdentityHandlerTest {
                 .thenReturn(
                         generateApiGatewayProxyResponse(
                                 302, "", Map.of(ResponseHeaders.LOCATION, redirectUrl), null));
-        when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
-        when(accountInterventionService.getAccountState(anyString(), any())).thenReturn(aisResult);
 
         var result = handler.handleRequest(event, context);
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -14,7 +14,7 @@ import software.amazon.awssdk.core.SdkBytes;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityInterventionResponse;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityResponse;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityStatus;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
@@ -194,11 +194,11 @@ class ProcessingIdentityHandlerTest {
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
         when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
-        when(accountInterventionService.getAccountStatus(anyString(), any()))
-                .thenReturn(new AccountInterventionStatus(false, false, false, false));
+        when(accountInterventionService.getAccountState(anyString(), any()))
+                .thenReturn(new AccountInterventionState(false, false, false, false));
 
         var result = handler.handleRequest(event, context);
-        verify(accountInterventionService).getAccountStatus(eq(PAIRWISE_SUBJECT), any());
+        verify(accountInterventionService).getAccountState(eq(PAIRWISE_SUBJECT), any());
         assertThat(result, hasStatus(200));
         assertThat(
                 result,
@@ -217,18 +217,20 @@ class ProcessingIdentityHandlerTest {
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
-        var aisResult = new AccountInterventionStatus(false, true, false, false);
+        var aisResult = new AccountInterventionState(false, true, false, false);
         when(dynamoIdentityService.getIdentityCredentials(anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
         when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
-        when(accountInterventionService.getAccountStatus(anyString(), any())).thenReturn(aisResult);
+        when(accountInterventionService.getAccountState(anyString(), any())).thenReturn(aisResult);
         String redirectUrl = "https://example.com/intervention";
         when(logoutService.handleAccountInterventionLogout(any(), any(), any(), any()))
                 .thenReturn(
                         generateApiGatewayProxyResponse(
                                 302, "", Map.of(ResponseHeaders.LOCATION, redirectUrl), null));
+        when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(true);
+        when(accountInterventionService.getAccountState(anyString(), any())).thenReturn(aisResult);
 
         var result = handler.handleRequest(event, context);
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -369,16 +369,23 @@ public class AuthenticationCallbackHandler
                 Boolean reproveIdentity = null;
                 if (configurationService.isAccountInterventionServiceActionEnabled()) {
                     reproveIdentity = accountInterventionState.reproveIdentity();
-                    if (accountStatus.equals(AccountInterventionStatus.BLOCKED)
-                            || accountStatus.equals(
-                                    AccountInterventionStatus.SUSPENDED_RESET_PASSWORD)
-                            || accountStatus.equals(
-                                    AccountInterventionStatus.SUSPENDED_RESET_PASSWORD_REPROVE_ID)
-                            || (!identityRequired
-                                    && accountStatus.equals(
-                                            AccountInterventionStatus.SUSPENDED_NO_ACTION))) {
-                        return logoutService.handleAccountInterventionLogout(
-                                userSession, input, clientId, accountInterventionState);
+                    switch (accountStatus) {
+                        case BLOCKED,
+                                SUSPENDED_RESET_PASSWORD,
+                                SUSPENDED_RESET_PASSWORD_REPROVE_ID -> {
+                            return logoutService.handleAccountInterventionLogout(
+                                    userSession, input, clientId, accountInterventionState);
+                        }
+                        case SUSPENDED_NO_ACTION -> {
+                            if (!identityRequired) {
+                                return logoutService.handleAccountInterventionLogout(
+                                        userSession, input, clientId, accountInterventionState);
+                            }
+                            // continue
+                        }
+                        case NO_INTERVENTION, SUSPENDED_REPROVE_ID -> {
+                            // continue
+                        }
                     }
                 }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -27,7 +27,7 @@ import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
 import uk.gov.di.authentication.oidc.services.InitiateIPVAuthorisationService;
 import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.shared.conditions.MfaHelper;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
@@ -360,8 +360,8 @@ public class AuthenticationCallbackHandler
                                         : userInfo.getPhoneNumber(),
                                 persistentSessionId);
 
-                AccountInterventionStatus accountStatus =
-                        accountInterventionService.getAccountStatus(
+                AccountInterventionState accountStatus =
+                        accountInterventionService.getAccountState(
                                 userInfo.getSubject().getValue(), auditContext);
 
                 Boolean reproveIdentity = null;

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -158,6 +158,8 @@ class AuthenticationCallbackHandlerTest {
 
         when(authorizationService.validateRequest(any(), any())).thenReturn(true);
         when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(accountInterventionService.getAccountState(anyString(), any()))
+                .thenReturn(new AccountInterventionState(false, false, false, false));
 
         when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -349,9 +349,9 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldRedirectToRpWhenAccountStatusIsNoIntervention() {
-                AccountInterventionStatus accountStatus =
-                        new AccountInterventionStatus(false, false, false, false);
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
+                AccountInterventionState accountStatus =
+                        new AccountInterventionState(false, false, false, false);
+                when(accountInterventionService.getAccountState(anyString(), any()))
                         .thenReturn(accountStatus);
 
                 var event = new APIGatewayProxyRequestEvent();
@@ -373,9 +373,9 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldLogoutWhenAccountStatusIsBlocked() {
-                AccountInterventionStatus accountStatus =
-                        new AccountInterventionStatus(true, false, false, false);
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
+                AccountInterventionState accountStatus =
+                        new AccountInterventionState(true, false, false, false);
+                when(accountInterventionService.getAccountState(anyString(), any()))
                         .thenReturn(accountStatus);
 
                 var event = new APIGatewayProxyRequestEvent();
@@ -390,9 +390,9 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldLogoutWhenAccountStatusIsSuspendedNoAction() {
-                AccountInterventionStatus accountStatus =
-                        new AccountInterventionStatus(false, true, false, false);
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
+                AccountInterventionState accountStatus =
+                        new AccountInterventionState(false, true, false, false);
+                when(accountInterventionService.getAccountState(anyString(), any()))
                         .thenReturn(accountStatus);
 
                 var event = new APIGatewayProxyRequestEvent();
@@ -407,9 +407,9 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldLogoutWhenAccountStatusIsSuspendedResetPassword() {
-                AccountInterventionStatus accountStatus =
-                        new AccountInterventionStatus(false, true, false, true);
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
+                AccountInterventionState accountStatus =
+                        new AccountInterventionState(false, true, false, true);
+                when(accountInterventionService.getAccountState(anyString(), any()))
                         .thenReturn(accountStatus);
 
                 var event = new APIGatewayProxyRequestEvent();
@@ -424,9 +424,9 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldRedirectToRpWhenAccountStatusIsSuspendedReproveIdentity() {
-                AccountInterventionStatus accountStatus =
-                        new AccountInterventionStatus(false, true, true, false);
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
+                AccountInterventionState accountStatus =
+                        new AccountInterventionState(false, true, true, false);
+                when(accountInterventionService.getAccountState(anyString(), any()))
                         .thenReturn(accountStatus);
 
                 var event = new APIGatewayProxyRequestEvent();
@@ -448,9 +448,9 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldLogoutWhenAccountStatusIsSuspendedResetPasswordReproveIdentity() {
-                AccountInterventionStatus accountStatus =
-                        new AccountInterventionStatus(false, true, true, true);
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
+                AccountInterventionState accountStatus =
+                        new AccountInterventionState(false, true, true, true);
+                when(accountInterventionService.getAccountState(anyString(), any()))
                         .thenReturn(accountStatus);
 
                 var event = new APIGatewayProxyRequestEvent();
@@ -476,10 +476,9 @@ class AuthenticationCallbackHandlerTest {
             @Test
             void shouldRedirectToIPVWhenThereIsNoIntervention() {
                 boolean reproveIdentity = true;
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
+                when(accountInterventionService.getAccountState(anyString(), any()))
                         .thenReturn(
-                                new AccountInterventionStatus(
-                                        false, false, reproveIdentity, false));
+                                new AccountInterventionState(false, false, reproveIdentity, false));
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -503,10 +502,10 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldLogoutWhenAccountStatusIsBlocked() {
-                AccountInterventionStatus aisStatus =
-                        new AccountInterventionStatus(true, false, false, false);
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
-                        .thenReturn(aisStatus);
+                AccountInterventionState aisState =
+                        new AccountInterventionState(true, false, false, false);
+                when(accountInterventionService.getAccountState(anyString(), any()))
+                        .thenReturn(aisState);
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -514,16 +513,16 @@ class AuthenticationCallbackHandlerTest {
                 handler.handleRequest(event, null);
 
                 verify(logoutService)
-                        .handleAccountInterventionLogout(any(), any(), any(), eq(aisStatus));
+                        .handleAccountInterventionLogout(any(), any(), any(), eq(aisState));
                 verifyNoInteractions(initiateIPVAuthorisationService);
             }
 
             @Test
             void shouldRedirectToIPVWhenAccountStatusIsSuspendedNoAction() {
                 boolean reproveIdentity = false;
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
+                when(accountInterventionService.getAccountState(anyString(), any()))
                         .thenReturn(
-                                new AccountInterventionStatus(false, true, reproveIdentity, false));
+                                new AccountInterventionState(false, true, reproveIdentity, false));
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -547,10 +546,10 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldLogoutWhenAccountStatusIsSuspendedResetPassword() {
-                AccountInterventionStatus aisStatus =
-                        new AccountInterventionStatus(false, true, false, true);
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
-                        .thenReturn(aisStatus);
+                AccountInterventionState aisState =
+                        new AccountInterventionState(false, true, false, true);
+                when(accountInterventionService.getAccountState(anyString(), any()))
+                        .thenReturn(aisState);
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -558,16 +557,16 @@ class AuthenticationCallbackHandlerTest {
                 handler.handleRequest(event, null);
 
                 verify(logoutService)
-                        .handleAccountInterventionLogout(any(), any(), any(), eq(aisStatus));
+                        .handleAccountInterventionLogout(any(), any(), any(), eq(aisState));
                 verifyNoInteractions(initiateIPVAuthorisationService);
             }
 
             @Test
             void shouldRedirectToIPVWhenAccountStatusIsSuspendedReproveIdentity() {
                 boolean reproveIdentity = true;
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
+                when(accountInterventionService.getAccountState(anyString(), any()))
                         .thenReturn(
-                                new AccountInterventionStatus(false, true, reproveIdentity, false));
+                                new AccountInterventionState(false, true, reproveIdentity, false));
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -591,10 +590,10 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldLogoutWhenAccountStatusIsSuspendedResetPasswordAndReproveIdentity() {
-                AccountInterventionStatus aisStatus =
-                        new AccountInterventionStatus(false, true, true, true);
-                when(accountInterventionService.getAccountStatus(anyString(), any()))
-                        .thenReturn(aisStatus);
+                AccountInterventionState aisState =
+                        new AccountInterventionState(false, true, true, true);
+                when(accountInterventionService.getAccountState(anyString(), any()))
+                        .thenReturn(aisState);
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -602,7 +601,7 @@ class AuthenticationCallbackHandlerTest {
                 handler.handleRequest(event, null);
 
                 verify(logoutService)
-                        .handleAccountInterventionLogout(any(), any(), any(), eq(aisStatus));
+                        .handleAccountInterventionLogout(any(), any(), any(), eq(aisState));
                 verifyNoInteractions(initiateIPVAuthorisationService);
             }
         }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -351,10 +351,10 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldRedirectToRpWhenAccountStatusIsNoIntervention() {
-                AccountInterventionState accountStatus =
+                AccountInterventionState accountState =
                         new AccountInterventionState(false, false, false, false);
                 when(accountInterventionService.getAccountState(anyString(), any()))
-                        .thenReturn(accountStatus);
+                        .thenReturn(accountState);
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -375,10 +375,10 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldLogoutWhenAccountStatusIsBlocked() {
-                AccountInterventionState accountStatus =
+                AccountInterventionState accountState =
                         new AccountInterventionState(true, false, false, false);
                 when(accountInterventionService.getAccountState(anyString(), any()))
-                        .thenReturn(accountStatus);
+                        .thenReturn(accountState);
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -387,15 +387,15 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                session, event, CLIENT_ID.toString(), accountStatus);
+                                session, event, CLIENT_ID.toString(), accountState);
             }
 
             @Test
             void shouldLogoutWhenAccountStatusIsSuspendedNoAction() {
-                AccountInterventionState accountStatus =
+                AccountInterventionState accountState =
                         new AccountInterventionState(false, true, false, false);
                 when(accountInterventionService.getAccountState(anyString(), any()))
-                        .thenReturn(accountStatus);
+                        .thenReturn(accountState);
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -404,15 +404,15 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                session, event, CLIENT_ID.toString(), accountStatus);
+                                session, event, CLIENT_ID.toString(), accountState);
             }
 
             @Test
             void shouldLogoutWhenAccountStatusIsSuspendedResetPassword() {
-                AccountInterventionState accountStatus =
+                AccountInterventionState accountState =
                         new AccountInterventionState(false, true, false, true);
                 when(accountInterventionService.getAccountState(anyString(), any()))
-                        .thenReturn(accountStatus);
+                        .thenReturn(accountState);
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -421,15 +421,15 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                session, event, CLIENT_ID.toString(), accountStatus);
+                                session, event, CLIENT_ID.toString(), accountState);
             }
 
             @Test
             void shouldRedirectToRpWhenAccountStatusIsSuspendedReproveIdentity() {
-                AccountInterventionState accountStatus =
+                AccountInterventionState accountState =
                         new AccountInterventionState(false, true, true, false);
                 when(accountInterventionService.getAccountState(anyString(), any()))
-                        .thenReturn(accountStatus);
+                        .thenReturn(accountState);
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -450,10 +450,10 @@ class AuthenticationCallbackHandlerTest {
 
             @Test
             void shouldLogoutWhenAccountStatusIsSuspendedResetPasswordReproveIdentity() {
-                AccountInterventionState accountStatus =
+                AccountInterventionState accountState =
                         new AccountInterventionState(false, true, true, true);
                 when(accountInterventionService.getAccountState(anyString(), any()))
-                        .thenReturn(accountStatus);
+                        .thenReturn(accountState);
 
                 var event = new APIGatewayProxyRequestEvent();
                 setValidHeadersAndQueryParameters(event);
@@ -462,7 +462,7 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                session, event, CLIENT_ID.getValue(), accountStatus);
+                                session, event, CLIENT_ID.getValue(), accountState);
             }
         }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/domain/CloudwatchMetricDimensions.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/domain/CloudwatchMetricDimensions.java
@@ -8,7 +8,7 @@ public enum CloudwatchMetricDimensions {
     REQUESTED_LEVEL_OF_CONFIDENCE("RequestedLevelOfConfidence"),
     MFA_REQUIRED("MfaRequired"),
     CLIENT_NAME("ClientName"),
-    ACCOUNT_INTERVENTION_STATUS("AccountInterventionStatus");
+    ACCOUNT_INTERVENTION_STATE("AccountInterventionState");
 
     private String value;
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionResponse.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionResponse.java
@@ -3,4 +3,4 @@ package uk.gov.di.orchestration.shared.entity;
 import com.google.gson.annotations.Expose;
 
 public record AccountInterventionResponse(
-        @Expose AccountInterventionStatus state, @Expose String auditLevel) {}
+        @Expose AccountInterventionState state, @Expose String auditLevel) {}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionState.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionState.java
@@ -3,13 +3,55 @@ package uk.gov.di.orchestration.shared.entity;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public record AccountInterventionState(
-        @Expose boolean blocked,
-        @Expose boolean suspended,
-        @Expose @SerializedName("reproveIdentity") boolean reproveIdentity,
-        @Expose @SerializedName("resetPassword") boolean resetPassword) {
+public class AccountInterventionState {
+
+    @Expose private final boolean blocked;
+
+    @Expose private final boolean suspended;
+
+    @Expose
+    @SerializedName("reproveIdentity")
+    private final boolean reproveIdentity;
+
+    @Expose
+    @SerializedName("resetPassword")
+    private final boolean resetPassword;
+
+    private AccountInterventionStatus status;
+
+    public AccountInterventionState(
+            boolean blocked, boolean suspended, boolean reproveIdentity, boolean resetPassword) {
+        this.blocked = blocked;
+        this.suspended = suspended;
+        this.reproveIdentity = reproveIdentity;
+        this.resetPassword = resetPassword;
+        this.status = calculateStatus();
+    }
+
+    public boolean blocked() {
+        return blocked;
+    }
+
+    public boolean suspended() {
+        return suspended;
+    }
+
+    public boolean resetPassword() {
+        return resetPassword;
+    }
+
+    public boolean reproveIdentity() {
+        return reproveIdentity;
+    }
 
     public AccountInterventionStatus getStatus() {
+        if (status == null) {
+            this.status = calculateStatus();
+        }
+        return status;
+    }
+
+    private AccountInterventionStatus calculateStatus() {
         if (blocked) return AccountInterventionStatus.BLOCKED;
         if (suspended) {
             if (!reproveIdentity && !resetPassword) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionState.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionState.java
@@ -7,4 +7,24 @@ public record AccountInterventionState(
         @Expose boolean blocked,
         @Expose boolean suspended,
         @Expose @SerializedName("reproveIdentity") boolean reproveIdentity,
-        @Expose @SerializedName("resetPassword") boolean resetPassword) {}
+        @Expose @SerializedName("resetPassword") boolean resetPassword) {
+
+    public AccountInterventionStatus getStatus() {
+        if (blocked) return AccountInterventionStatus.BLOCKED;
+        if (suspended) {
+            if (!reproveIdentity && !resetPassword) {
+                return AccountInterventionStatus.SUSPENDED_NO_ACTION;
+            }
+            if (reproveIdentity && !resetPassword) {
+                return AccountInterventionStatus.SUSPENDED_REPROVE_ID;
+            }
+            if (!reproveIdentity && resetPassword) {
+                return AccountInterventionStatus.SUSPENDED_RESET_PASSWORD;
+            }
+            if (reproveIdentity && resetPassword) {
+                return AccountInterventionStatus.SUSPENDED_RESET_PASSWORD_REPROVE_ID;
+            }
+        }
+        return AccountInterventionStatus.NO_INTERVENTION;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionState.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionState.java
@@ -3,7 +3,7 @@ package uk.gov.di.orchestration.shared.entity;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public record AccountInterventionStatus(
+public record AccountInterventionState(
         @Expose boolean blocked,
         @Expose boolean suspended,
         @Expose @SerializedName("reproveIdentity") boolean reproveIdentity,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionStatus.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionStatus.java
@@ -1,0 +1,10 @@
+package uk.gov.di.orchestration.shared.entity;
+
+public enum AccountInterventionStatus {
+    NO_INTERVENTION,
+    BLOCKED,
+    SUSPENDED_NO_ACTION,
+    SUSPENDED_REPROVE_ID,
+    SUSPENDED_RESET_PASSWORD,
+    SUSPENDED_RESET_PASSWORD_REPROVE_ID,
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -4,7 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionResponse;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.exceptions.AccountInterventionException;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AuditService.MetadataPair;
@@ -68,12 +68,12 @@ public class AccountInterventionService {
         this.configurationService = configService;
     }
 
-    public AccountInterventionStatus getAccountStatus(String internalPairwiseSubjectId)
+    public AccountInterventionState getAccountState(String internalPairwiseSubjectId)
             throws AccountInterventionException {
-        return getAccountStatus(internalPairwiseSubjectId, null);
+        return getAccountState(internalPairwiseSubjectId, null);
     }
 
-    public AccountInterventionStatus getAccountStatus(
+    public AccountInterventionState getAccountState(
             String internalPairwiseSubjectId, AuditContext auditContext)
             throws AccountInterventionException {
 
@@ -103,7 +103,7 @@ public class AccountInterventionService {
     }
 
     private static AuditContext addStatusMetadata(
-            AuditContext auditContext, AccountInterventionStatus status) {
+            AuditContext auditContext, AccountInterventionState status) {
         var existingMetadataPairs = Arrays.stream(auditContext.metadataPairs());
         var statusMetadataPairs =
                 Stream.of(
@@ -127,7 +127,7 @@ public class AccountInterventionService {
                 metadataPairs);
     }
 
-    private AccountInterventionStatus handleException(Exception e) {
+    private AccountInterventionState handleException(Exception e) {
         cloudwatchMetricsService.incrementCounter(
                 configurationService.getAccountInterventionsErrorMetricName(),
                 Map.of("Environment", configurationService.getEnvironment()));
@@ -141,7 +141,7 @@ public class AccountInterventionService {
         return noInterventionResponse();
     }
 
-    private AccountInterventionStatus retrieveAccountStatus(String internalPairwiseSubjectId)
+    private AccountInterventionState retrieveAccountStatus(String internalPairwiseSubjectId)
             throws IOException, InterruptedException, Json.JsonException {
 
         HttpRequest request =
@@ -159,9 +159,9 @@ public class AccountInterventionService {
                         .build();
 
         HttpResponse<String> response = sendRequestToAis(request);
-        AccountInterventionStatus accountInterventionStatus = serializeResponse(response);
-        incrementCloudwatchMetrics(accountInterventionStatus);
-        return accountInterventionStatus;
+        AccountInterventionState accountInterventionState = serializeResponse(response);
+        incrementCloudwatchMetrics(accountInterventionState);
+        return accountInterventionState;
     }
 
     private HttpResponse<String> sendRequestToAis(HttpRequest request) {
@@ -189,38 +189,38 @@ public class AccountInterventionService {
         }
     }
 
-    private AccountInterventionStatus serializeResponse(HttpResponse<String> httpResponse) {
-        AccountInterventionStatus accountInterventionStatus = null;
+    private AccountInterventionState serializeResponse(HttpResponse<String> httpResponse) {
+        AccountInterventionState accountInterventionState = null;
         try {
             var response =
                     SerializationService.getInstance()
                             .readValue(httpResponse.body(), AccountInterventionResponse.class);
-            accountInterventionStatus = response.state();
+            accountInterventionState = response.state();
         } catch (Exception e) {
             logAndThrowAccountInterventionException("Failed to serialize AIS response body.");
         }
-        if (Objects.isNull(accountInterventionStatus)) {
+        if (Objects.isNull(accountInterventionState)) {
             logAndThrowAccountInterventionException("Account Intervention Status is null.");
         }
-        return accountInterventionStatus;
+        return accountInterventionState;
     }
 
-    private void incrementCloudwatchMetrics(AccountInterventionStatus accountInterventionStatus) {
+    private void incrementCloudwatchMetrics(AccountInterventionState accountInterventionState) {
         cloudwatchMetricsService.incrementCounter(
                 "AISResult",
                 Map.of(
                         "blocked",
-                        String.valueOf(accountInterventionStatus.blocked()),
+                        String.valueOf(accountInterventionState.blocked()),
                         "suspended",
-                        String.valueOf(accountInterventionStatus.suspended()),
+                        String.valueOf(accountInterventionState.suspended()),
                         "resetPassword",
-                        String.valueOf(accountInterventionStatus.resetPassword()),
+                        String.valueOf(accountInterventionState.resetPassword()),
                         "reproveIdentity",
-                        String.valueOf(accountInterventionStatus.reproveIdentity())));
+                        String.valueOf(accountInterventionState.reproveIdentity())));
     }
 
-    private static AccountInterventionStatus noInterventionResponse() {
-        return new AccountInterventionStatus(false, false, false, false);
+    private static AccountInterventionState noInterventionResponse() {
+        return new AccountInterventionState(false, false, false, false);
     }
 
     private void logAndThrowAccountInterventionException(String message) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CloudwatchMetricsService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CloudwatchMetricsService.java
@@ -3,13 +3,13 @@ package uk.gov.di.orchestration.shared.services;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.Session;
 
 import java.util.Map;
 import java.util.Optional;
 
-import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.ACCOUNT_INTERVENTION_STATUS;
+import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.ACCOUNT_INTERVENTION_STATE;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.CLIENT;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.CLIENT_NAME;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
@@ -87,13 +87,13 @@ public class CloudwatchMetricsService {
 
     public void incrementLogout(
             Optional<String> clientId,
-            Optional<AccountInterventionStatus> accountInterventionStatus) {
+            Optional<AccountInterventionState> accountInterventionState) {
         String accountInterventionStr = "unknown";
-        if (accountInterventionStatus.isPresent()) {
-            if (accountInterventionStatus.get().suspended()) {
+        if (accountInterventionState.isPresent()) {
+            if (accountInterventionState.get().suspended()) {
                 accountInterventionStr = "suspended";
             }
-            if (accountInterventionStatus.get().blocked()) {
+            if (accountInterventionState.get().blocked()) {
                 accountInterventionStr = "blocked";
             }
         }
@@ -104,7 +104,7 @@ public class CloudwatchMetricsService {
                         configurationService.getEnvironment(),
                         CLIENT.getValue(),
                         clientId.orElse("unknown"),
-                        ACCOUNT_INTERVENTION_STATUS.getValue(),
+                        ACCOUNT_INTERVENTION_STATE.getValue(),
                         accountInterventionStr));
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -7,7 +7,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.domain.LogoutAuditableEvent;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
@@ -63,7 +63,7 @@ public class LogoutService {
             Session session,
             APIGatewayProxyRequestEvent input,
             String clientId,
-            AccountInterventionStatus accountStatus) {
+            AccountInterventionState accountStatus) {
         destroySessions(session);
         return generateAccountInterventionLogoutResponse(
                 input, clientId, session.getSessionId(), accountStatus);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -63,10 +63,10 @@ public class LogoutService {
             Session session,
             APIGatewayProxyRequestEvent input,
             String clientId,
-            AccountInterventionState accountStatus) {
+            AccountInterventionState accountState) {
         destroySessions(session);
         return generateAccountInterventionLogoutResponse(
-                input, clientId, session.getSessionId(), accountStatus);
+                input, clientId, session.getSessionId(), accountState);
     }
 
     public void destroySessions(Session session) {
@@ -165,19 +165,19 @@ public class LogoutService {
             APIGatewayProxyRequestEvent input,
             String clientId,
             String sessionId,
-            AccountInterventionStatus accountStatus) {
+            AccountInterventionState accountState) {
         URI redirectURI;
-        if (accountStatus.blocked()) {
+        if (accountState.blocked()) {
             redirectURI = configurationService.getAccountStatusBlockedURI();
             LOG.info("Generating Account Intervention blocked logout response");
-        } else if (accountStatus.suspended()) {
+        } else if (accountState.suspended()) {
             redirectURI = configurationService.getAccountStatusSuspendedURI();
             LOG.info("Generating Account Intervention suspended logout response");
         } else {
             throw new RuntimeException("Account status must be blocked or suspended");
         }
 
-        cloudwatchMetricsService.incrementLogout(Optional.of(clientId), Optional.of(accountStatus));
+        cloudwatchMetricsService.incrementLogout(Optional.of(clientId), Optional.of(accountState));
         return generateLogoutResponse(
                 redirectURI,
                 Optional.empty(),

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -92,7 +92,7 @@ class AccountInterventionServiceTest {
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
         when(httpResponse.body()).thenReturn(ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE);
 
-        ais.getAccountStatus(internalPairwiseSubjectId);
+        ais.getAccountState(internalPairwiseSubjectId);
 
         verify(httpClient).send(httpRequestCaptor.capture(), any());
         var requestUri = httpRequestCaptor.getValue();
@@ -114,7 +114,7 @@ class AccountInterventionServiceTest {
         when(httpResponse.body()).thenReturn(ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE);
         when(httpResponse.statusCode()).thenReturn(200);
 
-        var status = accountInterventionService.getAccountStatus(internalPairwiseSubjectId);
+        var status = accountInterventionService.getAccountState(internalPairwiseSubjectId);
 
         assertFalse(status.blocked());
         assertTrue(status.suspended());
@@ -140,7 +140,7 @@ class AccountInterventionServiceTest {
         var ais =
                 new AccountInterventionService(
                         config, httpClient, cloudwatchMetricsService, auditService);
-        var status = ais.getAccountStatus(internalPairwiseSubjectId);
+        var status = ais.getAccountState(internalPairwiseSubjectId);
 
         verifyNoInteractions(httpClient);
 
@@ -166,7 +166,7 @@ class AccountInterventionServiceTest {
         when(httpClient.send(any(), any())).thenThrow(new IOException("Test IO Exception"));
 
         assertDoesNotThrow(
-                () -> accountInterventionService.getAccountStatus(internalPairwiseSubjectId));
+                () -> accountInterventionService.getAccountState(internalPairwiseSubjectId));
     }
 
     @Test
@@ -186,7 +186,7 @@ class AccountInterventionServiceTest {
 
         assertThrows(
                 AccountInterventionException.class,
-                () -> accountInterventionService.getAccountStatus(internalPairwiseSubjectId));
+                () -> accountInterventionService.getAccountState(internalPairwiseSubjectId));
 
         verify(cloudwatchMetricsService)
                 .incrementCounter("AISException", Map.of("Environment", ENVIRONMENT));
@@ -210,7 +210,7 @@ class AccountInterventionServiceTest {
         when(httpResponse.body()).thenReturn(ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE);
         when(httpResponse.statusCode()).thenReturn(200);
 
-        accountInterventionService.getAccountStatus(internalPairwiseSubjectId, someAuditContext);
+        accountInterventionService.getAccountState(internalPairwiseSubjectId, someAuditContext);
 
         var expectedAuditContext =
                 new AuditContext(
@@ -246,7 +246,7 @@ class AccountInterventionServiceTest {
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
         when(httpResponse.body()).thenReturn(ACCOUNT_INTERVENTION_SERVICE_RESPONSE_SUSPEND_REPROVE);
 
-        accountInterventionService.getAccountStatus(internalPairwiseSubjectId, someAuditContext);
+        accountInterventionService.getAccountState(internalPairwiseSubjectId, someAuditContext);
 
         verifyNoInteractions(auditService);
     }
@@ -269,7 +269,7 @@ class AccountInterventionServiceTest {
 
         assertThrows(
                 AccountInterventionException.class,
-                () -> accountInterventionService.getAccountStatus(internalPairwiseSubjectId, null));
+                () -> accountInterventionService.getAccountState(internalPairwiseSubjectId, null));
     }
 
     private void assertMatchingAuditContext(AuditContext expected, AuditContext actual) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -265,10 +265,10 @@ public class LogoutServiceTest {
 
     @Test
     void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsBlocked() {
-        var accountStatus = new AccountInterventionState(true, false, false, false);
+        var accountState = new AccountInterventionState(true, false, false, false);
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
-                        session, event, CLIENT_ID, accountStatus);
+                        session, event, CLIENT_ID, accountState);
 
         verify(clientSessionService)
                 .deleteClientSessionFromRedis(session.getClientSessions().get(0));
@@ -285,7 +285,7 @@ public class LogoutServiceTest {
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID);
         verify(cloudwatchMetricsService)
-                .incrementLogout(Optional.of(CLIENT_ID), Optional.of(accountStatus));
+                .incrementLogout(Optional.of(CLIENT_ID), Optional.of(accountState));
 
         assertThat(response, hasStatus(302));
         assertThat(
@@ -295,10 +295,10 @@ public class LogoutServiceTest {
 
     @Test
     void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsSuspended() {
-        var accountStatus = new AccountInterventionState(false, true, false, false);
+        var accountState = new AccountInterventionState(false, true, false, false);
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
-                        session, event, CLIENT_ID, accountStatus);
+                        session, event, CLIENT_ID, accountState);
 
         verify(clientSessionService)
                 .deleteClientSessionFromRedis(session.getClientSessions().get(0));
@@ -315,7 +315,7 @@ public class LogoutServiceTest {
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID);
         verify(cloudwatchMetricsService)
-                .incrementLogout(Optional.of(CLIENT_ID), Optional.of(accountStatus));
+                .incrementLogout(Optional.of(CLIENT_ID), Optional.of(accountState));
 
         assertThat(response, hasStatus(302));
         assertThat(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.MockedStatic;
 import uk.gov.di.orchestration.shared.domain.LogoutAuditableEvent;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -265,7 +265,7 @@ public class LogoutServiceTest {
 
     @Test
     void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsBlocked() {
-        var accountStatus = new AccountInterventionStatus(true, false, false, false);
+        var accountStatus = new AccountInterventionState(true, false, false, false);
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
                         session, event, CLIENT_ID, accountStatus);
@@ -295,7 +295,7 @@ public class LogoutServiceTest {
 
     @Test
     void destroysSessionsAndReturnsAccountInterventionLogoutResponseWhenAccountIsSuspended() {
-        var accountStatus = new AccountInterventionStatus(false, true, false, false);
+        var accountStatus = new AccountInterventionState(false, true, false, false);
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
                         session, event, CLIENT_ID, accountStatus);
@@ -371,8 +371,7 @@ public class LogoutServiceTest {
 
     @Test
     void throwsWhenGenerateAccountInterventionLogoutResponseCalledInappropriately() {
-        AccountInterventionStatus status =
-                new AccountInterventionStatus(false, false, false, false);
+        AccountInterventionState status = new AccountInterventionState(false, false, false, false);
 
         RuntimeException exception =
                 assertThrows(


### PR DESCRIPTION
_This PR is solely refactoring. It contains no logical changes._

## What?
- Rename `AccountInterventionStatus` --> `AccountInterventionState` to better reflect its purpose
- Create `AccountInterventionStatus` `enum` to hold list of possible account interventions
- Encapsulate logic, for determining which account intervention is applied, into `AccountInterventionState` class

## Why?
To make the account intervention logic on return from auth (in `AuthenticationCallbackHandler`) easier to understand and maintain
