### PR TITLE
ATO-364: Return intervention response for action by auth frontend

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/ProcessingIdentityInterventionResponse.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/ProcessingIdentityInterventionResponse.java
@@ -1,0 +1,26 @@
+package uk.gov.di.authentication.ipv.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.orchestration.shared.validation.Required;
+
+public class ProcessingIdentityInterventionResponse {
+
+    @SerializedName("status")
+    @Expose
+    @Required
+    private ProcessingIdentityStatus status;
+
+    @SerializedName("redirectUrl")
+    @Expose
+    @Required
+    private String redirectUrl;
+
+    public ProcessingIdentityInterventionResponse() {}
+
+    public ProcessingIdentityInterventionResponse(
+            ProcessingIdentityStatus status, String redirectUrl) {
+        this.status = status;
+        this.redirectUrl = redirectUrl;
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/ProcessingIdentityStatus.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/ProcessingIdentityStatus.java
@@ -5,4 +5,5 @@ public enum ProcessingIdentityStatus {
     PROCESSING,
     ERROR,
     NO_ENTRY,
+    INTERVENTION
 }


### PR DESCRIPTION
## What?

Return the intervention redirect url in a format useful to the auth frontend

## Why?

We realised during testing that this intervention does not work

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/1352
