### PR TITLE
AUT-2295:  Added abortOnAccountInterventionsErrorResponse Flag and Refactored

### DIFF
--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -24,13 +24,15 @@ module "account_interventions" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DYNAMO_ENDPOINT                  = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT              = var.use_localstack ? var.localstack_endpoint : null
-    ENVIRONMENT                      = var.environment
-    TXMA_AUDIT_QUEUE_URL             = module.oidc_txma_audit.queue_url
-    INTERNAl_SECTOR_URI              = var.internal_sector_uri
-    REDIS_KEY                        = local.redis_key
-    ACCOUNT_INTERVENTION_SERVICE_URI = var.account_intervention_service_uri
+    DYNAMO_ENDPOINT                             = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT                         = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT                                 = var.environment
+    TXMA_AUDIT_QUEUE_URL                        = module.oidc_txma_audit.queue_url
+    INTERNAl_SECTOR_URI                         = var.internal_sector_uri
+    REDIS_KEY                                   = local.redis_key
+    ACCOUNT_INTERVENTION_SERVICE_URI            = var.account_intervention_service_uri
+    ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR = var.account_intervention_service_abort_on_error
+    ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AccountInterventionsHandler::handleRequest"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -143,6 +143,18 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                     "Error in Account Interventions response HttpCode: {}, ErrorMessage: {}.",
                     e.getHttpCode(),
                     e.getMessage());
+            if (!configurationService.abortOnAccountInterventionsErrorResponse()) {
+                try {
+                    LOG.error(
+                            "Swallowing error and returning default account interventions response");
+                    AccountInterventionsResponse defaultAccountInterventionsResponse =
+                            new AccountInterventionsResponse(false, false, false);
+                    return generateApiGatewayProxyResponse(
+                            200, defaultAccountInterventionsResponse, true);
+                } catch (JsonException ex) {
+                    return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+                }
+            }
             if (e.getHttpCode() == 429) {
                 return generateApiGatewayProxyErrorResponse(429, ErrorResponse.ERROR_1051);
             }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsInboundResponse;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.io.IOException;
@@ -20,11 +21,17 @@ public class AccountInterventionsService {
     private static final Logger LOG = LogManager.getLogger(AccountInterventionsService.class);
     private final Json objectMapper = SerializationService.getInstance();
 
+    private ConfigurationService configurationService = new ConfigurationService();
+
     public AccountInterventionsInboundResponse sendAccountInterventionsOutboundRequest(
             HTTPRequest request) throws UnsuccessfulAccountInterventionsResponseException {
 
         try {
             LOG.info("Sending account interventions outbound request");
+            int timeoutMillis =
+                    (int) configurationService.getAccountInterventionServiceCallTimeout();
+            request.setConnectTimeout(timeoutMillis);
+            request.setReadTimeout(timeoutMillis);
             var response = request.send();
             if (!response.indicatesSuccess()) {
                 throw new UnsuccessfulAccountInterventionsResponseException(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -648,4 +648,15 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     public URI getAccountInterventionServiceURI() {
         return URI.create(System.getenv("ACCOUNT_INTERVENTION_SERVICE_URI"));
     }
+
+    public boolean abortOnAccountInterventionsErrorResponse() {
+        return System.getenv()
+                .getOrDefault("ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR", "false")
+                .equals("true");
+    }
+
+    public long getAccountInterventionServiceCallTimeout() {
+        return Long.parseLong(
+                System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "1000"));
+    }
 }


### PR DESCRIPTION
## What?

Added abortOnAccountInterventionsErrorResponse feature flag that when turned on and AIS returns an error, the lambda aborts and returns the error response. When turned off, if AIS returns an error response, a default error response is returned. A default timeout has been added for AIS to respond within.

Also in this PR, some refactoring for improved readability.

## Why?

The purpose of this switch and associated logic is to handle errors that occur when AIS is not working as intended. 

## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.