### PR TITLE
BAU: Allow local use of the Build stub client

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -106,9 +106,11 @@ stub_rp_clients = [
     client_name = "relying-party-stub-build"
     callback_urls = [
       "https://rp-build.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+      "http://localhost:8080/oidc/authorization-code/callback",
     ]
     logout_urls = [
       "https://rp-build.build.stubs.account.gov.uk/signed-out",
+      "http://localhost:8080/signed-out",
     ]
     test_client                     = "0"
     consent_required                = "0"
@@ -120,16 +122,19 @@ stub_rp_clients = [
       "phone",
       "wallet-subject-id",
     ]
-    one_login_service = false
-    service_type      = "MANDATORY"
+    one_login_service     = false
+    service_type          = "MANDATORY"
+    sector_identifier_uri = "https://rp-build.build.stubs.account.gov.uk"
   },
   {
     client_name = "relying-party-stub-build-app"
     callback_urls = [
       "https://doc-app-rp-build.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+      "http://localhost:8080/oidc/authorization-code/callback",
     ]
     logout_urls = [
       "https://doc-app-rp-build.build.stubs.account.gov.uk/signed-out",
+      "http://localhost:8080/signed-out",
     ]
     test_client                     = "1"
     consent_required                = "0"
@@ -139,16 +144,19 @@ stub_rp_clients = [
       "openid",
       "doc-checking-app",
     ]
-    one_login_service = false
-    service_type      = "MANDATORY"
+    one_login_service     = false
+    service_type          = "MANDATORY"
+    sector_identifier_uri = "https://doc-app-rp-build.build.stubs.account.gov.uk"
   },
   {
     client_name = "relying-party-stub-build-acceptance-test"
     callback_urls = [
       "https://acceptance-test-rp-build.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+      "http://localhost:8080/oidc/authorization-code/callback",
     ]
     logout_urls = [
       "https://acceptance-test-rp-build.build.stubs.account.gov.uk/signed-out",
+      "http://localhost:8080/signed-out",
     ]
     test_client                     = "1"
     consent_required                = "0"
@@ -160,7 +168,8 @@ stub_rp_clients = [
       "phone",
       "wallet-subject-id",
     ]
-    one_login_service = false
-    service_type      = "MANDATORY"
+    one_login_service     = false
+    service_type          = "MANDATORY"
+    sector_identifier_uri = "https://acceptance-test-rp-build.build.stubs.account.gov.uk"
   },
 ]

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -109,5 +109,8 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
     OneLoginService = {
       BOOL = var.stub_rp_clients[count.index].one_login_service
     }
+    SectorIdentifierUri = {
+      S = coalesce(var.stub_rp_clients[count.index].sector_identifier_uri, var.stub_rp_clients[count.index].callback_urls[0])
+    }
   })
 }

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -89,7 +89,7 @@ variable "logging_endpoint_arns" {
 
 variable "stub_rp_clients" {
   default     = []
-  type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, consent_required : string, one_login_service : bool, service_type : string }))
+  type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, consent_required : string, one_login_service : bool, service_type : string, sector_identifier_uri : string }))
   description = "The details of RP clients to provision in the Client table"
 }
 


### PR DESCRIPTION
## What?
Add localhost to the stub client URLs

## Why?
To permit running the local stub against build


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.