### PR TITLE
ATO-95: Add storageAccessToken claim to JAR sent to IPV

### DIFF
--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -54,6 +54,7 @@ module "authentication_callback" {
     ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR = var.account_intervention_service_abort_on_error
     ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
     STORAGE_TOKEN_SIGNING_KEY_ALIAS             = aws_kms_alias.storage_token_signing_key_alias.name
+    SEND_STORAGE_TOKEN_TO_IPV_ENABLED           = var.send_storage_token_to_ipv_enabled
   }
 
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler::handleRequest"

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -23,6 +23,7 @@ account_intervention_service_call_enabled   = true
 account_intervention_service_action_enabled = true
 # account_intervention_service_uri is stored in AWS Secrets Manager and populated using read_secrets.sh
 account_intervention_service_abort_on_error = true
+send_storage_token_to_ipv_enabled           = true
 auth_frontend_public_encryption_key         = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApLJWOHz7uHLinSJr8XM0

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -13,6 +13,7 @@ logging_endpoint_arns                       = []
 account_intervention_service_call_enabled   = true
 account_intervention_service_action_enabled = true
 account_intervention_service_abort_on_error = true
+send_storage_token_to_ipv_enabled           = true
 auth_frontend_public_encryption_key         = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs41htFRe62BIfwQZ0OCT

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -30,6 +30,7 @@ account_intervention_service_call_enabled   = true
 account_intervention_service_action_enabled = true
 # account_intervention_service_uri is stored in AWS Secrets Manager and populated using read_secrets.sh
 account_intervention_service_abort_on_error = true
+send_storage_token_to_ipv_enabled           = true
 ipv_auth_public_encryption_key              = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyB5V0Tc9KEV5/zGUHLu0

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -541,6 +541,12 @@ variable "support_email_check_enabled" {
   description = "Feature flag which toggles the Experian email check on and off"
 }
 
