### PR TITLE
ATO-399: Tidy up references to stub

### DIFF
--- a/echo-int-test-vars.sh
+++ b/echo-int-test-vars.sh
@@ -14,7 +14,7 @@ export FRONTEND_API_GATEWAY_ID
 FRONTEND_API_KEY="$(terraform output -raw frontend_api_key)"
 export FRONTEND_API_KEY
 export RESET_PASSWORD_URL="http://localhost:3000/reset-password?code="
-export STUB_RELYING_PARTY_REDIRECT_URI="https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
+export STUB_RELYING_PARTY_REDIRECT_URI="https://rp-build.build.stubs.account.gov.uk/"
 popd >/dev/null
 
 echo "API_GATEWAY_ID=$API_GATEWAY_ID;AWS_ACCESS_KEY_ID=BOB;AWS_SECRET_ACCESS_KEY=builder;LOGIN_URI=http://localhost:3000/;API_KEY=$API_KEY;FRONTEND_API_GATEWAY_ID=$FRONTEND_API_GATEWAY_ID;FRONTEND_API_KEY=$FRONTEND_API_KEY;STUB_RELYING_PARTY_REDIRECT_URI=$STUB_RELYING_PARTY_REDIRECT_URI;"

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -58,7 +58,7 @@ test {
     environment "REDIS_KEY", "session"
     environment "RESET_PASSWORD_URL", "http://localhost:3000/reset-password?code="
     environment "SQS_ENDPOINT", "http://localhost:45678"
-    environment "STUB_RELYING_PARTY_REDIRECT_URI", "https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
+    environment "STUB_RELYING_PARTY_REDIRECT_URI", "https://rp-build.build.stubs.account.gov.uk/"
     environment "TERMS_CONDITIONS_VERSION", "1.0"
     environment "HEADERS_CASE_INSENSITIVE", "true"
     environment "IDENTITY_ENABLED", "false"

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -84,8 +84,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var authCodeResponse = objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
         assertThat(
                 authCodeResponse.getLocation(),
-                startsWith(
-                        "https://di-auth-stub-relying-party-build.london.cloudapps.digital/?code="));
+                startsWith("https://rp-build.build.stubs.account.gov.uk/?code="));
 
         assertTrue(redis.getSession(sessionID).isAuthenticated());
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_ISSUED));
@@ -120,8 +119,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var authCodeResponse = objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
         assertThat(
                 authCodeResponse.getLocation(),
-                startsWith(
-                        "https://di-auth-stub-relying-party-build.london.cloudapps.digital/?code="));
+                startsWith("https://rp-build.build.stubs.account.gov.uk/?code="));
 
         assertFalse(redis.getSession(sessionID).isAuthenticated());
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_ISSUED));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -43,8 +43,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String BASE_URL = System.getenv().getOrDefault("BASE_URL", "rubbish");
     public static final String STATE = "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU";
-    public static final String REDIRECT_URL =
-            "https://di-auth-stub-relying-party-build.london.cloudapps.digital/";
+    public static final String REDIRECT_URL = "https://rp-build.build.stubs.account.gov.uk/";
     public static final String SESSION_ID = "session-id";
     public static final String CLIENT_SESSION_ID = "client-session-id";
 

--- a/oidc-api/docs/AuthorisationHandler.md
+++ b/oidc-api/docs/AuthorisationHandler.md
@@ -40,11 +40,11 @@ The lambda performs the following functions, although not all functions take pla
 ```json
 {
 "queryStringParams": {
-  "vtr": ["Cl"]
+  "vtr": ["Cl"],
   "scope": "openid email phone",
   "claims": {"userinfo":{"https:\/\/vocab.account.gov.uk\/v1\/passport":{"essential":true},"https:\/\/vocab.account.gov.uk\/v1\/coreIdentityJWT":{"essential":true},"https:\/\/vocab.account.gov.uk\/v1\/address":{"essential":true}}},
   "response_type": "code",
-  "redirect_uri": "https://di-auth-stub-relying-party-production.london.cloudapps.digital/oidc/authorization-code/callback",
+  "redirect_uri": "https://rp.stubs.account.gov.uk/oidc/authorization-code/callback",
   "state": "D9fDA1Y_s8WwjJ2NOA_UDKY0wpV53NFNG4k8bLkyKDM",
   "prompt": "none",
   "nonce": "ZVOt6pvwZZDQzboS7Rzrd_16vZ"


### PR DESCRIPTION
## What?

Remove unnecessary references to old stub urls
## Why?

Stub is now hosted on AWS
## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.