### PR TITLE
Adding resource dependencies for Account interventions Alarm

### DIFF
--- a/ci/terraform/oidc/account-interventions-alerts.tf
+++ b/ci/terraform/oidc/account-interventions-alerts.tf
@@ -31,6 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "account_interventions_p1_cloudwatch_alar
 }
 
 data "aws_cloudwatch_log_group" "auth_account_interventions_lambda_log_group" {
+  depends_on = [ module.account_interventions ]
   count = var.environment == "production" || var.environment == "integration" ? 0 : 1
   name  = replace("/aws/lambda/${var.environment}-account-interventions-lambda", ".", "")
 }

--- a/ci/terraform/oidc/account-interventions-alerts.tf
+++ b/ci/terraform/oidc/account-interventions-alerts.tf
@@ -31,9 +31,9 @@ resource "aws_cloudwatch_metric_alarm" "account_interventions_p1_cloudwatch_alar
 }
 
 data "aws_cloudwatch_log_group" "auth_account_interventions_lambda_log_group" {
-  depends_on = [ module.account_interventions ]
-  count = var.environment == "production" || var.environment == "integration" ? 0 : 1
-  name  = replace("/aws/lambda/${var.environment}-account-interventions-lambda", ".", "")
+  depends_on = [module.account_interventions]
+  count      = var.environment == "production" || var.environment == "integration" ? 0 : 1
+  name       = replace("/aws/lambda/${var.environment}-account-interventions-lambda", ".", "")
 }
 
 resource "aws_cloudwatch_log_metric_filter" "auth_account_interventions_metric_filter" {


### PR DESCRIPTION
## What?

Adding resource dependencies for Account interventions Alarm

## Why?

In future if we enable  Account interventions flag for Prod or Int env there needs a dependencies for data read for Alarm Creation if this is not done the Terraform plan will fails "

## Related PRs

[3997](https://github.com/govuk-one-login/authentication-api/pull/3997)