### PR TITLE
ATO-319: New GitHub Action to Trigger Orch Deployment in Parallel

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -42,3 +42,26 @@ jobs:
         with:
           sarif_file: results.sarif
           category: ${{ matrix.module }}
+
+  scan-orch:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkov GitHub Action
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          file: template.yaml
+          framework: cloudformation
+          quiet: true
+          output_format: cli,sarif
+          output_file_path: console,results.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: orch-sam

--- a/.github/workflows/deploy-orch.yml
+++ b/.github/workflows/deploy-orch.yml
@@ -1,0 +1,43 @@
+name: Deploy Orchestration
+
+env:
+  AWS_REGION: eu-west-2
+
+on:
+  workflow_run:
+    workflows: ["Build modules"]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up SAM cli
+        uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+
+      - name: Set up AWS creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ORCH_GH_ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: SAM build
+        run: sam build
+
+      - name: Deploy SAM app
+        uses: alphagov/di-devplatform-upload-action@v3.3
+        with:
+          artifact-bucket-name: ${{ secrets.ORCH_ARTIFACT_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.ORCH_SIGNING_PROFILE_NAME }}
+          working-directory: .aws-sam/build

--- a/.github/workflows/pre-merge-checks-sam.yml
+++ b/.github/workflows/pre-merge-checks-sam.yml
@@ -1,0 +1,35 @@
+name: Pre-merge checks for SAM
+on:
+  pull_request:
+    paths: ['template.yaml']
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+jobs:
+  sam-checks:
+    name: SAM validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up SAM cli
+        uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+
+      - name: Set up AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ORCH_SAM_APP_VALIDATE_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: SAM validate
+        run: sam validate

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,56 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    PermissionsBoundary: !If
+      - UsePermissionsBoundary
+      - !Ref PermissionsBoundary
+      - !Ref AWS::NoValue
+
+Parameters:
+  Environment:
+    Type: String
+    Description: The name of the environment to deploy to
+  VpcStackName:
+    Type: String
+    Description: The name of the stack used to create the VPC
+  CodeSigningConfigArn:
+    Type: String
+    Description: The ARN of the Code Signing Config to use, provided by the deployment pipeline
+    Default: none
+  PermissionsBoundary:
+    Type: String
+    Description: The ARN of the permissions boundary to apply when creating IAM roles
+    Default: none
+
+Conditions:
+  UsePermissionsBoundary:
+    !Not [ !Equals [ none, !Ref PermissionsBoundary ] ]
+  IsProd:
+    !Equals [ production, !Ref Environment ]
+
+Resources:
+  WellKnownFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
+    # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work
+    Properties:
+      CodeUri: oidc-api
+      Handler: lambda.WellknownHandler::handleRequest
+      Runtime: java17
+      ReservedConcurrentExecutions: 1
+      Environment:
+        Variables:
+          # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+          OIDC_API_BASE_URL: !Sub https://oidc.${Environment}.account.gov.uk/
+          ENVIRONMENT: !Sub ${Environment}
+          FRONTEND_BASE_URL: !Sub https://signin.${Environment}.account.gov.uk/
+      Events:
+        WellKnown:
+          Type: Api
+          Properties:
+            Path: /Wellknown
+            Method: get
+      Tags:
+        CheckovRulesToSkip: CKV_AWS_116.CKV_AWS_117.CKV_AWS_173


### PR DESCRIPTION
## What?

New GitHub action that builds out the Java artefact and invokes the Dev Platform action for secure pipelines.

## Why?

Require for phase 3 of orch/auth split.

## Related PRs

[ATO-307](https://govukverify.atlassian.net/jira/software/c/projects/ATO/boards/390?selectedIssue=ATO-307)

[ATO-307]: https://govukverify.atlassian.net/browse/ATO-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