### PR TITLE
ATO-440: Account interventions reset password race condition

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -366,7 +366,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         throws Json.JsonException {
             setupTestWithDefaultEnvVars();
             accountInterventionApiStub.initWithAccountStatus(
-                    SUBJECT_ID.getValue(), false, true, false, true);
+                    SUBJECT_ID.getValue(), false, true, true, true);
 
             var session = redis.getSession(SESSION_ID);
             assertNotNull(session);
@@ -379,6 +379,50 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                             constructQueryStringParameters());
 
             assertRedirectToSuspendedPage(response);
+        }
+
+        @Test
+        void
+                shouldRedirectToRpWhenAccountStatusIsSuspendedResetPasswordAndPasswordWasResetAfterInterventionWasApplied()
+                        throws Json.JsonException {
+            setupTestWithDefaultEnvVars();
+            authExternalApiStub.init(SUBJECT_ID, Long.MAX_VALUE);
+            accountInterventionApiStub.initWithAccountStatus(
+                    SUBJECT_ID.getValue(), false, true, false, true);
+
+            var session = redis.getSession(SESSION_ID);
+            assertNotNull(session);
+
+            var response =
+                    makeRequest(
+                            Optional.of(TEST_EMAIL_ADDRESS),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            constructQueryStringParameters());
+
+            assertUserInfoStoredAndRedirectedToRp(response);
+        }
+
+        @Test
+        void
+                shouldRedirectToRpWhenAccountStatusIsSuspendedResetPasswordReproveIdentityAndPasswordWasResetAfterInterventionWasApplied()
+                        throws Json.JsonException {
+            setupTestWithDefaultEnvVars();
+            authExternalApiStub.init(SUBJECT_ID, Long.MAX_VALUE);
+            accountInterventionApiStub.initWithAccountStatus(
+                    SUBJECT_ID.getValue(), false, true, true, true);
+
+            var session = redis.getSession(SESSION_ID);
+            assertNotNull(session);
+
+            var response =
+                    makeRequest(
+                            Optional.of(TEST_EMAIL_ADDRESS),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            constructQueryStringParameters());
+
+            assertUserInfoStoredAndRedirectedToRp(response);
         }
 
         @Test
@@ -549,6 +593,56 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                             constructQueryStringParameters());
 
             assertRedirectToSuspendedPage(response);
+        }
+
+        @Test
+        void
+                shouldRedirectToIpvWhenAccountStatusIsSuspendedResetPasswordAndPasswordWasResetAfterInterventionWasApplied()
+                        throws Json.JsonException,
+                                java.text.ParseException,
+                                ParseException,
+                                JOSEException {
+            setupTestWithDefaultEnvVars();
+            authExternalApiStub.init(SUBJECT_ID, Long.MAX_VALUE);
+            accountInterventionApiStub.initWithAccountStatus(
+                    SUBJECT_ID.getValue(), false, true, false, true);
+
+            var session = redis.getSession(SESSION_ID);
+            assertNotNull(session);
+
+            var response =
+                    makeRequest(
+                            Optional.of(TEST_EMAIL_ADDRESS),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            constructQueryStringParameters());
+
+            assertRedirectToIpv(response, false);
+        }
+
+        @Test
+        void
+                shouldRedirectToIpvWhenAccountStatusIsSuspendedResetPasswordReproveIdentityAndPasswordWasResetAfterInterventionWasApplied()
+                        throws Json.JsonException,
+                                java.text.ParseException,
+                                ParseException,
+                                JOSEException {
+            setupTestWithDefaultEnvVars();
+            authExternalApiStub.init(SUBJECT_ID, Long.MAX_VALUE);
+            accountInterventionApiStub.initWithAccountStatus(
+                    SUBJECT_ID.getValue(), false, true, true, true);
+
+            var session = redis.getSession(SESSION_ID);
+            assertNotNull(session);
+
+            var response =
+                    makeRequest(
+                            Optional.of(TEST_EMAIL_ADDRESS),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            constructQueryStringParameters());
+
+            assertRedirectToIpv(response, true);
         }
 
         @Test

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.ipv.helpers.IPVCallbackHelper;
 import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.ipv.services.IPVTokenService;
 import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
