### PR TITLE
ATO-386: Always return false for consent required

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -169,7 +169,7 @@ class SignUpHandlerTest {
 
         assertThat(result, hasStatus(200));
         var signUpResponse = objectMapper.readValue(result.getBody(), SignUpResponse.class);
-        assertThat(signUpResponse.isConsentRequired(), equalTo(consentRequired));
+        assertThat(signUpResponse.isConsentRequired(), equalTo(false));
         verify(authenticationService)
                 .signUp(
                         eq(EMAIL),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CREATE_ACCOUNT;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
@@ -77,7 +77,7 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(200));
         var signUpResponse = objectMapper.readValue(response.getBody(), SignUpResponse.class);
-        assertThat(signUpResponse.isConsentRequired(), equalTo(consentRequired));
+        assertFalse(signUpResponse.isConsentRequired());
         assertTrue(
                 Objects.nonNull(redis.getSession(sessionId).getInternalCommonSubjectIdentifier()));
         assertTrue(userStore.userExists("joe.bloggs+5@digital.cabinet-office.gov.uk"));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -334,7 +334,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private void verifyStandardUserInformationSetOnResponse(
             UserStartInfo userStartInfo, Boolean consentRequired) {
-        assertThat(userStartInfo.isConsentRequired(), equalTo(consentRequired));
+        assertFalse(userStartInfo.isConsentRequired());
         assertThat(userStartInfo.isUpliftRequired(), equalTo(false));
         assertThat(userStartInfo.getCookieConsent(), equalTo(null));
         assertThat(userStartInfo.getGaCrossDomainTrackingId(), equalTo(null));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -177,14 +177,14 @@ public class TokenHandlerTest {
 
     private static Stream<Arguments> validVectorValues() {
         return Stream.of(
-                Arguments.of("Cl.Cm", true, true, true),
-                Arguments.of("Cl", true, true, true),
+                Arguments.of("Cl.Cm", true, false, true),
+                Arguments.of("Cl", true, false, true),
                 Arguments.of("P2.Cl.Cm", true, false, true),
                 Arguments.of("Cl.Cm", false, false, true),
                 Arguments.of("Cl", false, false, true),
                 Arguments.of("P2.Cl.Cm", false, false, true),
-                Arguments.of("Cl.Cm", true, true, false),
-                Arguments.of("Cl", true, true, false),
+                Arguments.of("Cl.Cm", true, false, false),
+                Arguments.of("Cl", true, false, false),
                 Arguments.of("P2.Cl.Cm", true, false, false),
                 Arguments.of("Cl.Cm", false, false, false),
                 Arguments.of("Cl", false, false, false),

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
@@ -240,7 +240,7 @@ public class ClientRegistry {
 
     @DynamoDbAttribute("ConsentRequired")
     public boolean isConsentRequired() {
-        return consentRequired;
+        return false;
     }
 
     public void setConsentRequired(boolean consentRequired) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -239,7 +239,7 @@ public class ClientRegistry {
 
     @DynamoDbAttribute("ConsentRequired")
     public boolean isConsentRequired() {
-        return consentRequired;
+        return false;
     }
 
     public void setConsentRequired(boolean consentRequired) {


### PR DESCRIPTION


## What?
Always return false for client consent from client reg

## Why?
Setting this value to true breaks the client

## Related PRs
https://github.com/govuk-one-login/authentication-api/pull/3694

## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.