### PR TITLE
AUT-1506: Remove synthetics_users variable from integration tfvars

### DIFF
--- a/ci/terraform/test-services/integration.tfvars
+++ b/ci/terraform/test-services/integration.tfvars
@@ -1,5 +1,4 @@
 logging_endpoint_arn              = ""
 logging_endpoint_arns             = []
 shared_state_bucket               = "digital-identity-dev-tfstate"
-synthetics_users                  = ""
 test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"

--- a/ci/terraform/test-services/variables.tf
+++ b/ci/terraform/test-services/variables.tf
@@ -89,7 +89,8 @@ variable "endpoint_memory_size" {
 }
 
 variable "synthetics_users" {
-  type = string
+  default = ""
+  type    = string
 }
 
 variable "txma_account_id" {


### PR DESCRIPTION
There is already a secret set for this that we read in as a terraform environment variable on deploy, but because we also set it to an empty string it overrides the variable we have for it set as a terraform variable.

This seems to be why the create account smoke test is failing, since it depends on deleting the synthetics user. At the moment, we don't set a synthetics user, meaning that the request to the test services api 404s (there is no user set in the environment variable to delete), and the smoke test fails as we attempt to create an account as a user where we have not deleted their account first.

I have also set a default on the variable in the case of it not being present in secrets.

## How to review

1. Code Review