### PR TITLE
AUT-2295: Bump account interventions timeout

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -84,7 +84,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public long getAccountInterventionServiceCallTimeout() {
         return Long.parseLong(
-                System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "1000"));
+                System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "3000"));
     }
 
     public String getAccountInterventionsErrorMetricName() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -657,6 +657,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public long getAccountInterventionServiceCallTimeout() {
         return Long.parseLong(
-                System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "1000"));
+                System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "3000"));
     }
 }


### PR DESCRIPTION
We think this is causing issues in build and staging

## What?

Bump default timeout from 1000ms to 3000ms for getting response from account interventions.

## Why?

We believe this is causing acceptance tests to fail as the lambdas cold start and taking longer to respond.