### PR TITLE
AUT-2543: Created audit event for completing a password reset intervention

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -47,7 +47,8 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     NO_INTERVENTION,
     PASSWORD_RESET_INTERVENTION,
     TEMP_SUSPENDED_INTERVENTION,
-    PERMANENTLY_BLOCKED_INTERVENTION;
+    PERMANENTLY_BLOCKED_INTERVENTION,
+    PASSWORD_RESET_INTERVENTION_COMPLETE;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordCompletionRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordCompletionRequest.java
@@ -4,20 +4,6 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.validation.Required;
 
-public class ResetPasswordCompletionRequest {
-
-    @SerializedName("password")
-    @Expose
-    @Required
-    private String password;
-
-    public ResetPasswordCompletionRequest() {}
-
-    public ResetPasswordCompletionRequest(String password) {
-        this.password = password;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-}
+public record ResetPasswordCompletionRequest(
+        @SerializedName("password") @Expose @Required String password,
+        @SerializedName("isForcedPasswordReset") @Expose @Required boolean isForcedPasswordReset) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -123,7 +123,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
         LOG.info("Request received to ResetPasswordHandler");
         try {
             Optional<ErrorResponse> passwordValidationError =
-                    passwordValidator.validate(request.getPassword());
+                    passwordValidator.validate(request.password());
 
             if (passwordValidationError.isPresent()) {
                 LOG.info("Error message: {}", passwordValidationError.get().getMessage());
@@ -134,13 +134,13 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                             userContext.getSession().getEmailAddress());
 
             if (Objects.nonNull(userCredentials.getPassword())) {
-                if (verifyPassword(userCredentials.getPassword(), request.getPassword())) {
+                if (verifyPassword(userCredentials.getPassword(), request.password())) {
                     return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1024);
                 }
             } else {
                 LOG.info("Resetting password for migrated user");
             }
-            authenticationService.updatePassword(userCredentials.getEmail(), request.getPassword());
+            authenticationService.updatePassword(userCredentials.getEmail(), request.password());
             var userProfile =
                     authenticationService.getUserProfileByEmail(
                             userContext.getSession().getEmailAddress());
@@ -186,6 +186,24 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                     LOG.info("Placing message on queue to send password reset confirmation to SMS");
                     sqsClient.send(serialiseRequest(smsNotifyRequest));
                 }
+            }
+            if (request.isForcedPasswordReset()) {
+                auditService.submitAuditEvent(
+                        FrontendAuditableEvent.PASSWORD_RESET_INTERVENTION_COMPLETE,
+                        userContext.getClientSessionId(),
+                        userContext.getSession().getSessionId(),
+                        userContext
+                                .getClient()
+                                .map(ClientRegistry::getClientID)
+                                .orElse(AuditService.UNKNOWN),
+                        internalCommonSubjectId.getValue(),
+                        userCredentials.getEmail(),
+                        IpAddressHelper.extractIpAddress(input),
+                        userContext
+                                .getUserProfile()
+                                .map(UserProfile::getPhoneNumber)
+                                .orElse(AuditService.UNKNOWN),
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
             }
             auditService.submitAuditEvent(
                     auditableEvent,


### PR DESCRIPTION
## What

Created PASSWORD_RESET_INTERVENTION_COMPLETE audit event to be submitted when the isForcedPasswordReset variable == true after receiving the request from the front end. 

Alongside this ResetPasswordCompletionRequest.java (and associated tests) has been refactored to use a record for brevity and readability.

## How to review

1. Review alongside the associated PR for the frontend (https://github.com/govuk-one-login/authentication-frontend/pull/1443)
2. Check that the argument being passed in the frontend as part of the updatePassword method can be accessed in the backend
3. Check that the acceptance criteria outlined in the ticket have been met (see https://govukverify.atlassian.net/browse/AUT-2543)


## Related PRs
https://github.com/govuk-one-login/authentication-frontend/pull/1443

