### PR TITLE
AUT-2397: Add feature flags for auth account interventions

### DIFF
--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -33,6 +33,7 @@ module "account_interventions" {
     ACCOUNT_INTERVENTION_SERVICE_URI            = var.account_intervention_service_uri
     ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR = var.account_intervention_service_abort_on_error
     ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
+    ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED = var.account_intervention_service_action_enabled
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AccountInterventionsHandler::handleRequest"

--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -34,6 +34,7 @@ module "account_interventions" {
     ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR = var.account_intervention_service_abort_on_error
     ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
     ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED = var.account_intervention_service_action_enabled
+    ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AccountInterventionsHandler::handleRequest"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -106,6 +106,16 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentSessionID);
         LOG.info("Request received to the AccountInterventionsHandler");
 
+        if (!configurationService.isAccountInterventionServiceCallEnabled()) {
+            LOG.info(
+                    "Account interventions service call is disabled, returning default no interventions response");
+            try {
+                return generateApiGatewayProxyResponse(200, noAccountInterventions, true);
+            } catch (JsonException e) {
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+            }
+        }
+
         var userProfile = authenticationService.getUserProfileByEmailMaybe(request.email());
         if (userProfile.isEmpty()) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1049);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -40,6 +40,9 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
     private final AccountInterventionsService accountInterventionsService;
     private final AuditService auditService;
 
+    private final AccountInterventionsResponse noAccountInterventions =
+            new AccountInterventionsResponse(false, false, false);
+
     private static final Map<State, FrontendAuditableEvent>
             ACCOUNT_INTERVENTIONS_STATE_TO_AUDIT_EVENT =
                     Map.of(
@@ -125,15 +128,30 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
 
             LOG.info("Generating Account Interventions outbound response for frontend");
             var accountInterventionsResponse =
-                    new AccountInterventionsResponse(
-                            accountInterventionsInboundResponse.state().resetPassword(),
-                            accountInterventionsInboundResponse.state().blocked(),
-                            accountInterventionsInboundResponse.state().suspended());
+                    getAccountInterventionsResponse(accountInterventionsInboundResponse);
             return generateApiGatewayProxyResponse(200, accountInterventionsResponse, true);
         } catch (UnsuccessfulAccountInterventionsResponseException e) {
             return handleErrorForAIS(e);
         } catch (JsonException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+        }
+    }
+
+    private AccountInterventionsResponse getAccountInterventionsResponse(
+            AccountInterventionsInboundResponse response) {
+        var responseFromApi =
+                new AccountInterventionsResponse(
+                        response.state().resetPassword(),
+                        response.state().blocked(),
+                        response.state().suspended());
+        if (!configurationService.accountInterventionsServiceActionEnabled()) {
+            LOG.info(
+                    String.format(
+                            "Account interventions action disabled, discarding response %s from api and returning no interventions",
+                            responseFromApi));
+            return noAccountInterventions;
+        } else {
+            return responseFromApi;
         }
     }
 
@@ -143,13 +161,11 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                 "Error in Account Interventions response HttpCode: {}, ErrorMessage: {}.",
                 e.getHttpCode(),
                 e.getMessage());
-        if (!configurationService.abortOnAccountInterventionsErrorResponse()) {
+        if (!configurationService.abortOnAccountInterventionsErrorResponse()
+                || !configurationService.accountInterventionsServiceActionEnabled()) {
             try {
                 LOG.error("Swallowing error and returning default account interventions response");
-                AccountInterventionsResponse defaultAccountInterventionsResponse =
-                        new AccountInterventionsResponse(false, false, false);
-                return generateApiGatewayProxyResponse(
-                        200, defaultAccountInterventionsResponse, true);
+                return generateApiGatewayProxyResponse(200, noAccountInterventions, true);
             } catch (JsonException ex) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
             }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -145,6 +145,10 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
         public boolean accountInterventionsServiceActionEnabled() {
             return true;
         }
+
+        public boolean isAccountInterventionServiceCallEnabled() {
+            return true;
+        }
     }
 
     private String setupUserAndRetrieveUserId(String emailAddress) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -140,6 +140,11 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
         public String getTxmaAuditQueueUrl() {
             return txmaAuditQueue.getQueueUrl();
         }
+
+        @Override
+        public boolean accountInterventionsServiceActionEnabled() {
+            return true;
+        }
     }
 
     private String setupUserAndRetrieveUserId(String emailAddress) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -665,6 +665,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals("true");
     }
 
+    public boolean isAccountInterventionServiceCallEnabled() {
+        return System.getenv()
+                .getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED", "false")
+                .equals("true");
+    }
+
     public long getAccountInterventionServiceCallTimeout() {
         return Long.parseLong(
                 System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "3000"));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -659,6 +659,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals("true");
     }
 
+    public boolean accountInterventionsServiceActionEnabled() {
+        return System.getenv()
+                .getOrDefault("ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED", "false")
+                .equals("true");
+    }
+
     public long getAccountInterventionServiceCallTimeout() {
         return Long.parseLong(
                 System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "3000"));


### PR DESCRIPTION
Adds two feature flags:

1. ACCOUNT_INTERVENTIONS_SERVICE_ACTION_ENABLED - when false,  we still make a call to the account interventions service, but we discard the result (whether a 4xx
 or 5xx, or a successful response that may indicate interventions) and return the no interventions response.
2. ACCOUNT_INTERVENTIONS_CALL_ENABLED - when false, the account intervention handler takes no action (does not call the account interventions api) and just returns a no interventions response, so this has the effect of being a feature flag for all the behaviour.

This will allow us to validate the implement account interventions slowly, by adding a step where we can analyse the results of the interventions without having an impact on the user journey.

## 🔴  Depends on 🔴 

I've based this off the changes in [this PR](https://github.com/govuk-one-login/authentication-api/pull/3965) since they involve some refactoring of the code here, so that PR should be merged first, and this PR should then be changed to be against a base of `main` (will happen automatically when that PR merged)
