### PR TITLE
AUT-2398: Raise alarm when receiving invalid AIS responses/auth AIS lambda fails

### DIFF
--- a/ci/terraform/oidc/account-interventions-alerts.tf
+++ b/ci/terraform/oidc/account-interventions-alerts.tf
@@ -29,3 +29,36 @@ resource "aws_cloudwatch_metric_alarm" "account_interventions_p1_cloudwatch_alar
   alarm_description   = "${var.account_interventions_p1_alarm_error_threshold} or more Account Interventions errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
   alarm_actions       = [var.environment == "production" && var.account_intervention_service_abort_on_error ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : data.aws_sns_topic.slack_events.arn]
 }
+
+data "aws_cloudwatch_log_group" "auth_account_interventions_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+  name  = replace("/aws/lambda/${var.environment}-account-interventions-lambda", ".", "")
+}
+
+resource "aws_cloudwatch_log_metric_filter" "auth_account_interventions_metric_filter" {
+  count          = var.use_localstack ? 0 : 1
+  name           = replace("${var.environment}-auth-account-interventions-errors-responses", ".", "")
+  pattern        = "{($.${var.account_interventions_error_metric_name} = 1)}"
+  log_group_name = data.aws_cloudwatch_log_group.auth_account_interventions_lambda_log_group[0].name
+
+  metric_transformation {
+    name      = replace("${var.environment}-auth-account-interventions-error-count", ".", "")
+    namespace = "LambdaErrorsNamespace"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "auth_account_interventions_cloudwatch_alarm" {
+  count               = var.use_localstack ? 0 : 1
+  alarm_name          = replace("${var.environment}-auth-account-interventions-cloudwatch-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.auth_account_interventions_metric_filter[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.auth_account_interventions_metric_filter[0].metric_transformation[0].namespace
+  period              = var.account_interventions_p1_alarm_error_time_period
+  statistic           = "Sum"
+  threshold           = var.account_interventions_p1_alarm_error_threshold
+  alarm_description   = "${var.account_interventions_p1_alarm_error_threshold} or more Account Interventions errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
+  alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : null]
+
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -29,13 +29,7 @@ import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventio
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.AuditService;
-import uk.gov.di.authentication.shared.services.AuthenticationService;
-import uk.gov.di.authentication.shared.services.ClientService;
-import uk.gov.di.authentication.shared.services.ClientSessionService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.services.*;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.net.URI;
@@ -69,6 +63,7 @@ public class AccountInterventionsHandlerTest {
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String TEST_SUBJECT_ID = "subject-id";
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
+    private static final String TEST_ENVIRONMENT = "test-environment";
     private static final byte[] SALT = SaltHelper.generateNewSalt();
 
     private AccountInterventionsHandler handler;
@@ -82,6 +77,8 @@ public class AccountInterventionsHandlerTest {
     private final AccountInterventionsService accountInterventionsService =
             mock(AccountInterventionsService.class);
     private final ClientService clientService = mock(ClientService.class);
+    private final CloudwatchMetricsService cloudwatchMetricsService =
+            mock(CloudwatchMetricsService.class);
     private static final ClientSession clientSession = getClientSession();
     private final Session session =
             new Session(IdGenerator.generate())
@@ -108,6 +105,9 @@ public class AccountInterventionsHandlerTest {
         when(userContext.getClientSession()).thenReturn(clientSession);
         when(userContext.getClientId()).thenReturn(TEST_CLIENT_ID);
         when(userContext.getClientSessionId()).thenReturn(TEST_CLIENT_SESSION_ID);
+        when(configurationService.getAccountInterventionsErrorMetricName())
+                .thenReturn("AISException");
+        when(configurationService.getEnvironment()).thenReturn(TEST_ENVIRONMENT);
         handler =
                 new AccountInterventionsHandler(
                         configurationService,
@@ -116,7 +116,8 @@ public class AccountInterventionsHandlerTest {
                         clientService,
                         authenticationService,
                         accountInterventionsService,
-                        auditService);
+                        auditService,
+                        cloudwatchMetricsService);
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -675,4 +675,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(
                 System.getenv().getOrDefault("ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT", "3000"));
     }
+
+    public String getAccountInterventionsErrorMetricName() {
+        return System.getenv().getOrDefault("ACCOUNT_INTERVENTIONS_ERROR_METRIC_NAME", "");
+    }
 }


### PR DESCRIPTION
## What?

- Added alarm that goes off when receiving a specified amount of 4xx or 5xx responses from AIS
- Added an alarm that goes off when the auth AIS lambda fails specified number of times. This then notifies whoever is on pager duty.

## Why?

Alarms needed to be implemented since it indicates issues with the interventions api, or our integration with it. 

## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.