### PR TITLE
AUT-2552: Add applied at timestamp to account interventions response

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsResponse.java
@@ -6,4 +6,5 @@ import org.apache.logging.log4j.core.config.plugins.validation.constraints.Requi
 public record AccountInterventionsResponse(
         @Expose @Required boolean passwordResetRequired,
         @Expose @Required boolean blocked,
-        @Expose @Required boolean temporarilySuspended) {}
+        @Expose @Required boolean temporarilySuspended,
+        @Expose @Required String appliedAt) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -37,7 +37,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
     private final CloudwatchMetricsService cloudwatchMetricsService;
 
     private final AccountInterventionsResponse noAccountInterventions =
-            new AccountInterventionsResponse(false, false, false);
+            new AccountInterventionsResponse(false, false, false, "");
 
     private static final Map<State, FrontendAuditableEvent>
             ACCOUNT_INTERVENTIONS_STATE_TO_AUDIT_EVENT =
@@ -152,7 +152,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                 new AccountInterventionsResponse(
                         response.state().resetPassword(),
                         response.state().blocked(),
-                        response.state().suspended());
+                        response.state().suspended(),
+                        response.intervention().appliedAt());
         if (!configurationService.accountInterventionsServiceActionEnabled()) {
             LOG.info(
                     String.format(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -16,12 +16,14 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.NowHelper.NowClock;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.*;
 import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.time.Clock;
 import java.util.Map;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -36,8 +38,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
     private final AuditService auditService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
 
-    private final AccountInterventionsResponse noAccountInterventions =
-            new AccountInterventionsResponse(false, false, false, "");
+    private NowClock clock;
 
     private static final Map<State, FrontendAuditableEvent>
             ACCOUNT_INTERVENTIONS_STATE_TO_AUDIT_EVENT =
@@ -63,7 +64,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             AuthenticationService authenticationService,
             AccountInterventionsService accountInterventionsService,
             AuditService auditService,
-            CloudwatchMetricsService cloudwatchMetricsService) {
+            CloudwatchMetricsService cloudwatchMetricsService,
+            NowClock clock) {
         super(
                 AccountInterventionsRequest.class,
                 configurationService,
@@ -74,6 +76,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         this.accountInterventionsService = accountInterventionsService;
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
+        this.clock = clock;
     }
 
     public AccountInterventionsHandler() {
@@ -85,6 +88,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         accountInterventionsService = new AccountInterventionsService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
+        this.clock = new NowClock(Clock.systemUTC());
     }
 
     @Override
@@ -109,7 +113,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             LOG.info(
                     "Account interventions service call is disabled, returning default no interventions response");
             try {
-                return generateApiGatewayProxyResponse(200, noAccountInterventions, true);
+                return generateApiGatewayProxyResponse(200, noAccountInterventions(), true);
             } catch (JsonException e) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
             }
@@ -159,7 +163,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                     String.format(
                             "Account interventions action disabled, discarding response %s from api and returning no interventions",
                             responseFromApi));
-            return noAccountInterventions;
+            return noAccountInterventions();
         } else {
             return responseFromApi;
         }
@@ -178,7 +182,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                 || !configurationService.accountInterventionsServiceActionEnabled()) {
             try {
                 LOG.error("Swallowing error and returning default account interventions response");
-                return generateApiGatewayProxyResponse(200, noAccountInterventions, true);
+                return generateApiGatewayProxyResponse(200, noAccountInterventions(), true);
             } catch (JsonException ex) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
             }
@@ -234,5 +238,10 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                     accountInterventionsInboundResponse.state().resetPassword(),
                     accountInterventionsInboundResponse.state().reproveIdentity());
         }
