### PR TITLE
AUT-2480: separate 15min lockout for sms code entry during registration and 2fa account recovery

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -134,6 +134,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             var errorResponse =
                     ValidationHelper.validateVerificationCode(
                             notificationType,
+                            journeyType,
                             code,
                             codeRequest.getCode(),
                             codeStorageService,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -83,6 +83,7 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
         var errorResponse =
                 ValidationHelper.validateVerificationCode(
                         notificationType,
+                        codeRequest.getJourneyType(),
                         storedCode,
                         codeRequest.getCode(),
                         codeStorageService,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -178,7 +178,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         String sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         for (int i = 0; i < 5; i++) {
-            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
+            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, false);
         }
         var codeRequest = new VerifyCodeRequest(VERIFY_EMAIL, "123456");
 
@@ -229,7 +229,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         String sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         for (int i = 0; i < 5; i++) {
-            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
+            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, false);
         }
         var codeRequest = new VerifyCodeRequest(VERIFY_CHANGE_HOW_GET_SECURITY_CODES, "123456");
 
@@ -255,7 +255,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         String sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         for (int i = 0; i < 5; i++) {
-            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
+            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, false);
         }
         var codeRequest = new VerifyCodeRequest(RESET_PASSWORD_WITH_CODE, "123456");
 
@@ -286,7 +286,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         String sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         for (int i = 0; i < 5; i++) {
-            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
+            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, false);
         }
         var codeRequest = new VerifyCodeRequest(MFA_SMS, "123456", journeyType);
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -265,8 +265,8 @@ public class RedisExtension
         codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email, mfaMethodType);
     }
 
-    public void increaseMfaCodeAttemptsCount(String email) {
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email);
+    public void increaseMfaCodeAttemptsCount(String email, boolean reducedLockout) {
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email, reducedLockout);
     }
 
     public void addToRedis(String key, String value, Long expiry) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -84,6 +84,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("LOCKOUT_DURATION", "900"));
     }
 
