### PR TITLE
AUT-2263 Enable KMS key rotation for kMS key

### DIFF
--- a/ci/terraform/modules/txma-audit-queue/key.tf
+++ b/ci/terraform/modules/txma-audit-queue/key.tf
@@ -3,6 +3,7 @@ resource "aws_kms_key" "txma_audit_queue_encryption_key" {
   deletion_window_in_days  = 30
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
   key_usage                = "ENCRYPT_DECRYPT"
+  enable_key_rotation      = true
 
   policy = data.aws_iam_policy_document.txma_audit_queue_encryption_key_access_policy.json
 

--- a/ci/terraform/oidc/spot-sqs.tf
+++ b/ci/terraform/oidc/spot-sqs.tf
@@ -146,6 +146,7 @@ resource "aws_kms_key" "spot_request_sqs_key" {
 
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
   key_usage                = "ENCRYPT_DECRYPT"
+  enable_key_rotation      = true
 
   tags = local.default_tags
 }

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -243,7 +243,7 @@ resource "aws_kms_key" "events_topic_encryption" {
   description = "alias/${var.environment}/events-encryption-key"
 
   policy = data.aws_iam_policy_document.events_encryption_key_permissions.json
-
+  enable_key_rotation      = true
   tags = local.default_tags
 }
 
@@ -342,6 +342,7 @@ resource "aws_kms_key" "auth_code_store_signing_key" {
   deletion_window_in_days  = 30
   key_usage                = "ENCRYPT_DECRYPT"
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
   policy = jsonencode({
     Version = "2012-10-17"
     Id      = "key-policy-dynamodb",

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -242,9 +242,9 @@ resource "aws_iam_role_policy_attachment" "lambda_env_vars_encryption_kms_policy
 resource "aws_kms_key" "events_topic_encryption" {
   description = "alias/${var.environment}/events-encryption-key"
 
-  policy = data.aws_iam_policy_document.events_encryption_key_permissions.json
-  enable_key_rotation      = true
-  tags = local.default_tags
+  policy              = data.aws_iam_policy_document.events_encryption_key_permissions.json
+  enable_key_rotation = true
+  tags                = local.default_tags
 }
 
 resource "aws_kms_alias" "events_topic_encryption_alias" {


### PR DESCRIPTION
## What?

AWS Customer Managed Keys Backing Key Rotation Enabled (CPC-221)

## Why?

KMS key are missing Rotation Enabled enabling the same as they are getting Flagged as non compliance in CPC-221 