+    }
+
+    private AccountInterventionsResponse noAccountInterventions() {
+        return new AccountInterventionsResponse(
+                false, false, false, String.valueOf(clock.now().toInstant().toEpochMilli()));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsInboundResponse;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsRequest;
-import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsResponse;
 import uk.gov.di.authentication.frontendapi.entity.Intervention;
 import uk.gov.di.authentication.frontendapi.entity.State;
 import uk.gov.di.authentication.frontendapi.services.AccountInterventionsService;
@@ -64,6 +63,11 @@ public class AccountInterventionsHandlerTest {
     private static final String TEST_SUBJECT_ID = "subject-id";
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final String TEST_ENVIRONMENT = "test-environment";
+    private static final String APPLIED_AT_TIMESTAMP = "1696869005821";
+    private static final String DEFAULT_NO_INTERVENTIONS_RESPONSE =
+            String.format(
+                    "{\"passwordResetRequired\":%b,\"blocked\":%b,\"temporarilySuspended\":%b,\"appliedAt\":\"\"}",
+                    false, false, false);
     private static final byte[] SALT = SaltHelper.generateNewSalt();
 
     private AccountInterventionsHandler handler;
@@ -168,7 +172,7 @@ public class AccountInterventionsHandlerTest {
     @Test
     void
             shouldReturn200AndDefaultAccountInterventionsResponseWhenAccountInterventionsRequestUnsuccessfulAndAbortOnErrorIsFalse()
-                    throws Json.JsonException, UnsuccessfulAccountInterventionsResponseException {
+                    throws UnsuccessfulAccountInterventionsResponseException {
         when(configurationService.abortOnAccountInterventionsErrorResponse()).thenReturn(false);
         when(authenticationService.getUserProfileByEmailMaybe(anyString()))
                 .thenReturn(Optional.of(generateUserProfile()));
@@ -178,11 +182,7 @@ public class AccountInterventionsHandlerTest {
                                 "Any 4xx/5xx error valid here", 404));
         var result = handler.handleRequest(apiRequestEventWithEmail(TEST_EMAIL_ADDRESS), context);
         assertThat(result, hasStatus(200));
-        assertEquals(
-                result.getBody(),
-                String.format(
-                        "{\"passwordResetRequired\":%b,\"blocked\":%b,\"temporarilySuspended\":%b}",
-                        false, false, false));
+        assertEquals(DEFAULT_NO_INTERVENTIONS_RESPONSE, result.getBody());
     }
 
     @Test
@@ -199,11 +199,7 @@ public class AccountInterventionsHandlerTest {
                                 "Any 4xx/5xx error valid here", 404));
         var result = handler.handleRequest(apiRequestEventWithEmail(TEST_EMAIL_ADDRESS), context);
         assertThat(result, hasStatus(200));
-        assertEquals(
-                result.getBody(),
-                String.format(
-                        "{\"passwordResetRequired\":%b,\"blocked\":%b,\"temporarilySuspended\":%b}",
-                        false, false, false));
+        assertEquals(DEFAULT_NO_INTERVENTIONS_RESPONSE, result.getBody());
     }
 
     @Test
@@ -214,14 +210,12 @@ public class AccountInterventionsHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(anyString()))
                 .thenReturn(Optional.of(generateUserProfile()));
         when(accountInterventionsService.sendAccountInterventionsOutboundRequest(any()))
-                .thenReturn(generateAccountInterventionResponse(true, true, true, true));
+                .thenReturn(
+                        generateAccountInterventionResponse(
+                                true, true, true, true, APPLIED_AT_TIMESTAMP));
         var result = handler.handleRequest(apiRequestEventWithEmail(TEST_EMAIL_ADDRESS), context);
         assertThat(result, hasStatus(200));
-        assertEquals(
-                result.getBody(),
-                String.format(
-                        "{\"passwordResetRequired\":%b,\"blocked\":%b,\"temporarilySuspended\":%b}",
-                        false, false, false));
+        assertEquals(DEFAULT_NO_INTERVENTIONS_RESPONSE, result.getBody());
     }
 
     @Test
