### PR TITLE
AUT-2094: Create invalid email entered lock when during re-authentication

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/exceptions/AccountLockedException.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/exceptions/AccountLockedException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.frontendapi.exceptions;
+
+public class AccountLockedException extends RuntimeException {
+    public AccountLockedException(String message) {
+        super(message);
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -135,6 +135,10 @@ public class RedisExtension
         codeStorageService.increaseIncorrectPasswordCount(email);
     }
 
+    public void incrementEmailCount(String email) {
+        codeStorageService.increaseIncorrectEmailCount(email);
+    }
+
     public void addAuthRequestToSession(
             String clientSessionId,
             String sessionId,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -67,7 +67,8 @@ public enum ErrorResponse {
     ERROR_1053(1053, "Account Interventions API Bad Gateway"),
     ERROR_1054(1054, "Account Interventions API Gateway Timeout"),
     ERROR_1055(1055, "Account Interventions API Unexpected Error"),
-    ERROR_1056(1056, "User not found or no match");
+    ERROR_1056(1056, "User not found or no match"),
+    ERROR_1057(1057, "User entered invalid email too many times");
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -28,6 +28,8 @@ public class CodeStorageService {
     private static final String RESET_PASSWORD_KEY_PREFIX = "reset-password-code:";
     private static final String MULTIPLE_INCORRECT_PASSWORDS_PREFIX =
             "multiple-incorrect-passwords:";
+    private static final String MULTIPLE_INCORRECT_REAUTH_EMAIL_PREFIX =
+            "multiple-incorrect-reauth-email:";
     private static final String MULTIPLE_INCORRECT_PASSWORDS_REAUTH_PREFIX =
             "multiple-incorrect-passwords-reauth:";
 
@@ -74,6 +76,10 @@ public class CodeStorageService {
         increaseCount(email, MULTIPLE_INCORRECT_PASSWORDS_PREFIX);
     }
 
+    public void increaseIncorrectEmailCount(String email) {
+        increaseCount(email, MULTIPLE_INCORRECT_REAUTH_EMAIL_PREFIX);
+    }
+
     public void increaseIncorrectPasswordCountReauthJourney(String email) {
         increaseCount(email, MULTIPLE_INCORRECT_PASSWORDS_REAUTH_PREFIX);
     }
@@ -95,6 +101,10 @@ public class CodeStorageService {
         return getIncorrectCount(email, MULTIPLE_INCORRECT_PASSWORDS_PREFIX);
     }
 
+    public int getIncorrectEmailCount(String email) {
+        return getIncorrectCount(email, MULTIPLE_INCORRECT_REAUTH_EMAIL_PREFIX);
+    }
+
     public int getIncorrectPasswordCountReauthJourney(String email) {
         return getIncorrectCount(email, MULTIPLE_INCORRECT_PASSWORDS_REAUTH_PREFIX);
     }
@@ -109,6 +119,10 @@ public class CodeStorageService {
 
     public void deleteIncorrectPasswordCount(String email) {
         deleteCount(email, MULTIPLE_INCORRECT_PASSWORDS_PREFIX);
+    }
+
+    public void deleteIncorrectEmailCount(String email) {
+        deleteCount(email, MULTIPLE_INCORRECT_REAUTH_EMAIL_PREFIX);
     }
 
     public void deleteIncorrectPasswordCountReauthJourney(String email) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -197,6 +197,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Integer.parseInt(System.getenv().getOrDefault("PASSWORD_MAX_RETRIES", "5"));
     }
 
+    public int getMaxEmailReAuthRetries() {
+        return Integer.parseInt(System.getenv().getOrDefault("EMAIL_MAX_RE_AUTH_RETRIES", "5"));
+    }
+
     public boolean isCustomDocAppClaimEnabled() {
         return System.getenv().getOrDefault("CUSTOM_DOC_APP_CLAIM_ENABLED", "false").equals("true");
     }


### PR DESCRIPTION
## What?

Create invalid email entered lock when during re-authentication

- Create a new lock when user has entered their sign-in details too many times
- Creates a new prefix value in Redis `multiple-incorrect-reauth-email`

## Why?

- Prevents the user from attempting to sign in multiple times