### PR TITLE
AUT-2551-Adding redis daily Automated backup

### DIFF
--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -35,6 +35,8 @@ resource "aws_elasticache_replication_group" "account_management_sessions_store"
   port                        = local.redis_port_number
   maintenance_window          = "tue:22:00-tue:23:00"
   notification_topic_arn      = data.aws_sns_topic.slack_events.arn
+  snapshot_retention_limit    = 5
+  snapshot_window             = "00:00-04:00"
 
   multi_az_enabled = true
 

--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -35,6 +35,8 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   multi_az_enabled            = true
   maintenance_window          = "wed:22:00-wed:23:00"
   notification_topic_arn      = aws_sns_topic.slack_events.arn
+  snapshot_retention_limit    = 5
+  snapshot_window             = "00:00-04:00"
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true


### PR DESCRIPTION
## What

AUT-2551 Adding redis daily Automated backup

## How to review

This can be review using  this branch and try to deploy to Authdev1 ( Shared & Account mgmt api)  , it must show below high lighted changes

  **# aws_elasticache_replication_group.sessions_store[0] will be updated in-place**
  ~ resource "aws_elasticache_replication_group" "sessions_store" {
        id                          = "authdev1-sessions-store"
```
      ~ snapshot_retention_limit    = 0 -> 5
      ~ snapshot_window             = "00:00-01:00" -> "00:00-04:00"
```

**# aws_elasticache_replication_group.account_management_sessions_store[0] will be updated in-place**
  ~ resource "aws_elasticache_replication_group" "account_management_sessions_store" {
        id                          = "authdev1-acct-mgmt-session-store"
```
      ~ snapshot_retention_limit    = 0 -> 5
      ~ snapshot_window             = "04:00-05:00" -> "00:00-04:00"
```
