### PR TITLE
ATO-436: Add a lambda to manually delete accounts

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
@@ -1,0 +1,61 @@
+package uk.gov.di.accountmanagement.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import uk.gov.di.accountmanagement.services.AccountDeletionService;
+import uk.gov.di.accountmanagement.services.AwsSqsClient;
+import uk.gov.di.accountmanagement.services.DynamoDeleteService;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
+
+public class ManuallyDeleteAccountHandler implements RequestHandler<String, String> {
+    private final AuthenticationService authenticationService;
+    private final AccountDeletionService accountDeletionService;
+
+    public ManuallyDeleteAccountHandler(
+            AuthenticationService authenticationService,
+            AccountDeletionService accountDeletionService) {
+        this.authenticationService = authenticationService;
+        this.accountDeletionService = accountDeletionService;
+    }
+
+    public ManuallyDeleteAccountHandler(ConfigurationService configurationService) {
+        this.authenticationService = new DynamoService(configurationService);
+        var sqsClient =
+                new AwsSqsClient(
+                        configurationService.getAwsRegion(),
+                        configurationService.getEmailQueueUri(),
+                        configurationService.getSqsEndpointUri());
+        var auditService = new AuditService(configurationService);
+        var dynamoDeleteService = new DynamoDeleteService(configurationService);
+        this.accountDeletionService =
+                new AccountDeletionService(
+                        authenticationService,
+                        sqsClient,
+                        auditService,
+                        configurationService,
+                        dynamoDeleteService);
+    }
+
+    public ManuallyDeleteAccountHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    @Override
+    public String handleRequest(String userEmail, Context context) {
+        var userProfile =
+                authenticationService
+                        .getUserProfileByEmailMaybe(userEmail)
+                        .orElseThrow(() -> new RuntimeException("User not found with given email"));
+
+        try {
+            var userIdentifiers = accountDeletionService.removeAccount(userProfile);
+            return userIdentifiers.toString();
+        } catch (Json.JsonException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -1,0 +1,91 @@
+package uk.gov.di.accountmanagement.services;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
+import uk.gov.di.accountmanagement.entity.NotificationType;
+import uk.gov.di.accountmanagement.entity.NotifyRequest;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+
+public class AccountDeletionService {
+    private static final Logger LOG = LogManager.getLogger(AccountDeletionService.class);
+
+    private final AuthenticationService authenticationService;
+    private final AwsSqsClient sqsClient;
+    private final AuditService auditService;
+    private final ConfigurationService configurationService;
+    private final DynamoDeleteService dynamoDeleteService;
+    private final Json objectMapper = SerializationService.getInstance();
+
+    public AccountDeletionService(
+            AuthenticationService authenticationService,
+            AwsSqsClient sqsClient,
+            AuditService auditService,
+            ConfigurationService configurationService,
+            DynamoDeleteService dynamoDeleteService) {
+        this.authenticationService = authenticationService;
+        this.sqsClient = sqsClient;
+        this.auditService = auditService;
+        this.configurationService = configurationService;
+        this.dynamoDeleteService = dynamoDeleteService;
+    }
+
+    public DeletedAccountIdentifiers removeAccount(UserProfile userProfile)
+            throws Json.JsonException {
+        var accountIdentifiers =
+                new DeletedAccountIdentifiers(
+                        userProfile.getPublicSubjectID(),
+                        userProfile.getLegacySubjectID(),
+                        userProfile.getSubjectID());
+
+        LOG.info("Calculating internal common subject identifier");
+        var internalCommonSubjectIdentifier =
+                ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                        userProfile,
+                        configurationService.getInternalSectorUri(),
+                        authenticationService);
+        LOG.info("Internal common subject identifier: {}", internalCommonSubjectIdentifier);
+        var email = userProfile.getEmail();
+
+        LOG.info("Deleting user account");
+        dynamoDeleteService.deleteAccount(email, internalCommonSubjectIdentifier.getValue());
+
+        try {
+            LOG.info("User account removed. Adding message to SQS queue");
+            NotifyRequest notifyRequest =
+                    new NotifyRequest(
+                            email,
+                            NotificationType.DELETE_ACCOUNT,
+                            LocaleHelper.SupportedLanguage.EN);
+            sqsClient.send(objectMapper.writeValueAsString((notifyRequest)));
+        } catch (Exception e) {
+            LOG.error("Failed to send account deletion email: ", e);
+        }
+
+        try {
+            auditService.submitAuditEvent(
+                    AccountManagementAuditableEvent.DELETE_ACCOUNT,
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    internalCommonSubjectIdentifier.getValue(),
+                    userProfile.getEmail(),
+                    AuditService.UNKNOWN,
+                    userProfile.getPhoneNumber(),
+                    AuditService.UNKNOWN);
+        } catch (Exception e) {
+            LOG.error("Failed to audit account deletion: ", e);
+        }
+        return accountIdentifiers;
+    }
+
+    public record DeletedAccountIdentifiers(
+            String publicSubjectId, String legacySubjectId, String subjectId) {}
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandlerTest.java
@@ -1,0 +1,66 @@
+package uk.gov.di.accountmanagement.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.accountmanagement.services.AccountDeletionService;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ManuallyDeleteAccountHandlerTest {
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final AccountDeletionService accountDeletionService =
+            mock(AccountDeletionService.class);
+    private static final Context CONTEXT = mock(Context.class);
+    private final ManuallyDeleteAccountHandler underTest =
+            new ManuallyDeleteAccountHandler(authenticationService, accountDeletionService);
+
+    @Test
+    void callsRemoveAccountWithTheCorrectParameters() throws Json.JsonException {
+        // given
+        var expectedEmail = "test@example.com";
+        var userProfile = mock(UserProfile.class);
+        when(authenticationService.getUserProfileByEmailMaybe(any()))
+                .thenReturn(Optional.ofNullable(userProfile));
+        when(accountDeletionService.removeAccount(any()))
+                .thenReturn(mock(AccountDeletionService.DeletedAccountIdentifiers.class));
+
+        // when
+        underTest.handleRequest(expectedEmail, CONTEXT);
+
+        // then
+        verify(authenticationService).getUserProfileByEmailMaybe(expectedEmail);
+        verify(accountDeletionService).removeAccount(userProfile);
+    }
+
+    @Test
+    void throwsAnExceptionWhenTheUserIsNotFound() {
+        // given
+        when(authenticationService.getUserProfileByEmailMaybe(any())).thenReturn(Optional.empty());
+
+        // then
+        assertThrows(
+                RuntimeException.class, () -> underTest.handleRequest("test@example.com", CONTEXT));
+    }
+
+    @Test
+    void throwsAnExceptionWhenUserDeletionFails() throws Json.JsonException {
+        // given
+        var userProfile = mock(UserProfile.class);
+        when(authenticationService.getUserProfileByEmailMaybe(any()))
+                .thenReturn(Optional.ofNullable(userProfile));
+        when(accountDeletionService.removeAccount(any())).thenThrow(Json.JsonException.class);
+
+        // then
+        assertThrows(
+                RuntimeException.class, () -> underTest.handleRequest("test@example.com", CONTEXT));
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
@@ -1,0 +1,196 @@
+package uk.gov.di.accountmanagement.services;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+
+import java.util.HashMap;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.DELETE_ACCOUNT;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
+
+class AccountDeletionServiceTest {
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
+    private final AuditService auditService = mock(AuditService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final DynamoDeleteService dynamoDeleteService = mock(DynamoDeleteService.class);
+    private final UserProfile userProfile = mock(UserProfile.class);
+    private final AccountDeletionService underTest =
+            new AccountDeletionService(
+                    authenticationService,
+                    sqsClient,
+                    auditService,
+                    configurationService,
+                    dynamoDeleteService);
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(AccountDeletionService.class);
+
+    @BeforeEach
+    public void setup() {
+        when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
+        when(authenticationService.getOrGenerateSalt(any())).thenReturn(new byte[0xaa]);
+    }
+
+    @ParameterizedTest
+    @MethodSource("identifiersSource")
+    void removeAccountReturnsCorrectIdentifiers(
+            String expectedPublicSubjectId,
+            String expectedLegacySubjectId,
+            String expectedSubjectId)
+            throws Json.JsonException {
+        // given
+        when(userProfile.getPublicSubjectID()).thenReturn(expectedPublicSubjectId);
+        when(userProfile.getLegacySubjectID()).thenReturn(expectedLegacySubjectId);
+        when(userProfile.getSubjectID()).thenReturn(expectedSubjectId);
+
+        // when
+        var deletedAccountIdentifiers = underTest.removeAccount(userProfile);
+
+        // then
+        assertEquals(expectedPublicSubjectId, deletedAccountIdentifiers.publicSubjectId());
+        assertEquals(expectedLegacySubjectId, deletedAccountIdentifiers.legacySubjectId());
+        assertEquals(expectedSubjectId, deletedAccountIdentifiers.subjectId());
+    }
+
+    private static Stream<Arguments> identifiersSource() {
+        var publicSubjectId = new Subject().getValue();
+        var legacySubjectId = new Subject().getValue();
+        var subjectId = new Subject().getValue();
+
+        return Stream.of(
+                Arguments.of(publicSubjectId, legacySubjectId, subjectId),
+                Arguments.of(publicSubjectId, null, subjectId),
+                Arguments.of(null, legacySubjectId, subjectId),
+                Arguments.of(null, null, subjectId));
+    }
+
+    @Test
+    void removeAccountCallsDeleteAccount() throws Json.JsonException {
+        // given
+        var expectedEmail = "test@example.com";
+        when(userProfile.getEmail()).thenReturn(expectedEmail);
+        when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
+
+        // when
+        underTest.removeAccount(userProfile);
+
+        // then
+        verify(dynamoDeleteService).deleteAccount(eq(expectedEmail), any());
+    }
+
+    @Test
+    void removeAccountThrowsIfDeleteAccountFails() {
+        // given
+        var expectedException = new RuntimeException();
+        when(userProfile.getEmail()).thenReturn("test@example.com");
+        when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
+        doThrow(expectedException).when(dynamoDeleteService).deleteAccount(any(), any());
+
+        // then
+        assertThrows(expectedException.getClass(), () -> underTest.removeAccount(userProfile));
+    }
+
+    @Test
+    void removeAccountSendsNotificationEmail() throws Json.JsonException {
+        // given
+        var expectedEmail = "test@example.com";
+        when(userProfile.getEmail()).thenReturn(expectedEmail);
+        when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
+
+        // when
+        underTest.removeAccount(userProfile);
+
+        // then
+        var captor = ArgumentCaptor.forClass(String.class);
+        verify(sqsClient).send(captor.capture());
+        var notifyRequest =
+                SerializationService.getInstance().readValue(captor.getValue(), HashMap.class);
+        assertEquals(expectedEmail, notifyRequest.get("destination"));
+        assertEquals("DELETE_ACCOUNT", notifyRequest.get("notificationType"));
+        assertEquals("EN", notifyRequest.get("language"));
+    }
+
+    @Test
+    void removeAccountSucceedsIfEmailNotificationFails() {
+        // given
+        when(userProfile.getEmail()).thenReturn("test@example.com");
+        when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
+        doThrow(new RuntimeException()).when(sqsClient).send(any());
+
+        // then
+        assertDoesNotThrow(() -> underTest.removeAccount(userProfile));
+        assertThat(
+                logging.events(),
+                hasItem(withMessageContaining("Failed to send account deletion email")));
+    }
+
+    @Test
+    void removeAccountAudits() throws Json.JsonException {
+        // given
+        var expectedEmail = "test@example.com";
+        var expectedPhoneNumber = "+44123456789";
+        when(userProfile.getEmail()).thenReturn(expectedEmail);
+        when(userProfile.getPhoneNumber()).thenReturn(expectedPhoneNumber);
+        when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
+
+        // when
+        underTest.removeAccount(userProfile);
+
+        // then
+        verify(auditService)
+                .submitAuditEvent(
+                        eq(DELETE_ACCOUNT),
+                        eq(AuditService.UNKNOWN),
+                        eq(AuditService.UNKNOWN),
+                        eq(AuditService.UNKNOWN),
+                        anyString(),
+                        eq(expectedEmail),
+                        eq(AuditService.UNKNOWN),
+                        eq(expectedPhoneNumber),
+                        eq(AuditService.UNKNOWN));
+    }
+
+    @Test
+    void removeAccountSucceedsIfAuditingFails() {
+        // given
+        when(userProfile.getEmail()).thenReturn("test@example.com");
+        when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
+        doThrow(new RuntimeException())
+                .when(auditService)
+                .submitAuditEvent(any(), any(), any(), any(), any(), any(), any(), any(), any());
+
+        // then
+        assertDoesNotThrow(() -> underTest.removeAccount(userProfile));
+        assertThat(
+                logging.events(),
+                hasItem(withMessageContaining("Failed to audit account deletion")));
+    }
+}

--- a/ci/terraform/account-management/manually-delete-account.tf
+++ b/ci/terraform/account-management/manually-delete-account.tf
@@ -1,0 +1,91 @@
+module "account_management_manually_delete_account_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "account-management-manually-delete-account-role"
+  vpc_arn     = local.vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.dynamo_am_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_am_user_delete_access_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    module.account_management_txma_audit.access_policy_arn,
+    aws_iam_policy.dynamo_am_account_modifiers_read_access_policy.arn,
+    aws_iam_policy.dynamo_am_account_modifiers_delete_access_policy.arn,
+    local.account_modifiers_encryption_policy_arn,
+    aws_iam_policy.permit_send_email_queue_policy.arn
+  ]
+}
+
+resource "aws_lambda_function" "manually_delete_account_lambda" {
+  function_name = replace("${var.environment}-manually-delete-account-lambda", ".", "")
+  role          = module.account_management_manually_delete_account_role.arn
+  handler       = "uk.gov.di.accountmanagement.lambda.ManuallyDeleteAccountHandler::handleRequest"
+  timeout       = 30
+  publish       = true
+
+
+  s3_bucket               = aws_s3_bucket.source_bucket.bucket
+  s3_key                  = aws_s3_object.account_management_api_release_zip.key
+  s3_object_version       = aws_s3_object.account_management_api_release_zip.version_id
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  vpc_config {
+    security_group_ids = [
+      local.allow_aws_service_access_security_group_id,
+      aws_security_group.allow_access_to_am_redis.id,
+    ]
+    subnet_ids = local.private_subnet_ids
+  }
+
+  environment {
+    variables = {
+      JAVA_TOOL_OPTIONS    = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+      ENVIRONMENT          = var.environment
+      EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
+      TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
+      INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    }
+  }
+
+  kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
+  runtime     = "java17"
+
+  tags = local.default_tags
+}
+
+resource "aws_cloudwatch_log_group" "manually_delete_account_lambda_log_group" {
+  name              = "/aws/lambda/${aws_lambda_function.manually_delete_account_lambda.function_name}"
+  tags              = local.default_tags
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
+
+  depends_on = [
+    aws_lambda_function.manually_delete_account_lambda
+  ]
+}
+
+data "aws_iam_policy_document" "permit_send_email_queue_policy_document" {
+  statement {
+    sid    = "SendSQS"
+    effect = "Allow"
+
+
+    actions = [
+      "sqs:SendMessage",
+      "sqs:ChangeMessageVisibility",
+      "sqs:GetQueueAttributes",
+    ]
+
+    resources = [
+      aws_sqs_queue.email_queue.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "permit_send_email_queue_policy" {
+  name_prefix = "permit-send-email-queue-policy"
+  path        = "/${var.environment}/am/"
+  description = "IAM policy to allow sending messages to the account management email queue"
+
+  policy = data.aws_iam_policy_document.permit_send_email_queue_policy_document.json
+}


### PR DESCRIPTION
## What

This lambda is intended to me manually invoked from the AWS console, and provides a method to emit the correct audit events when actioning manual account deletions.

## How to review
Pay particular attention to the error handling I think. We always want to know the IDs of the account being deleted.
The intended use of this is that it would be invoked manually from the console using the "test" functionality. The return value can then be copied into the account deletion ticket.

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.