@@ -232,11 +226,7 @@ public class AccountInterventionsHandlerTest {
 
         verify(accountInterventionsService, never()).sendAccountInterventionsOutboundRequest(any());
         assertThat(result, hasStatus(200));
-        assertEquals(
-                result.getBody(),
-                String.format(
-                        "{\"passwordResetRequired\":%b,\"blocked\":%b,\"temporarilySuspended\":%b}",
-                        false, false, false));
+        assertEquals(DEFAULT_NO_INTERVENTIONS_RESPONSE, result.getBody());
     }
 
     static Stream<Arguments> accountInterventionResponseParameters() {
@@ -284,22 +274,21 @@ public class AccountInterventionsHandlerTest {
         when(accountInterventionsService.sendAccountInterventionsOutboundRequest(any()))
                 .thenReturn(
                         generateAccountInterventionResponse(
-                                blocked, suspended, reproveIdentity, resetPassword));
+                                blocked,
+                                suspended,
+                                reproveIdentity,
+                                resetPassword,
+                                APPLIED_AT_TIMESTAMP));
         var result =
                 handler.handleRequestWithUserContext(
                         event, context, new AccountInterventionsRequest("test"), userContext);
         assertThat(result, hasStatus(200));
 
-        var accountInterventionsResponse =
-                new AccountInterventionsResponse(resetPassword, blocked, suspended);
-        assertThat(
-                result,
-                hasBody(objectMapper.writeValueAsStringCamelCase(accountInterventionsResponse)));
         assertEquals(
-                result.getBody(),
                 String.format(
-                        "{\"passwordResetRequired\":%b,\"blocked\":%b,\"temporarilySuspended\":%b}",
-                        resetPassword, blocked, suspended));
+                        "{\"passwordResetRequired\":%b,\"blocked\":%b,\"temporarilySuspended\":%b,\"appliedAt\":\"%s\"}",
+                        resetPassword, blocked, suspended, APPLIED_AT_TIMESTAMP),
+                result.getBody());
         verify(auditService)
                 .submitAuditEvent(
                         expectedEvent,
@@ -323,11 +312,15 @@ public class AccountInterventionsHandlerTest {
     }
 
     private AccountInterventionsInboundResponse generateAccountInterventionResponse(
-            boolean blocked, boolean suspended, boolean reproveIdentity, boolean resetPassword) {
+            boolean blocked,
+            boolean suspended,
+            boolean reproveIdentity,
+            boolean resetPassword,
+            String appliedAtTimestamp) {
         return new AccountInterventionsInboundResponse(
                 new Intervention(
                         "1696969322935",
-                        "1696869005821",
+                        appliedAtTimestamp,
                         "1696869003456",
                         "AIS_USER_PASSWORD_RESET_AND_IDENTITY_VERIFIED",
                         "1696969322935",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -42,6 +42,7 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
     private static final String TEST_PASSWORD = "password-1";
     private static final String INTERNAl_SECTOR_HOST = "test.account.gov.uk";
     private static final Subject SUBJECT = new Subject();
+    private static final String APPLIED_AT_TIMESTAMP = "1696869005821";
 
     @RegisterExtension
     public static final AccountInterventionsStubExtension accountInterventionsStubExtension =
@@ -84,14 +85,14 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
                         Map.of());
         assertThat(response, hasStatus(200));
         var accountInterventionsResponse =
-                new AccountInterventionsResponse(false, isUserBlocked, false);
+                new AccountInterventionsResponse(false, isUserBlocked, false, APPLIED_AT_TIMESTAMP);
         assertThat(
                 response,
                 hasBody(objectMapper.writeValueAsStringCamelCase(accountInterventionsResponse)));
         assertEquals(
                 String.format(
-                        "{\"passwordResetRequired\":false,\"blocked\":%b,\"temporarilySuspended\":false}",
-                        isUserBlocked),
+                        "{\"passwordResetRequired\":false,\"blocked\":%b,\"temporarilySuspended\":false,\"appliedAt\":\"%s\"}",
+                        isUserBlocked, APPLIED_AT_TIMESTAMP),
                 response.getBody());
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(expectedAuditEvent));
     }


### PR DESCRIPTION
 This is returned to us by the account interventions api, but we do not pass it back in the api response to the frontend. Exposing this information to the frontend will enable us to add logic to ensure that people do not go through a password reset journey twice before the account interventions api has been updated with the fact that the user has reset their password, while also ensuring that newer interventions are respected.

## How to review

1. Code Review should suffice

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

This PR has a do not merge label until the following PR is merged:
* [Change to the response we're expecting on the frontend](https://github.com/govuk-one-login/authentication-frontend/pull/1444) (that change can be merged safely before this one) 
