### PR TITLE
ATO-97: Create KMS signing key for storage token sent to IPV

### DIFF
--- a/ci/terraform/oidc/ecc-signing-key.tf
+++ b/ci/terraform/oidc/ecc-signing-key.tf
@@ -1,0 +1,13 @@
+resource "aws_kms_key" "storage_token_signing_key_ecc" {
+  description              = "KMS signing key (ECC) for VC storage token"
+  deletion_window_in_days  = 30
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "ECC_NIST_P256"
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "storage_token_signing_key_alias" {
+  name          = "alias/${var.environment}-storage-token-signing-key-ecc-alias"
+  target_key_id = aws_kms_key.storage_token_signing_key_ecc.key_id
+}

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -5,6 +5,7 @@ module "ipv_authorize_role" {
   vpc_arn     = local.authentication_vpc_arn
 
   policies_to_attach = [
+    aws_iam_policy.storage_token_kms_signing_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
@@ -18,6 +19,29 @@ module "ipv_authorize_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
+}
+
+data "aws_iam_policy_document" "storage_token_kms_signing_policy_document" {
+  statement {
+    sid    = "AllowAccessToVcTokenKmsSigningKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Sign",
+      "kms:GetPublicKey",
+    ]
+    resources = [
+      aws_kms_key.storage_token_signing_key_ecc.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "storage_token_kms_signing_policy" {
+  name_prefix = "kms-signing-policy"
+  path        = "/${var.environment}/storage-token/"
+  description = "IAM policy for managing KMS connection for a lambda which allows signing of storage token payloads"
+
+  policy = data.aws_iam_policy_document.storage_token_kms_signing_policy_document.json
 }
 
 module "ipv-authorize" {


### PR DESCRIPTION
## What?

- Create a new KMS key using the ES256 signing algorithm
- Create a new policy for use of the signing key
- Attach the policy to the Lambda role for IPVAuthorisationHandler

## Why?

This will allow Orchestration to send a signed JWT in the JAR request to IPV

## Testing
Tested in sandpit: new KMS key can be retrieved and used to sign a message, only by the lambda with the permission to do so


## Orchestration and Authentication mutual dependencies

- [✓] Impact on orch and auth mutual dependencies has been checked.