### PR TITLE
ATO-320: Fix lambda deployment

### DIFF
--- a/.github/workflows/deploy-orch.yml
+++ b/.github/workflows/deploy-orch.yml
@@ -4,14 +4,12 @@ env:
   AWS_REGION: eu-west-2
 
 on:
-  workflow_run:
-    workflows: ["Build modules"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -32,11 +30,18 @@ jobs:
           role-to-assume: ${{ secrets.ORCH_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+          cache: gradle
+
       - name: SAM build
         run: sam build
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.3
+        uses: govuk-one-login/di-devplatform-upload-action@v3.5
         with:
           artifact-bucket-name: ${{ secrets.ORCH_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.ORCH_SIGNING_PROFILE_NAME }}

--- a/template.yaml
+++ b/template.yaml
@@ -36,8 +36,8 @@ Resources:
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work
     Properties:
-      CodeUri: oidc-api
-      Handler: lambda.WellknownHandler::handleRequest
+      CodeUri: ./oidc-api
+      Handler: uk.gov.di.authentication.oidc.lambda.WellknownHandler::handleRequest
       Runtime: java17
       ReservedConcurrentExecutions: 1
       Environment:


### PR DESCRIPTION
## What?

Get Orch's first backend lambda working

## Why?

Orch be pipeline currently failing.

## Related PRs

## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.