### PR TITLE
BAU: Trigger lambda deploy with an extra newline

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -235,6 +235,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             Subject internalCommonSubjectId,
             UserContext userContext,
             APIGatewayProxyRequestEvent input) {
+
         LOG.info("AccountRecoveryBlock enabled: {}", accountRecoveryBlockEnabled);
         var authAppVerified =
                 Optional.ofNullable(userCredentials.getMfaMethods())


### PR DESCRIPTION

## What?

Trigger lambda deploy with an extra newline.

## Why?

A previous config change did not trigger a deploy to apply the config, so making a code change to do so.

## Related PRs

#4030

## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.