### PR TITLE
BAU: Checklist item for orch auth mutual dependencies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,13 @@ Please include reason for the change and any other relevant context.
 
 Please include links to PRs in other repositories relevant to this PR.
 Delete this section if not needed.
+
+
+## Orchestration and Authentication mutual dependencies
+
+Be careful when making changes to code in 'shared' components where each team has a copy.
+Check with counterparts to see if changes need to be made in the other team's code.
+
+In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
+
+- [ ] Impact on orch and auth mutual dependencies has been checked.


### PR DESCRIPTION
## What?

Checklist item for orch auth mutual dependencies.

## Why?

Make PR authors and reviewers aware of mutual dependencies.
