### PR TITLE
ATO-404: Add new client registry entries for stub using for_each

### DIFF
--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -157,6 +157,18 @@ output "stub_rp_client_credentials" {
   sensitive = true
 }
 
+output "stub_relying_party_client_credentials" {
+  value = [
+    for i, rp in var.stub_rp_clients : {
+      client_name = rp.client_name
+      client_id   = random_string.stub_relying_party_client_id[rp.client_name].result
+      private_key = tls_private_key.stub_relying_party_client_private_key[rp.client_name].private_key_pem_pkcs8
+      public_key  = tls_private_key.stub_relying_party_client_private_key[rp.client_name].public_key_pem
+    }
+  ]
+  sensitive = true
+}
+
 output "cloudwatch_encryption_key_arn" {
   value = aws_kms_key.cloudwatch_log_encryption.arn
 }

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -5,8 +5,25 @@ resource "tls_private_key" "stub_rp_client_private_key" {
   rsa_bits  = 2048
 }
 
+resource "tls_private_key" "stub_relying_party_client_private_key" {
+  for_each = { for client in var.stub_rp_clients : client.client_name => client }
+
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
 resource "random_string" "stub_rp_client_id" {
   count = length(var.stub_rp_clients)
+
+  lower   = true
+  upper   = true
+  special = false
+  numeric = true
+  length  = 32
+}
+
+resource "random_string" "stub_relying_party_client_id" {
+  for_each = { for client in var.stub_rp_clients : client.client_name => client }
 
   lower   = true
   upper   = true
@@ -111,6 +128,105 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
     }
     OneLoginService = {
       BOOL = var.stub_rp_clients[count.index].one_login_service
+    }
+  })
+}
+
+resource "aws_dynamodb_table_item" "stub_relying_party_client" {
+  for_each = { for client in var.stub_rp_clients : client.client_name => client }
+
+  table_name = aws_dynamodb_table.client_registry_table.name
+  hash_key   = aws_dynamodb_table.client_registry_table.hash_key
+
+  item = jsonencode({
+    ClientID = {
+      S = random_string.stub_relying_party_client_id[each.value.client_name].result
+    }
+    ClientName = {
+      S = each.value.client_name
+    }
+    Contacts = {
+      L = [{
+        S = "contact+${each.value.client_name}@example.com"
+      }]
+    }
+    SectorIdentifierUri = {
+      S = each.value.sector_identifier_uri
+    }
+    PostLogoutRedirectUrls = {
+      L = [for url in each.value.logout_urls : {
+        S = url
+      }]
+    }
+    RedirectUrls = {
+      L = [for url in each.value.callback_urls : {
+        S = url
+      }]
+    }
+    Scopes = {
+      L = [for scope in each.value.scopes : {
+        S = scope
+      }]
+    },
+    Claims = {
+      L = [
+        {
+          S = "https://vocab.account.gov.uk/v1/coreIdentityJWT"
+        },
+        {
+          S = "https://vocab.account.gov.uk/v1/passport"
+        },
+        {
+          S = "https://vocab.account.gov.uk/v1/address"
+        },
+        {
+          S = "https://vocab.account.gov.uk/v1/drivingPermit"
+        },
+        {
+          S = "https://vocab.account.gov.uk/v1/socialSecurityRecord"
+        },
+        {
+          S = "https://vocab.account.gov.uk/v1/returnCode"
+        },
+        {
+          S = "https://vocab.account.gov.uk/v1/inheritedIdentityJWT"
+        },
+      ]
+    }
+    PublicKey = {
+      S = replace(replace(
+        replace(
+        tls_private_key.stub_relying_party_client_private_key[each.value.client_name].public_key_pem, "-----BEGIN PUBLIC KEY-----", ""),
+      "-----END PUBLIC KEY-----", ""), "\n", "")
+    }
+    ServiceType = {
+      S = each.value.service_type
+    }
+    SubjectType = {
+      S = "pairwise"
+    }
+    CookieConsentShared = {
+      N = "1"
+    }
+    ConsentRequired = {
+      N = each.value.consent_required
+    }
+    IdentityVerificationSupported = {
+      N = each.value.identity_verification_supported
+    }
+    ClientType = {
+      S = each.value.client_type
+    }
+    TestClient = {
+      N = each.value.test_client
+    }
+    TestClientEmailAllowlist = {
+      L = [for email in split(",", var.test_client_email_allowlist) : {
+        S = email
+      }]
+    }
+    OneLoginService = {
+      BOOL = each.value.one_login_service
     }
   })
 }


### PR DESCRIPTION
## What

We need to remove the old stub client registry entries. However we currently can't do this without causing stub downtime, as removing one entry will update them all, as they are generated using 'count'. I've a second set of entries indexed by the name of the stub, which means if we remove one from the list, it will only affect that entry (checked with a terraform plan).
