### PR TITLE
AUT-2613: Check if account has been locked for entering max password attempts in re-auth journey

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/exceptions/AccountLockedException.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/exceptions/AccountLockedException.java
@@ -1,7 +1,16 @@
 package uk.gov.di.authentication.frontendapi.exceptions;
 
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+
 public class AccountLockedException extends RuntimeException {
-    public AccountLockedException(String message) {
+    private final ErrorResponse errorResponse;
+
+    public AccountLockedException(String message, ErrorResponse errorResponse) {
         super(message);
+        this.errorResponse = errorResponse;
+    }
+
+    public ErrorResponse getErrorResponse() {
+        return this.errorResponse;
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.orchestration.shared.entity.ErrorResponse;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 
 import java.net.URI;
@@ -30,6 +31,7 @@ import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -133,6 +135,35 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
                         Map.of("principalId", expectedPairwiseId));
 
         assertThat(response, hasStatus(400));
+    }
+
+    @Test
+    void shouldReturn400WhenUserHasBeenBlockedForMaxPasswordRetries() {
+        userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
+        registerClient("https://randomSectorIDuRI.COM");
+
+        redis.incrementPasswordCountReauthJourney(TEST_EMAIL);
+        redis.incrementPasswordCountReauthJourney(TEST_EMAIL);
+        redis.incrementPasswordCountReauthJourney(TEST_EMAIL);
+        redis.incrementPasswordCountReauthJourney(TEST_EMAIL);
+        redis.incrementPasswordCountReauthJourney(TEST_EMAIL);
+        redis.incrementPasswordCountReauthJourney(TEST_EMAIL);
+
+        byte[] salt = userStore.addSalt(TEST_EMAIL);
+        var expectedPairwiseId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        SUBJECT.getValue(), INTERNAl_SECTOR_HOST, salt);
+        var request = new CheckReauthUserRequest(TEST_EMAIL, expectedPairwiseId);
+        var response =
+                makeRequest(
+                        Optional.of(request),
+                        headers,
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("principalId", expectedPairwiseId));
+
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1045));
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -135,6 +135,10 @@ public class RedisExtension
         codeStorageService.increaseIncorrectPasswordCount(email);
     }
 
+    public void incrementPasswordCountReauthJourney(String email) {
+        codeStorageService.increaseIncorrectPasswordCountReauthJourney(email);
+    }
+
     public void incrementEmailCount(String email) {
         codeStorageService.increaseIncorrectEmailCount(email);
     }


### PR DESCRIPTION
## What

- During re-auth, when a user has been blocked for entering incorrect password too many times, the user is still able to proceed to complete the re-auth journey.
- The Reauth handler will now validate to check whether the user has been blocked from entering too many incorrect password

## How to review

1. Code Review
