### PR TITLE
ATO-350: Add new sandpit stubs to client registry

### DIFF
--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -27,6 +27,46 @@ stub_rp_clients = [
     one_login_service = false
     service_type      = "MANDATORY"
   },
+  {
+    client_name = "relying-party-stub-sandpit"
+    callback_urls = [
+      "https://rp-sandpit.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://rp-sandpit.build.stubs.account.gov.uk/signed-out",
+    ]
+    test_client                     = "0"
+    consent_required                = "0"
+    client_type                     = "web"
+    identity_verification_supported = "0"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
+    one_login_service = false
+    service_type      = "MANDATORY"
+  },
+  {
+    client_name = "relying-party-stub-sandpit-app"
+    callback_urls = [
+      "https://doc-app-rp-sandpit.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://doc-app-rp-sandpit.build.stubs.account.gov.uk/signed-out",
+    ]
+    test_client                     = "1"
+    consent_required                = "0"
+    client_type                     = "app"
+    identity_verification_supported = "1"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
+    one_login_service = false
+    service_type      = "MANDATORY"
+  },
 ]
 
 logging_endpoint_enabled = false


### PR DESCRIPTION
## What?

Add new sandpit stubs to client registry

## Why?

So we can use sandpit stubs to enter the flow

Note: I've added a docapp stub here, but it won't work currently as we don't have a cri stub set up. The resources will be generated so that in future if we do set it up it will be available to us
