### PR TITLE
Aut 2553/pass timestamp to orch

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
@@ -155,7 +155,8 @@ public class TokenHandler
                     authCodeStore.getSubjectID(),
                     authCodeStore.getClaims(),
                     authCodeStore.getIsNewAccount(),
-                    authCodeStore.getSectorIdentifier());
+                    authCodeStore.getSectorIdentifier(),
+                    authCodeStore.getPasswordResetTime());
 
             authorisationCodeService.updateHasBeenUsed(authCodeStore.getAuthCode(), true);
 

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -48,6 +48,7 @@ public class UserInfoService {
 
         userInfo.setClaim("rp_pairwise_id", rpPairwiseId);
         userInfo.setClaim("new_account", accessTokenInfo.getIsNewAccount());
+        userInfo.setClaim("password_reset_time", accessTokenInfo.getPasswordResetTime());
 
         if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.LEGACY_SUBJECT_ID.getValue())) {
             userInfo.setClaim("legacy_subject_id", userProfile.getLegacySubjectID());

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
@@ -52,6 +52,7 @@ class TokenHandlerTest {
     private static final String VALID_AUTH_CODE = "valid-auth-code";
     private static final String SUBJECT_ID = "any";
     private static final String CLIENT_ID = "test-client-id";
+    private static final Long PASSWORD_RESET_TIME = 1710255274L;
     private static final UserProfile USER_PROFILE =
             new UserProfile().withSubjectID("any").withSalt(ByteBuffer.allocateDirect(12345));
     private static final AuthCodeStore VALID_AUTH_CODE_STORE =
@@ -62,7 +63,8 @@ class TokenHandlerTest {
                     .withClaims(List.of("any"))
                     .withSubjectID("any")
                     .withHasBeenUsed(false)
-                    .withTimeToExist(UNIX_TIME_16_08_2099);
+                    .withTimeToExist(UNIX_TIME_16_08_2099)
+                    .withPasswordResetTime(PASSWORD_RESET_TIME);
     private static final String USED_AUTH_CODE = "used-auth-code";
     private static final AuthCodeStore USED_AUTH_CODE_STORE =
             new AuthCodeStore()
@@ -223,7 +225,8 @@ class TokenHandlerTest {
                         VALID_AUTH_CODE_STORE.getSubjectID(),
                         VALID_AUTH_CODE_STORE.getClaims(),
                         VALID_AUTH_CODE_STORE.getIsNewAccount(),
-                        VALID_AUTH_CODE_STORE.getSectorIdentifier());
+                        VALID_AUTH_CODE_STORE.getSectorIdentifier(),
+                        VALID_AUTH_CODE_STORE.getPasswordResetTime());
         verify(authCodeService).updateHasBeenUsed(VALID_AUTH_CODE, true);
 
         verify(auditService)

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -49,6 +49,7 @@ public class UserInfoServiceTest {
     private static final String TEST_PHONE = "test-phone";
     private static final boolean TEST_PHONE_VERIFIED = true;
     private static final boolean TEST_IS_NEW_ACCOUNT = true;
+    private static final long TEST_PASSWORD_RESET_TIME = 1710255380L;
     private static final UserProfile TEST_USER_PROFILE =
             new UserProfile()
                     .withLegacySubjectID(TEST_LEGACY_SUBJECT_ID)
@@ -98,6 +99,7 @@ public class UserInfoServiceTest {
         assertEquals(expectedPhoneNumber, actual.getPhoneNumber());
         assertEquals(expectedPhoneNumberVerified, actual.getPhoneNumberVerified());
         assertEquals(expectedSalt, actual.getClaim("salt"));
+        assertEquals(TEST_PASSWORD_RESET_TIME, actual.getClaim("password_reset_time"));
     }
 
     private static Stream<Arguments> provideTestData() {
@@ -149,6 +151,7 @@ public class UserInfoServiceTest {
         when(accessTokenStore.getSubjectID()).thenReturn(TEST_SUBJECT.getValue());
         when(accessTokenStore.getSectorIdentifier()).thenReturn(TEST_RP_SECTOR_HOST);
         when(accessTokenStore.getIsNewAccount()).thenReturn(TEST_IS_NEW_ACCOUNT);
+        when(accessTokenStore.getPasswordResetTime()).thenReturn(TEST_PASSWORD_RESET_TIME);
         when(accessTokenStore.getClaims()).thenReturn(claims);
         return accessTokenStore;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.validation.Required;
 
 import java.util.List;
+import java.util.Optional;
 
 public class AuthCodeRequest {
 
@@ -32,17 +33,23 @@ public class AuthCodeRequest {
     @Required
     private boolean isNewAccount;
 
+    @SerializedName("password-reset-time")
+    @Expose
+    private Long passwordResetTime;
+
     public AuthCodeRequest(
             String redirectUri,
             String state,
             List<String> claims,
             String sectorIdentifier,
-            boolean isNewAccount) {
+            boolean isNewAccount,
+            Optional<Long> passwordResetTime) {
         this.redirectUri = redirectUri;
         this.state = state;
         this.claims = claims;
         this.sectorIdentifier = sectorIdentifier;
         this.isNewAccount = isNewAccount;
+        passwordResetTime.ifPresent(p -> this.passwordResetTime = p);
     }
 
     public String getRedirectUri() {
@@ -79,6 +86,10 @@ public class AuthCodeRequest {
 
     public boolean isNewAccount() {
         return isNewAccount;
+    }
+
+    public Long getPasswordResetTime() {
+        return passwordResetTime;
     }
 
     public void setNewAccount(boolean newAccount) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -88,7 +88,8 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                     authCodeRequest.getClaims(),
                     false,
                     authCodeRequest.getSectorIdentifier(),
-                    authCodeRequest.isNewAccount());
+                    authCodeRequest.isNewAccount(),
+                    authCodeRequest.getPasswordResetTime());
 
             var state = State.parse(authCodeRequest.getState());
             var redirectUri = URI.create(authCodeRequest.getRedirectUri());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -205,7 +205,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                 claims,
                 isNewAccount,
                 RP_SECTOR_ID_HOST,
-                null);
+                1710255455L);
 
         userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, TEST_SUBJECT);
         userStore.addVerifiedPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -200,7 +200,12 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
     private UserProfile addTokenToDynamoAndCreateAssociatedUser(
             String accessToken, List<String> claims, boolean isNewAccount) {
         accessTokenStoreExtension.addAccessTokenStore(
-                accessToken, TEST_SUBJECT.getValue(), claims, isNewAccount, RP_SECTOR_ID_HOST);
+                accessToken,
+                TEST_SUBJECT.getValue(),
+                claims,
+                isNewAccount,
+                RP_SECTOR_ID_HOST,
+                null);
 
         userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, TEST_SUBJECT);
         userStore.addVerifiedPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -61,7 +61,8 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                         TEST_STATE,
                         List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                         TEST_SECTOR_IDENTIFIER,
-                        false);
+                        false,
+                        Optional.empty());
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(200));
     }
