### PR TITLE
ATO-395: Move AIS timeout from HttpClient config to HttpRequest config

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -38,11 +38,7 @@ public class AccountInterventionService {
     public AccountInterventionService(ConfigurationService configService) {
         this(
                 configService,
-                HttpClient.newBuilder()
-                        .connectTimeout(
-                                Duration.ofMillis(
-                                        configService.getAccountInterventionServiceCallTimeout()))
-                        .build(),
+                HttpClient.newHttpClient(),
                 new CloudwatchMetricsService(),
                 new AuditService(configService));
     }
@@ -147,6 +143,7 @@ public class AccountInterventionService {
 
     private AccountInterventionStatus retrieveAccountStatus(String internalPairwiseSubjectId)
             throws IOException, InterruptedException, Json.JsonException {
+
         HttpRequest request =
                 HttpRequest.newBuilder()
                         .uri(
@@ -154,6 +151,10 @@ public class AccountInterventionService {
                                         accountInterventionServiceURI.getPath()
                                                 + "/v1/ais/"
                                                 + internalPairwiseSubjectId))
+                        .timeout(
+                                Duration.ofMillis(
+                                        configurationService
+                                                .getAccountInterventionServiceCallTimeout()))
                         .GET()
                         .build();
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -75,6 +75,7 @@ class AccountInterventionServiceTest {
         when(config.isAccountInterventionServiceCallEnabled()).thenReturn(true);
         when(config.isAccountInterventionServiceActionEnabled()).thenReturn(false);
         when(config.getEnvironment()).thenReturn(ENVIRONMENT);
+        when(config.getAccountInterventionServiceCallTimeout()).thenReturn(3000L);
     }
 
     @Test


### PR DESCRIPTION
## What?

Move AIS timeout from HttpClient config to HttpRequest config

## Why?

Timeout was incorrectly configured to be on HttpClient; timeout on HttpRequest is the intended behaviour.


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.