### PR TITLE
ATO-97: Move storage token kms signing policy from ipv-authorize to authentication-callback

### DIFF
--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -5,7 +5,6 @@ module "ipv_authorize_role" {
   vpc_arn     = local.authentication_vpc_arn
 
   policies_to_attach = [
-    aws_iam_policy.storage_token_kms_signing_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
@@ -19,29 +18,6 @@ module "ipv_authorize_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
-}
-
-data "aws_iam_policy_document" "storage_token_kms_signing_policy_document" {
-  statement {
-    sid    = "AllowAccessToVcTokenKmsSigningKey"
-    effect = "Allow"
-
-    actions = [
-      "kms:Sign",
-      "kms:GetPublicKey",
-    ]
-    resources = [
-      aws_kms_key.storage_token_signing_key_ecc.arn
-    ]
-  }
-}
-
-resource "aws_iam_policy" "storage_token_kms_signing_policy" {
-  name_prefix = "kms-signing-policy"
-  path        = "/${var.environment}/storage-token/"
-  description = "IAM policy for managing KMS connection for a lambda which allows signing of storage token payloads"
-
-  policy = data.aws_iam_policy_document.storage_token_kms_signing_policy_document.json
 }
 
 module "ipv-authorize" {


### PR DESCRIPTION
## What?

Move storage token kms signing policy from ipv-authorize to authentication-callback

## Why?

Policy mistakenly added to wrong lambda: ipv-authorize is deprecated, authentication-callback is the lambda which requries these permissions.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3944


## Orchestration and Authentication mutual dependencies

- [x] Impact on orch and auth mutual dependencies has been checked.