### PR TITLE
AUT-2295: Bump account interventions timeout default

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -507,7 +507,7 @@ variable "account_intervention_service_uri" {
 }
 
 variable "account_intervention_service_call_timeout" {
-  default     = 1000
+  default     = 3000
   type        = number
   description = "The HTTP Client connection timeout for requests to Account Intervention Service (in milliseconds)."
 }


### PR DESCRIPTION
We think this is causing issues in build and staging

## What?

Bump default timeout from 1000ms to 3000ms for getting response from account interventions.

## Why?

We believe this is causing acceptance tests to fail as the lambdas cold start and taking longer to respond.