### PR TITLE
INCIDEN-723: record rp state length

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -303,6 +303,12 @@ public class AuthorisationHandler
                     clientSessionId);
         }
         authRequest = RequestObjectToAuthRequestHelper.transform(authRequest);
+
+        cloudwatchMetricsService.putEmbeddedValue(
+                "rpStateLength",
+                authRequest.getState().getValue().length(),
+                Map.of("clientId", authRequest.getClientID().getValue()));
+
         boolean reauthRequested =
                 authRequest.getCustomParameter("id_token_hint") != null
                         && !authRequest.getCustomParameter("id_token_hint").isEmpty()


### PR DESCRIPTION
## What
Records metrics of the length of RP state parameter. In response to the attached incident, we may want to limit the length of RP state parameters. To do this with confidence, we should gather data on state lengths being sent currently.

