### PR TITLE
BAU: Fix reauthentication

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -842,22 +842,24 @@ public class AuthorisationHandler
             throw new RuntimeException("Unable to validate id_token_hint");
         }
 
-        String audience;
+        String aud;
+        String sub;
         try {
             SignedJWT idToken =
                     SignedJWT.parse(
                             authenticationRequest.getCustomParameter("id_token_hint").get(0));
-            audience = idToken.getJWTClaimsSet().getAudience().stream().findFirst().orElse(null);
+            aud = idToken.getJWTClaimsSet().getAudience().stream().findFirst().orElse(null);
+            sub = idToken.getJWTClaimsSet().getSubject();
         } catch (java.text.ParseException e) {
             LOG.warn("Unable to parse id_token_hint into SignedJWT");
             throw new RuntimeException("Invalid id_token_hint");
         }
 
-        if (audience == null || !audience.equals(authenticationRequest.getClientID().getValue())) {
+        if (aud == null || !aud.equals(authenticationRequest.getClientID().getValue())) {
             LOG.warn("Audience on id_token_hint does not match client ID");
             throw new RuntimeException("Invalid id_token_hint for client");
         }
 
-        return audience;
+        return sub;
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1121,9 +1121,7 @@ class AuthorisationHandlerTest {
 
             verifyAuthorisationRequestParsedAuditEvent(AuditService.UNKNOWN, false, true);
 
-            assertThat(
-                    uri.getQuery(),
-                    containsString(String.format("reauthenticate=%s", ID_TOKEN_AUDIENCE)));
+            assertThat(uri.getQuery(), containsString(String.format("reauthenticate=%s", SUBJECT)));
         }
 
         @Test
@@ -1163,7 +1161,7 @@ class AuthorisationHandlerTest {
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
             assertThat(
                     argument.getValue().getStringClaim("reauthenticate"),
-                    equalTo(ID_TOKEN_AUDIENCE));
+                    equalTo(SUBJECT.getValue()));
         }
 
         private static Stream<Prompt.Type> prompts() {


### PR DESCRIPTION
## What?

We should be passing the RP pairwise identifier from the id token hint to auth, not the audience
