### PR TITLE
ATO-369: Add stack for deploying TxMA infrastructure to Orchestration accounts

### DIFF
--- a/ci/stack-orchestration/manual-stacks/txma/README.md
+++ b/ci/stack-orchestration/manual-stacks/txma/README.md
@@ -1,0 +1,43 @@
+# Manual stacks - TxMA
+
+## Intro
+
+The CloudFormation template sets up all the infrastructure for integration with TxMA.
+
+This Stack is deployed manually once per account/environment.
+
+## Deployment
+
+To deploy the template to the appropriate AWS account, ensure you are at the root of the project.
+
+Replace `<environment>` with `dev`, `build`, `staging`, `integration`, `production` in either of the commands below.
+
+### Creating a New Stack
+
+Set your AWS profile to the correct environment, then run `export ENVIRONMENT=<environment>`, then run:
+
+```bash
+aws cloudformation create-stack --stack-name txma \
+  --template-body file://$(pwd)/template.yml \
+  --region eu-west-2 \
+  --parameters ParameterKey=Environment,ParameterValue="$ENVIRONMENT" \
+  --tags Key=Product,Value="GOV.UK One Login" \
+         Key=System,Value="Orchestration" \
+         Key=Environment,Value="$ENVIRONMENT" \
+         Key=Owner,Value="di-orchestration@digital.cabinet-office.gov.uk"
+```
+
+### Updating the Stack
+
+Set your AWS profile to the correct environment, run `export ENVIRONMENT=<environment>` then run:
+
+```bash
+aws cloudformation update-stack --stack-name txma \
+  --template-body file://$(pwd)/template.yml \
+  --region eu-west-2 \
+  --parameters ParameterKey=Environment,ParameterValue="$ENVIRONMENT" \
+  --tags Key=Product,Value="GOV.UK One Login" \
+         Key=System,Value="Orchestration" \
+         Key=Environment,Value="$ENVIRONMENT" \
+         Key=Owner,Value="di-orchestration@digital.cabinet-office.gov.uk"
+```

--- a/ci/stack-orchestration/manual-stacks/txma/template.yml
+++ b/ci/stack-orchestration/manual-stacks/txma/template.yml
@@ -97,16 +97,6 @@ Resources:
             Action:
               - 'kms:*'
             Resource: '*'
-          - Sid: 'Allow Lambda Access'
-            Effect: Allow
-            Principal:
-              Service: 'lambda.amazonaws.com'
-            Action:
-              - kms:Encrypt
-              - kms:Decrypt
-              - kms:ReEncrypt
-              - kms:GenerateDataKey
-            Resource: '*'
           - !If
             - TxMAIntegrationEnabled
             - Sid: 'Allow decryption of events by TxMA'

--- a/ci/stack-orchestration/manual-stacks/txma/template.yml
+++ b/ci/stack-orchestration/manual-stacks/txma/template.yml
@@ -1,4 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Metadata:
+  Repo: "https://github.com/govuk-one-login/authentication-api/tree/main/ci/stack-orchestration/manual-stacks/txma"
 
 Description: SQS queues for audit events
 

--- a/ci/stack-orchestration/manual-stacks/txma/template.yml
+++ b/ci/stack-orchestration/manual-stacks/txma/template.yml
@@ -129,51 +129,6 @@ Resources:
       AliasName: !Sub alias/${AWS::StackName}/AuditEventEncryptionKey
       TargetKeyId: !Ref TxMASQSProducerAuditEventQueueEncryptionKey
 
-  KMSARNParameter:
-    Condition: TxMAIntegrationEnabled
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub '/${AWS::StackName}/KMSARN'
-      Type: String
-      Value: !Sub '${TxMASQSProducerAuditEventQueueEncryptionKey.Arn}'
-      Description: ARN of the KMS key used for encryption.
-      Tags:
-        AuthoredBy: TxMA
-        ProducerType: SQS
-
-  SQSQueueARNParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub '/${AWS::StackName}/QueueARN'
-      Type: String
-      Value: !Sub '${TxMASQSProducerAuditEventQueue.Arn}'
-      Description: ARN of the queue to submit events to.
-      Tags:
-        AuthoredBy: TxMA
-        ProducerType: SQS
-
-  SQSQueueNameParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub '/${AWS::StackName}/QueueName'
-      Type: String
-      Value: !Sub '${TxMASQSProducerAuditEventQueue.QueueName}'
-      Description: Name of the queue to submit events to.
-      Tags:
-        AuthoredBy: TxMA
-        ProducerType: SQS
-
-  SQSQueueURLParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub '/${AWS::StackName}/QueueURL'
-      Type: String
-      Value: !Sub '${TxMASQSProducerAuditEventQueue.QueueUrl}'
-      Description: URL of the queue to submit events to.
-      Tags:
-        AuthoredBy: TxMA
-        ProducerType: SQS
-
 Outputs:
   KMSARN:
     Description: 'ARN of the KMS key used for encryption.'

