### PR TITLE
ATO-320: Fix Orch well-known Lambda

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -27,6 +27,8 @@ Conditions:
 
 Globals:
   Function:
+    MemorySize: 1536
+    Timeout: 30
     PermissionsBoundary: !If
       - UsePermissionsBoundary
       - !Ref PermissionsBoundary
@@ -56,7 +58,7 @@ Resources:
         WellKnown:
           Type: Api
           Properties:
-            Path: /Wellknown
+            Path: /.well-known/openid-configuration
             Method: get
       Tags:
         CheckovRulesToSkip: CKV_AWS_116.CKV_AWS_117.CKV_AWS_173


### PR DESCRIPTION
## What?

- Set orch default lambda memory size
- Set orch default lambda timeout
- Update orch WellKnownFunction path

## Why?

Lambda failing to run due to default settings.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.