### PR TITLE
DO NOT MERGE: BAU: Switch off the account recovery block in prod

### DIFF
--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -31,5 +31,3 @@ EOT
 orch_client_id                     = "orchestrationAuth"
 orch_redirect_uri                  = "https://oidc.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
-
-account_recovery_block_enabled = true

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -235,7 +235,6 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             Subject internalCommonSubjectId,
             UserContext userContext,
             APIGatewayProxyRequestEvent input) {
-
         LOG.info("AccountRecoveryBlock enabled: {}", accountRecoveryBlockEnabled);
         var authAppVerified =
                 Optional.ofNullable(userCredentials.getMfaMethods())


### PR DESCRIPTION
## What?

Switch off the account recovery block in prod.

## Why?

The account recovery block is no longer needed given the 2FA before password reset flow

## Related PRs

#4030 

Only to be merged with: https://github.com/govuk-one-login/authentication-frontend/pull/1412