### PR TITLE
AUT-2530: Increase incorrect enter password max retries

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -141,7 +141,7 @@ class LoginHandlerTest {
 
     @BeforeEach
     void setUp() {
-        when(configurationService.getMaxPasswordRetries()).thenReturn(5);
+        when(configurationService.getMaxPasswordRetries()).thenReturn(6);
         when(configurationService.getTermsAndConditionsVersion()).thenReturn("1.0");
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(clientSession));
@@ -694,7 +694,7 @@ class LoginHandlerTest {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
-        when(codeStorageService.getIncorrectPasswordCountReauthJourney(EMAIL)).thenReturn(4);
+        when(codeStorageService.getIncorrectPasswordCountReauthJourney(EMAIL)).thenReturn(5);
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
         usingDefaultVectorOfTrust();
@@ -726,7 +726,7 @@ class LoginHandlerTest {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
-        when(codeStorageService.getIncorrectPasswordCount(EMAIL)).thenReturn(5);
+        when(codeStorageService.getIncorrectPasswordCount(EMAIL)).thenReturn(6);
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
         usingDefaultVectorOfTrust();
@@ -839,7 +839,7 @@ class LoginHandlerTest {
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         incorrectPasswordCountPair,
-                        pair("attemptNoFailedAt", 5));
+                        pair("attemptNoFailedAt", 6));
 
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1008));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -133,6 +133,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         redis.incrementPasswordCount(emailAddress);
         redis.incrementPasswordCount(emailAddress);
         redis.incrementPasswordCount(emailAddress);
+        redis.incrementPasswordCount(emailAddress);
 
         BaseFrontendRequest request = new CheckUserExistsRequest(emailAddress);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -185,7 +185,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
-    void shouldCallLoginEndpoint5TimesAndReturn400WhenUserIdLockedOut() throws Json.JsonException {
+    void shouldCallLoginEndpoint6TimesAndReturn400WhenUserIdLockedOut() throws Json.JsonException {
         String email = "joe.bloggs+4@digital.cabinet-office.gov.uk";
         String password = "password-1";
         userStore.signUp(email, "wrong-password");
@@ -223,11 +223,18 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
                         headers,
                         Map.of());
-        assertThat(response5, hasStatus(400));
+        assertThat(response5, hasStatus(401));
+        var response6 =
+                makeRequest(
+                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
+                        headers,
+                        Map.of());
+        assertThat(response6, hasStatus(400));
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(
                         ACCOUNT_TEMPORARILY_LOCKED,
+                        INVALID_CREDENTIALS,
                         INVALID_CREDENTIALS,
                         INVALID_CREDENTIALS,
                         INVALID_CREDENTIALS,
@@ -275,7 +282,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
                         headers,
                         Map.of());
-        assertThat(response5, hasStatus(400));
+        assertThat(response5, hasStatus(401));
         var response6 =
                 makeRequest(
                         Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -204,7 +204,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public int getMaxPasswordRetries() {
-        return Integer.parseInt(System.getenv().getOrDefault("PASSWORD_MAX_RETRIES", "5"));
+        return Integer.parseInt(System.getenv().getOrDefault("PASSWORD_MAX_RETRIES", "6"));
     }
 
     public int getMaxEmailReAuthRetries() {


### PR DESCRIPTION
## What

When a user is in the re-auth or the default sign-in journey, and they are entering their password they should hit a lockout when they enter the wrong password more than 5 times, on the 6th attempt

- The lockout is activated on the 5th attempt which is incorrect, it should activate on the 6th attempt
- This change will also apply to the standard sign-in journey
- Modify the `PASSWORD_MAX_RETRIES` env variable from 5 to 6 in the configuration service

## How to review

1. Code Review
2. Test the default sign in journey in sandpit
3. After merge, test the reauth sign-in journey in build as reauth is untestable in sandpit at the moment

