### PR TITLE
INCIDEN-688: Fix environment variable name

### DIFF
--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -42,9 +42,9 @@ resource "aws_lambda_function" "authorizer" {
   }
   environment {
     variables = {
-      EXTERNAL_TOKEN_SIGNING_KEY_ALIAS = data.aws_kms_key.id_token_public_key.key_id
-      ENVIRONMENT                      = var.environment
-      JAVA_TOOL_OPTIONS                = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+      TOKEN_SIGNING_KEY_ALIAS = data.aws_kms_key.id_token_public_key.key_id
+      ENVIRONMENT             = var.environment
+      JAVA_TOOL_OPTIONS       = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     }
   }
   kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn


### PR DESCRIPTION
## What?
Revert the change to the account mgmt authorizer env var name.

## Why?

It uses shared, not orch-shared, so needs the old name

## Related PRs
https://github.com/govuk-one-login/authentication-api/pull/3981


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.