### PR TITLE
AUT-2623: Add reprove identity to account interventions service response

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsResponse.java
@@ -7,4 +7,5 @@ public record AccountInterventionsResponse(
         @Expose @Required boolean passwordResetRequired,
         @Expose @Required boolean blocked,
         @Expose @Required boolean temporarilySuspended,
+        @Expose @Required boolean reproveIdentity,
         @Expose @Required String appliedAt) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -157,6 +157,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                         response.state().resetPassword(),
                         response.state().blocked(),
                         response.state().suspended(),
+                        response.state().reproveIdentity(),
                         response.intervention().appliedAt());
         if (!configurationService.accountInterventionsServiceActionEnabled()) {
             LOG.info(
@@ -242,6 +243,6 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
 
     private AccountInterventionsResponse noAccountInterventions() {
         return new AccountInterventionsResponse(
-                false, false, false, String.valueOf(clock.now().toInstant().toEpochMilli()));
+                false, false, false, false, String.valueOf(clock.now().toInstant().toEpochMilli()));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -75,8 +75,8 @@ public class AccountInterventionsHandlerTest {
             String.valueOf(fixedDate.toEpochMilli());
     private final String DEFAULT_NO_INTERVENTIONS_RESPONSE =
             String.format(
-                    "{\"passwordResetRequired\":%b,\"blocked\":%b,\"temporarilySuspended\":%b,\"appliedAt\":\"%s\"}",
-                    false, false, false, fixedDateUnixTimestampString);
+                    "{\"passwordResetRequired\":%b,\"blocked\":%b,\"temporarilySuspended\":%b,\"reproveIdentity\":%b,\"appliedAt\":\"%s\"}",
+                    false, false, false, false, fixedDateUnixTimestampString);
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private AccountInterventionsHandler handler;
     private final Context context = mock(Context.class);
@@ -296,8 +296,8 @@ public class AccountInterventionsHandlerTest {
 
         assertEquals(
                 String.format(
-                        "{\"passwordResetRequired\":%b,\"blocked\":%b,\"temporarilySuspended\":%b,\"appliedAt\":\"%s\"}",
-                        resetPassword, blocked, suspended, APPLIED_AT_TIMESTAMP),
+                        "{\"passwordResetRequired\":%b,\"blocked\":%b,\"temporarilySuspended\":%b,\"reproveIdentity\":%b,\"appliedAt\":\"%s\"}",
+                        resetPassword, blocked, suspended, reproveIdentity, APPLIED_AT_TIMESTAMP),
                 result.getBody());
         verify(auditService)
                 .submitAuditEvent(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -85,13 +85,14 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
                         Map.of());
         assertThat(response, hasStatus(200));
         var accountInterventionsResponse =
-                new AccountInterventionsResponse(false, isUserBlocked, false, APPLIED_AT_TIMESTAMP);
+                new AccountInterventionsResponse(
+                        false, isUserBlocked, false, false, APPLIED_AT_TIMESTAMP);
         assertThat(
                 response,
                 hasBody(objectMapper.writeValueAsStringCamelCase(accountInterventionsResponse)));
         assertEquals(
                 String.format(
-                        "{\"passwordResetRequired\":false,\"blocked\":%b,\"temporarilySuspended\":false,\"appliedAt\":\"%s\"}",
+                        "{\"passwordResetRequired\":false,\"blocked\":%b,\"temporarilySuspended\":false,\"reproveIdentity\":false,\"appliedAt\":\"%s\"}",
                         isUserBlocked, APPLIED_AT_TIMESTAMP),
                 response.getBody());
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(expectedAuditEvent));


### PR DESCRIPTION
We will need this on the frontend to differentiate between a reprove identity temporary suspension (in which case certain actions are allowed, like resetting a forgotten password) and a suspension without actions (in which case certain actions are not allowed).

## How to review

1. Code Review

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

[PR](https://github.com/govuk-one-login/authentication-frontend/pull/1468) that adds this to the response type on the backend (plan is to merge that first)

