### PR TITLE
BAU: Explicitly specify the API Key Source for the API Gateway

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -59,7 +59,8 @@ resource "aws_iam_role_policy_attachment" "api_gateway_logging_logs" {
 }
 
 resource "aws_api_gateway_rest_api" "di_authentication_api" {
-  name = "${var.environment}-di-authentication-api"
+  name           = "${var.environment}-di-authentication-api"
+  api_key_source = "HEADER"
 
   tags = local.default_tags
 }


### PR DESCRIPTION
## What

Manually specify the API Key Source for API Gateway. It defaults to "HEADER" when no value is specified. SSE tool depends on this. This was manually changed in one environment, and lead to some hard to find issues

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.