+variable "send_storage_token_to_ipv_enabled" {
+  default     = false
+  type        = bool
+  description = "Feature flag which toggles whether signed VC storage token is included as claim in JAR sent to IPV"
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -65,6 +65,7 @@ test {
     environment "TRACING_ENABLED", "false"
     environment "INTERNAl_SECTOR_URI", "https://test.account.gov.uk"
     environment "BULK_USER_EMAIL_INCLUDED_TERMS_AND_CONDITIONS", "1.0,1.1,1.2,1.3,1.4"
+    environment "SEND_STORAGE_TOKEN_TO_IPV_ENABLED", "true"
 
     doLast {
         tasks.getByName("jacocoTestReport").sourceDirectories.from(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -791,6 +791,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                 boolean abortOnAisErrorResponse) {
             super(
                     tokenSigningKey,
+                    storageTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
                     docAppPrivateKeyJwtSigner,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -112,6 +112,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final IntegrationTestConfigurationService configuration =
             new IntegrationTestConfigurationService(
                     externalTokenSigner,
+                    storageTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
                     docAppPrivateKeyJwtSigner,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
@@ -158,6 +158,7 @@ class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegration
         public DocAppTestConfigurationService(DocAppJwksExtension jwksExtension) {
             super(
                     externalTokenSigner,
+                    storageTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
                     docAppPrivateKeyJwtSigner,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -408,6 +408,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                 boolean userInfoV2Enabled) {
             super(
                     tokenSigningKey,
+                    storageTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
                     docAppPrivateKeyJwtSigner,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -158,6 +158,7 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
         public IPVTestConfigurationService(IPVStubExtension ipvStub) {
             super(
                     externalTokenSigner,
+                    storageTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
                     docAppPrivateKeyJwtSigner,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -545,6 +545,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 SqsQueueExtension spotQueue) {
             super(
                     tokenSigningKey,
+                    storageTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
                     docAppPrivateKeyJwtSigner,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCapacityHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCapacityHandlerIntegrationTest.java
@@ -43,6 +43,7 @@ class IPVCapacityHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     public ConfigurationService capacityAwareConfiguration(String value) {
         return new IntegrationTestConfigurationService(
                 externalTokenSigner,
+                storageTokenSigner,
                 ipvPrivateKeyJwtSigner,
                 spotQueue,
                 docAppPrivateKeyJwtSigner,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -21,6 +21,7 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var configurationService =
                 new IntegrationTestConfigurationService(
                         externalTokenSigner,
+                        storageTokenSigner,
                         ipvPrivateKeyJwtSigner,
                         spotQueue,
                         docAppPrivateKeyJwtSigner,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -338,6 +338,7 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
         public TestConfigurationService(boolean authOrchSplitEnabled) {
             super(
                     externalTokenSigner,
+                    storageTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
                     docAppPrivateKeyJwtSigner,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -103,6 +103,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var configuration =
                 new IntegrationTestConfigurationService(
                         externalTokenSigner,
+                        storageTokenSigner,
                         ipvPrivateKeyJwtSigner,
                         spotQueue,
                         docAppPrivateKeyJwtSigner,
@@ -559,6 +560,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         public UserInfoConfigurationService() {
             super(
                     externalTokenSigner,
+                    storageTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
                     docAppPrivateKeyJwtSigner,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -44,7 +44,6 @@ import java.time.Clock;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 public class IPVAuthorisationService {
@@ -187,9 +186,8 @@ public class IPVAuthorisationService {
                 && reproveIdentity != null) {
             claimsBuilder.claim("reprove_identity", reproveIdentity);
         }
-        if (Objects.nonNull(claims)) {
-            claimsBuilder.claim("claims", claimsRequest.toJSONObject());
-        }
+        claimsBuilder.claim("claims", claimsRequest.toJSONObject());
+
         var encodedHeader = jwsHeader.toBase64URL();
         var encodedClaims = Base64URL.encode(claimsBuilder.build().toString());
         var message = encodedHeader + "." + encodedClaims;

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -72,7 +72,7 @@ class IPVAuthorisationServiceTest {
     private static final URI IPV_CALLBACK_URI = URI.create("http://localhost/oidc/ipv/callback");
     private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv/authorize");
     private static final String SERIALIZED_JWT =
-            "eyJhbGciOiJFUzI1NiJ9.e30.Ocd0zjblolysCck2LLVgenMKNDQ9GAGCSjlg1kkWVzYcK31qzcJR68bw4b1MdgIEvxZhZ_4ZxWlKIx4OOFixTw";
+            "eyJraWQiOiIwOWRkYjY1ZWIzY2U0MWEzYjczYTJhOTM0ZTM5NDg4NmQyYTIyYjU0ZmQwMzVmYWJlZWM3YWMxYzllYzliNzBiIiwiYWxnIjoiRVMyNTYifQ.eyJhdWQiOlsiaHR0cHM6Ly9jcmVkZW50aWFsLXN0b3JlLnRlc3QuYWNjb3VudC5nb3YudWsiLCJodHRwczovL2lkZW50aXR5LnRlc3QuYWNjb3VudC5nb3YudWsiXSwic3ViIjoia3NFUjVWcDRuZU1ONWM2WHJlSV9uUDhGNFZuc2VqS2x1b3BOX05mZjlfNCIsImlzcyI6Imh0dHBzOi8vb2lkYy50ZXN0LmFjY291bnQuZ292LnVrLyIsImV4cCI6MTcwOTA1MTE2MywiaWF0IjoxNzA5MDQ3NTYzLCJqdGkiOiJkZmNjZjc1MS1iZTU1LTRkZjQtYWEzZi1hOTkzMTkzZDUyMTYifQ.rpZ2IqMwlFLbZ8a7En-EuQ480zcorvNd-GZcwjlxlK3Twq9J1GNiuj9teSLINP_zmeirx7Y8p3DUYWk_hyRhww";
 
     private static final Json objectMapper = SerializationService.getInstance();
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -71,6 +71,9 @@ class IPVAuthorisationServiceTest {
     private static final URI IPV_URI = URI.create("http://ipv/");
     private static final URI IPV_CALLBACK_URI = URI.create("http://localhost/oidc/ipv/callback");
     private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv/authorize");
+    private static final String SERIALIZED_JWT =
+            "eyJhbGciOiJFUzI1NiJ9.e30.Ocd0zjblolysCck2LLVgenMKNDQ9GAGCSjlg1kkWVzYcK31qzcJR68bw4b1MdgIEvxZhZ_4ZxWlKIx4OOFixTw";
+
     private static final Json objectMapper = SerializationService.getInstance();
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
@@ -243,7 +246,11 @@ class IPVAuthorisationServiceTest {
                             .add(
                                     new ClaimsSetRequest.Entry(
                                                     "https://vocab.account.gov.uk/v1/inheritedIdentityJWT")
-                                            .withValues(List.of("jwt")));
+                                            .withValues(List.of("jwt")))
+                            .add(
+                                    new ClaimsSetRequest.Entry(
+                                                    "https://vocab.account.gov.uk/v1/storageAccessToken")
+                                            .withValues(List.of(SERIALIZED_JWT)));
 
             EncryptedJWT encryptedJWT;
             try (var mockIdGenerator = mockStatic(IdGenerator.class)) {

--- a/ipv-api/src/test/resources/uk/gov/di/authentication/ipv/services/approvals/IPVAuthorisationServiceTest.SignedJwtRequest.shouldConstructASignedRequestJWT.approved.json
+++ b/ipv-api/src/test/resources/uk/gov/di/authentication/ipv/services/approvals/IPVAuthorisationServiceTest.SignedJwtRequest.shouldConstructASignedRequestJWT.approved.json
@@ -15,6 +15,11 @@
   "scope": "openid",
   "claims": {
     "userinfo": {
+      "https://vocab.account.gov.uk/v1/storageAccessToken": {
+        "values": [
+          "eyJhbGciOiJFUzI1NiJ9.e30.Ocd0zjblolysCck2LLVgenMKNDQ9GAGCSjlg1kkWVzYcK31qzcJR68bw4b1MdgIEvxZhZ_4ZxWlKIx4OOFixTw"
+        ]
+      },
       "https://vocab.account.gov.uk/v1/coreIdentityJWT": {
         "essential": true
       },

--- a/ipv-api/src/test/resources/uk/gov/di/authentication/ipv/services/approvals/IPVAuthorisationServiceTest.SignedJwtRequest.shouldConstructASignedRequestJWT.approved.json
+++ b/ipv-api/src/test/resources/uk/gov/di/authentication/ipv/services/approvals/IPVAuthorisationServiceTest.SignedJwtRequest.shouldConstructASignedRequestJWT.approved.json
@@ -17,7 +17,7 @@
     "userinfo": {
       "https://vocab.account.gov.uk/v1/storageAccessToken": {
         "values": [
-          "eyJhbGciOiJFUzI1NiJ9.e30.Ocd0zjblolysCck2LLVgenMKNDQ9GAGCSjlg1kkWVzYcK31qzcJR68bw4b1MdgIEvxZhZ_4ZxWlKIx4OOFixTw"
+          "eyJraWQiOiIwOWRkYjY1ZWIzY2U0MWEzYjczYTJhOTM0ZTM5NDg4NmQyYTIyYjU0ZmQwMzVmYWJlZWM3YWMxYzllYzliNzBiIiwiYWxnIjoiRVMyNTYifQ.eyJhdWQiOlsiaHR0cHM6Ly9jcmVkZW50aWFsLXN0b3JlLnRlc3QuYWNjb3VudC5nb3YudWsiLCJodHRwczovL2lkZW50aXR5LnRlc3QuYWNjb3VudC5nb3YudWsiXSwic3ViIjoia3NFUjVWcDRuZU1ONWM2WHJlSV9uUDhGNFZuc2VqS2x1b3BOX05mZjlfNCIsImlzcyI6Imh0dHBzOi8vb2lkYy50ZXN0LmFjY291bnQuZ292LnVrLyIsImV4cCI6MTcwOTA1MTE2MywiaWF0IjoxNzA5MDQ3NTYzLCJqdGkiOiJkZmNjZjc1MS1iZTU1LTRkZjQtYWEzZi1hOTkzMTkzZDUyMTYifQ.rpZ2IqMwlFLbZ8a7En-EuQ480zcorvNd-GZcwjlxlK3Twq9J1GNiuj9teSLINP_zmeirx7Y8p3DUYWk_hyRhww"
         ]
       },
       "https://vocab.account.gov.uk/v1/coreIdentityJWT": {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.oidc.exceptions.AuthenticationCallbackException;
 import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
 import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
 import uk.gov.di.authentication.oidc.services.InitiateIPVAuthorisationService;
+import uk.gov.di.authentication.oidc.services.StorageTokenService;
 import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.shared.conditions.MfaHelper;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
@@ -126,7 +127,8 @@ public class AuthenticationCallbackHandler
                         new IPVAuthorisationService(
                                 configurationService, redisConnectionService, kmsConnectionService),
                         cloudwatchMetricsService,
-                        new NoSessionOrchestrationService(configurationService));
+                        new NoSessionOrchestrationService(configurationService),
+                        new StorageTokenService(configurationService));
         this.accountInterventionService =
                 new AccountInterventionService(
                         configurationService, cloudwatchMetricsService, auditService);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
@@ -2,10 +2,13 @@ package uk.gov.di.authentication.oidc.services;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
@@ -41,18 +44,21 @@ public class InitiateIPVAuthorisationService {
     private final IPVAuthorisationService authorisationService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final NoSessionOrchestrationService noSessionOrchestrationService;
+    private final StorageTokenService storageTokenService;
 
     public InitiateIPVAuthorisationService(
             ConfigurationService configurationService,
             AuditService auditService,
             IPVAuthorisationService authorisationService,
             CloudwatchMetricsService cloudwatchMetricsService,
-            NoSessionOrchestrationService noSessionOrchestrationService) {
+            NoSessionOrchestrationService noSessionOrchestrationService,
+            StorageTokenService storageTokenService) {
         this.configurationService = configurationService;
         this.auditService = auditService;
         this.authorisationService = authorisationService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.noSessionOrchestrationService = noSessionOrchestrationService;
+        this.storageTokenService = storageTokenService;
     }
 
     public APIGatewayProxyResponseEvent sendRequestToIPV(
@@ -76,7 +82,7 @@ public class InitiateIPVAuthorisationService {
         var pairwiseSubject = userInfo.getSubject();
 
         var state = new State();
-        var claimsSetRequest = buildIpvClaimsRequest(authRequest).orElse(null);
+        var claimsSetRequest = buildIpvClaimsRequest(authRequest, pairwiseSubject);
 
         var encryptedJWT =
                 authorisationService.constructRequestJWT(
@@ -127,9 +133,26 @@ public class InitiateIPVAuthorisationService {
                 null);
     }
 
-    private Optional<ClaimsSetRequest> buildIpvClaimsRequest(AuthenticationRequest authRequest) {
-        return Optional.ofNullable(authRequest)
-                .map(AuthenticationRequest::getOIDCClaims)
-                .map(OIDCClaimsRequest::getUserInfoClaimsRequest);
+    private ClaimsSetRequest buildIpvClaimsRequest(
+            AuthenticationRequest authRequest, Subject internalPairwiseSubject) {
+
+        ClaimsSetRequest claimsSetRequest =
+                Optional.ofNullable(authRequest)
+                        .map(AuthenticationRequest::getOIDCClaims)
+                        .map(OIDCClaimsRequest::getUserInfoClaimsRequest)
+                        .orElse(new ClaimsSetRequest());
+
+        if (configurationService.sendStorageTokenToIpvEnabled()) {
+            LOG.info("Adding storageAccessToken claim to IPV claims request");
+            AccessToken storageToken =
+                    storageTokenService.generateAndSignStorageToken(
+                            internalPairwiseSubject, JWSAlgorithm.ES256);
+
+            claimsSetRequest.add(
+                    new ClaimsSetRequest.Entry(configurationService.getStorageTokenClaimName())
+                            .withValues(List.of(storageToken.getValue())));
+        }
+
+        return claimsSetRequest;
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/StorageTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/StorageTokenService.java
@@ -1,0 +1,121 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SignResponse;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static uk.gov.di.orchestration.shared.helpers.HashHelper.hashSha256String;
+
+public class StorageTokenService {
+
+    private static final Logger LOG = LogManager.getLogger(StorageTokenService.class);
+    private final ConfigurationService configurationService;
+    private final KmsConnectionService kmsConnectionService;
+
+    public StorageTokenService(ConfigurationService configurationService) {
+        this(configurationService, new KmsConnectionService(configurationService));
+    }
+
+    public StorageTokenService(
+            ConfigurationService configurationService, KmsConnectionService kmsConnectionService) {
+        this.configurationService = configurationService;
+        this.kmsConnectionService = kmsConnectionService;
+    }
+
+    public AccessToken generateAndSignStorageToken(
+            Subject internalPairwiseSubject, JWSAlgorithm signingAlgorithm) {
+
+        LOG.info("Generating storage token");
+        Date expiryDate =
+                NowHelper.nowPlus(configurationService.getSessionExpiry(), ChronoUnit.SECONDS);
+        var jwtID = UUID.randomUUID().toString();
+
+        LOG.info("Storage token being created with JWTID: {}", jwtID);
+
+        List<String> aud =
+                List.of(
+                        configurationService.getCredentialStoreURI().toString(),
+                        configurationService.getIPVAudience());
+
+        JWTClaimsSet.Builder claimSetBuilder =
+                new JWTClaimsSet.Builder()
+                        .issuer(configurationService.getOidcApiBaseURL().get())
+                        .audience(aud)
+                        .expirationTime(expiryDate)
+                        .issueTime(NowHelper.now())
+                        .subject(internalPairwiseSubject.getValue())
+                        .jwtID(jwtID);
+
+        SignedJWT signedJWT =
+                generateSignedJWT(claimSetBuilder.build(), Optional.empty(), signingAlgorithm);
+
+        return new BearerAccessToken(
+                signedJWT.serialize(), configurationService.getAccessTokenExpiry(), null);
+    }
+
+    public SignedJWT generateSignedJWT(
+            JWTClaimsSet claimsSet, Optional<String> type, JWSAlgorithm algorithm) {
+
+        var signingKeyId = getSigningKeyId();
+
+        try {
+            var jwsHeader = new JWSHeader.Builder(algorithm).keyID(hashSha256String(signingKeyId));
+
+            type.map(JOSEObjectType::new).ifPresent(jwsHeader::type);
+
+            Base64URL encodedHeader = jwsHeader.build().toBase64URL();
+            Base64URL encodedClaims = Base64URL.encode(claimsSet.toString());
+            String message = encodedHeader + "." + encodedClaims;
+            SignRequest signRequest =
+                    SignRequest.builder()
+                            .message(SdkBytes.fromByteArray(message.getBytes()))
+                            .keyId(signingKeyId)
+                            .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
+                            .build();
+            SignResponse signResult = kmsConnectionService.sign(signRequest);
+            LOG.info("Storage token has been signed successfully using {}", algorithm.getName());
+
+            String signature =
+                    Base64URL.encode(
+                                    ECDSA.transcodeSignatureToConcat(
+                                            signResult.signature().asByteArray(),
+                                            ECDSA.getSignatureByteArrayLength(algorithm)))
+                            .toString();
+            return SignedJWT.parse(message + "." + signature);
+        } catch (java.text.ParseException | JOSEException e) {
+            LOG.error("Exception thrown when trying to parse SignedJWT or JWTClaimSet", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getSigningKeyId() {
+        var signingKey = configurationService.getStorageTokenSigningKeyAlias();
+        return kmsConnectionService
+                .getPublicKey(GetPublicKeyRequest.builder().keyId(signingKey).build())
+                .keyId();
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -136,6 +136,7 @@ public class InitiateIPVAuthorisationServiceTest {
         when(configService.isIdentityEnabled()).thenReturn(true);
         when(configService.getIPVAuthorisationURI()).thenReturn(IPV_AUTHORISATION_URI);
         when(configService.getEnvironment()).thenReturn(ENVIRONMENT);
+        when(configService.sendStorageTokenToIpvEnabled()).thenReturn(true);
         when(configService.getStorageTokenClaimName())
                 .thenReturn("https://vocab.account.gov.uk/v1/storageAccessToken");
         AccessToken storageToken = new BearerAccessToken(SERIALIZED_JWT, 180, null);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -84,7 +84,7 @@ public class InitiateIPVAuthorisationServiceTest {
     private static final String IP_ADDRESS = "123.123.123.123";
     private static final Boolean REPROVE_IDENTITY = true;
     private static final String SERIALIZED_JWT =
-            "eyJhbGciOiJFUzI1NiJ9.e30.Ocd0zjblolysCck2LLVgenMKNDQ9GAGCSjlg1kkWVzYcK31qzcJR68bw4b1MdgIEvxZhZ_4ZxWlKIx4OOFixTw";
+            "eyJraWQiOiIwOWRkYjY1ZWIzY2U0MWEzYjczYTJhOTM0ZTM5NDg4NmQyYTIyYjU0ZmQwMzVmYWJlZWM3YWMxYzllYzliNzBiIiwiYWxnIjoiRVMyNTYifQ.eyJhdWQiOlsiaHR0cHM6Ly9jcmVkZW50aWFsLXN0b3JlLnRlc3QuYWNjb3VudC5nb3YudWsiLCJodHRwczovL2lkZW50aXR5LnRlc3QuYWNjb3VudC5nb3YudWsiXSwic3ViIjoia3NFUjVWcDRuZU1ONWM2WHJlSV9uUDhGNFZuc2VqS2x1b3BOX05mZjlfNCIsImlzcyI6Imh0dHBzOi8vb2lkYy50ZXN0LmFjY291bnQuZ292LnVrLyIsImV4cCI6MTcwOTA1MTE2MywiaWF0IjoxNzA5MDQ3NTYzLCJqdGkiOiJkZmNjZjc1MS1iZTU1LTRkZjQtYWEzZi1hOTkzMTkzZDUyMTYifQ.rpZ2IqMwlFLbZ8a7En-EuQ480zcorvNd-GZcwjlxlK3Twq9J1GNiuj9teSLINP_zmeirx7Y8p3DUYWk_hyRhww";
 
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final AuditService auditService = mock(AuditService.class);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -22,6 +22,8 @@ import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
@@ -81,6 +83,8 @@ public class InitiateIPVAuthorisationServiceTest {
     private static final String RP_PAIRWISE_ID = "urn:fdc:gov.uk:2022:dkjfshsdkjh";
     private static final String IP_ADDRESS = "123.123.123.123";
     private static final Boolean REPROVE_IDENTITY = true;
+    private static final String SERIALIZED_JWT =
+            "eyJhbGciOiJFUzI1NiJ9.e30.Ocd0zjblolysCck2LLVgenMKNDQ9GAGCSjlg1kkWVzYcK31qzcJR68bw4b1MdgIEvxZhZ_4ZxWlKIx4OOFixTw";
 
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -91,6 +95,7 @@ public class InitiateIPVAuthorisationServiceTest {
     private final NoSessionOrchestrationService noSessionOrchestrationService =
             mock(NoSessionOrchestrationService.class);
     private InitiateIPVAuthorisationService initiateAuthorisationService;
+    private final StorageTokenService storageTokenService = mock(StorageTokenService.class);
     private APIGatewayProxyRequestEvent event;
     private final ClaimsSetRequest.Entry nameEntry =
             new ClaimsSetRequest.Entry("name").withClaimRequirement(ClaimRequirement.ESSENTIAL);
@@ -120,7 +125,8 @@ public class InitiateIPVAuthorisationServiceTest {
                         auditService,
                         authorisationService,
                         cloudwatchMetricsService,
-                        noSessionOrchestrationService);
+                        noSessionOrchestrationService,
+                        storageTokenService);
 
         event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(contextWithSourceIp(IP_ADDRESS));
@@ -130,6 +136,11 @@ public class InitiateIPVAuthorisationServiceTest {
         when(configService.isIdentityEnabled()).thenReturn(true);
         when(configService.getIPVAuthorisationURI()).thenReturn(IPV_AUTHORISATION_URI);
         when(configService.getEnvironment()).thenReturn(ENVIRONMENT);
+        when(configService.getStorageTokenClaimName())
+                .thenReturn("https://vocab.account.gov.uk/v1/storageAccessToken");
+        AccessToken storageToken = new BearerAccessToken(SERIALIZED_JWT, 180, null);
+        when(storageTokenService.generateAndSignStorageToken(any(), any()))
+                .thenReturn(storageToken);
     }
 
     @Test
@@ -192,7 +203,7 @@ public class InitiateIPVAuthorisationServiceTest {
         verify(authorisationService).storeState(eq(session.getSessionId()), any(State.class));
         verify(noSessionOrchestrationService)
                 .storeClientSessionIdAgainstState(eq(CLIENT_SESSION_ID), any(State.class));
-
+        verify(storageTokenService).generateAndSignStorageToken(any(), eq(JWSAlgorithm.ES256));
         verify(authorisationService)
                 .constructRequestJWT(
                         any(State.class),

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/HandlerIntegrationTest.java
@@ -92,6 +92,9 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final TokenSigningExtension externalTokenSigner = new TokenSigningExtension();
 
     @RegisterExtension
+    protected static final TokenSigningExtension storageTokenSigner = new TokenSigningExtension();
+
+    @RegisterExtension
     protected static final TokenSigningExtension ipvPrivateKeyJwtSigner =
             new TokenSigningExtension("ipv-token-auth-key");
 
@@ -134,6 +137,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final ConfigurationService TEST_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
                     externalTokenSigner,
+                    storageTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
                     docAppPrivateKeyJwtSigner,
@@ -142,6 +146,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final ConfigurationService TXMA_ENABLED_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
                     externalTokenSigner,
+                    storageTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
                     docAppPrivateKeyJwtSigner,
@@ -156,6 +161,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final ConfigurationService TXMA_AND_AIS_ENABLED_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
                     externalTokenSigner,
+                    storageTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
                     docAppPrivateKeyJwtSigner,
@@ -237,18 +243,21 @@ public abstract class HandlerIntegrationTest<Q, S> {
     public static class IntegrationTestConfigurationService extends ConfigurationService {
 
         private final TokenSigningExtension externalTokenSigningKey;
+        private final TokenSigningExtension storageTokenSigningKey;
         private final TokenSigningExtension ipvPrivateKeyJwtSigner;
         private final SqsQueueExtension spotQueue;
         private final TokenSigningExtension docAppPrivateKeyJwtSigner;
 
         public IntegrationTestConfigurationService(
                 TokenSigningExtension externalTokenSigningKey,
+                TokenSigningExtension storageTokenSigningKey,
                 TokenSigningExtension ipvPrivateKeyJwtSigner,
                 SqsQueueExtension spotQueue,
                 TokenSigningExtension docAppPrivateKeyJwtSigner,
                 ParameterStoreExtension parameterStoreExtension) {
             super(parameterStoreExtension.getClient());
             this.externalTokenSigningKey = externalTokenSigningKey;
+            this.storageTokenSigningKey = storageTokenSigningKey;
             this.ipvPrivateKeyJwtSigner = ipvPrivateKeyJwtSigner;
             this.spotQueue = spotQueue;
             this.docAppPrivateKeyJwtSigner = docAppPrivateKeyJwtSigner;
@@ -256,6 +265,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
 
         public IntegrationTestConfigurationService(
                 TokenSigningExtension externalTokenSigningKey,
+                TokenSigningExtension storageTokenSigningKey,
                 TokenSigningExtension ipvPrivateKeyJwtSigner,
                 SqsQueueExtension spotQueue,
                 TokenSigningExtension docAppPrivateKeyJwtSigner,
@@ -263,6 +273,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
                 SystemService systemService) {
             super(parameterStoreExtension.getClient());
             this.externalTokenSigningKey = externalTokenSigningKey;
+            this.storageTokenSigningKey = storageTokenSigningKey;
             this.ipvPrivateKeyJwtSigner = ipvPrivateKeyJwtSigner;
             this.spotQueue = spotQueue;
             this.docAppPrivateKeyJwtSigner = docAppPrivateKeyJwtSigner;
@@ -272,6 +283,11 @@ public abstract class HandlerIntegrationTest<Q, S> {
         @Override
         public String getExternalTokenSigningKeyAlias() {
             return externalTokenSigningKey.getKeyAlias();
+        }
+
+        @Override
+        public String getStorageTokenSigningKeyAlias() {
+            return storageTokenSigningKey.getKeyAlias();
         }
 
         @Override

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -143,6 +143,13 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return URI.create(System.getenv().getOrDefault("AUTHENTICATION_BACKEND_URI", ""));
     }
 
+    public URI getCredentialStoreURI() {
+        return URI.create(
+                System.getenv()
+                        .getOrDefault(
+                                "CREDENTIAL_STORE_URI", "https://credential-store.account.gov.uk"));
+    }
+
     public boolean isCustomDocAppClaimEnabled() {
         return System.getenv().getOrDefault("CUSTOM_DOC_APP_CLAIM_ENABLED", "false").equals("true");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -419,6 +419,13 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("SESSION_EXPIRY", "3600"));
     }
 
+    public String getStorageTokenClaimName() {
+        return System.getenv()
+                .getOrDefault(
+                        "STORAGE_TOKEN_CLAIM_NAME",
+                        "https://vocab.account.gov.uk/v1/storageAccessToken");
+    }
+
     public Optional<String> getSqsEndpointUri() {
         return Optional.ofNullable(System.getenv("SQS_ENDPOINT"));
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -426,6 +426,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                         "https://vocab.account.gov.uk/v1/storageAccessToken");
     }
 
+    public boolean sendStorageTokenToIpvEnabled() {
+        return System.getenv()
+                .getOrDefault("SEND_STORAGE_TOKEN_TO_IPV_ENABLED", "false")
+                .equals("true");
+    }
+
     public Optional<String> getSqsEndpointUri() {
         return Optional.ofNullable(System.getenv("SQS_ENDPOINT"));
     }


### PR DESCRIPTION
## What?
- Add storageAccessToken claim to JAR sent to IPV
- Create a new service (StorageTokenService) to generate and sign the token.
- Feature flag the implementation and enable in sandpit, build, and staging envs.
- No unit test coverage for StorageTokenService as a subsequent PR will combine this service with the existing shared/TokenService.

## Why?
- IPV need this token in order to request VCs from Bravo 

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3981


## Orchestration and Authentication mutual dependencies

- [x] Impact on orch and auth mutual dependencies has been checked.