### PR TITLE
ATO-480: Fix deployment of Orchestration CloudWatch alarms

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -196,10 +196,11 @@ Resources:
       Threshold: 10
       Metrics:
         - Id: e1
+          ReturnData: true
           Expression: m2/m1*100
           Label: Error Rate
-          ReturnData: true
         - Id: m1
+          ReturnData: false
           MetricStat:
             Metric:
               Namespace: AWS/Lambda
@@ -211,6 +212,7 @@ Resources:
             Stat: Sum
             Unit: Count
         - Id: m2
+          ReturnData: false
           MetricStat:
             Metric:
               Namespace: AWS/Lambda


### PR DESCRIPTION
## What

Fix deployment of Orchestration CloudWatch alarms

- `ReturnData` defaults to `true`
- `ReturnData` must be `true` for exactly one of the list of metrics
- Therefore need to explicitly set `ReturnData` for every metric

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudwatch-alarm-metricdataquery.html#cfn-cloudwatch-alarm-metricdataquery-returndata

## How to review

1. Code review only

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PR
This issue was noticed after adding the deploy dev script:  https://github.com/govuk-one-login/authentication-api/pull/4173