@@ -72,7 +73,12 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         setUpDynamo();
         var authRequest =
                 new AuthCodeRequest(
-                        TEST_REDIRECT_URI, TEST_STATE, null, TEST_SECTOR_IDENTIFIER, false);
+                        TEST_REDIRECT_URI,
+                        TEST_STATE,
+                        null,
+                        TEST_SECTOR_IDENTIFIER,
+                        false,
+                        Optional.empty());
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(200));
     }
@@ -86,7 +92,8 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                         TEST_STATE,
                         List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                         TEST_SECTOR_IDENTIFIER,
-                        false);
+                        false,
+                        Optional.empty());
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
@@ -101,7 +108,8 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                         null,
                         List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                         TEST_SECTOR_IDENTIFIER,
-                        false);
+                        false,
+                        Optional.empty());
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static uk.gov.di.authentication.external.entity.AuthUserInfoClaims.EMAIL;
 import static uk.gov.di.authentication.external.entity.AuthUserInfoClaims.EMAIL_VERIFIED;
@@ -22,6 +23,7 @@ class DynamoAuthCodeServiceIntegrationTest {
     private static final boolean HAS_BEEN_USED = false;
     private static final boolean IS_NEW_ACCOUNT = false;
     private static final String TEST_SECTOR_IDENTIFIER = "sectorIdentifier";
+    private static final Long PASSWORD_RESET_TIME = 1696869005821L;
 
     @RegisterExtension
     protected static final AuthCodeExtension authCodeExtension = new AuthCodeExtension(180);
@@ -58,5 +60,37 @@ class DynamoAuthCodeServiceIntegrationTest {
         var updatedAuthCode = dynamoAuthCodeService.getAuthCodeStore(SUBJECT_ID);
 
         assertFalse(updatedAuthCode.isPresent());
+    }
+
+    @Test
+    void shouldStoreAnAuthCodeWithoutPasswordResetTime() {
+        dynamoAuthCodeService.saveAuthCode(
+                SUBJECT_ID,
+                AUTH_CODE,
+                List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
+                HAS_BEEN_USED,
+                TEST_SECTOR_IDENTIFIER,
+                IS_NEW_ACCOUNT,
+                null);
+
+        var updatedAuthCode = dynamoAuthCodeService.getAuthCodeStore(AUTH_CODE).get();
+        assertEquals(AUTH_CODE, updatedAuthCode.getAuthCode());
+        assertEquals(null, updatedAuthCode.getPasswordResetTime());
+    }
+
+    @Test
+    void shouldStoreAnAuthCodeWithPasswordResetTime() {
+        dynamoAuthCodeService.saveAuthCode(
+                SUBJECT_ID,
+                AUTH_CODE,
+                List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
+                HAS_BEEN_USED,
+                TEST_SECTOR_IDENTIFIER,
+                IS_NEW_ACCOUNT,
+                PASSWORD_RESET_TIME);
+
+        var updatedAuthCode = dynamoAuthCodeService.getAuthCodeStore(AUTH_CODE).get();
+        assertEquals(AUTH_CODE, updatedAuthCode.getAuthCode());
+        assertEquals(PASSWORD_RESET_TIME, updatedAuthCode.getPasswordResetTime());
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccessTokenStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccessTokenStoreExtension.java
@@ -60,13 +60,19 @@ public class AccessTokenStoreExtension extends DynamoExtension implements AfterE
             String subjectID,
             List<String> claims,
             boolean isNewAccount,
-            String sectorIdentifier) {
+            String sectorIdentifier,
+            Long passwordResetTime) {
         dynamoService.addAccessTokenStore(
-                accessToken, subjectID, claims, isNewAccount, sectorIdentifier);
+                accessToken, subjectID, claims, isNewAccount, sectorIdentifier, passwordResetTime);
     }
 
     public void addAccessTokenStore(String accessToken, String subjectID, List<String> claims) {
-        this.addAccessTokenStore(accessToken, subjectID, claims, false, "any");
+        this.addAccessTokenStore(accessToken, subjectID, claims, false, "any", null);
+    }
+
+    public void addAccessTokenStore(String accessToken, Long passwordResetTime) {
+        this.addAccessTokenStore(
+                accessToken, "subjectId", List.of(), false, "any", passwordResetTime);
     }
 
     public void setAccessTokenStoreUsed(String accessToken, boolean used) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