@@ -248,17 +249,16 @@ public class IPVCallbackHandler
                             persistentId);
 
             if (errorObject.isPresent()) {
-                var accountInterventionState =
+                AccountIntervention intervention =
                         segmentedFunctionCall(
-                                "AIS: getAccountState",
+                                "AIS: getAccountIntervention",
                                 () ->
-                                        this.accountInterventionService.getAccountState(
+                                        this.accountInterventionService.getAccountIntervention(
                                                 internalPairwiseSubjectId, auditContext));
                 if (configurationService.isAccountInterventionServiceActionEnabled()
-                        && (accountInterventionState.blocked()
-                                || accountInterventionState.suspended())) {
+                        && (intervention.getBlocked() || intervention.getSuspended())) {
                     return logoutService.handleAccountInterventionLogout(
-                            session, input, clientId, accountInterventionState);
+                            session, input, clientId, intervention);
                 }
 
                 return ipvCallbackHelper.generateAuthenticationErrorResponse(
@@ -339,17 +339,16 @@ public class IPVCallbackHandler
             var userIdentityError =
                     ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, vtrList);
             if (userIdentityError.isPresent()) {
-                var accountInterventionState =
+                AccountIntervention intervention =
                         segmentedFunctionCall(
-                                "AIS: getAccountState",
+                                "AIS: getAccountIntervention",
                                 () ->
-                                        this.accountInterventionService.getAccountState(
+                                        this.accountInterventionService.getAccountIntervention(
                                                 internalPairwiseSubjectId, auditContext));
                 if (configurationService.isAccountInterventionServiceActionEnabled()
-                        && (accountInterventionState.blocked()
-                                || accountInterventionState.suspended())) {
+                        && (intervention.getBlocked() || intervention.getSuspended())) {
                     return logoutService.handleAccountInterventionLogout(
-                            session, input, clientId, accountInterventionState);
+                            session, input, clientId, intervention);
                 }
 
                 var returnCode = userIdentityUserInfo.getClaim(RETURN_CODE.getValue());

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -11,7 +11,7 @@ import uk.gov.di.authentication.ipv.entity.ProcessingIdentityRequest;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityResponse;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityStatus;
 import uk.gov.di.orchestration.audit.AuditContext;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
+import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
@@ -163,15 +163,15 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                     "Generating ProcessingIdentityResponse with ProcessingIdentityStatus: {}",
                     processingStatus);
             if (processingStatus == ProcessingIdentityStatus.COMPLETED) {
-                var aisResult =
+                AccountIntervention intervention =
                         segmentedFunctionCall(
-                                "AIS: getAccountState",
+                                "AIS: getAccountIntervention",
                                 () ->
-                                        accountInterventionService.getAccountState(
+                                        accountInterventionService.getAccountIntervention(
                                                 internalPairwiseSubjectId, auditContext));
                 if (configurationService.isAccountInterventionServiceActionEnabled()
-                        && (aisResult.suspended() || aisResult.blocked())) {
-                    return performIntervention(input, userContext, client, aisResult);
+                        && (intervention.getSuspended() || intervention.getBlocked())) {
+                    return performIntervention(input, userContext, client, intervention);
                 }
             }
             return generateApiGatewayProxyResponse(
@@ -192,11 +192,11 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             APIGatewayProxyRequestEvent input,
             UserContext userContext,
             ClientRegistry client,
-            AccountInterventionState aisResult)
+            AccountIntervention intervention)
             throws Json.JsonException {
         var logoutResult =
                 logoutService.handleAccountInterventionLogout(
-                        userContext.getSession(), input, client.getClientID(), aisResult);
+                        userContext.getSession(), input, client.getClientID(), intervention);
         var redirectUrl = logoutResult.getHeaders().get(ResponseHeaders.LOCATION);
         return generateApiGatewayProxyResponse(
                 200,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.IpvCallbackException;
 import uk.gov.di.authentication.ipv.entity.LogIds;
 import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
@@ -157,11 +158,15 @@ class IPVCallbackHelperTest {
                         SerializationService.getInstance(),
                         sessionService,
                         sqsClient);
-        when(accountInterventionService.getAccountState(INTERNAL_PAIRWISE_ID, auditContext))
-                .thenReturn(new AccountInterventionState(false, false, false, false));
-        when(accountInterventionService.getAccountState(
+        when(accountInterventionService.getAccountIntervention(INTERNAL_PAIRWISE_ID, auditContext))
+                .thenReturn(
+                        new AccountIntervention(
+                                new AccountInterventionState(false, false, false, false)));
+        when(accountInterventionService.getAccountIntervention(
                         INTERNAL_PAIRWISE_ID_WITH_INTERVENTION, auditContext))
-                .thenReturn(new AccountInterventionState(false, true, false, false));
+                .thenReturn(
+                        new AccountIntervention(
+                                new AccountInterventionState(false, true, false, false)));
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
                         anyString(), anyString(), any(ClientSession.class)))
                 .thenReturn(AUTH_CODE);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -40,6 +40,7 @@ import uk.gov.di.authentication.ipv.helpers.IPVCallbackHelper;
 import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.ipv.services.IPVTokenService;
 import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
@@ -269,8 +270,10 @@ class IPVCallbackHandlerTest {
         when(context.getAwsRequestId()).thenReturn(REQUEST_ID);
         when(cookieHelper.parseSessionCookie(anyMap())).thenCallRealMethod();
         when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(salt);
-        when(accountInterventionService.getAccountState(any(), any()))
-                .thenReturn(new AccountInterventionState(false, false, false, false));
+        when(accountInterventionService.getAccountIntervention(anyString(), any()))
+                .thenReturn(
+                        new AccountIntervention(
+                                new AccountInterventionState(false, false, false, false)));
         when(ipvCallbackHelper.generateAuthenticationErrorResponse(
                         any(), any(), anyBoolean(), anyString(), anyString()))
                 .thenReturn(
@@ -331,7 +334,8 @@ class IPVCallbackHandlerTest {
                                 userProfile, configService.getInternalSectorUri(), dynamoService)
                         .getValue();
         verify(accountInterventionService)
-                .getAccountState(eq(expectedInternalPairwiseSubjectId), any(AuditContext.class));
+                .getAccountIntervention(
+                        eq(expectedInternalPairwiseSubjectId), any(AuditContext.class));
     }
 
     @ParameterizedTest
@@ -678,7 +682,8 @@ class IPVCallbackHandlerTest {
         assertEquals(
                 accessDeniedURI.toString(), response.getHeaders().get(ResponseHeaders.LOCATION));
         verify(accountInterventionService)
-                .getAccountState(eq(expectedInternalPairwiseSubjectId), any(AuditContext.class));
+                .getAccountIntervention(
+                        eq(expectedInternalPairwiseSubjectId), any(AuditContext.class));
 
         verifyNoInteractions(ipvTokenService);
         verifyNoInteractions(dynamoIdentityService);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.core.SdkBytes;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityInterventionResponse;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityResponse;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityStatus;
+import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
@@ -194,11 +195,13 @@ class ProcessingIdentityHandlerTest {
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
         when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
-        when(accountInterventionService.getAccountState(anyString(), any()))
-                .thenReturn(new AccountInterventionState(false, false, false, false));
+        when(accountInterventionService.getAccountIntervention(anyString(), any()))
+                .thenReturn(
+                        new AccountIntervention(
+                                new AccountInterventionState(false, false, false, false)));
 
         var result = handler.handleRequest(event, context);
-        verify(accountInterventionService).getAccountState(eq(PAIRWISE_SUBJECT), any());
+        verify(accountInterventionService).getAccountIntervention(eq(PAIRWISE_SUBJECT), any());
         assertThat(result, hasStatus(200));
         assertThat(
                 result,
@@ -217,13 +220,15 @@ class ProcessingIdentityHandlerTest {
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
-        var aisResult = new AccountInterventionState(false, true, false, false);
+        AccountIntervention intervention =
+                new AccountIntervention(new AccountInterventionState(false, true, false, false));
         when(dynamoIdentityService.getIdentityCredentials(anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
         when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
-        when(accountInterventionService.getAccountState(anyString(), any())).thenReturn(aisResult);
+        when(accountInterventionService.getAccountIntervention(anyString(), any()))
+                .thenReturn(intervention);
         String redirectUrl = "https://example.com/intervention";
         when(logoutService.handleAccountInterventionLogout(any(), any(), any(), any()))
                 .thenReturn(
@@ -232,7 +237,8 @@ class ProcessingIdentityHandlerTest {
 
         var result = handler.handleRequest(event, context);
 
-        verify(logoutService).handleAccountInterventionLogout(session, event, CLIENT_ID, aisResult);
+        verify(logoutService)
+                .handleAccountInterventionLogout(session, event, CLIENT_ID, intervention);
         assertThat(result, hasStatus(200));
         assertThat(
                 result,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -564,12 +564,15 @@ public class AuthenticationCallbackHandler
     private Long getPasswordResetTimeClaim(UserInfo userInfo) {
         Object passwordResetTimeClaim = userInfo.getClaim("password_reset_time");
         if (passwordResetTimeClaim == null) {
+            LOG.info("password_reset_time claim not found");
             return Long.MIN_VALUE;
         }
+        LOG.info("password_reset_time claim found");
         Long passwordResetTimeLong;
         try {
             passwordResetTimeLong = (Long) passwordResetTimeClaim;
         } catch (ClassCastException e) {
+            LOG.error("Failed to cast password_reset_time claim to Long", e);
             passwordResetTimeLong = Long.MIN_VALUE;
         }
         return passwordResetTimeLong;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -27,8 +27,7 @@ import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
 import uk.gov.di.authentication.oidc.services.InitiateIPVAuthorisationService;
 import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.shared.conditions.MfaHelper;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionStatus;
+import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
@@ -361,25 +360,25 @@ public class AuthenticationCallbackHandler
                                         : userInfo.getPhoneNumber(),
                                 persistentSessionId);
 
-                AccountInterventionState accountInterventionState =
-                        accountInterventionService.getAccountState(
-                                userInfo.getSubject().getValue(), auditContext);
-                AccountInterventionStatus accountStatus = accountInterventionState.getStatus();
+                Long passwordResetTime = getPasswordResetTimeClaim(userInfo);
+                AccountIntervention intervention =
+                        accountInterventionService.getAccountIntervention(
+                                userInfo.getSubject().getValue(), passwordResetTime, auditContext);
 
                 Boolean reproveIdentity = null;
                 if (configurationService.isAccountInterventionServiceActionEnabled()) {
-                    reproveIdentity = accountInterventionState.reproveIdentity();
-                    switch (accountStatus) {
+                    reproveIdentity = intervention.getReproveIdentity();
+                    switch (intervention.getStatus()) {
                         case BLOCKED,
                                 SUSPENDED_RESET_PASSWORD,
                                 SUSPENDED_RESET_PASSWORD_REPROVE_ID -> {
                             return logoutService.handleAccountInterventionLogout(
-                                    userSession, input, clientId, accountInterventionState);
+                                    userSession, input, clientId, intervention);
                         }
                         case SUSPENDED_NO_ACTION -> {
                             if (!identityRequired) {
                                 return logoutService.handleAccountInterventionLogout(
-                                        userSession, input, clientId, accountInterventionState);
+                                        userSession, input, clientId, intervention);
                             }
                             // continue
                         }
@@ -560,5 +559,19 @@ public class AuthenticationCallbackHandler
                         authenticationRequest.getResponseMode());
         return generateApiGatewayProxyResponse(
                 302, "", Map.of(ResponseHeaders.LOCATION, errorResponse.toURI().toString()), null);
+    }
+
+    private Long getPasswordResetTimeClaim(UserInfo userInfo) {
+        Object passwordResetTimeClaim = userInfo.getClaim("password_reset_time");
+        if (passwordResetTimeClaim == null) {
+            return Long.MIN_VALUE;
+        }
+        Long passwordResetTimeLong;
+        try {
+            passwordResetTimeLong = (Long) passwordResetTimeClaim;
+        } catch (ClassCastException e) {
+            passwordResetTimeLong = Long.MIN_VALUE;
+        }
+        return passwordResetTimeLong;
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthExternalApiStubExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthExternalApiStubExtension.java
@@ -36,4 +36,30 @@ public class AuthExternalApiStubExtension extends HttpStubExtension {
 
         register("/userinfo", 200, "application/json", userInfoContent);
     }
+
+    public void init(Subject subjectId, Long passwordResetTime) {
+        register(
+                "/token",
+                200,
+                "application/json",
+                format(
+                        "{"
+                                + "  \"access_token\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
+                                + "  \"token_type\": \"bearer\","
+                                + "  \"expires_in\": \"3600\","
+                                + "  \"uri\": \"http://localhost:%1$d\""
+                                + "}",
+                        getHttpPort()));
+
+        String userInfoContent =
+                String.format(
+                        "{"
+                                + "\"sub\": \"%s\","
+                                + "\"new_account\": true,"
+                                + "\"password_reset_time\": %s"
+                                + "}",
+                        subjectId.getValue(), passwordResetTime.toString());
+
+        register("/userinfo", 200, "application/json", userInfoContent);
+    }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountIntervention.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountIntervention.java
@@ -1,0 +1,97 @@
+package uk.gov.di.orchestration.shared.entity;
+
+public class AccountIntervention {
+
+    private final AccountInterventionDetails details;
+    private final AccountInterventionState state;
+    private final AccountInterventionStatus status;
+    private final boolean ignoreResetPassword;
+
+    public AccountIntervention(AccountInterventionState state) {
+        this.details =
+                new AccountInterventionDetails(
+                        Long.MIN_VALUE,
+                        Long.MIN_VALUE,
+                        Long.MIN_VALUE,
+                        "",
+                        Long.MIN_VALUE,
+                        Long.MIN_VALUE);
+        this.state = state;
+        this.ignoreResetPassword = false;
+        this.status = deduceStatus();
+    }
+
+    public AccountIntervention(
+            AccountInterventionDetails details,
+            AccountInterventionState state,
+            Long passwordResetTime) {
+        this.details = details;
+        this.state = state;
+        this.ignoreResetPassword = details.appliedAt() < passwordResetTime;
+        this.status = deduceStatus();
+    }
+
+    public AccountIntervention(AccountInterventionState state, Long passwordResetTime) {
+        this.details =
+                new AccountInterventionDetails(
+                        Long.MIN_VALUE,
+                        Long.MIN_VALUE,
+                        Long.MIN_VALUE,
+                        "",
+                        Long.MIN_VALUE,
+                        Long.MIN_VALUE);
+        this.state = state;
+        this.ignoreResetPassword = details.appliedAt() < passwordResetTime;
+        this.status = deduceStatus();
+    }
+
+    public AccountInterventionStatus getStatus() {
+        if (status == null) {
+            return deduceStatus();
+        }
+        return status;
+    }
+
+    public boolean getSuspended() {
+        return state.suspended();
+    }
+
+    public boolean getBlocked() {
+        return state.blocked();
+    }
+
+    public boolean getReproveIdentity() {
+        return state.reproveIdentity();
+    }
+
+    public boolean getResetPassword() {
+        return state.resetPassword();
+    }
+
+    private AccountInterventionStatus deduceStatus() {
+        if (state.blocked()) {
+            return AccountInterventionStatus.BLOCKED;
+        }
+        AccountInterventionStatus status = AccountInterventionStatus.NO_INTERVENTION;
+        if (state.suspended()) {
+            if (!state.reproveIdentity() && !state.resetPassword()) {
+                status = AccountInterventionStatus.SUSPENDED_NO_ACTION;
+            } else if (state.reproveIdentity() && !state.resetPassword()) {
+                status = AccountInterventionStatus.SUSPENDED_REPROVE_ID;
+            } else if (!state.reproveIdentity() && state.resetPassword()) {
+                status = AccountInterventionStatus.SUSPENDED_RESET_PASSWORD;
+            } else if (state.reproveIdentity() && state.resetPassword()) {
+                status = AccountInterventionStatus.SUSPENDED_RESET_PASSWORD_REPROVE_ID;
+            }
+        }
+        if (ignoreResetPassword) {
+            if (status.equals(AccountInterventionStatus.SUSPENDED_RESET_PASSWORD)) {
+                status = AccountInterventionStatus.NO_INTERVENTION;
+            } else if (status.equals(
+                    AccountInterventionStatus.SUSPENDED_RESET_PASSWORD_REPROVE_ID)) {
+                status = AccountInterventionStatus.SUSPENDED_REPROVE_ID;
+            }
+        }
+        return status;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountIntervention.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountIntervention.java
@@ -31,20 +31,6 @@ public class AccountIntervention {
         this.status = deduceStatus();
     }
 
-    public AccountIntervention(AccountInterventionState state, Long passwordResetTime) {
-        this.details =
-                new AccountInterventionDetails(
-                        Long.MIN_VALUE,
-                        Long.MIN_VALUE,
-                        Long.MIN_VALUE,
-                        "",
-                        Long.MIN_VALUE,
-                        Long.MIN_VALUE);
-        this.state = state;
-        this.ignoreResetPassword = details.appliedAt() < passwordResetTime;
-        this.status = deduceStatus();
-    }
-
     public AccountInterventionStatus getStatus() {
         if (status == null) {
             return deduceStatus();

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountIntervention.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountIntervention.java
@@ -8,14 +8,7 @@ public class AccountIntervention {
     private final boolean ignoreResetPassword;
 
     public AccountIntervention(AccountInterventionState state) {
-        this.details =
-                new AccountInterventionDetails(
-                        Long.MIN_VALUE,
-                        Long.MIN_VALUE,
-                        Long.MIN_VALUE,
-                        "",
-                        Long.MIN_VALUE,
-                        Long.MIN_VALUE);
+        this.details = new AccountInterventionDetails(0L, 0L, 0L, "", 0L, 0L);
         this.state = state;
         this.ignoreResetPassword = false;
         this.status = deduceStatus();

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionDetails.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionDetails.java
@@ -1,0 +1,12 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public record AccountInterventionDetails(
+        @Expose @SerializedName("updatedAt") Long updatedAt,
+        @Expose @SerializedName("appliedAt") Long appliedAt,
+        @Expose @SerializedName("sentAt") Long sentAt,
+        @Expose @SerializedName("description") String description,
+        @Expose @SerializedName("reprovedIdentityAt") Long reprovedIdentityAt,
+        @Expose @SerializedName("resetPasswordAt") Long resetPasswordAt) {}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionResponse.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionResponse.java
@@ -3,4 +3,6 @@ package uk.gov.di.orchestration.shared.entity;
 import com.google.gson.annotations.Expose;
 
 public record AccountInterventionResponse(
-        @Expose AccountInterventionState state, @Expose String auditLevel) {}
+        @Expose AccountInterventionDetails intervention,
+        @Expose AccountInterventionState state,
+        @Expose String auditLevel) {}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionState.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccountInterventionState.java
@@ -3,70 +3,8 @@ package uk.gov.di.orchestration.shared.entity;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class AccountInterventionState {
-
-    @Expose private final boolean blocked;
-
-    @Expose private final boolean suspended;
-
-    @Expose
-    @SerializedName("reproveIdentity")
-    private final boolean reproveIdentity;
-
-    @Expose
-    @SerializedName("resetPassword")
-    private final boolean resetPassword;
-
-    private AccountInterventionStatus status;
-
-    public AccountInterventionState(
-            boolean blocked, boolean suspended, boolean reproveIdentity, boolean resetPassword) {
-        this.blocked = blocked;
-        this.suspended = suspended;
-        this.reproveIdentity = reproveIdentity;
-        this.resetPassword = resetPassword;
-        this.status = calculateStatus();
-    }
-
-    public boolean blocked() {
-        return blocked;
-    }
-
-    public boolean suspended() {
-        return suspended;
-    }
-
-    public boolean resetPassword() {
-        return resetPassword;
-    }
-
-    public boolean reproveIdentity() {
-        return reproveIdentity;
-    }
-
-    public AccountInterventionStatus getStatus() {
-        if (status == null) {
-            this.status = calculateStatus();
-        }
-        return status;
-    }
-
-    private AccountInterventionStatus calculateStatus() {
-        if (blocked) return AccountInterventionStatus.BLOCKED;
-        if (suspended) {
-            if (!reproveIdentity && !resetPassword) {
-                return AccountInterventionStatus.SUSPENDED_NO_ACTION;
-            }
-            if (reproveIdentity && !resetPassword) {
-                return AccountInterventionStatus.SUSPENDED_REPROVE_ID;
-            }
-            if (!reproveIdentity && resetPassword) {
-                return AccountInterventionStatus.SUSPENDED_RESET_PASSWORD;
-            }
-            if (reproveIdentity && resetPassword) {
-                return AccountInterventionStatus.SUSPENDED_RESET_PASSWORD_REPROVE_ID;
-            }
-        }
-        return AccountInterventionStatus.NO_INTERVENTION;
-    }
-}
+public record AccountInterventionState(
+        @Expose boolean blocked,
+        @Expose boolean suspended,
+        @Expose @SerializedName("reproveIdentity") boolean reproveIdentity,
+        @Expose @SerializedName("resetPassword") boolean resetPassword) {}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CloudwatchMetricsService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CloudwatchMetricsService.java
@@ -3,7 +3,7 @@ package uk.gov.di.orchestration.shared.services;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
+import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.Session;
 
 import java.util.Map;
@@ -86,14 +86,13 @@ public class CloudwatchMetricsService {
     }
 
     public void incrementLogout(
-            Optional<String> clientId,
-            Optional<AccountInterventionState> accountInterventionState) {
+            Optional<String> clientId, Optional<AccountIntervention> intervention) {
         String accountInterventionStr = "unknown";
-        if (accountInterventionState.isPresent()) {
-            if (accountInterventionState.get().suspended()) {
+        if (intervention.isPresent()) {
+            if (intervention.get().getSuspended()) {
                 accountInterventionStr = "suspended";
             }
-            if (accountInterventionState.get().blocked()) {
+            if (intervention.get().getBlocked()) {
                 accountInterventionStr = "blocked";
             }
         }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -7,7 +7,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.domain.LogoutAuditableEvent;
-import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
+import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
@@ -63,10 +63,10 @@ public class LogoutService {
             Session session,
             APIGatewayProxyRequestEvent input,
             String clientId,
-            AccountInterventionState accountState) {
+            AccountIntervention intervention) {
         destroySessions(session);
         return generateAccountInterventionLogoutResponse(
-                input, clientId, session.getSessionId(), accountState);
+                input, clientId, session.getSessionId(), intervention);
     }
 
     public void destroySessions(Session session) {
@@ -165,19 +165,19 @@ public class LogoutService {
             APIGatewayProxyRequestEvent input,
             String clientId,
             String sessionId,
-            AccountInterventionState accountState) {
+            AccountIntervention intervention) {
         URI redirectURI;
-        if (accountState.blocked()) {
+        if (intervention.getBlocked()) {
             redirectURI = configurationService.getAccountStatusBlockedURI();
             LOG.info("Generating Account Intervention blocked logout response");
-        } else if (accountState.suspended()) {
+        } else if (intervention.getSuspended()) {
             redirectURI = configurationService.getAccountStatusSuspendedURI();
             LOG.info("Generating Account Intervention suspended logout response");
         } else {
             throw new RuntimeException("Account status must be blocked or suspended");
         }
 
-        cloudwatchMetricsService.incrementLogout(Optional.of(clientId), Optional.of(accountState));
+        cloudwatchMetricsService.incrementLogout(Optional.of(clientId), Optional.of(intervention));
         return generateLogoutResponse(
                 redirectURI,
                 Optional.empty(),

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/AccountInterventionTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/AccountInterventionTest.java
@@ -1,0 +1,66 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class AccountInterventionTest {
+    private static final AccountInterventionState CLEAR_STATE =
+            new AccountInterventionState(false, false, false, false);
+    private static final AccountInterventionState BLOCKED_STATE =
+            new AccountInterventionState(true, false, false, false);
+    private static final AccountInterventionState SUSPENDED_STATE =
+            new AccountInterventionState(false, true, false, false);
+    private static final AccountInterventionState SUSPENDED_RESET_PASSWORD_STATE =
+            new AccountInterventionState(false, true, false, true);
+    private static final AccountInterventionState SUSPENDED_REPROVE_ID_STATE =
+            new AccountInterventionState(false, true, true, false);
+    private static final AccountInterventionState SUSPENDED_RESET_PASSWORD_REPROVE_ID_STATE =
+            new AccountInterventionState(false, true, true, true);
+
+    @ParameterizedTest
+    @MethodSource("standardTestCases")
+    void shouldHaveCorrectStatusAfterInitialisingFromState(
+            AccountInterventionState state, AccountInterventionStatus status) {
+        AccountIntervention intervention = new AccountIntervention(state);
+        assertThat(intervention.getStatus(), equalTo(status));
+    }
+
+    @ParameterizedTest
+    @MethodSource("ignoreResetPasswordTestCases")
+    void shouldHaveCorrectStatusWhenPasswordWasResetAfterInterventionWasApplied(
+            AccountInterventionState state, AccountInterventionStatus status) {
+        AccountIntervention intervention = new AccountIntervention(state, Long.MAX_VALUE);
+        assertThat(intervention.getStatus(), equalTo(status));
+    }
+
+    private static Object[][] standardTestCases() {
+        return new Object[][] {
+            {CLEAR_STATE, AccountInterventionStatus.NO_INTERVENTION},
+            {BLOCKED_STATE, AccountInterventionStatus.BLOCKED},
+            {SUSPENDED_STATE, AccountInterventionStatus.SUSPENDED_NO_ACTION},
+            {SUSPENDED_RESET_PASSWORD_STATE, AccountInterventionStatus.SUSPENDED_RESET_PASSWORD},
+            {SUSPENDED_REPROVE_ID_STATE, AccountInterventionStatus.SUSPENDED_REPROVE_ID},
+            {
+                SUSPENDED_RESET_PASSWORD_REPROVE_ID_STATE,
+                AccountInterventionStatus.SUSPENDED_RESET_PASSWORD_REPROVE_ID
+            },
+        };
+    }
+
+    private static Object[][] ignoreResetPasswordTestCases() {
+        return new Object[][] {
+            {CLEAR_STATE, AccountInterventionStatus.NO_INTERVENTION},
+            {BLOCKED_STATE, AccountInterventionStatus.BLOCKED},
+            {SUSPENDED_STATE, AccountInterventionStatus.SUSPENDED_NO_ACTION},
+            {SUSPENDED_RESET_PASSWORD_STATE, AccountInterventionStatus.NO_INTERVENTION},
+            {SUSPENDED_REPROVE_ID_STATE, AccountInterventionStatus.SUSPENDED_REPROVE_ID},
+            {
+                SUSPENDED_RESET_PASSWORD_REPROVE_ID_STATE,
+                AccountInterventionStatus.SUSPENDED_REPROVE_ID
+            },
+        };
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/AccountInterventionTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/AccountInterventionTest.java
@@ -32,7 +32,8 @@ class AccountInterventionTest {
     @MethodSource("ignoreResetPasswordTestCases")
     void shouldHaveCorrectStatusWhenPasswordWasResetAfterInterventionWasApplied(
             AccountInterventionState state, AccountInterventionStatus status) {
-        AccountIntervention intervention = new AccountIntervention(state, Long.MAX_VALUE);
+        AccountInterventionDetails details = new AccountInterventionDetails(0L, 0L, 0L, "", 0L, 0L);
+        AccountIntervention intervention = new AccountIntervention(details, state, Long.MAX_VALUE);
         assertThat(intervention.getStatus(), equalTo(status));
     }
 


### PR DESCRIPTION
## What

- Redefined account interventions class structure. Two immutable classes are defined which hold the the raw response from AIS (`AccountInterventionState` and `AccountInterventionDetails`). A further class, `AccountIntervention`, handles account interventions logic applicable to Orchestration.  The idea is that in future, a developer should only need to use `AccountIntervention` and none of the other classes in production code.
- Updated codebase to use new structure.
- Serialised more of the response from account intervention service into `AccountInterventionDetails` which includes `appliedAt` value (the time that the intervention was applied).
- Read `password_reset_time` claim from Authentication
- Implement fix for race condition: if `password_reset_time` is after `appliedAt` then ignore `passwordReset` on the intervention.

## How to review
1. Code Review - commit by commit will be easiest

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs
PR to send `password_reset_time` claim from Authentication: https://github.com/govuk-one-login/authentication-api/pull/4104
