### PR TITLE
ATO-449: Pass RP state to auth

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -642,6 +642,7 @@ public class AuthorisationHandler
                             .claim("rp_client_id", client.getClientID())
                             .claim("rp_sector_host", rpSectorIdentifierHost)
                             .claim("rp_redirect_uri", authenticationRequest.getRedirectionURI())
+                            .claim("rp_state", authenticationRequest.getState())
                             .claim("client_name", client.getClientName())
                             .claim("cookie_consent_shared", client.isCookieConsentShared())
                             .claim("consent_required", client.isConsentRequired())


### PR DESCRIPTION


## What
Pass RP state to auth.
They need this to correctly return to the RP from ipv-callback in the event of an error.

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/1472
