### PR TITLE
BAU: Switch on the auth orch split in authdev1

### DIFF
--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -49,10 +49,14 @@ extended_feature_flags_enabled = false
 
 orch_client_id = "orchestrationAuth"
 
-support_auth_orch_split = false
+support_auth_orch_split = true
+
+support_auth_orch_split_user_info = true
 
 orch_frontend_api_gateway_integration_enabled = false
 
 orch_redirect_uri = "https://oidc.authdev1.sandpit.account.gov.uk/orchestration-redirect"
+
+authorize_protected_subnet_enabled = true
 
 support_email_check_enabled = true


### PR DESCRIPTION

## What

Switch on the auth orch split in authdev1.

Not having this switched on is stopping the local frontend connection to the backend in authdev1 from working

## How to review

1. Deploy the oidc component to authdev1.
2. Open the AWS console and go to the 'authdev1-authorise' lambda.
3. Check that the environment variable SUPPORT_AUTH_ORCH_SPLIT is set to true.

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.


