### PR TITLE
BAU: Fix pact path for oidc-api contract tests

### DIFF
--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -45,7 +45,7 @@ test {
 task contractTest (type: Test) {
     useJUnitPlatform()
     include '/uk/gov/di/authentication/oidc/contract/**'
-    systemProperties['pact.rootDir'] = "$rootDir/oidc/src/test/pact"
+    systemProperties['pact.rootDir'] = "$rootDir/oidc-api/src/test/pact"
 }
 
 task buildZip(type: Zip) {


### PR DESCRIPTION


## What
- Fix pact path for contract tests in OIDC API
- `/oidc/` doesn't exist, it should be `/oidc-api/`

## How to review

- Code review only

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.

