### PR TITLE
ATO-439: Allow backchannel logout URI to be updated using the client registry API

### DIFF
--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
@@ -11,11 +11,13 @@ import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.sharedtest.basetest.DynamoTestConfiguration;
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 
@@ -408,6 +410,10 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
 
     public boolean clientExists(String clientID) {
         return dynamoClientService.isValidClient(clientID);
+    }
+
+    public Optional<ClientRegistry> getClient(String clientId) {
+        return dynamoClientService.getClient(clientId);
     }
 
     @Override

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
@@ -59,6 +59,10 @@ public class UpdateClientConfigRequest {
     @Expose
     private List<String> clientLoCs;
 
+    @SerializedName("back_channel_logout_uri")
+    @Expose
+    private String backChannelLogoutUri;
+
     public UpdateClientConfigRequest() {}
 
     public String getClientId() {
@@ -111,6 +115,10 @@ public class UpdateClientConfigRequest {
 
     public List<String> getClientLoCs() {
         return clientLoCs;
+    }
+
+    public String getBackChannelLogoutUri() {
+        return backChannelLogoutUri;
     }
 
     public UpdateClientConfigRequest setClientId(String clientId) {
@@ -176,5 +184,10 @@ public class UpdateClientConfigRequest {
 
     public void setSectorIdentifierUri(String sectorIdentifierUri) {
         this.sectorIdentifierUri = sectorIdentifierUri;
+    }
+
+    public UpdateClientConfigRequest setBackChannelLogoutUri(String backChannelLogoutUri) {
+        this.backChannelLogoutUri = backChannelLogoutUri;
+        return this;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
@@ -116,6 +116,8 @@ public class DynamoClientService implements ClientService {
         Optional.ofNullable(updateRequest.getClaims()).ifPresent(clientRegistry::withClaims);
         Optional.ofNullable(updateRequest.getClientLoCs())
                 .ifPresent(clientRegistry::withClientLoCs);
+        Optional.ofNullable(updateRequest.getBackChannelLogoutUri())
+                .ifPresent(clientRegistry::withBackChannelLogoutUri);
         dynamoClientRegistryTable.putItem(clientRegistry);
         return clientRegistry;
     }


### PR DESCRIPTION
## What

Update the client registry API to allow the backchannel logout URI to be configured. This is required by the self-serve interface

## How to review

Code review only

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.


