### PR TITLE
INCIDEN-702: Add alerting to AM API Gateway lambda authorizer

### DIFF
--- a/ci/terraform/account-management/account.tf
+++ b/ci/terraform/account-management/account.tf
@@ -1,0 +1,1 @@
+data "aws_iam_account_alias" "current" {}


### PR DESCRIPTION
## What?
Add alerting to AM API Gateway lambda authorizer

## Why?
We had an incident where we were unaware that this was broken for approx 2 hours.


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.