### PR TITLE
ATO-385: update production and integration doc app audience claims

### DIFF
--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -2,6 +2,7 @@ doc_app_cri_data_endpoint          = "userinfo"
 doc_app_backend_uri                = "https://api-backend-api.review-b.integration.account.gov.uk"
 doc_app_domain                     = "https://api.review-b.integration.account.gov.uk"
 doc_app_aud                        = "https://www.review-b.integration.account.gov.uk"
+doc_app_new_aud_claim_enabled      = true
 doc_app_authorisation_client_id    = "authOrchestratorDocApp"
 doc_app_authorisation_callback_uri = "https://oidc.integration.account.gov.uk/doc-app-callback"
 doc_app_authorisation_uri          = "https://www.review-b.integration.account.gov.uk/dca/oauth2/authorize"

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -18,6 +18,7 @@ doc_app_use_cri_data_v2_endpoint = true
 doc_app_backend_uri                = "https://api-backend-api.review-b.account.gov.uk"
 doc_app_domain                     = "https://api.review-b.account.gov.uk"
 doc_app_aud                        = "https://www.review-b.account.gov.uk"
+doc_app_new_aud_claim_enabled      = true
 doc_app_authorisation_client_id    = "authOrchestratorDocApp"
 doc_app_authorisation_callback_uri = "https://oidc.account.gov.uk/doc-app-callback"
 doc_app_authorisation_uri          = "https://www.review-b.account.gov.uk/dca/oauth2/authorize"


### PR DESCRIPTION

## What?

Use new aud claim for docapp in int and prod

## Why?

This has been tested in staging, this change rolls out to production and integration

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3967


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.