--- a/ci/stack-orchestration/manual-stacks/txma/template.yml
+++ b/ci/stack-orchestration/manual-stacks/txma/template.yml
@@ -23,6 +23,13 @@ Mappings:
       integration: 'arn:aws:iam::729485541398:root'
       production: 'arn:aws:iam::451773080033:root'
 
+Conditions:
+  TxMAIntegrationEnabled:
+    Fn::Or:
+      - Fn::Equals: [!Ref Environment, "staging"]
+      - Fn::Equals: [!Ref Environment, "integration"]
+      - Fn::Equals: [!Ref Environment, "production"]
+
 Resources:
   TxMASQSProducerAuditEventQueue:
     Type: AWS::SQS::Queue
@@ -42,6 +49,7 @@ Resources:
           Value: 'SQS'
 
   TxMASQSProducerAuditEventQueuePolicy:
+    Condition: TxMAIntegrationEnabled
     Type: AWS::SQS::QueuePolicy
     Properties:
       Queues:
@@ -97,13 +105,16 @@ Resources:
               - kms:ReEncrypt
               - kms:GenerateDataKey
             Resource: '*'
-          - Sid: 'Allow decryption of events by TxMA'
-            Effect: Allow
-            Principal:
-              AWS: !FindInMap [TxMAAccountARN, Environment, !Ref 'Environment']
-            Action:
-              - 'kms:decrypt'
-            Resource: '*'
+          - !If
+            - TxMAIntegrationEnabled
+            - Sid: 'Allow decryption of events by TxMA'
+              Effect: Allow
+              Principal:
+                AWS: !FindInMap [TxMAAccountARN, Environment, !Ref 'Environment']
+              Action:
+                - 'kms:decrypt'
+              Resource: '*'
+            - !Ref AWS::NoValue
       Tags:
         - Key: 'AuthoredBy'
           Value: 'TxMA'
@@ -117,6 +128,7 @@ Resources:
       TargetKeyId: !Ref TxMASQSProducerAuditEventQueueEncryptionKey
 
   KMSARNParameter:
+    Condition: TxMAIntegrationEnabled
     Type: AWS::SSM::Parameter
     Properties:
       Name: !Sub '/${AWS::StackName}/KMSARN'

