### PR TITLE
AUT-2583: Verify account locked for user not found during reauthentication

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
@@ -135,6 +135,30 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
         assertThat(response, hasStatus(400));
     }
 
+    @Test
+    void shouldReturn400WhenUserProfileNotFoundAndHasEnteredInvalidEmailTooManyTimes() {
+        userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
+        registerClient("https://" + INTERNAl_SECTOR_HOST);
+
+        var randomEmail = "random_email@email.com";
+
+        redis.incrementEmailCount(randomEmail);
+        redis.incrementEmailCount(randomEmail);
+        redis.incrementEmailCount(randomEmail);
+        redis.incrementEmailCount(randomEmail);
+        redis.incrementEmailCount(randomEmail);
+
+        var request = new CheckReauthUserRequest(randomEmail, "random-pairwise-id");
+        var response =
+                makeRequest(
+                        Optional.of(request),
+                        headers,
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of());
+        assertThat(response, hasStatus(400));
+    }
+
     private ClientSession createClientSession() {
         var authRequestBuilder =
                 new AuthenticationRequest.Builder(


### PR DESCRIPTION
## What

- When a user attempts to reauthenticate with a different email that does not exist in the user profiles store, the user is allowed to make multiple attempts
- This gives the user a large number of tries and is also a backdoor way to find out which emails have accounts
- Verify if the account has been locked and return the appropriate error

## How to review

1. Code Review
2. Test in build only as reauthentication journey unable to test in sandpit environments
