### PR TITLE
AUT-2646: Provide information about user lockouts inside the CheckUse…

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
@@ -4,6 +4,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 
+import java.util.List;
+
 public class CheckUserExistsResponse {
 
     @SerializedName("email")
@@ -21,6 +23,10 @@ public class CheckUserExistsResponse {
     @SerializedName("phoneNumberLastThree")
     @Expose
     private String phoneNumberLastThree;
+
+    @SerializedName("lockoutInformation")
+    @Expose
+    private List<LockoutInformation> lockoutInformation;
 
     public CheckUserExistsResponse() {}
 
@@ -42,6 +48,19 @@ public class CheckUserExistsResponse {
         this.phoneNumberLastThree = phoneNumberLastThree;
     }
 
+    public CheckUserExistsResponse(
+            String email,
+            boolean doesUserExist,
+            MFAMethodType mfaMethodType,
+            String phoneNumberLastThree,
+            List<LockoutInformation> lockoutInformation) {
+        this.email = email;
+        this.doesUserExist = doesUserExist;
+        this.mfaMethodType = mfaMethodType;
+        this.phoneNumberLastThree = phoneNumberLastThree;
+        this.lockoutInformation = lockoutInformation;
+    }
+
     public String getEmail() {
         return email;
     }
@@ -56,5 +75,9 @@ public class CheckUserExistsResponse {
 
     public String getPhoneNumberLastThree() {
         return phoneNumberLastThree;
+    }
+
+    public List<LockoutInformation> getLockoutInformation() {
+        return lockoutInformation;
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LockoutInformation.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LockoutInformation.java
@@ -1,0 +1,13 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public record LockoutInformation(
+        @SerializedName("lockType") @Expose @Required String lockType,
+        @SerializedName("mfaMethodType") @Expose @Required MFAMethodType mfaMethodType,
+        @SerializedName("lockTTL") @Expose @Required Long lockTTL,
+        @SerializedName("journeyType") @Expose @Required JourneyType journeyType) {}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -9,7 +9,9 @@ import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
 import uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
@@ -23,13 +25,15 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -57,12 +61,14 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionId = redis.createSession();
         var clientSessionId = IdGenerator.generate();
         userStore.signUp(emailAddress, "password-1");
+
         if (MFAMethodType.SMS == mfaMethodType) {
             userStore.addMfaMethod(emailAddress, mfaMethodType, false, true, "credential");
             userStore.addVerifiedPhoneNumber(emailAddress, "+44987654321");
         } else {
             userStore.addMfaMethod(emailAddress, mfaMethodType, true, true, "credential");
         }
+
         setUpClientSession(
                 "joe.bloggs+1@digital.cabinet-office.gov.uk",
                 clientSessionId,
@@ -87,9 +93,53 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             assertThat(checkUserExistsResponse.getPhoneNumberLastThree(), equalTo("321"));
         } else if (MFAMethodType.AUTH_APP.equals(mfaMethodType)) {
             assertNull(checkUserExistsResponse.getPhoneNumberLastThree());
-        } else {
-            fail();
         }
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CHECK_USER_KNOWN_EMAIL));
+    }
+
+    @Test
+    void shouldCallUserExistsEndpointAndReturnLockoutInformationForAuthAppMfa()
+            throws JsonException {
+        var emailAddress = "joe.bloggs+1@digital.cabinet-office.gov.uk";
+
+        String sessionId = redis.createUnauthenticatedSessionWithEmail(emailAddress);
+        var codeRequestType =
+                CodeRequestType.getCodeRequestType(MFAMethodType.AUTH_APP, JourneyType.SIGN_IN);
+
+        userStore.signUp(emailAddress, "password-1");
+        userStore.addMfaMethod(emailAddress, MFAMethodType.AUTH_APP, true, true, "credential");
+
+        var clientSessionId = IdGenerator.generate();
+
+        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+        redis.blockMfaCodesForEmail(emailAddress, codeBlockedKeyPrefix);
+
+        setUpClientSession(
+                "joe.bloggs+1@digital.cabinet-office.gov.uk",
+                clientSessionId,
+                CLIENT_ID,
+                CLIENT_NAME,
+                REDIRECT_URI);
+
+        var request = new CheckUserExistsRequest(emailAddress);
+        var response =
+                makeRequest(
+                        Optional.of(request),
+                        constructFrontendHeaders(sessionId, clientSessionId),
+                        Map.of());
+
+        assertThat(response, hasStatus(200));
+        CheckUserExistsResponse checkUserExistsResponse =
+                objectMapper.readValue(response.getBody(), CheckUserExistsResponse.class);
+        assertThat(checkUserExistsResponse.getEmail(), equalTo(emailAddress));
+        assertThat(checkUserExistsResponse.getMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
+        assertTrue(checkUserExistsResponse.doesUserExist());
+        var lockoutInformation = checkUserExistsResponse.getLockoutInformation();
+        assertNotNull(lockoutInformation);
+        assertThat(lockoutInformation.get(0).lockTTL() > 0, is(true));
+        assertThat(lockoutInformation.get(0).journeyType(), is(JourneyType.SIGN_IN));
+        assertThat(lockoutInformation.get(0).mfaMethodType(), is(MFAMethodType.AUTH_APP));
+
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CHECK_USER_KNOWN_EMAIL));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/RedisConnectionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/RedisConnectionServiceIntegrationTest.java
@@ -81,6 +81,23 @@ class RedisConnectionServiceIntegrationTest {
     }
 
     @Test
+    void getTimeToLiveReturnsCorrectCodeIfKeyDoesNotExist() {
+        try (RedisConnectionService redis =
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false)) {
+            assertThat(redis.getTimeToLive(testKey), is(-2L));
+        }
+    }
+
+    @Test
+    void getTimeToLiveReturnsCorrectValueIfKeyExistsAndHasExpiry() {
+        try (RedisConnectionService redis =
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false)) {
+            redis.saveWithExpiry(testKey, TEST_VALUE, TEN_SECOND_EXPIRY);
+            assertThat(redis.getTimeToLive(testKey) > 0, is(true));
+        }
+    }
+
+    @Test
     void deleteValueRemovesValueFromRedisIfExists() {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false)) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -2,6 +2,8 @@ package uk.gov.di.authentication.shared.services;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.helpers.HashHelper;
