### PR TITLE
ATO-332: Update where to get vtr on reauth

### DIFF
--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/TokenGeneratorHelper.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/TokenGeneratorHelper.java
@@ -31,11 +31,27 @@ public class TokenGeneratorHelper {
     public static SignedJWT generateIDToken(
             String clientId, Subject subject, String issuerUrl, JWK signingKey) {
         Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
-        return generateIDToken(clientId, subject, issuerUrl, signingKey, expiryDate);
+        return generateIDToken(clientId, subject, issuerUrl, signingKey, expiryDate, null);
     }
 
     public static SignedJWT generateIDToken(
             String clientId, Subject subject, String issuerUrl, JWK signingKey, Date expiryDate) {
+        return generateIDToken(clientId, subject, issuerUrl, signingKey, expiryDate, null);
+    }
+
+    public static SignedJWT generateIDToken(
+            String clientId, Subject subject, String issuerUrl, JWK signingKey, String vot) {
+        Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
+        return generateIDToken(clientId, subject, issuerUrl, signingKey, expiryDate, vot);
+    }
+
+    public static SignedJWT generateIDToken(
+            String clientId,
+            Subject subject,
+            String issuerUrl,
+            JWK signingKey,
+            Date expiryDate,
+            String vot) {
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(
                         new Issuer(issuerUrl),
@@ -43,6 +59,8 @@ public class TokenGeneratorHelper {
                         List.of(new Audience(clientId)),
                         expiryDate,
                         new Date());
+        if (Objects.nonNull(vot)) idTokenClaims.setClaim("vot", vot);
+
         try {
             JWSSigner signer;
             JWSHeader.Builder jwsHeaderBuilder;


### PR DESCRIPTION
- Add `getVtrList` to get the vtrList from either the authRequest or, if not present in request and reauth has been requested, from the `id_token_hint` (in which case the previously granted vot will be used)
- Add vot claim to `generateIDToken` in `TokenGeneratorHelper` for mocking in tests

## What?

Please include a summary of the change.

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.