### PR TITLE
ATO-NONE: Add sector_identifier_uri to the client reg for stubs

### DIFF
--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -8,7 +8,8 @@ di_tools_signing_profile_version_arn         = "arn:aws:signer:eu-west-2:7066156
 
 stub_rp_clients = [
   {
-    client_name = "di-auth-stub-relying-party-authdev1"
+    client_name           = "di-auth-stub-relying-party-authdev1"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-authdev1.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-authdev1.london.cloudapps.digital/oidc/authorization-code/callback",
     ]

--- a/ci/terraform/shared/authdev2.tfvars
+++ b/ci/terraform/shared/authdev2.tfvars
@@ -8,7 +8,8 @@ di_tools_signing_profile_version_arn         = "arn:aws:signer:eu-west-2:7066156
 
 stub_rp_clients = [
   {
-    client_name = "di-auth-stub-relying-party-authdev2"
+    client_name           = "di-auth-stub-relying-party-authdev2"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-authdev2.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-authdev2.london.cloudapps.digital/oidc/authorization-code/callback",
     ]

--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -1,6 +1,7 @@
 stub_rp_clients = [
   {
-    client_name = "di-auth-stub-relying-party-build"
+    client_name           = "di-auth-stub-relying-party-build"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-build.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-build.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -21,7 +22,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "di-auth-stub-relying-party-build-s2"
+    client_name           = "di-auth-stub-relying-party-build-s2"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-build-s2.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-build-s2.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -42,7 +44,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "di-auth-stub-relying-party-build-app"
+    client_name           = "di-auth-stub-relying-party-build-app"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-build-app.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-build-app.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -61,7 +64,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "di-auth-stub-relying-party-build-optional"
+    client_name           = "di-auth-stub-relying-party-build-optional"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-build-optional.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-build-optional.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -82,7 +86,8 @@ stub_rp_clients = [
     service_type      = "OPTIONAL"
   },
   {
-    client_name = "di-auth-stub-relying-party-dev"
+    client_name           = "di-auth-stub-relying-party-dev"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-build-dev.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-build-dev.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -103,9 +108,11 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-build"
+    client_name           = "relying-party-stub-build"
+    sector_identifier_uri = "https://rp-build.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-build.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+      "http://localhost:8080/oidc/authorization-code/callback",
     ]
     logout_urls = [
       "https://rp-build.build.stubs.account.gov.uk/signed-out",
@@ -124,9 +131,11 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-build-app"
+    client_name           = "relying-party-stub-build-app"
+    sector_identifier_uri = "https://doc-app-rp-build.build.stubs.account.gov.uk"
     callback_urls = [
       "https://doc-app-rp-build.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+      "http://localhost:8080/oidc/authorization-code/callback",
     ]
     logout_urls = [
       "https://doc-app-rp-build.build.stubs.account.gov.uk/signed-out",
@@ -143,9 +152,11 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-build-acceptance-test"
+    client_name           = "relying-party-stub-build-acceptance-test"
+    sector_identifier_uri = "https://acceptance-test-rp-build.build.stubs.account.gov.uk"
     callback_urls = [
       "https://acceptance-test-rp-build.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+      "http://localhost:8080/oidc/authorization-code/callback",
     ]
     logout_urls = [
       "https://acceptance-test-rp-build.build.stubs.account.gov.uk/signed-out",

--- a/ci/terraform/shared/dev-stub-clients.tfvars
+++ b/ci/terraform/shared/dev-stub-clients.tfvars
@@ -1,6 +1,7 @@
 stub_rp_clients = [
   {
-    client_name = "di-auth-stub-relying-party-dev"
+    client_name           = "di-auth-stub-relying-party-dev"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-build-dev.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-build-dev.london.cloudapps.digital/oidc/authorization-code/callback",
     ]

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -1,6 +1,7 @@
 stub_rp_clients = [
   {
-    client_name = "di-auth-stub-relying-party-integration"
+    client_name           = "di-auth-stub-relying-party-integration"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-integration.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-integration.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -21,7 +22,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "di-auth-stub-relying-party-integration-app"
+    client_name           = "di-auth-stub-relying-party-integration-app"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-integration-app.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-integration-app.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -40,7 +42,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-integration"
+    client_name           = "relying-party-stub-integration"
+    sector_identifier_uri = "https://rp-integration.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-integration.build.stubs.account.gov.uk/oidc/authorization-code/callback",
     ]
@@ -61,7 +64,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-integration-app"
+    client_name           = "relying-party-stub-integration-app"
+    sector_identifier_uri = "https://doc-app-rp-integration.build.stubs.account.gov.uk"
     callback_urls = [
       "https://doc-app-rp-integration.build.stubs.account.gov.uk/oidc/authorization-code/callback",
     ]

--- a/ci/terraform/shared/localstack.tfvars
+++ b/ci/terraform/shared/localstack.tfvars
@@ -4,7 +4,8 @@ aws_dynamodb_endpoint = "http://localhost:8000"
 use_localstack        = true
 stub_rp_clients = [
   {
-    client_name = "di-auth-stub-relying-party-local"
+    client_name           = "di-auth-stub-relying-party-local"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-build.london.cloudapps.digital"
     callback_urls = [
       "http://localhost:8081/oidc/authorization-code/callback",
       "https://di-auth-stub-relying-party-build.london.cloudapps.digital/oidc/authorization-code/callback",

--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -1,6 +1,7 @@
 stub_rp_clients = [
   {
-    client_name = "di-auth-stub-relying-party-production"
+    client_name           = "di-auth-stub-relying-party-production"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-production.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-production.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -21,7 +22,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "di-auth-stub-relying-party-production-app"
+    client_name           = "di-auth-stub-relying-party-production-app"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-production-app.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-production-app.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -40,7 +42,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-production"
+    client_name           = "relying-party-stub-production"
+    sector_identifier_uri = "https://rp.stubs.account.gov.uk"
     callback_urls = [
       "https://rp.stubs.account.gov.uk/oidc/authorization-code/callback",
     ]
@@ -61,7 +64,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-production-app"
+    client_name           = "relying-party-stub-production-app"
+    sector_identifier_uri = "https://doc-app-rp.stubs.account.gov.uk"
     callback_urls = [
       "https://doc-app-rp.stubs.account.gov.uk/oidc/authorization-code/callback",
     ]

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -8,7 +8,8 @@ di_tools_signing_profile_version_arn         = "arn:aws:signer:eu-west-2:7066156
 
 stub_rp_clients = [
   {
-    client_name = "di-auth-stub-relying-party-sandpit"
+    client_name           = "di-auth-stub-relying-party-sandpit"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-sandpit.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-sandpit.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -29,7 +30,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-sandpit"
+    client_name           = "relying-party-stub-sandpit"
+    sector_identifier_uri = "https://rp-dev.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-dev.build.stubs.account.gov.uk/oidc/authorization-code/callback",
     ]
@@ -50,7 +52,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-sandpit-app"
+    client_name           = "relying-party-stub-sandpit-app"
+    sector_identifier_uri = "https://doc-app-rp-dev.build.stubs.account.gov.uk"
     callback_urls = [
       "https://doc-app-rp-dev.build.stubs.account.gov.uk/oidc/authorization-code/callback",
     ]

--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -1,6 +1,7 @@
 stub_rp_clients = [
   {
-    client_name = "di-auth-stub-relying-party-staging"
+    client_name           = "di-auth-stub-relying-party-staging"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-staging.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-staging.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -21,7 +22,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "di-auth-stub-relying-party-staging-app"
+    client_name           = "di-auth-stub-relying-party-staging-app"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-staging-app.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-staging-app.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -40,7 +42,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "di-auth-stub-relying-party-staging-t1"
+    client_name           = "di-auth-stub-relying-party-staging-t1"
+    sector_identifier_uri = "https://di-auth-stub-relying-party-staging-t1.london.cloudapps.digital"
     callback_urls = [
       "https://di-auth-stub-relying-party-staging-t1.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
@@ -61,7 +64,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-staging"
+    client_name           = "relying-party-stub-staging"
+    sector_identifier_uri = "https://rp-staging.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-staging.build.stubs.account.gov.uk/oidc/authorization-code/callback",
     ]
@@ -82,7 +86,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-staging-app"
+    client_name           = "relying-party-stub-staging-app"
+    sector_identifier_uri = "https://doc-app-rp-staging.build.stubs.account.gov.uk"
     callback_urls = [
       "https://doc-app-rp-staging.build.stubs.account.gov.uk/oidc/authorization-code/callback",
     ]
@@ -101,7 +106,8 @@ stub_rp_clients = [
     service_type      = "MANDATORY"
   },
   {
-    client_name = "relying-party-stub-staging-perf-test"
+    client_name           = "relying-party-stub-staging-perf-test"
+    sector_identifier_uri = "https://perf-test-rp-staging.build.stubs.account.gov.uk"
     callback_urls = [
       "https://perf-test-rp-staging.build.stubs.account.gov.uk/oidc/authorization-code/callback",
     ]

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -34,6 +34,9 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
         S = "contact+${var.stub_rp_clients[count.index].client_name}@example.com"
       }]
     }
+    SectorIdentifierUri = {
+      S = var.stub_rp_clients[count.index].sector_identifier_uri
+    }
     PostLogoutRedirectUrls = {
       L = [for url in var.stub_rp_clients[count.index].logout_urls : {
         S = url

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -89,7 +89,7 @@ variable "logging_endpoint_arns" {
 
 variable "stub_rp_clients" {
   default     = []
-  type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, consent_required : string, one_login_service : bool, service_type : string }))
+  type        = list(object({ client_name : string, sector_identifier_uri : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, consent_required : string, one_login_service : bool, service_type : string }))
   description = "The details of RP clients to provision in the Client table"
 }
 


### PR DESCRIPTION
## What?

Add sector_identifier_uri to the client reg for stubs and add redirect_uri to allow for local running of the stubs

## Why?

This allows for local running of the stub as it can then redirect to localhost

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.