### PR TITLE
BAU: Switch off account recovery block in all envs except prod

### DIFF
--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -31,3 +31,5 @@ EOT
 orch_client_id                     = "orchestrationAuth"
 orch_redirect_uri                  = "https://oidc.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
+
+account_recovery_block_enabled = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -116,7 +116,7 @@ variable "service_domain" {
 }
 
 variable "account_recovery_block_enabled" {
-  default = true
+  default = false
 }
 
 variable "support_auth_orch_split" {


### PR DESCRIPTION

## What?

Switch off account recovery block in all envs except prod.

## Why?

The 2FA before password reset flow obviates the need for the recovery block.