### PR TITLE
ATO-296: Fix Audit Event Consistency Issues

### DIFF
--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -38,6 +38,7 @@ module "doc-app-authorize" {
     DOC_APP_ENCRYPTION_KEY_ID          = var.doc_app_encryption_key_id
     DOC_APP_TOKEN_SIGNING_KEY_ALIAS    = local.doc_app_auth_key_alias_name
     INTERNAl_SECTOR_URI                = var.internal_sector_uri
+    OIDC_API_BASE_URL                  = local.api_base_url
   }
   handler_function_name = "uk.gov.di.authentication.app.lambda.DocAppAuthorizeHandler::handleRequest"
 

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -44,6 +44,7 @@ module "doc-app-callback" {
     LOGIN_URI                          = "https://${local.frontend_fqdn}/"
     REDIS_KEY                          = local.redis_key
     TXMA_AUDIT_QUEUE_URL               = module.oidc_txma_audit.queue_url
+    OIDC_API_BASE_URL                  = local.api_base_url
   }
   handler_function_name = "uk.gov.di.authentication.app.lambda.DocAppCallbackHandler::handleRequest"
 

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -29,6 +29,7 @@ module "identity_progress" {
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                = local.redis_key
+    OIDC_API_BASE_URL        = local.api_base_url
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IdentityProgressFrontendHandler::handleRequest"
 

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -42,6 +42,7 @@ module "processing-identity" {
     ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR = var.account_intervention_service_abort_on_error
     ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
     FRONTEND_BASE_URL                           = "https://${local.frontend_fqdn}/"
+    OIDC_API_BASE_URL                           = local.api_base_url
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.ProcessingIdentityHandler::handleRequest"
 

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -97,6 +97,7 @@ resource "aws_lambda_function" "spot_response_lambda" {
       TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
       FRONTEND_BASE_URL    = "https://${local.frontend_fqdn}/"
       INTERNAl_SECTOR_URI  = var.internal_sector_uri
+      OIDC_API_BASE_URL    = local.api_base_url
     })
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -41,6 +41,7 @@ module "userinfo" {
     IDENTITY_ENABLED                     = var.ipv_api_enabled
     INTERNAl_SECTOR_URI                  = var.internal_sector_uri
     SUPPORT_AUTH_ORCH_SPLIT              = var.support_auth_orch_split_user_info
+    OIDC_API_BASE_URL                    = local.api_base_url
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest"
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.orchestration.shared.services;
 
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.domain.AuditableEvent;
@@ -78,7 +79,11 @@ public class AuditService {
         var txmaAuditEvent =
                 auditEventWithTime(event, () -> Date.from(clock.instant()))
                         .withClientId(clientId)
-                        .withComponentId(configurationService.getOidcApiBaseURL().orElse("UNKNOWN"))
+                        .withComponentId(
+                                configurationService
+                                        .getOidcApiBaseURL()
+                                        .map(url -> StringUtils.removeEnd(url, "/"))
+                                        .orElse("UNKNOWN"))
                         .withUser(user);
 
         Arrays.stream(metadataPairs)

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuditServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuditServiceTest.java
@@ -42,7 +42,7 @@ class AuditServiceTest {
 
     @BeforeEach
     void beforeEach() {
-        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of("oidc-base-url"));
+        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of("oidc-base-url/"));
     }
 
     @Test
@@ -67,6 +67,7 @@ class AuditServiceTest {
         assertThat(txmaMessage, hasFieldWithValue("event_name", equalTo("AUTH_TEST_EVENT_ONE")));
         assertThat(txmaMessage, hasNumericFieldWithValue("timestamp", equalTo(1630534200L)));
         assertThat(txmaMessage, hasFieldWithValue("client_id", equalTo("client-id")));
+        // component_id shouldn't include trailing slash
         assertThat(txmaMessage, hasFieldWithValue("component_id", equalTo("oidc-base-url")));
 
         var userObject = txmaMessage.getAsJsonObject().get("user").getAsJsonObject();


### PR DESCRIPTION
- Removed "/" from end of audit event component ID
- Add OIDC_API_BASE_URL env var to config for handlers emitting audit events with "UNKNOWN" component ID

See [here](https://govukverify.atlassian.net/wiki/spaces/~712020ca5ac93cd97f4e89b368ea8355f2af55/pages/3901685867/Component+ID+Analysis) for a breakdown of the known issues.