### PR TITLE
AUT-2453: Increase retry attempt count for email OPT codes during registration journey

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -324,6 +324,11 @@ variable "internal_sector_uri" {
   default = "undefined"
 }
 
+variable "remove_retry_limit_registration_email_code" {
+  type    = bool
+  default = false
+}
+
 variable "endpoint_memory_size" {
   default = 1536
   type    = number

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -29,17 +29,18 @@ module "verify_code" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT                         = var.environment
-    LOCKOUT_DURATION                    = var.lockout_duration
-    TXMA_AUDIT_QUEUE_URL                = module.oidc_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT                 = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY                           = local.redis_key
-    DYNAMO_ENDPOINT                     = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TERMS_CONDITIONS_VERSION            = var.terms_and_conditions
-    TEST_CLIENT_VERIFY_EMAIL_OTP        = var.test_client_verify_email_otp
-    TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP = var.test_client_verify_phone_number_otp
-    TEST_CLIENTS_ENABLED                = var.test_clients_enabled
-    INTERNAl_SECTOR_URI                 = var.internal_sector_uri
+    ENVIRONMENT                                = var.environment
+    LOCKOUT_DURATION                           = var.lockout_duration
+    TXMA_AUDIT_QUEUE_URL                       = module.oidc_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT                        = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                                  = local.redis_key
+    DYNAMO_ENDPOINT                            = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TERMS_CONDITIONS_VERSION                   = var.terms_and_conditions
+    TEST_CLIENT_VERIFY_EMAIL_OTP               = var.test_client_verify_email_otp
+    TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP        = var.test_client_verify_phone_number_otp
+    TEST_CLIENTS_ENABLED                       = var.test_clients_enabled
+    INTERNAl_SECTOR_URI                        = var.internal_sector_uri
+    REMOVE_RETRY_LIMIT_REGISTRATION_EMAIL_CODE = var.remove_retry_limit_registration_email_code
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest"
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -130,7 +130,12 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             ? getOtpCodeForTestClient(notificationType)
                             : codeStorageService.getOtpCode(
                                     session.getEmailAddress(), notificationType);
-
+            var maxRetries =
+                    codeRequestType == CodeRequestType.EMAIL_REGISTRATION
+                                    && configurationService
+                                            .removeRetryLimitForRegistrationEmailCodeEntry()
+                            ? configurationService.getIncreasedCodeMaxRetries()
+                            : configurationService.getCodeMaxRetries();
             var errorResponse =
                     ValidationHelper.validateVerificationCode(
                             notificationType,
@@ -138,7 +143,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             codeRequest.getCode(),
                             codeStorageService,
                             session.getEmailAddress(),
-                            configurationService.getCodeMaxRetries());
+                            maxRetries);
 
             if (errorResponse.stream().anyMatch(ErrorResponse.ERROR_1002::equals)) {
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
@@ -36,17 +36,13 @@ public class MfaCodeProcessorFactory {
 
     public Optional<MfaCodeProcessor> getMfaCodeProcessor(
             MFAMethodType mfaMethodType, CodeRequest codeRequest, UserContext userContext) {
-
         switch (mfaMethodType) {
             case AUTH_APP:
                 int codeMaxRetries =
-                        List.of(
-                                                JourneyType.SIGN_IN,
-                                                JourneyType.PASSWORD_RESET_MFA,
-                                                JourneyType.REAUTHENTICATION)
+                        List.of(JourneyType.REGISTRATION, JourneyType.ACCOUNT_RECOVERY)
                                         .contains(codeRequest.getJourneyType())
-                                ? configurationService.getCodeMaxRetries()
-                                : configurationService.getCodeMaxRetriesRegistration();
+                                ? configurationService.getIncreasedCodeMaxRetries()
+                                : configurationService.getCodeMaxRetries();
                 return Optional.of(
                         new AuthAppCodeProcessor(
                                 userContext,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
@@ -37,7 +37,7 @@ class MfaCodeProcessorFactoryTest {
     @BeforeEach
     void setUp() {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
-        when(configurationService.getCodeMaxRetriesRegistration()).thenReturn(999999);
+        when(configurationService.getIncreasedCodeMaxRetries()).thenReturn(999999);
 
         when(userContext.getSession()).thenReturn(session);
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -180,6 +180,33 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         for (int i = 0; i < 5; i++) {
             redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
         }
+        var codeRequest = new VerifyCodeRequest(VERIFY_EMAIL, "123456", JourneyType.PASSWORD_RESET);
+
+        var response =
+                makeRequest(
+                        Optional.of(codeRequest), constructFrontendHeaders(sessionId), Map.of());
+
+        var codeRequestType =
+                CodeRequestType.getCodeRequestType(
+                        codeRequest.getNotificationType(), JourneyType.PASSWORD_RESET);
+        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1033));
+        assertThat(
+                redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
+                equalTo(false));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_MAX_RETRIES_REACHED));
+    }
+
+    @Test
+    void shouldHaveMaxRetryCountANDSetBlockDuringRegistrationWithFeatureFlagOff()
+            throws Json.JsonException {
+        String sessionId = redis.createSession();
+        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        for (int i = 0; i < 5; i++) {
+            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
+        }
         var codeRequest = new VerifyCodeRequest(VERIFY_EMAIL, "123456");
 
         var response =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -145,9 +145,15 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Integer.parseInt(System.getenv().getOrDefault("CODE_MAX_RETRIES", "5"));
     }
 
-    public int getCodeMaxRetriesRegistration() {
+    public int getIncreasedCodeMaxRetries() {
         return Integer.parseInt(
-                System.getenv().getOrDefault("CODE_MAX_RETRIES_REGISTRATION", "999999"));
+                System.getenv().getOrDefault("CODE_MAX_RETRIES_INCREASED", "999999"));
+    }
+
+    public boolean removeRetryLimitForRegistrationEmailCodeEntry() {
+        return System.getenv()
+                .getOrDefault("REMOVE_RETRY_LIMIT_REGISTRATION_EMAIL_CODE", "false")
+                .equals("true");
     }
 
     public int getAuthAppCodeWindowLength() {


### PR DESCRIPTION
## What?

Email OTP code retry limit has been removed for registration journey. VerifyCodeHandler required updating and some minor refactoring elsewhere.

## Why?

From a review of existing OPT/MFA code attempts and retry functionality it was highlighted that there is no security need for blocking users due to incorrect email OTP code entries for registration journey only.