### PR TITLE
AUT-2319: Set lockout time to 1 minute in build

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -33,7 +33,7 @@ dqhoDR3/THktb4KThc+U5EOWCWpH4OIAetYtjFChnkR8kU05Ol9zfdR08uO0RxMk
 -----END PUBLIC KEY-----
 EOT
 
-blocked_email_duration = 30
+blocked_email_duration = 60
 otp_code_ttl_duration  = 120
 
 logging_endpoint_arns = [


### PR DESCRIPTION

## What?

Set lockout time to 1 minute in build.

## Why?

Frontend only currently supports lockout times in minutes so 1 min is the minimum.  Setting to the minimum in build to facilitate testing.

## Related PRs