--- a/ci/stack-orchestration/manual-stacks/txma/template.yml
+++ b/ci/stack-orchestration/manual-stacks/txma/template.yml
@@ -1,0 +1,183 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: SQS queues for audit events
+
+Parameters:
+  Environment:
+    Description: 'The environment type'
+    Type: 'String'
+    AllowedValues:
+      - 'dev'
+      - 'build'
+      - 'staging'
+      - 'integration'
+      - 'production'
+    ConstraintDescription: must be dev, build, staging, integration or production
+
+Mappings:
+  TxMAAccountARN:
+    Environment:
+      dev: 'unused'
+      build: 'unused'
+      staging: 'arn:aws:iam::178023842775:root'
+      integration: 'arn:aws:iam::729485541398:root'
+      production: 'arn:aws:iam::451773080033:root'
+
+Resources:
+  TxMASQSProducerAuditEventQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600 # 14 days in seconds
+      QueueName: !Sub '${AWS::StackName}-AuditEventQueue'
+      KmsMasterKeyId: !Ref TxMASQSProducerAuditEventQueueEncryptionKeyAlias
+      RedriveAllowPolicy:
+        redrivePermission: denyAll
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt TxMAAuditEventDeadLetterQueue.Arn
+        maxReceiveCount: 10
+      Tags:
+        - Key: 'AuthoredBy'
+          Value: 'TxMA'
+        - Key: 'ProducerType'
+          Value: 'SQS'
+
+  TxMASQSProducerAuditEventQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref TxMASQSProducerAuditEventQueue
+      PolicyDocument:
+        Statement:
+          - Sid: 'AllowReadByTxMAAccount'
+            Effect: Allow
+            Principal:
+              AWS: !FindInMap [TxMAAccountARN, Environment, !Ref 'Environment']
+            Action:
+              - 'sqs:ChangeMessageVisibility'
+              - 'sqs:ReceiveMessage'
+              - 'sqs:DeleteMessage'
+              - 'sqs:GetQueueAttributes'
+            Resource: !GetAtt TxMASQSProducerAuditEventQueue.Arn
+
+  TxMAAuditEventDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600 # 14 days in seconds
+      QueueName: !Sub '${AWS::StackName}-AuditEventDeadLetterQueue'
+      KmsMasterKeyId: !Ref TxMASQSProducerAuditEventQueueEncryptionKeyAlias
+      Tags:
+        - Key: 'AuthoredBy'
+          Value: 'TxMA'
+        - Key: 'ProducerType'
+          Value: 'SQS'
+
+  TxMASQSProducerAuditEventQueueEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Symmetric key used to encrypt TxMA audit messages at rest in SQS
+      EnableKeyRotation: true
+      KeySpec: SYMMETRIC_DEFAULT
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: 'Enable root account access'
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action:
+              - 'kms:*'
+            Resource: '*'
+          - Sid: 'Allow Lambda Access'
+            Effect: Allow
+            Principal:
+              Service: 'lambda.amazonaws.com'
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt
+              - kms:GenerateDataKey
+            Resource: '*'
+          - Sid: 'Allow decryption of events by TxMA'
+            Effect: Allow
+            Principal:
+              AWS: !FindInMap [TxMAAccountARN, Environment, !Ref 'Environment']
+            Action:
+              - 'kms:decrypt'
+            Resource: '*'
+      Tags:
+        - Key: 'AuthoredBy'
+          Value: 'TxMA'
+        - Key: 'ProducerType'
+          Value: 'SQS'
+
+  TxMASQSProducerAuditEventQueueEncryptionKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub alias/${AWS::StackName}/AuditEventEncryptionKey
+      TargetKeyId: !Ref TxMASQSProducerAuditEventQueueEncryptionKey
+
+  KMSARNParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${AWS::StackName}/KMSARN'
+      Type: String
+      Value: !Sub '${TxMASQSProducerAuditEventQueueEncryptionKey.Arn}'
+      Description: ARN of the KMS key used for encryption.
+      Tags:
+        AuthoredBy: TxMA
+        ProducerType: SQS
+
+  SQSQueueARNParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${AWS::StackName}/QueueARN'
+      Type: String
+      Value: !Sub '${TxMASQSProducerAuditEventQueue.Arn}'
+      Description: ARN of the queue to submit events to.
+      Tags:
+        AuthoredBy: TxMA
+        ProducerType: SQS
+
+  SQSQueueNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${AWS::StackName}/QueueName'
+      Type: String
+      Value: !Sub '${TxMASQSProducerAuditEventQueue.QueueName}'
+      Description: Name of the queue to submit events to.
+      Tags:
+        AuthoredBy: TxMA
+        ProducerType: SQS
+
+  SQSQueueURLParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${AWS::StackName}/QueueURL'
+      Type: String
+      Value: !Sub '${TxMASQSProducerAuditEventQueue.QueueUrl}'
+      Description: URL of the queue to submit events to.
+      Tags:
+        AuthoredBy: TxMA
+        ProducerType: SQS
+
+Outputs:
+  KMSARN:
+    Description: 'ARN of the KMS key used for encryption.'
+    Value: !Sub '${TxMASQSProducerAuditEventQueueEncryptionKey.Arn}'
+    Export:
+      Name: !Sub '${AWS::StackName}-KMSARN'
+  QueueARN:
+    Description: 'ARN of the queue to submit events to.'
+    Value: !Sub '${TxMASQSProducerAuditEventQueue.Arn}'
+    Export:
+      Name: !Sub '${AWS::StackName}-QueueARN'
+  QueueName:
+    Description: 'Name of the queue to submit events to.'
+    Value: !Sub '${TxMASQSProducerAuditEventQueue.QueueName}'
+    Export:
+      Name: !Sub '${AWS::StackName}-QueueName'
+  QueueURL:
+    Description: 'URL of the queue to submit events to.'
+    Value: !Sub '${TxMASQSProducerAuditEventQueue.QueueUrl}'
+    Export:
+      Name: !Sub '${AWS::StackName}-QueueURL'


### PR DESCRIPTION
## What

- TxMA infrastructure added as a manual stack - it is intended to be deployed to Orchestration accounts only once, and not as part of the pipeline.
- Note that the stack has already been deployed to all envs.

## How to review

1. Code review

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.

- [x] Impact on orch and auth mutual dependencies has been checked.