@@ -68,7 +68,7 @@ public class AuthCodeExtension extends DynamoExtension implements AfterEachCallb
             boolean isNewAccount) {
 
         dynamoAuthCodeService.saveAuthCode(
-                subjectID, authCode, claims, hasBeenUsed, sectorIdentifier, isNewAccount);
+                subjectID, authCode, claims, hasBeenUsed, sectorIdentifier, isNewAccount, null);
     }
 
     private void createAuthCodeStoreTable() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
@@ -16,6 +16,7 @@ public class AuthCodeStore {
     private static final String ATTRIBUTE_HAS_BEEN_USED = "HasBeenUsed";
     private static final String ATTRIBUTE_SECTOR_IDENTIFIER = "SectorIdentifier";
     private static final String ATTRIBUTE_IS_NEW_ACCOUNT = "IsNewAccount";
+    private static final String ATTRIBUTE_PASSWORD_RESET_TIME = "PasswordResetTime";
 
     private String subjectID;
     private String authCode;
@@ -24,6 +25,7 @@ public class AuthCodeStore {
     private boolean hasBeenUsed;
     private String sectorIdentifier;
     private boolean isNewAccount;
+    private Long passwordResetTime;
 
     public AuthCodeStore() {}
 
@@ -123,6 +125,20 @@ public class AuthCodeStore {
 
     public AuthCodeStore withIsNewAccount(boolean isNewAccount) {
         this.isNewAccount = isNewAccount;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_PASSWORD_RESET_TIME)
+    public Long getPasswordResetTime() {
+        return passwordResetTime;
+    }
+
+    public void setPasswordResetTime(Long passwordResetTime) {
+        this.passwordResetTime = passwordResetTime;
+    }
+
+    public AuthCodeStore withPasswordResetTime(Long passwordResetTime) {
+        this.passwordResetTime = passwordResetTime;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/token/AccessTokenStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/token/AccessTokenStore.java
@@ -17,6 +17,7 @@ public class AccessTokenStore {
     private boolean used;
     private String sectorIdentifier;
     private boolean isNewAccount;
+    private Long passwordResetTime;
 
     @DynamoDbPartitionKey
     @DynamoDbAttribute("AccessToken")
@@ -114,6 +115,20 @@ public class AccessTokenStore {
 
     public AccessTokenStore withNewAccount(boolean isNewAccount) {
         this.isNewAccount = isNewAccount;
+        return this;
+    }
+
+    @DynamoDbAttribute("PasswordResetTime")
+    public Long getPasswordResetTime() {
+        return passwordResetTime;
+    }
+
+    public void setPasswordResetTime(Long passwordResetTime) {
+        this.passwordResetTime = passwordResetTime;
+    }
+
+    public AccessTokenStore withPasswordResetTime(Long passwordResetTime) {
+        this.passwordResetTime = passwordResetTime;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenService.java
@@ -34,7 +34,8 @@ public class AccessTokenService extends BaseDynamoService<AccessTokenStore> {
             String subjectID,
             List<String> claims,
             boolean isNewAccount,
-            String sectorIdentifier) {
+            String sectorIdentifier,
+            Long passwordResetTime) {
         if (isAccessTokenStoreEnabled) {
             var tokenStore =
                     get(accessToken)
@@ -48,7 +49,8 @@ public class AccessTokenService extends BaseDynamoService<AccessTokenStore> {
                             .withTimeToExist(
                                     NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
                                             .toInstant()
-                                            .getEpochSecond());
+                                            .getEpochSecond())
+                            .withPasswordResetTime(passwordResetTime);
             update(tokenStore);
         }
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthCodeService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthCodeService.java
@@ -43,7 +43,8 @@ public class DynamoAuthCodeService extends BaseDynamoService<AuthCodeStore> {
             List<String> claims,
             boolean hasBeenUsed,
             String sectorIdentifier,
-            boolean isNewAccount) {
+            boolean isNewAccount,
+            Long passwordResetTime) {
         if (isAuthOrchSplitEnabled) {
             var authCodeStore =
                     new AuthCodeStore()
@@ -56,7 +57,8 @@ public class DynamoAuthCodeService extends BaseDynamoService<AuthCodeStore> {
                             .withTimeToExist(
                                     NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
                                             .toInstant()
-                                            .getEpochSecond());
+                                            .getEpochSecond())
+                            .withPasswordResetTime(passwordResetTime);
 
             put(authCodeStore);
         }


### PR DESCRIPTION
## What

Adds the ability to send a "password reset time" through in the request to the auth code handler. 

If this is present in the request to auth code, we:

* Add it to the auth code table in the Authentication Auth Code Handler
* Add it to the access token table in the Token Handler (which reads from the auth code table)
* Send this back as a claim in the user info response.

This will enable orchestration to implement logic to ignore a password reset intervention when a password has been reset more recently than the intervention was applied. This makes our system more robust, meaning we're not reliant on the async process which updates the account interventions data when a password is reset.

This is very similar to what we did for `isNewAccount`.

## How this has been tested

We've deployed this to sandpit on its own, and checked that a normal sign in journey works (we haven't broken anything existing). Then, we deployed the change to the frontend that sends this password reset timestamp through, and verified it appears in all tables and is sent back in the claim.

## How to review


1. Code Review commit by commit
1. [Optional] you can repeat our testing in sandpit, by:

- deploying this to sandpit
- doing a normal sign in journey and seeing no existing breakages
- deploy the frontend to sandpit
- give yourself a password reset intervention
- go through a sign-in journey and reset your password
- see that the relevant tables are populated 
- we also added logging to log the specific claim that we're adding in user info, this is optional


## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

* [PR in frontend ](https://github.com/govuk-one-login/authentication-frontend/pull/1449)

(The plan is to merge this PR first, and then the above frontend PR)
