### PR TITLE
AUT-2152: Add CW alarm and Slack alerting on pending email check DLQ

### DIFF
--- a/ci/terraform/shared/production.tfvars
+++ b/ci/terraform/shared/production.tfvars
@@ -2,3 +2,4 @@ logging_endpoint_enabled             = false
 common_state_bucket                  = "digital-identity-prod-tfstate"
 di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:114407264696:/signing-profiles/di_auth_lambda_signing_20220215170204371800000001/zLiNn2Hi1I"
 tools_account_id                     = 114407264696
+dlq_alarm_threshold                  = 999999

--- a/ci/terraform/shared/sqs.tf
+++ b/ci/terraform/shared/sqs.tf
@@ -16,17 +16,6 @@ resource "aws_sqs_queue" "pending_email_check_queue" {
   tags = local.default_tags
 }
 
-resource "aws_sqs_queue" "pending_email_check_dead_letter_queue" {
-  name = "${var.environment}-pending-email-check-dlq"
-
-  kms_master_key_id                 = var.use_localstack ? null : aws_kms_key.pending_email_check_queue_encryption_key.arn
-  kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
-
-  message_retention_seconds = 1209600
-
-  tags = local.default_tags
-}
-
 data "aws_iam_policy_document" "pending_email_queue_access_policy_document" {
   version   = "2012-10-17"
   policy_id = "${var.environment}-pending-email-check-queue-access-policy"
@@ -57,4 +46,32 @@ resource "aws_iam_policy" "pending_email_check_queue_access_policy" {
   description = "IAM Policy for write access to the pending email queue"
 
   policy = data.aws_iam_policy_document.pending_email_queue_access_policy_document.json
+}
+
+resource "aws_sqs_queue" "pending_email_check_dead_letter_queue" {
+  name = "${var.environment}-pending-email-check-dlq"
+
+  kms_master_key_id                 = var.use_localstack ? null : aws_kms_key.pending_email_check_queue_encryption_key.arn
+  kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
+
+  message_retention_seconds = 1209600
+
+  tags = local.default_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "pending_email_check_dlq_cloudwatch_alarm" {
+  alarm_name          = replace("${var.environment}-pending-email-check-dlq-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = var.dlq_alarm_threshold
+
+  dimensions = {
+    QueueName = aws_sqs_queue.pending_email_check_dead_letter_queue.name
+  }
+  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.pending_email_check_dead_letter_queue.name}"
+  alarm_actions     = [aws_sns_topic.slack_events.arn]
 }

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -161,3 +161,9 @@ variable "auth_check_account_id" {
   type        = string
   description = "Account id of the auth check aws account"
 }
+
+variable "dlq_alarm_threshold" {
+  default     = 1
+  type        = number
+  description = "The number of messages on a DLQ before a Cloudwatch alarm is generated"
+}


### PR DESCRIPTION
## What?
- Cloudwatch alarm feeds message into pre-existing SNS topic
- This topic is already configured with a lambda subscription
- That lambda uses a Slack webhook to transmit the message to internal Slack channel
- The thrreshold for the CW alarm has been set high in prod to avoid spamming the channel whilst the email check is still in development
- The same will be true of integration, but that will be done in a separate commit/PR as we will want to test that the alert works, so default of 1 has been left for now

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.