### PR TITLE
BAU: Log reauthentication header in StartHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -133,6 +133,10 @@ public class StartHandler
                             configurationService.getHeadersCaseInsensitive());
             var reauthenticate =
                     reauthenticateHeader != null && reauthenticateHeader.equals("true");
+            LOG.info(
+                    "reauthenticateHeader: {} reauthenticate: {}",
+                    reauthenticateHeader,
+                    reauthenticate);
             var userStartInfo =
                     startService.buildUserStartInfo(
                             userContext,


### PR DESCRIPTION
## What?

Log reauthentication header in StartHandler.

## Why?

Gain visibility on whether reauthentication is set.