### PR TITLE
BAU: Enforce running SSO setup script from wrapper

### DIFF
--- a/scripts/_set-up-sso.py
+++ b/scripts/_set-up-sso.py
@@ -11,11 +11,22 @@ from datetime import datetime
 from pathlib import Path
 from time import sleep
 
+if os.getenv("FROM_WRAPPER", "false") != "true":
+    print(
+        "This script is intended to be run from the wrapper `scripts/set-up-sso.sh`. "
+        "Please use that instead."
+    )
+    sys.exit(1)
+
 try:
     import boto3
 except ImportError:
-    print("boto3 is not installed. Please install it using `pip3 install boto3`")
+    print(
+        "boto3 is not installed. Please refer to "
+        "https://govukverify.atlassian.net/wiki/x/IgFm5 for instructions."
+    )
     sys.exit(1)
+
 
 StrAnyDict = dict[str, object()]
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,7 +1,2 @@
-boto3==1.34.56
-botocore==1.34.56
-jmespath==1.0.1
-python-dateutil==2.9.0.post0
-s3transfer==0.10.0
-six==1.16.0
-urllib3==2.0.7
+boto3
+botocore

--- a/scripts/set-up-sso.sh
+++ b/scripts/set-up-sso.sh
@@ -7,7 +7,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 if [ -d "${DIR}/.venv" ]; then
     echo "! Using existing virtualenv"
 else
-    echo "C! reating virtualenv"
+    echo "! Creating virtualenv"
     python3 -m venv "${DIR}/.venv"
 fi
 
@@ -22,4 +22,4 @@ pip3 install -r "${DIR}/requirements.txt"
 echo
 echo
 
-python3 "${DIR}/_set-up-sso.py"
+FROM_WRAPPER=true python3 "${DIR}/_set-up-sso.py"

--- a/scripts/set-up-sso.sh
+++ b/scripts/set-up-sso.sh
@@ -3,6 +3,15 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
+# Ensure python is at least 3.10
+min_python_version=3.10
+python_version="$(python3 --version | cut -d' ' -f2)"
+if [ "$(printf '%s\n' "${min_python_version}" "${python_version}" | sort -V | head -n1)" != "${min_python_version}" ]; then
+    # shellcheck disable=SC2016
+    printf 'Please install python %s or later (found: %s). You could probably use `brew install python@3.12`' "${min_python_version}" "${python_version}"
+    exit 1
+fi
+
 # test if a python virtualenv already exists
 if [ -d "${DIR}/.venv" ]; then
     echo "! Using existing virtualenv"


### PR DESCRIPTION
## What

To avoid dependency errors, enforce running the SSO setup script from the wrapper script.

This will ensure that the virtual environment is set up correctly and that the necessary dependencies are installed.

Also, remove the fixed versioning on the python dependencies - we are safe to use latest here as these are well-established APIs, and this increases the number of supported python versions.

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Run the script with `python3 scripts/_set_up_sso.py`, observe that an error occurs and the script does not run.
1. Run the script with `scripts/set-up-sso.sh`, observe that the script runs as expected.
