### PR TITLE
ATO-361: Add wallet-subject-id scope to stubs allowed scopes

### DIFF
--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -23,6 +23,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"

--- a/ci/terraform/shared/authdev2.tfvars
+++ b/ci/terraform/shared/authdev2.tfvars
@@ -23,6 +23,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"

--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -15,6 +15,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"
@@ -35,6 +36,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"
@@ -74,6 +76,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "OPTIONAL"
@@ -94,6 +97,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"
@@ -114,6 +118,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"
@@ -153,6 +158,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"

--- a/ci/terraform/shared/dev-stub-clients.tfvars
+++ b/ci/terraform/shared/dev-stub-clients.tfvars
@@ -15,6 +15,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -15,6 +15,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"
@@ -54,6 +55,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"

--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -15,6 +15,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"
@@ -54,6 +55,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -23,6 +23,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"
@@ -43,6 +44,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"
@@ -63,6 +65,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"

--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -15,6 +15,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"
@@ -54,6 +55,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"
@@ -74,6 +76,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"
@@ -113,6 +116,7 @@ stub_rp_clients = [
       "openid",
       "email",
       "phone",
+      "wallet-subject-id",
     ]
     one_login_service = false
     service_type      = "MANDATORY"


### PR DESCRIPTION
## What?

Add the wallet-subject-id to scopes for the stubs so that they are added to the client registry and can be requested

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.