### PR TITLE
ATO-457: Fix deploying orchestration frontend to sandpit

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -701,7 +701,7 @@ resource "aws_api_gateway_method" "orch_frontend_proxy_method" {
 
 data "aws_cloudformation_stack" "orch_frontend_stack" {
   count = var.orch_frontend_api_gateway_integration_enabled ? 1 : 0
-  name  = "${var.environment}-orch-frontend"
+  name  = "${var.environment}-orch-fe-deploy"
 }
 
 locals {

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -510,6 +510,8 @@ variable "orch_client_id" {
 }
 
 variable "orch_frontend_api_gateway_integration_enabled" {
+  # When this flag is enabled in a particular environment, the corresponding orchestration-frontend flag
+  # (OidcApiGatewayIntegrationEnabled) should also be enabled for that environment.
   description = "Flag to enable API Gateway integration with the Orchestration frontend"
   type        = bool
   default     = false


### PR DESCRIPTION
## What

- Update orch frontend stack name to match updated name in orchestration-frontend repo
- Add comment about flag in orchestration-frontend (see PR below) which should be kept in sync with `orch_frontend_api_gateway_integration_enabled` flag

## How to review

1. Check that stack names now match (see CloudFormation in AWS)
2. Does comment make sense?

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs
PR which adds new flag to orchestration-frontend:
https://github.com/govuk-one-login/orchestration-frontend/pull/221
