### PR TITLE
ATO-98: Added JsonUpdateHelper class to avoid overwriting ClientSession fields in Redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,8 @@ subprojects {
 
     dependencies {
         apache "commons-codec:commons-codec:1.16.1",
-                "org.apache.httpcomponents:httpclient:4.5.14"
+                "org.apache.httpcomponents:httpclient:4.5.14",
+                "org.apache.commons:commons-collections4:4.1"
 
         bouncycastle "org.bouncycastle:bcpkix-jdk15on:1.70"
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -155,7 +155,7 @@ public class StartHandler
                                 userContext.getClientSession().getAuthRequestParams(),
                                 configurationService.isCustomDocAppClaimEnabled(),
                                 configurationService.getDocAppDomain());
-                clientSessionService.saveClientSession(
+                clientSessionService.updateStoredClientSession(
                         clientSessionId, clientSession.get().setDocAppSubjectId(docAppSubjectId));
                 LOG.info("Subject saved to ClientSession for DocCheckingAppUser");
             }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -258,7 +258,7 @@ class StartHandlerTest {
         assertFalse(response.getUser().isConsentRequired());
         assertThat(response.getUser().getCookieConsent(), equalTo(null));
         assertThat(response.getUser().getGaCrossDomainTrackingId(), equalTo(null));
-        verify(clientSessionService).saveClientSession(anyString(), any());
+        verify(clientSessionService).updateStoredClientSession(anyString(), any());
 
         verify(auditService)
                 .submitAuditEvent(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/ClientSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/ClientSessionServiceIntegrationTest.java
@@ -1,0 +1,117 @@
+package uk.gov.di.authentication.shared.services;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
+import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ClientSessionServiceIntegrationTest {
+
+    private static final String REDIS_HOST =
+            System.getenv().getOrDefault("REDIS_HOST", "localhost");
+    private static final Optional<String> REDIS_PASSWORD =
+            Optional.ofNullable(System.getenv("REDIS_PASSWORD"));
+    private static final String CLIENT_NAME = "CLIENT_NAME";
+    private static List<VectorOfTrust> VTR_LIST =
+            List.of(VectorOfTrust.of(CredentialTrustLevel.MEDIUM_LEVEL, LevelOfConfidence.NONE));
+    private static final Subject SUBJECT_ID = new Subject("SUBJECT_ID");
+    private static final String ID_TOKEN_HINT = "TOKEN_ID_HINT";
+
+    private uk.gov.di.orchestration.shared.services.ClientSessionService orchClientSessionService;
+    private uk.gov.di.authentication.shared.services.ClientSessionService authClientSessionService;
+
+    @BeforeEach
+    void setup() {
+        var orchConfigurationService =
+                uk.gov.di.orchestration.shared.services.ConfigurationService.getInstance();
+        var authConfigurationService =
+                uk.gov.di.authentication.shared.services.ConfigurationService.getInstance();
+        var orchRedisConnectionService =
+                new uk.gov.di.orchestration.shared.services.RedisConnectionService(
+                        REDIS_HOST, 6379, false, REDIS_PASSWORD, false);
+        var authRedisConnectionService =
+                new uk.gov.di.authentication.shared.services.RedisConnectionService(
+                        REDIS_HOST, 6379, false, REDIS_PASSWORD, false);
+
+        orchClientSessionService =
+                new uk.gov.di.orchestration.shared.services.ClientSessionService(
+                        orchConfigurationService, orchRedisConnectionService);
+        authClientSessionService =
+                new uk.gov.di.authentication.shared.services.ClientSessionService(
+                        authConfigurationService, authRedisConnectionService);
+    }
+
+    @Test
+    void authAndOrchClientSessionsShouldBeAbleToHaveDifferentFieldsWithoutOverwritingOneAnother() {
+        // Create Orch Client Session and store in Redis.
+        var clientSessionId = orchClientSessionService.generateClientSessionId();
+        var orchClientSession =
+                new ClientSession(Map.of(), LocalDateTime.now(), VTR_LIST, CLIENT_NAME);
+        orchClientSessionService.storeClientSession(clientSessionId, orchClientSession);
+
+        // Get Auth Client Session from Redis, set Subject ID, and update in Redis.
+        var authClientSession = authClientSessionService.getClientSession(clientSessionId).get();
+        authClientSession.setDocAppSubjectId(SUBJECT_ID);
+        authClientSessionService.updateStoredClientSession(clientSessionId, authClientSession);
+
+        // Get Orch Client Session from Redis, set ID Token Hint, and update in Redis.
+        orchClientSession = orchClientSessionService.getClientSession(clientSessionId).get();
+        orchClientSession.setIdTokenHint(ID_TOKEN_HINT);
+        orchClientSessionService.updateStoredClientSession(clientSessionId, orchClientSession);
+
+        // Get Auth Client Session from Redis.
+        authClientSession = authClientSessionService.getClientSession(clientSessionId).get();
+
+        // Check fields have expected values in Orch copy.
+        assertThat(orchClientSession.getClientName(), is(equalTo(CLIENT_NAME)));
+        assertThat(orchClientSession.getDocAppSubjectId(), is(equalTo(SUBJECT_ID)));
+        assertThat(orchClientSession.getVtrList(), is(equalTo(VTR_LIST)));
+
+        // Check fields have expected values in Auth copy.
+        assertThat(authClientSession.getClientName(), is(equalTo(CLIENT_NAME)));
+        assertThat(authClientSession.getDocAppSubjectId(), is(equalTo(SUBJECT_ID)));
+    }
+
+    @Test
+    void authAndOrchClientSessionsShouldBeAbleToDeleteFieldValuesBySettingThemToNull() {
+        // Create Orch client session, set ID Token Hint and Subject ID and store in Redis.
+        var clientSessionId = orchClientSessionService.generateClientSessionId();
+        var orchClientSession =
+                new ClientSession(Map.of(), LocalDateTime.now(), VTR_LIST, CLIENT_NAME);
+        orchClientSession.setIdTokenHint(ID_TOKEN_HINT);
+        orchClientSession.setDocAppSubjectId(SUBJECT_ID);
+        orchClientSessionService.storeClientSession(clientSessionId, orchClientSession);
+
+        // Get Auth Client Session from Redis, set Subject ID to null, and update in Redis.
+        var authClientSession = authClientSessionService.getClientSession(clientSessionId).get();
+        authClientSession.setDocAppSubjectId(null);
+        authClientSessionService.updateStoredClientSession(clientSessionId, authClientSession);
+
+        // Get Orch Client Session from Redis, set ID Token Hint to null, and update in Redis.
+        orchClientSession = orchClientSessionService.getClientSession(clientSessionId).get();
+        orchClientSession.setIdTokenHint(null);
+        orchClientSessionService.updateStoredClientSession(clientSessionId, orchClientSession);
+
+        // Get Orch / Auth client sessions from Redis.
+        orchClientSession = orchClientSessionService.getClientSession(clientSessionId).get();
+        authClientSession = authClientSessionService.getClientSession(clientSessionId).get();
+
+        // Check expected null fields are null.
+        assertThat(orchClientSession.getIdTokenHint(), is(nullValue()));
+        assertThat(orchClientSession.getDocAppSubjectId(), is(nullValue()));
+        assertThat(authClientSession.getDocAppSubjectId(), is(nullValue()));
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -422,7 +422,7 @@ public class AuthorisationHandler
                         configurationService.getDocAppDomain());
         LOG.info("Doc app request received");
 
-        clientSessionService.saveClientSession(
+        clientSessionService.storeClientSession(
                 clientSessionId, clientSession.setDocAppSubjectId(subjectId));
         LOG.info("Subject saved to ClientSession for DocCheckingAppUser");
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -211,7 +211,7 @@ public class TokenHandler
                         getSigningAlgorithm(clientRegistry),
                         authCodeExchangeData);
 
-        clientSessionService.saveClientSession(
+        clientSessionService.updateStoredClientSession(
                 authCodeExchangeData.getClientSessionId(),
                 clientSession.setIdTokenHint(
                         tokenResponse.getOIDCTokens().getIDToken().serialize()));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1703,7 +1703,7 @@ class AuthorisationHandlerTest {
 
             var response = makeDocAppHandlerRequest();
 
-            verify(clientSessionService).saveClientSession(anyString(), any());
+            verify(clientSessionService).storeClientSession(anyString(), any());
 
             assertThat(response, hasStatus(302));
             assertThat(

--- a/orchestration-shared/build.gradle
+++ b/orchestration-shared/build.gradle
@@ -24,7 +24,8 @@ dependencies {
             configurations.ssm,
             configurations.xray,
             configurations.cloudwatch,
-            configurations.gson
+            configurations.gson,
+            configurations.apache
 
     testImplementation configurations.tests,
             configurations.lambda_tests,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/JsonUpdateHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/JsonUpdateHelper.java
@@ -1,0 +1,55 @@
+package uk.gov.di.orchestration.shared.helpers;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import org.apache.commons.collections4.SetUtils;
+
+public class JsonUpdateHelper {
+
+    public static String updateJson(String oldJson, String newJson) throws JsonSyntaxException {
+        var oldElem = JsonParser.parseString(oldJson);
+        var newElem = JsonParser.parseString(newJson);
+        var updateElem = update(oldElem, newElem);
+        return updateElem.toString();
+    }
+
+    private static JsonElement update(JsonElement oldElem, JsonElement newElem) {
+        if (oldElem instanceof JsonObject oldObj && newElem instanceof JsonObject newObj) {
+            var updatedObj = new JsonObject();
+            var oldKeys = oldObj.keySet();
+            var newKeys = newObj.keySet();
+            var oldOnlyKeys = SetUtils.difference(oldKeys, newKeys);
+            var newOnlyKeys = SetUtils.difference(newKeys, oldKeys);
+            var updateKeys = SetUtils.intersection(oldKeys, newKeys);
+
+            for (var oldKey : oldOnlyKeys) {
+                updatedObj.add(oldKey, oldObj.get(oldKey));
+            }
+
+            for (var newKey : newOnlyKeys) {
+                updatedObj.add(newKey, newObj.get(newKey));
+            }
+
+            for (var updateKey : updateKeys) {
+                updatedObj.add(updateKey, update(oldObj.get(updateKey), newObj.get(updateKey)));
+            }
+
+            return updatedObj;
+        } else if (oldElem instanceof JsonArray oldArr
+                && newElem instanceof JsonArray newArr
+                && oldArr.size() == newArr.size()) {
+            var updatedArr = new JsonArray();
+
+            for (int i = 0; i < oldArr.size(); i++) {
+                updatedArr.add(update(oldArr.get(i), newArr.get(i)));
+            }
+
+            return updatedArr;
+        }
+
+        return newElem;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSessionService.java
@@ -1,10 +1,12 @@
 package uk.gov.di.orchestration.shared.services;
 
+import com.google.gson.JsonSyntaxException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
+import uk.gov.di.orchestration.shared.helpers.JsonUpdateHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 
@@ -13,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.text.MessageFormat.format;
 import static uk.gov.di.orchestration.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
@@ -94,22 +97,33 @@ public class ClientSessionService {
         }
     }
 
-    public void saveClientSession(String clientSessionId, ClientSession clientSession) {
+    public void updateStoredClientSession(String clientSessionId, ClientSession clientSession) {
         attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
 
+        var clientSessionKey = CLIENT_SESSION_PREFIX.concat(clientSessionId);
+
+        if (!redisConnectionService.keyExists(clientSessionKey)) {
+            LOG.error(
+                    "Couldn't update client session with given key as it was not present in redis");
+            throw new IllegalArgumentException(
+                    format("Client session with ID {0} not found.", clientSessionId));
+        }
+
         try {
-            redisConnectionService.saveWithExpiry(
-                    CLIENT_SESSION_PREFIX.concat(clientSessionId),
-                    objectMapper.writeValueAsString(clientSession),
-                    configurationService.getSessionExpiry());
-        } catch (JsonException e) {
+            var oldClientSession = redisConnectionService.getValue(clientSessionKey);
+            var newClientSession = objectMapper.writeValueAsString(clientSession);
+            var updatedClientSession =
+                    JsonUpdateHelper.updateJson(oldClientSession, newClientSession);
+            var expiry = configurationService.getSessionExpiry();
+            redisConnectionService.saveWithExpiry(clientSessionKey, updatedClientSession, expiry);
+        } catch (JsonException | JsonSyntaxException e) {
             LOG.error("Error saving client session to Redis");
             throw new RuntimeException(e);
         }
     }
 
-    public void deleteClientSessionFromRedis(String clientSessionId) {
+    public void deleteStoredClientSession(String clientSessionId) {
         redisConnectionService.deleteValue(clientSessionId);
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -85,7 +85,7 @@ public class LogoutService {
                                             session.getEmailAddress(),
                                             configurationService.getInternalSectorUri()));
             LOG.info("Deleting Client Session");
-            clientSessionService.deleteClientSessionFromRedis(clientSessionId);
+            clientSessionService.deleteStoredClientSession(clientSessionId);
         }
         LOG.info("Deleting Session");
         sessionService.deleteSessionFromRedis(session.getSessionId());

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/JsonUpdateHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/JsonUpdateHelperTest.java
@@ -1,0 +1,286 @@
+package uk.gov.di.orchestration.shared.helpers;
+
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class JsonUpdateHelperTest {
+
+    @Test
+    void testUpdateStringReturnsNewValue() {
+        var oldJson = "\"abc\"";
+        var newJson = "\"def\"";
+        var expectedJson = "\"def\"";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateNumberReturnsNewNumber() {
+        var oldJson = "123";
+        var newJson = "789";
+        var expectedJson = "789";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateBooleanReturnsNewBoolean() {
+        var oldJson = "true";
+        var newJson = "false";
+        var expectedJson = "false";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateToNullReturnNull() {
+        var oldJson = "true";
+        var newJson = "null";
+        var expectedJson = "null";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateFromNullReturnNewValue() {
+        var oldJson = "null";
+        var newJson = "[]";
+        var expectedJson = "[]";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateVariableTypeReturnNewValue() {
+        var oldJson = "[]";
+        var newJson = "{}";
+        var expectedJson = "{}";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateObjectReturnsUpdatedObject() {
+        var oldJson =
+                """
+                {
+                    "field_a": 11,
+                    "field_b": 12
+                }
+                """;
+        var newJson =
+                """
+                {
+                    "field_a": 21,
+                    "field_c": 22
+                }
+                """;
+        var expectedJson =
+                """
+                {
+                    "field_a": 21,
+                    "field_b": 12,
+                    "field_c": 22
+                }
+                """;
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateArrayOfSameLengthReturnsUpdatedArray() {
+        var oldJson =
+                """
+                [
+                    {
+                        "field_a": 11,
+                        "field_b": 12
+                    },
+                    {
+                        "field_a": 21,
+                        "field_b": 22
+                    }
+                ]
+                """;
+        var newJson =
+                """
+                [
+                    {
+                        "field_a": 10,
+                        "field_c": 13
+                    },
+                    {
+                        "field_a": 20,
+                        "field_c": 23
+                    }
+                ]
+                """;
+        var expectedJson =
+                """
+                [
+                    {
+                        "field_a": 10,
+                        "field_b": 12,
+                        "field_c": 13
+                    },
+                    {
+                        "field_a": 20,
+                        "field_b": 22,
+                        "field_c": 23
+                    }
+                ]
+                """;
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateArrayOfDifferentLengthReturnsNewArray() {
+        var oldJson =
+                """
+                [
+                    {
+                        "field_a": 11,
+                        "field_b": 12
+                    },
+                    {
+                        "field_a": 21,
+                        "field_b": 22
+                    }
+                ]
+                """;
+        var newJson =
+                """
+                [
+                    {
+                        "field_a": 10,
+                        "field_c": 13
+                    }
+                ]
+                """;
+        var expectedJson =
+                """
+                [
+                    {
+                        "field_a": 10,
+                        "field_c": 13
+                    }
+                ]
+                """;
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateNestedReturnsCorrectValue() {
+        var oldJson =
+                """
+                {
+                    "field_a":
+                    {
+                        "nested_field_a": "StringValue1",
+                        "nested_field_b": 1
+                    },
+                    "field_b":
+                    {
+                        "nested_field_a": "StringValue2",
+                        "nested_field_b": 2
+                    },
+                    "field_c": [
+                        {
+                            "nested_field_a": "StringValue3",
+                            "nested_field_b": 3
+                        },
+                        {
+                            "nested_field_a": "StringValue4",
+                            "nested_field_b": 4
+                        }
+                    ],
+                    "field_d": [
+                        {
+                            "nested_field_a": "StringValue5",
+                            "nested_field_b": 5
+                        }
+                    ]
+                }
+                """;
+        var newJson =
+                """
+                {
+                    "field_a":
+                    {
+                        "nested_field_b": null,
+                        "nested_field_c": true
+                    },
+                    "field_e":
+                    {
+                        "nested_field_b": 2,
+                        "nested_field_c": true
+                    },
+                    "field_c": [
+                        {
+                            "nested_field_b": 300,
+                            "nested_field_c": true
+                        },
+                        {
+                            "nested_field_b": 400,
+                            "nested_field_c": false
+                        }
+                    ],
+                    "field_d": [
+                        {
+                            "nested_field_b": 500,
+                            "nested_field_c": false
+                        },
+                        {
+                            "nested_field_b": 600,
+                            "nested_field_c": true
+                        }
+                    ]
+                }
+                """;
+        var expectedJson =
+                """
+                {
+                    "field_a":
+                    {
+                        "nested_field_a": "StringValue1",
+                        "nested_field_b": null,
+                        "nested_field_c": true
+                    },
+                    "field_b":
+                    {
+                        "nested_field_a": "StringValue2",
+                        "nested_field_b": 2
+                    },
+                    "field_e":
+                    {
+                        "nested_field_b": 2,
+                        "nested_field_c": true
+                    },
+                    "field_c": [
+                        {
+                            "nested_field_a": "StringValue3",
+                            "nested_field_b": 300,
+                            "nested_field_c": true
+                        },
+                        {
+                            "nested_field_a": "StringValue4",
+                            "nested_field_b": 400,
+                            "nested_field_c": false
+                        }
+                    ],
+                    "field_d": [
+                        {
+                            "nested_field_b": 500,
+                            "nested_field_c": false
+                        },
+                        {
+                            "nested_field_b": 600,
+                            "nested_field_c": true
+                        }
+                    ]
+                }
+                """;
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    public void assertJsonEqual(String jsonA, String jsonB) {
+        assertThat(JsonParser.parseString(jsonA), is(equalTo(JsonParser.parseString(jsonB))));
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -272,8 +272,7 @@ public class LogoutServiceTest {
                 logoutService.handleAccountInterventionLogout(
                         session, event, CLIENT_ID, intervention);
 
-        verify(clientSessionService)
-                .deleteClientSessionFromRedis(session.getClientSessions().get(0));
+        verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
         verify(sessionService).deleteSessionFromRedis(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
@@ -304,8 +303,7 @@ public class LogoutServiceTest {
                 logoutService.handleAccountInterventionLogout(
                         session, event, CLIENT_ID, intervention);
 
-        verify(clientSessionService)
-                .deleteClientSessionFromRedis(session.getClientSessions().get(0));
+        verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
         verify(sessionService).deleteSessionFromRedis(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
@@ -367,9 +365,9 @@ public class LogoutServiceTest {
                 .sendLogoutMessage(
                         argThat(withClientId("client-id-3")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
 
-        verify(clientSessionService).deleteClientSessionFromRedis("client-session-id-1");
-        verify(clientSessionService).deleteClientSessionFromRedis("client-session-id-2");
-        verify(clientSessionService).deleteClientSessionFromRedis("client-session-id-3");
+        verify(clientSessionService).deleteStoredClientSession("client-session-id-1");
+        verify(clientSessionService).deleteStoredClientSession("client-session-id-2");
+        verify(clientSessionService).deleteStoredClientSession("client-session-id-3");
         verify(sessionService, times(1)).deleteSessionFromRedis(SESSION_ID);
     }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -169,19 +169,6 @@ public class RedisExtension
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
-    public void addIDTokenToSession(String clientSessionId, String idTokenHint)
-            throws Json.JsonException {
-        ClientSession clientSession =
-                objectMapper.readValue(
-                        redis.getValue(CLIENT_SESSION_PREFIX.concat(clientSessionId)),
-                        ClientSession.class);
-        clientSession.setIdTokenHint(idTokenHint);
-        redis.saveWithExpiry(
-                CLIENT_SESSION_PREFIX.concat(clientSessionId),
-                objectMapper.writeValueAsString(clientSession),
-                3600);
-    }
-
     public void addEmailToSession(String sessionId, String emailAddress) throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.setEmailAddress(emailAddress);

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -24,7 +24,8 @@ dependencies {
             configurations.ssm,
             configurations.xray,
             configurations.cloudwatch,
-            configurations.gson
+            configurations.gson,
+            configurations.apache
 
     testImplementation configurations.tests,
             configurations.lambda_tests,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
@@ -4,23 +4,15 @@ import com.google.gson.annotations.Expose;
 import com.nimbusds.oauth2.sdk.id.Subject;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class ClientSession {
 
     @Expose private Map<String, List<String>> authRequestParams;
 
-    @Expose private String idTokenHint;
-
     @Expose private LocalDateTime creationDate;
-
     @Expose private VectorOfTrust effectiveVectorOfTrust;
-
-    @Expose private List<VectorOfTrust> vtrList = new ArrayList<>();
 
     @Expose private Subject docAppSubjectId;
 
@@ -34,52 +26,19 @@ public class ClientSession {
         this.authRequestParams = authRequestParams;
         this.creationDate = creationDate;
         this.effectiveVectorOfTrust = effectiveVectorOfTrust;
-        this.vtrList.add(effectiveVectorOfTrust);
         this.clientName = clientName;
-    }
-
-    public ClientSession(
-            Map<String, List<String>> authRequestParams,
-            LocalDateTime creationDate,
-            List<VectorOfTrust> vtrList,
-            String clientName) {
-        this.authRequestParams = authRequestParams;
-        this.creationDate = creationDate;
-        this.vtrList = vtrList;
-        if (vtrList.size() > 0) {
-            this.effectiveVectorOfTrust = orderVtrList().get(0);
-        }
-        this.clientName = clientName;
-    }
-
-    public ClientSession setIdTokenHint(String idTokenHint) {
-        this.idTokenHint = idTokenHint;
-        return this;
     }
 
     public Map<String, List<String>> getAuthRequestParams() {
         return authRequestParams;
     }
 
-    public String getIdTokenHint() {
-        return idTokenHint;
-    }
-
     public LocalDateTime getCreationDate() {
         return creationDate;
     }
 
-    public List<VectorOfTrust> getVtrList() {
-        return vtrList;
-    }
-
     public VectorOfTrust getEffectiveVectorOfTrust() {
         return effectiveVectorOfTrust;
-    }
-
-    public ClientSession setEffectiveVectorOfTrust(VectorOfTrust effectiveVectorOfTrust) {
-        this.effectiveVectorOfTrust = effectiveVectorOfTrust;
-        return this;
     }
 
     public Subject getDocAppSubjectId() {
@@ -93,17 +52,5 @@ public class ClientSession {
 
     public String getClientName() {
         return clientName;
-    }
-
-    private List<VectorOfTrust> orderVtrList() {
-        return this.vtrList.stream()
-                .sorted(
-                        Comparator.comparing(
-                                        VectorOfTrust::getLevelOfConfidence,
-                                        Comparator.nullsFirst(Comparator.naturalOrder()))
-                                .thenComparing(
-                                        VectorOfTrust::getCredentialTrustLevel,
-                                        Comparator.nullsFirst(Comparator.naturalOrder())))
-                .collect(Collectors.toList());
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/JsonUpdateHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/JsonUpdateHelper.java
@@ -1,0 +1,55 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import org.apache.commons.collections4.SetUtils;
+
+public class JsonUpdateHelper {
+
+    public static String updateJson(String oldJson, String newJson) throws JsonSyntaxException {
+        var oldElem = JsonParser.parseString(oldJson);
+        var newElem = JsonParser.parseString(newJson);
+        var updateElem = update(oldElem, newElem);
+        return updateElem.toString();
+    }
+
+    private static JsonElement update(JsonElement oldElem, JsonElement newElem) {
+        if (oldElem instanceof JsonObject oldObj && newElem instanceof JsonObject newObj) {
+            var updatedObj = new JsonObject();
+            var oldKeys = oldObj.keySet();
+            var newKeys = newObj.keySet();
+            var oldOnlyKeys = SetUtils.difference(oldKeys, newKeys);
+            var newOnlyKeys = SetUtils.difference(newKeys, oldKeys);
+            var updateKeys = SetUtils.intersection(oldKeys, newKeys);
+
+            for (var oldKey : oldOnlyKeys) {
+                updatedObj.add(oldKey, oldObj.get(oldKey));
+            }
+
+            for (var newKey : newOnlyKeys) {
+                updatedObj.add(newKey, newObj.get(newKey));
+            }
+
+            for (var updateKey : updateKeys) {
+                updatedObj.add(updateKey, update(oldObj.get(updateKey), newObj.get(updateKey)));
+            }
+
+            return updatedObj;
+        } else if (oldElem instanceof JsonArray oldArr
+                && newElem instanceof JsonArray newArr
+                && oldArr.size() == newArr.size()) {
+            var updatedArr = new JsonArray();
+
+            for (int i = 0; i < oldArr.size(); i++) {
+                updatedArr.add(update(oldArr.get(i), newArr.get(i)));
+            }
+
+            return updatedArr;
+        }
+
+        return newElem;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
@@ -1,15 +1,17 @@
 package uk.gov.di.authentication.shared.services;
 
+import com.google.gson.JsonSyntaxException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ClientSession;
-import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.JsonUpdateHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 
 import java.util.Map;
 import java.util.Optional;
 
+import static java.text.MessageFormat.format;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
@@ -45,23 +47,6 @@ public class ClientSessionService {
         objectMapper = SerializationService.getInstance();
     }
 
-    public void storeClientSession(String clientSessionId, ClientSession clientSession) {
-        try {
-            redisConnectionService.saveWithExpiry(
-                    CLIENT_SESSION_PREFIX.concat(clientSessionId),
-                    objectMapper.writeValueAsString(clientSession),
-                    configurationService.getSessionExpiry());
-        } catch (JsonException e) {
-            LOG.error("Error saving client session to Redis");
-            throw new RuntimeException(e);
-        }
-        LOG.info("Generated new ClientSession");
-    }
-
-    public String generateClientSessionId() {
-        return IdGenerator.generate();
-    }
-
     public Optional<ClientSession> getClientSession(String clientSessionId) {
         attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
@@ -83,23 +68,30 @@ public class ClientSessionService {
         }
     }
 
-    public void saveClientSession(String clientSessionId, ClientSession clientSession) {
+    public void updateStoredClientSession(String clientSessionId, ClientSession clientSession) {
         attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
 
+        var clientSessionKey = CLIENT_SESSION_PREFIX.concat(clientSessionId);
+
+        if (!redisConnectionService.keyExists(clientSessionKey)) {
+            LOG.error(
+                    "Couldn't update client session with given key as it was not present in redis");
+            throw new IllegalArgumentException(
+                    format("Client session with ID {0} not found.", clientSessionId));
+        }
+
         try {
-            redisConnectionService.saveWithExpiry(
-                    CLIENT_SESSION_PREFIX.concat(clientSessionId),
-                    objectMapper.writeValueAsString(clientSession),
-                    configurationService.getSessionExpiry());
-        } catch (JsonException e) {
+            var oldClientSession = redisConnectionService.getValue(clientSessionKey);
+            var newClientSession = objectMapper.writeValueAsString(clientSession);
+            var updatedClientSession =
+                    JsonUpdateHelper.updateJson(oldClientSession, newClientSession);
+            var expiry = configurationService.getSessionExpiry();
+            redisConnectionService.saveWithExpiry(clientSessionKey, updatedClientSession, expiry);
+        } catch (JsonException | JsonSyntaxException e) {
             LOG.error("Error saving client session to Redis");
             throw new RuntimeException(e);
         }
-    }
-
-    public void deleteClientSessionFromRedis(String clientSessionId) {
-        redisConnectionService.deleteValue(clientSessionId);
     }
 
     public Optional<ClientSession> getClientSessionFromRequestHeaders(Map<String, String> headers) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/JsonUpdateHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/JsonUpdateHelperTest.java
@@ -1,0 +1,286 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class JsonUpdateHelperTest {
+
+    @Test
+    void testUpdateStringReturnsNewValue() {
+        var oldJson = "\"abc\"";
+        var newJson = "\"def\"";
+        var expectedJson = "\"def\"";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateNumberReturnsNewNumber() {
+        var oldJson = "123";
+        var newJson = "789";
+        var expectedJson = "789";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateBooleanReturnsNewBoolean() {
+        var oldJson = "true";
+        var newJson = "false";
+        var expectedJson = "false";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateToNullReturnNull() {
+        var oldJson = "true";
+        var newJson = "null";
+        var expectedJson = "null";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateFromNullReturnNewValue() {
+        var oldJson = "null";
+        var newJson = "[]";
+        var expectedJson = "[]";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateVariableTypeReturnNewValue() {
+        var oldJson = "[]";
+        var newJson = "{}";
+        var expectedJson = "{}";
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateObjectReturnsUpdatedObject() {
+        var oldJson =
+                """
+                {
+                    "field_a": 11,
+                    "field_b": 12
+                }
+                """;
+        var newJson =
+                """
+                {
+                    "field_a": 21,
+                    "field_c": 22
+                }
+                """;
+        var expectedJson =
+                """
+                {
+                    "field_a": 21,
+                    "field_b": 12,
+                    "field_c": 22
+                }
+                """;
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateArrayOfSameLengthReturnsUpdatedArray() {
+        var oldJson =
+                """
+                [
+                    {
+                        "field_a": 11,
+                        "field_b": 12
+                    },
+                    {
+                        "field_a": 21,
+                        "field_b": 22
+                    }
+                ]
+                """;
+        var newJson =
+                """
+                [
+                    {
+                        "field_a": 10,
+                        "field_c": 13
+                    },
+                    {
+                        "field_a": 20,
+                        "field_c": 23
+                    }
+                ]
+                """;
+        var expectedJson =
+                """
+                [
+                    {
+                        "field_a": 10,
+                        "field_b": 12,
+                        "field_c": 13
+                    },
+                    {
+                        "field_a": 20,
+                        "field_b": 22,
+                        "field_c": 23
+                    }
+                ]
+                """;
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateArrayOfDifferentLengthReturnsNewArray() {
+        var oldJson =
+                """
+                [
+                    {
+                        "field_a": 11,
+                        "field_b": 12
+                    },
+                    {
+                        "field_a": 21,
+                        "field_b": 22
+                    }
+                ]
+                """;
+        var newJson =
+                """
+                [
+                    {
+                        "field_a": 10,
+                        "field_c": 13
+                    }
+                ]
+                """;
+        var expectedJson =
+                """
+                [
+                    {
+                        "field_a": 10,
+                        "field_c": 13
+                    }
+                ]
+                """;
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    @Test
+    void testUpdateNestedReturnsCorrectValue() {
+        var oldJson =
+                """
+                {
+                    "field_a":
+                    {
+                        "nested_field_a": "StringValue1",
+                        "nested_field_b": 1
+                    },
+                    "field_b":
+                    {
+                        "nested_field_a": "StringValue2",
+                        "nested_field_b": 2
+                    },
+                    "field_c": [
+                        {
+                            "nested_field_a": "StringValue3",
+                            "nested_field_b": 3
+                        },
+                        {
+                            "nested_field_a": "StringValue4",
+                            "nested_field_b": 4
+                        }
+                    ],
+                    "field_d": [
+                        {
+                            "nested_field_a": "StringValue5",
+                            "nested_field_b": 5
+                        }
+                    ]
+                }
+                """;
+        var newJson =
+                """
+                {
+                    "field_a":
+                    {
+                        "nested_field_b": null,
+                        "nested_field_c": true
+                    },
+                    "field_e":
+                    {
+                        "nested_field_b": 2,
+                        "nested_field_c": true
+                    },
+                    "field_c": [
+                        {
+                            "nested_field_b": 300,
+                            "nested_field_c": true
+                        },
+                        {
+                            "nested_field_b": 400,
+                            "nested_field_c": false
+                        }
+                    ],
+                    "field_d": [
+                        {
+                            "nested_field_b": 500,
+                            "nested_field_c": false
+                        },
+                        {
+                            "nested_field_b": 600,
+                            "nested_field_c": true
+                        }
+                    ]
+                }
+                """;
+        var expectedJson =
+                """
+                {
+                    "field_a":
+                    {
+                        "nested_field_a": "StringValue1",
+                        "nested_field_b": null,
+                        "nested_field_c": true
+                    },
+                    "field_b":
+                    {
+                        "nested_field_a": "StringValue2",
+                        "nested_field_b": 2
+                    },
+                    "field_e":
+                    {
+                        "nested_field_b": 2,
+                        "nested_field_c": true
+                    },
+                    "field_c": [
+                        {
+                            "nested_field_a": "StringValue3",
+                            "nested_field_b": 300,
+                            "nested_field_c": true
+                        },
+                        {
+                            "nested_field_a": "StringValue4",
+                            "nested_field_b": 400,
+                            "nested_field_c": false
+                        }
+                    ],
+                    "field_d": [
+                        {
+                            "nested_field_b": 500,
+                            "nested_field_c": false
+                        },
+                        {
+                            "nested_field_b": 600,
+                            "nested_field_c": true
+                        }
+                    ]
+                }
+                """;
+        assertJsonEqual(JsonUpdateHelper.updateJson(oldJson, newJson), expectedJson);
+    }
+
+    public void assertJsonEqual(String jsonA, String jsonB) {
+        assertThat(JsonParser.parseString(jsonA), is(equalTo(JsonParser.parseString(jsonB))));
+    }
+}


### PR DESCRIPTION
## What
- ClientSessionService now updates new / altered ClientSession fields without deleting existing fields if they are not maintained in both Orchestration and Authentication versions of ClientSession
- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/4039