@@ -116,6 +118,17 @@ public class CodeStorageService {
 
     public int getIncorrectPasswordCountReauthJourney(String email) {
         return getCount(email, MULTIPLE_INCORRECT_PASSWORDS_REAUTH_PREFIX);
+    }
+
+    public long getMfaCodeBlockTimeToLive(
+            String email, MFAMethodType mfaMethodType, JourneyType journeyType) {
+        var codeRequestType = CodeRequestType.getCodeRequestType(mfaMethodType, journeyType);
+        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+        return getTTL(email, codeBlockedKeyPrefix);
+    }
+
+    private long getTTL(String email, String prefix) {
+        return redisConnectionService.getTimeToLive(prefix + HashHelper.hashSha256String(email));
     }
 
     private int getCount(String email, String prefix) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
@@ -64,6 +64,11 @@ public class RedisConnectionService implements AutoCloseable {
                 () -> executeCommand(commands -> commands.setex(key, expiry, value)));
     }
 
+    public Long getTimeToLive(final String key) {
+        return segmentedFunctionCall(
+                "Redis: getTimeToLive", () -> executeCommand(commands -> commands.ttl(key)));
+    }
+
     public boolean keyExists(final String key) {
         return segmentedFunctionCall(
                 "Redis: keyExists", () -> executeCommand(commands -> commands.exists(key) == 1));

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
@@ -4,7 +4,10 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
@@ -18,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
 class CodeStorageServiceTest {
 
@@ -305,6 +309,20 @@ class CodeStorageServiceTest {
         assertThat(
                 codeStorageService.getIncorrectMfaCodeAttemptsCount(TEST_EMAIL, mfaMethodType),
                 equalTo(4));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AUTH_APP", "SMS"})
+    void shouldReturnMfaCodeBlockTimeForAuthAppAndSMS(MFAMethodType mfaMethodType) {
+        var codeRequestType =
+                CodeRequestType.getCodeRequestType(mfaMethodType, JourneyType.SIGN_IN);
+        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+        when(redisConnectionService.getTimeToLive(codeBlockedKeyPrefix + TEST_EMAIL_HASH))
+                .thenReturn(4L);
+        assertThat(
+                codeStorageService.getMfaCodeBlockTimeToLive(
+                        TEST_EMAIL, mfaMethodType, JourneyType.SIGN_IN),
+                equalTo(4L));
     }
 
     @Test


### PR DESCRIPTION
…rExists Api

## What

Currently, we don't have a way to retrieve information about how much time is left until a lockout expires. 
This PR adds the field lockoutInformation to CheckUserExistsResponse, which contains information about the existing locks for authapp in the SIGN_IN and PW_RESET Journeys.  
## How to review

1. Code Review


## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.

The screenshot below demonstrates how the changes are being sent to the<img width="1728" alt="Screenshot 2024-04-03 at 17 40 42" src="https://github.com/govuk-one-login/authentication-api/assets/146068663/1e65d7e0-b6e4-4f1e-8f21-fb51584240d1">FE. 

