### PR TITLE
ATO-361: Add wallet subject id to auth user info

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthUserInfoClaims.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthUserInfoClaims.java
@@ -12,6 +12,7 @@ public enum AuthUserInfoClaims {
     EMAIL_VERIFIED("email_verified"),
     PHONE_NUMBER("phone_number"),
     PHONE_VERIFIED("phone_number_verified"),
+    WALLET_SUBJECT_ID("wallet_subject_id"),
     SALT("salt");
 
     private final String value;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -751,6 +751,8 @@ public class AuthorisationHandler
                 requestedScopesContain(CustomScopeValue.GOVUK_ACCOUNT, authenticationRequest);
         var phoneScopePresent = requestedScopesContain(OIDCScopeValue.PHONE, authenticationRequest);
         var emailScopePresent = requestedScopesContain(OIDCScopeValue.EMAIL, authenticationRequest);
+        var walletSubjectIdScopePresent =
+                requestedScopesContain(CustomScopeValue.WALLET_SUBJECT_ID, authenticationRequest);
 
         var claimsSet = new HashSet<AuthUserInfoClaims>();
         if (identityRequired) {
@@ -779,6 +781,10 @@ public class AuthorisationHandler
             LOG.info("email scope is present. Adding the email and email_verified claim");
             claimsSet.add(AuthUserInfoClaims.EMAIL);
             claimsSet.add(AuthUserInfoClaims.EMAIL_VERIFIED);
+        }
+        if (walletSubjectIdScopePresent) {
+            LOG.info("wallet-subject-id scope is present. Adding the wallet-subject-id claim");
+            claimsSet.add(AuthUserInfoClaims.WALLET_SUBJECT_ID);
         }
 
         var claimSetEntries =


### PR DESCRIPTION
## What?

Adding it to the AuthUserInfoClaims so that it can be part of the authenticationRequest

## Why?

Request for wallet subject id isn't going through; not showing in the stubs

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.


## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.