### PR TITLE
BAU: Set minimum provisionned concurrency for the interventions stub lambda

### DIFF
--- a/ci/terraform/interventions-api-stub/variables.tf
+++ b/ci/terraform/interventions-api-stub/variables.tf
@@ -43,7 +43,7 @@ variable "scaling_trigger" {
 }
 
 variable "lambda_min_concurrency" {
-  default     = 0
+  default     = 1
   type        = number
   description = "The number of lambda instance to keep 'warm'"
 }


### PR DESCRIPTION

## What?

Set minimum provisionned concurrency for the interventions stub lambda.

## Why?

There are intermittent failures in the build pipeline which look related to long cold starts for the lambda.

## Related PRs

#3963 