### PR TITLE
ATO-440: Replace instances of `Long.MIN_VALUE` with `0L`

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -524,7 +524,7 @@ public class AuthenticationCallbackHandler
         Object passwordResetTimeClaim = userInfo.getClaim("password_reset_time");
         if (passwordResetTimeClaim == null) {
             LOG.info("password_reset_time claim not found");
-            return Long.MIN_VALUE;
+            return 0L;
         }
         LOG.info("password_reset_time claim found");
         Long passwordResetTimeLong;
@@ -532,7 +532,7 @@ public class AuthenticationCallbackHandler
             passwordResetTimeLong = (Long) passwordResetTimeClaim;
         } catch (ClassCastException e) {
             LOG.error("Failed to cast password_reset_time claim to Long", e);
-            passwordResetTimeLong = Long.MIN_VALUE;
+            passwordResetTimeLong = 0L;
         }
         return passwordResetTimeLong;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -71,13 +71,13 @@ public class AccountInterventionService {
 
     public AccountIntervention getAccountIntervention(String internalPairwiseSubjectId)
             throws AccountInterventionException {
-        return getAccountIntervention(internalPairwiseSubjectId, Long.MIN_VALUE, null);
+        return getAccountIntervention(internalPairwiseSubjectId, 0L, null);
     }
 
     public AccountIntervention getAccountIntervention(
             String internalPairwiseSubjectId, AuditContext auditContext)
             throws AccountInterventionException {
-        return getAccountIntervention(internalPairwiseSubjectId, Long.MIN_VALUE, auditContext);
+        return getAccountIntervention(internalPairwiseSubjectId, 0L, auditContext);
     }
 
     public AccountIntervention getAccountIntervention(


### PR DESCRIPTION
## What

When an account intervention should not ignore the password reset flag, this is enforced by setting `passwordResetTime` to a small number. This works because `ignorePasswordReset` is `false` when the time that the intervention was applied is greater than or equal to `passwordResetTime` (comparison of unix timestamps).

Replace instances of `Long.MIN_VALUE` with `0L`, because it doesn't make sense to set `passwordResetTime` to a negative value, and it doesn't affect functionality.

## How to review

Code review only

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

PR where `Long.MIN_VALUE` was introduced: https://github.com/govuk-one-login/authentication-api/pull/4108
