### PR TITLE
Aut 2399/fix logging on timeouts

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.frontendapi.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
@@ -28,9 +27,9 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.net.http.HttpRequest;
 import java.util.Map;
 
-import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.GET;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
@@ -122,7 +121,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                     configurationService.getAccountInterventionServiceURI().toString();
             var accountInterventionsURI =
                     buildURI(accountInterventionsEndpoint, "/v1/ais/" + internalPairwiseId);
-            var accountInterventionsInboundRequest = new HTTPRequest(GET, accountInterventionsURI);
+            var accountInterventionsInboundRequest =
+                    HttpRequest.newBuilder(accountInterventionsURI).build();
             var accountInterventionsInboundResponse =
                     accountInterventionsService.sendAccountInterventionsOutboundRequest(
                             accountInterventionsInboundRequest);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -27,12 +27,10 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
-import java.net.http.HttpRequest;
 import java.util.Map;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
-import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
@@ -83,7 +81,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
 
     public AccountInterventionsHandler(ConfigurationService configurationService) {
         super(AccountInterventionsRequest.class, configurationService);
-        accountInterventionsService = new AccountInterventionsService();
+        accountInterventionsService = new AccountInterventionsService(configurationService);
         this.auditService = new AuditService(configurationService);
     }
 
@@ -117,15 +115,9 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                                     configurationService.getInternalSectorUri(),
                                     authenticationService)
                             .getValue();
-            var accountInterventionsEndpoint =
-                    configurationService.getAccountInterventionServiceURI().toString();
-            var accountInterventionsURI =
-                    buildURI(accountInterventionsEndpoint, "/v1/ais/" + internalPairwiseId);
-            var accountInterventionsInboundRequest =
-                    HttpRequest.newBuilder(accountInterventionsURI).build();
             var accountInterventionsInboundResponse =
                     accountInterventionsService.sendAccountInterventionsOutboundRequest(
-                            accountInterventionsInboundRequest);
+                            internalPairwiseId);
 
             logAisResponse(accountInterventionsInboundResponse);
             submitAuditEvents(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
@@ -1,9 +1,6 @@
 package uk.gov.di.authentication.frontendapi.services;
 
 import com.google.gson.JsonParseException;
-import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.http.HTTPRequest;
-import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsInboundResponse;
@@ -13,6 +10,9 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 
 import static java.lang.String.format;
 
@@ -21,41 +21,50 @@ public class AccountInterventionsService {
     private static final Logger LOG = LogManager.getLogger(AccountInterventionsService.class);
     private final Json objectMapper = SerializationService.getInstance();
 
+    private static HttpClient httpClient;
+
     private ConfigurationService configurationService = new ConfigurationService();
 
+    public AccountInterventionsService() {
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    public AccountInterventionsService(HttpClient client) {
+        httpClient = client;
+    }
+
     public AccountInterventionsInboundResponse sendAccountInterventionsOutboundRequest(
-            HTTPRequest request) throws UnsuccessfulAccountInterventionsResponseException {
+            HttpRequest request) throws UnsuccessfulAccountInterventionsResponseException {
 
         try {
             LOG.info("Sending account interventions outbound request");
-            int timeoutMillis =
-                    (int) configurationService.getAccountInterventionServiceCallTimeout();
-            request.setConnectTimeout(timeoutMillis);
-            request.setReadTimeout(timeoutMillis);
-            var response = request.send();
-            if (!response.indicatesSuccess()) {
+            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() > 299) {
                 throw new UnsuccessfulAccountInterventionsResponseException(
                         format(
                                 "Error %s when attempting to call Account Interventions outbound endpoint: %s",
-                                response.getStatusCode(), response.getContent()),
-                        response.getStatusCode());
+                                response.statusCode(), response.body()),
+                        response.statusCode());
             }
             LOG.info("Received successful account interventions outbound response");
             return parseResponse(response);
         } catch (IOException e) {
             throw new UnsuccessfulAccountInterventionsResponseException(
                     "Error when attempting to call Account Interventions outbound endpoint", e);
-        } catch (ParseException | Json.JsonException | JsonParseException e) {
+        } catch (Json.JsonException | JsonParseException e) {
             throw new UnsuccessfulAccountInterventionsResponseException(
                     "Error parsing HTTP response", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new UnsuccessfulAccountInterventionsResponseException(
+                    "Interrupted exception when attempting to call Account Interventions outbound endpoint",
+                    e);
         }
     }
 
-    private AccountInterventionsInboundResponse parseResponse(HTTPResponse response)
-            throws Json.JsonException, ParseException, JsonParseException {
+    private AccountInterventionsInboundResponse parseResponse(HttpResponse response)
+            throws Json.JsonException, JsonParseException {
         return objectMapper.readValue(
-                response.getContentAsJSONObject().toString(),
-                AccountInterventionsInboundResponse.class,
-                true);
+                response.body().toString(), AccountInterventionsInboundResponse.class, true);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnsuccessfulAccountInterventionsResponseException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnsuccessfulAccountInterventionsResponseException.java
@@ -1,5 +1,10 @@
 package uk.gov.di.authentication.shared.exceptions;
 
+import java.io.IOException;
+import java.net.http.HttpTimeoutException;
+
+import static java.lang.String.format;
+
 public class UnsuccessfulAccountInterventionsResponseException extends Exception {
 
     private final int httpCode;
@@ -12,6 +17,42 @@ public class UnsuccessfulAccountInterventionsResponseException extends Exception
     public UnsuccessfulAccountInterventionsResponseException(String message, Throwable cause) {
         super(message, cause);
         this.httpCode = 0;
+    }
+
+    public static UnsuccessfulAccountInterventionsResponseException ioException(IOException e) {
+        return new UnsuccessfulAccountInterventionsResponseException(
+                "Error when attempting to call Account Interventions outbound endpoint", e);
+    }
+
+    public static UnsuccessfulAccountInterventionsResponseException interruptedException(
+            InterruptedException e) {
+        return new UnsuccessfulAccountInterventionsResponseException(
+                "Interrupted exception when attempting to call Account Interventions outbound endpoint",
+                e);
+    }
+
+    public static UnsuccessfulAccountInterventionsResponseException timeoutException(
+            Long timeout, HttpTimeoutException e) {
+
+        return new UnsuccessfulAccountInterventionsResponseException(
+                format(
+                        "Timeout when calling Account Interventions endpoint with timeout of %d",
+                        timeout),
+                e);
+    }
+
+    public static UnsuccessfulAccountInterventionsResponseException httpResponseCodeException(
+            Integer statusCode, Object body) {
+        return new UnsuccessfulAccountInterventionsResponseException(
+                format(
+                        "Error %s when attempting to call Account Interventions outbound endpoint: %s",
+                        statusCode, body),
+                statusCode);
+    }
+
+    public static UnsuccessfulAccountInterventionsResponseException parseException(Exception e) {
+        return new UnsuccessfulAccountInterventionsResponseException(
+                "Error parsing HTTP response", e);
     }
 
     public int getHttpCode() {


### PR DESCRIPTION
## What?

* Adds a specific log message for when the request to the Account Interventions Service times out
* Refactors the Account Interventions Service to use the standard java http library, rather than the OAuth library (since we're not making an OAuth request to the Account Interventions service). This also makes it easier to catch the specific timeout exception and log.
* Moves all the logic to call the account interventions api to the Account Interventions service, so it's all in one place.

## Why?

We're seeing generic IOExceptions being thrown in build and staging, we think because the call to the API is timing out. It is useful for debugging purposes to specifically log when a request has timed out, since it's more difficult to know what happened with the more generic error.