+    public long getReducedLockoutDuration() {
+        return Long.parseLong(System.getenv().getOrDefault("REDUCED_LOCKOUT_DURATION", "900"));
+    }
+
     public int getBulkUserEmailBatchQueryLimit() {
         return Integer.parseInt(
                 System.getenv().getOrDefault("BULK_USER_EMAIL_BATCH_QUERY_LIMIT", "25"));

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 
@@ -205,86 +206,131 @@ class ValidationHelperTest {
 
     private static Stream<Arguments> validateCodeTestParameters() {
         return Stream.of(
-                arguments(VERIFY_EMAIL, Optional.empty(), VALID_CODE, 0, STORED_VALID_CODE),
-                arguments(VERIFY_PHONE_NUMBER, Optional.empty(), VALID_CODE, 0, STORED_VALID_CODE),
-                arguments(MFA_SMS, Optional.empty(), VALID_CODE, 0, STORED_VALID_CODE),
+                arguments(
+                        VERIFY_EMAIL,
+                        JourneyType.PASSWORD_RESET,
+                        Optional.empty(),
+                        VALID_CODE,
+                        0,
+                        STORED_VALID_CODE),
+                arguments(
+                        VERIFY_PHONE_NUMBER,
+                        JourneyType.REGISTRATION,
+                        Optional.empty(),
+                        VALID_CODE,
+                        0,
+                        STORED_VALID_CODE),
+                arguments(
+                        MFA_SMS,
+                        JourneyType.PASSWORD_RESET_MFA,
+                        Optional.empty(),
+                        VALID_CODE,
+                        0,
+                        STORED_VALID_CODE),
                 arguments(
                         RESET_PASSWORD_WITH_CODE,
+                        JourneyType.PASSWORD_RESET,
                         Optional.empty(),
                         VALID_CODE,
                         0,
                         STORED_VALID_CODE),
                 arguments(
                         VERIFY_EMAIL,
+                        JourneyType.PASSWORD_RESET,
                         Optional.of(ErrorResponse.ERROR_1036),
                         VALID_CODE,
                         0,
                         NO_CODE_STORED),
                 arguments(
                         VERIFY_PHONE_NUMBER,
+                        JourneyType.ACCOUNT_RECOVERY,
                         Optional.of(ErrorResponse.ERROR_1037),
                         VALID_CODE,
                         0,
                         NO_CODE_STORED),
                 arguments(
                         MFA_SMS,
+                        JourneyType.REAUTHENTICATION,
                         Optional.of(ErrorResponse.ERROR_1035),
                         VALID_CODE,
                         0,
                         NO_CODE_STORED),
                 arguments(
                         RESET_PASSWORD_WITH_CODE,
+                        JourneyType.PASSWORD_RESET,
                         Optional.of(ErrorResponse.ERROR_1021),
                         VALID_CODE,
                         0,
                         NO_CODE_STORED),
                 arguments(
                         VERIFY_EMAIL,
+                        JourneyType.PASSWORD_RESET,
                         Optional.of(ErrorResponse.ERROR_1036),
                         INVALID_CODE,
                         1,
                         STORED_VALID_CODE),
                 arguments(
                         VERIFY_PHONE_NUMBER,
+                        JourneyType.REGISTRATION,
                         Optional.of(ErrorResponse.ERROR_1037),
                         INVALID_CODE,
                         1,
                         STORED_VALID_CODE),
                 arguments(
                         MFA_SMS,
+                        JourneyType.PASSWORD_RESET_MFA,
                         Optional.of(ErrorResponse.ERROR_1035),
                         INVALID_CODE,
                         1,
                         STORED_VALID_CODE),
                 arguments(
                         RESET_PASSWORD_WITH_CODE,
+                        JourneyType.PASSWORD_RESET,
                         Optional.of(ErrorResponse.ERROR_1021),
                         INVALID_CODE,
                         1,
                         STORED_VALID_CODE),
                 arguments(
                         VERIFY_EMAIL,
+                        JourneyType.PASSWORD_RESET,
                         Optional.of(ErrorResponse.ERROR_1033),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE),
                 arguments(
                         VERIFY_PHONE_NUMBER,
+                        JourneyType.REGISTRATION,
                         Optional.of(ErrorResponse.ERROR_1034),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE),
                 arguments(
                         MFA_SMS,
+                        JourneyType.PASSWORD_RESET_MFA,
                         Optional.of(ErrorResponse.ERROR_1027),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE),
                 arguments(
                         RESET_PASSWORD_WITH_CODE,
+                        JourneyType.PASSWORD_RESET,
                         Optional.of(ErrorResponse.ERROR_1039),
                         INVALID_CODE,
                         6,
+                        STORED_VALID_CODE),
+                arguments(
+                        VERIFY_PHONE_NUMBER,
+                        JourneyType.PASSWORD_RESET_MFA,
+                        Optional.of(ErrorResponse.ERROR_1034),
+                        INVALID_CODE,
+                        100,
+                        STORED_VALID_CODE),
+                arguments(
+                        VERIFY_PHONE_NUMBER,
+                        JourneyType.PASSWORD_RESET_MFA,
+                        Optional.of(ErrorResponse.ERROR_1034),
+                        INVALID_CODE,
+                        100,
                         STORED_VALID_CODE));
     }
 
@@ -357,6 +403,7 @@ class ValidationHelperTest {
     @MethodSource("validateCodeTestParameters")
     void shouldReturnCorrectErrorForCodeValidationScenarios(
             NotificationType notificationType,
+            JourneyType journeyType,
             Optional<ErrorResponse> expectedResult,
             String input,
             int previousAttempts,
@@ -373,6 +420,12 @@ class ValidationHelperTest {
         assertEquals(
                 expectedResult,
                 ValidationHelper.validateVerificationCode(
-                        notificationType, storedCode, input, codeStorageService, EMAIL_ADDRESS, 5));
+                        notificationType,
+                        journeyType,
+                        storedCode,
+                        input,
+                        codeStorageService,
+                        EMAIL_ADDRESS,
+                        5));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
@@ -312,7 +312,7 @@ class CodeStorageServiceTest {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
                 .thenReturn(null);
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL, false);
 
         verify(redisConnectionService)
                 .saveWithExpiry(
@@ -342,7 +342,7 @@ class CodeStorageServiceTest {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
                 .thenReturn(String.valueOf(3));
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL, false);
 
         verify(redisConnectionService)
                 .saveWithExpiry(


### PR DESCRIPTION
## What?

validateVerificationCode in the ValidationHelper class has been enhanced so that journeyType is passed in as well as notificationType. As this is where we pass the lockout duration to the codeStorageService it's the best place to check if we are dealing with SMS codes during registration or 2fa account recovery and pass a lower lockout duration of 15 mins.

## Why?

From a review of existing OPT/MFA code attempts and retry functionality it was highlighted that SMS MFA code retry lockout duration should not be extended to 2 hours like other codes.
