### PR TITLE
AUT-1709: cleanup isNotifyTemplatePerLanguage feature flag

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotificationType.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotificationType.java
@@ -45,14 +45,7 @@ public enum NotificationType implements TemplateAware {
     @Override
     public String getTemplateId(
             SupportedLanguage language, ConfigurationService configurationService) {
-        String templateId = configurationService.getNotifyTemplateId(getTemplateName(language));
-        if (!configurationService.isNotifyTemplatePerLanguage()
-                || templateId == null
-                || templateId.length() == 0) {
-            return configurationService.getNotifyTemplateId(templateName);
-        } else {
-            return templateId;
-        }
+        return configurationService.getNotifyTemplateId(templateName);
     }
 
     String getTemplateName(SupportedLanguage language) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotificationType.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotificationType.java
@@ -43,8 +43,7 @@ public enum NotificationType implements TemplateAware {
     }
 
     @Override
-    public String getTemplateId(
-            SupportedLanguage language, ConfigurationService configurationService) {
+    public String getTemplateId(ConfigurationService configurationService) {
         return configurationService.getNotifyTemplateId(templateName);
     }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
@@ -80,8 +80,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     emailPersonalisation,
-                                    NotificationType.VERIFY_EMAIL,
-                                    notifyRequest.getLanguage());
+                                    NotificationType.VERIFY_EMAIL);
                             LOG.info("VERIFY_EMAIL email has been sent using Notify");
                             break;
                         case VERIFY_PHONE_NUMBER:
@@ -91,8 +90,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendText(
                                     notifyRequest.getDestination(),
                                     phonePersonalisation,
-                                    NotificationType.VERIFY_PHONE_NUMBER,
-                                    notifyRequest.getLanguage());
+                                    NotificationType.VERIFY_PHONE_NUMBER);
                             LOG.info("VERIFY_PHONE_NUMBER text has been sent using Notify");
                             break;
                         case EMAIL_UPDATED:
@@ -104,8 +102,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     emailUpdatePersonalisation,
-                                    NotificationType.EMAIL_UPDATED,
-                                    notifyRequest.getLanguage());
+                                    NotificationType.EMAIL_UPDATED);
                             LOG.info("EMAIL_UPDATED email has been sent using Notify");
                             break;
                         case DELETE_ACCOUNT:
@@ -116,8 +113,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     accountDeletedPersonalisation,
-                                    NotificationType.DELETE_ACCOUNT,
-                                    notifyRequest.getLanguage());
+                                    NotificationType.DELETE_ACCOUNT);
                             LOG.info("DELETE_ACCOUNT email has been sent using Notify");
                             break;
                         case PHONE_NUMBER_UPDATED:
@@ -128,8 +124,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     phoneNumberUpdatedPersonalisation,
-                                    NotificationType.PHONE_NUMBER_UPDATED,
-                                    notifyRequest.getLanguage());
+                                    NotificationType.PHONE_NUMBER_UPDATED);
                             LOG.info("PHONE_NUMBER_UPDATED email has been sent using Notify");
                             break;
                         case PASSWORD_UPDATED:
@@ -140,8 +135,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     passwordUpdatedPersonalisation,
-                                    NotificationType.PASSWORD_UPDATED,
-                                    notifyRequest.getLanguage());
+                                    NotificationType.PASSWORD_UPDATED);
                             LOG.info("PASSWORD_UPDATED email has been sent using Notify");
                             break;
                     }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/NotificationService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/NotificationService.java
@@ -1,7 +1,6 @@
 package uk.gov.di.accountmanagement.services;
 
 import uk.gov.di.accountmanagement.entity.NotificationType;
-import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -20,26 +19,19 @@ public class NotificationService {
     }
 
     public void sendEmail(
-            String email,
-            Map<String, Object> personalisation,
-            NotificationType notificationType,
-            SupportedLanguage userLanguage)
+            String email, Map<String, Object> personalisation, NotificationType notificationType)
             throws NotificationClientException {
         notifyClient.sendEmail(
-                notificationType.getTemplateId(userLanguage, configurationService),
-                email,
-                personalisation,
-                "");
+                notificationType.getTemplateId(configurationService), email, personalisation, "");
     }
 
     public void sendText(
             String phoneNumber,
             Map<String, Object> personalisation,
-            NotificationType notificationType,
-            SupportedLanguage userLanguage)
+            NotificationType notificationType)
             throws NotificationClientException {
         notifyClient.sendSms(
-                notificationType.getTemplateId(userLanguage, configurationService),
+                notificationType.getTemplateId(configurationService),
                 phoneNumber,
                 personalisation,
                 "");

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/entity/NotificationTypeTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/entity/NotificationTypeTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.accountmanagement.entity;
 
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,9 +20,7 @@ class NotificationTypeTest {
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("AM_VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.EN, configurationService),
-                equalTo("12345"));
+        assertThat(VERIFY_EMAIL.getTemplateId(configurationService), equalTo("12345"));
     }
 
     @Test
@@ -32,9 +29,7 @@ class NotificationTypeTest {
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("AM_VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
-                equalTo("12345"));
+        assertThat(VERIFY_EMAIL.getTemplateId(configurationService), equalTo("12345"));
     }
 
     @Test
@@ -44,9 +39,7 @@ class NotificationTypeTest {
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("DELETE_ACCOUNT_TEMPLATE_ID"))
                 .thenReturn("12345");
-        assertThat(
-                DELETE_ACCOUNT.getTemplateId(SupportedLanguage.CY, configurationService),
-                equalTo("12345"));
+        assertThat(DELETE_ACCOUNT.getTemplateId(configurationService), equalTo("12345"));
     }
 
     @Test
@@ -55,8 +48,6 @@ class NotificationTypeTest {
                 .thenReturn("");
         when(configurationService.getNotifyTemplateId("AM_VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
-                equalTo("12345"));
+        assertThat(VERIFY_EMAIL.getTemplateId(configurationService), equalTo("12345"));
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/entity/NotificationTypeTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/entity/NotificationTypeTest.java
@@ -27,39 +27,14 @@ class NotificationTypeTest {
     }
 
     @Test
-    void shouldReturnDefaultTemplateForVerifyEmailWhenLanguageCYAndSingleTemplatePerLanguage() {
-        when(configurationService.getNotifyTemplateId("AM_VERIFY_EMAIL_TEMPLATE_ID_CY"))
-                .thenReturn("67890");
-        when(configurationService.getNotifyTemplateId("AM_VERIFY_EMAIL_TEMPLATE_ID"))
-                .thenReturn("12345");
-        when(configurationService.isNotifyTemplatePerLanguage()).thenReturn(true);
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
-                equalTo("67890"));
-    }
-
-    @Test
     void shouldReturnDefaultTemplateForVerifyEmailWhenLanguageCYAndNotSingleTemplatePerLanguage() {
         when(configurationService.getNotifyTemplateId("AM_VERIFY_EMAIL_TEMPLATE_ID_CY"))
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("AM_VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        when(configurationService.isNotifyTemplatePerLanguage()).thenReturn(false);
         assertThat(
                 VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
                 equalTo("12345"));
-    }
-
-    @Test
-    void shouldReturnCYTemplateForDeleteAccountWhenLanguageCYAndSingleTemplatePerLanguage() {
-        when(configurationService.getNotifyTemplateId("DELETE_ACCOUNT_TEMPLATE_ID_CY"))
-                .thenReturn("67890");
-        when(configurationService.getNotifyTemplateId("DELETE_ACCOUNT_TEMPLATE_ID"))
-                .thenReturn("12345");
-        when(configurationService.isNotifyTemplatePerLanguage()).thenReturn(true);
-        assertThat(
-                DELETE_ACCOUNT.getTemplateId(SupportedLanguage.CY, configurationService),
-                equalTo("67890"));
     }
 
     @Test
@@ -69,7 +44,6 @@ class NotificationTypeTest {
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("DELETE_ACCOUNT_TEMPLATE_ID"))
                 .thenReturn("12345");
-        when(configurationService.isNotifyTemplatePerLanguage()).thenReturn(false);
         assertThat(
                 DELETE_ACCOUNT.getTemplateId(SupportedLanguage.CY, configurationService),
                 equalTo("12345"));

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
@@ -66,8 +66,7 @@ public class NotificationHandlerTest {
         personalisation.put("email-address", notifyRequest.getDestination());
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
-        verify(notificationService)
-                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL, SupportedLanguage.EN);
+        verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL);
     }
 
     @Test
@@ -86,11 +85,7 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(
-                        TEST_PHONE_NUMBER,
-                        personalisation,
-                        VERIFY_PHONE_NUMBER,
-                        SupportedLanguage.EN);
+                .sendText(TEST_PHONE_NUMBER, personalisation, VERIFY_PHONE_NUMBER);
     }
 
     @Test
@@ -109,9 +104,7 @@ public class NotificationHandlerTest {
         personalisation.put("email-address", notifyRequest.getDestination());
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
-        verify(notificationService)
-                .sendEmail(
-                        TEST_EMAIL_ADDRESS, personalisation, EMAIL_UPDATED, SupportedLanguage.EN);
+        verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, EMAIL_UPDATED);
     }
 
     @Test
@@ -130,11 +123,7 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
-                .sendEmail(
-                        TEST_EMAIL_ADDRESS,
-                        personalisation,
-                        PASSWORD_UPDATED,
-                        SupportedLanguage.EN);
+                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, PASSWORD_UPDATED);
     }
 
     @Test
@@ -153,11 +142,7 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
-                .sendEmail(
-                        TEST_EMAIL_ADDRESS,
-                        personalisation,
-                        PHONE_NUMBER_UPDATED,
-                        SupportedLanguage.EN);
+                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, PHONE_NUMBER_UPDATED);
     }
 
     @Test
@@ -175,9 +160,7 @@ public class NotificationHandlerTest {
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
-        verify(notificationService)
-                .sendEmail(
-                        TEST_EMAIL_ADDRESS, personalisation, DELETE_ACCOUNT, SupportedLanguage.EN);
+        verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, DELETE_ACCOUNT);
     }
 
     @Test
@@ -211,7 +194,7 @@ public class NotificationHandlerTest {
 
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
-                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL, SupportedLanguage.EN);
+                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL);
 
         RuntimeException exception =
                 assertThrows(
@@ -238,11 +221,7 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
-                .sendText(
-                        TEST_PHONE_NUMBER,
-                        personalisation,
-                        VERIFY_PHONE_NUMBER,
-                        SupportedLanguage.EN);
+                .sendText(TEST_PHONE_NUMBER, personalisation, VERIFY_PHONE_NUMBER);
 
         RuntimeException exception =
                 assertThrows(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/NotificationServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/NotificationServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.accountmanagement.services;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.entity.NotificationType;
-import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -32,10 +31,7 @@ class NotificationServiceTest {
         emailPersonalisation.put("email-address", TEST_EMAIL);
 
         notificationService.sendEmail(
-                TEST_EMAIL,
-                emailPersonalisation,
-                NotificationType.EMAIL_UPDATED,
-                SupportedLanguage.EN);
+                TEST_EMAIL, emailPersonalisation, NotificationType.EMAIL_UPDATED);
 
         verify(notificationClient).sendEmail("123456", TEST_EMAIL, emailPersonalisation, "");
     }
@@ -47,10 +43,7 @@ class NotificationServiceTest {
         Map<String, Object> phonePersonalisation = new HashMap<>();
         phonePersonalisation.put("validation-code", "some-code");
         notificationService.sendText(
-                TEST_PHONE_NUMBER,
-                phonePersonalisation,
-                NotificationType.PHONE_NUMBER_UPDATED,
-                SupportedLanguage.EN);
+                TEST_PHONE_NUMBER, phonePersonalisation, NotificationType.PHONE_NUMBER_UPDATED);
 
         verify(notificationClient).sendSms("567890", TEST_PHONE_NUMBER, phonePersonalisation, "");
     }

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -180,12 +180,11 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   }
   environment {
     variables = merge(var.notify_template_map, {
-      FRONTEND_BASE_URL            = "https://${local.frontend_fqdn}/"
-      CONTACT_US_LINK_ROUTE        = var.contact_us_link_route
-      NOTIFY_API_KEY               = var.notify_api_key
-      NOTIFY_URL                   = var.notify_url
-      NOTIFY_TEMPLATE_PER_LANGUAGE = var.notify_template_per_language
-      JAVA_TOOL_OPTIONS            = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+      FRONTEND_BASE_URL     = "https://${local.frontend_fqdn}/"
+      CONTACT_US_LINK_ROUTE = var.contact_us_link_route
+      NOTIFY_API_KEY        = var.notify_api_key
+      NOTIFY_URL            = var.notify_url
+      JAVA_TOOL_OPTIONS     = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     })
   }
   kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -14,11 +14,6 @@ variable "notify_url" {
   default = null
 }
 
-variable "notify_template_per_language" {
-  default = false
-  type    = bool
-}
-
 variable "notify_template_map" {
   type = map(string)
   default = {

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -172,18 +172,17 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   }
   environment {
     variables = merge(var.notify_template_map, {
-      FRONTEND_BASE_URL            = "https://${local.frontend_fqdn}/"
-      ACCOUNT_MANAGEMENT_URI       = "https://${local.account_management_fqdn}/"
-      RESET_PASSWORD_ROUTE         = var.reset_password_route
-      CONTACT_US_LINK_ROUTE        = var.contact_us_link_route
-      GOV_UK_ACCOUNTS_URL          = var.gov_uk_accounts_url
-      NOTIFY_API_KEY               = var.notify_api_key
-      NOTIFY_URL                   = var.notify_url
-      NOTIFY_TEST_DESTINATIONS     = var.notify_test_destinations
-      NOTIFY_TEMPLATE_PER_LANGUAGE = var.notify_template_per_language
-      SMOKETEST_SMS_BUCKET_NAME    = local.sms_bucket_name
-      JAVA_TOOL_OPTIONS            = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
-      ENVIRONMENT                  = var.environment
+      FRONTEND_BASE_URL         = "https://${local.frontend_fqdn}/"
+      ACCOUNT_MANAGEMENT_URI    = "https://${local.account_management_fqdn}/"
+      RESET_PASSWORD_ROUTE      = var.reset_password_route
+      CONTACT_US_LINK_ROUTE     = var.contact_us_link_route
+      GOV_UK_ACCOUNTS_URL       = var.gov_uk_accounts_url
+      NOTIFY_API_KEY            = var.notify_api_key
+      NOTIFY_URL                = var.notify_url
+      NOTIFY_TEST_DESTINATIONS  = var.notify_test_destinations
+      SMOKETEST_SMS_BUCKET_NAME = local.sms_bucket_name
+      JAVA_TOOL_OPTIONS         = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+      ENVIRONMENT               = var.environment
     })
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -494,11 +494,6 @@ variable "language_cy_enabled" {
   type    = bool
 }
 
-variable "notify_template_per_language" {
-  default = false
-  type    = bool
-}
-
 variable "extended_feature_flags_enabled" {
   default = false
   type    = bool

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -138,16 +138,10 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
 
             if (request.getNotificationType().isEmail()) {
                 notificationService.sendEmail(
-                        request.getDestination(),
-                        personalisation,
-                        request.getNotificationType(),
-                        request.getLanguage());
+                        request.getDestination(), personalisation, request.getNotificationType());
             } else {
                 notificationService.sendText(
-                        request.getDestination(),
-                        personalisation,
-                        request.getNotificationType(),
-                        request.getLanguage());
+                        request.getDestination(), personalisation, request.getNotificationType());
             }
             writeTestClientOtpToS3(
                     request.getNotificationType(), request.getCode(), request.getDestination());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -86,8 +86,7 @@ public class NotificationHandlerTest {
         personalisation.put("email-address", notifyRequest.getDestination());
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
-        verify(notificationService)
-                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL, SupportedLanguage.EN);
+        verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL);
     }
 
     @Test
@@ -106,11 +105,7 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
-                .sendEmail(
-                        TEST_EMAIL_ADDRESS,
-                        personalisation,
-                        PASSWORD_RESET_CONFIRMATION,
-                        SupportedLanguage.EN);
+                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, PASSWORD_RESET_CONFIRMATION);
     }
 
     @Test
@@ -127,11 +122,7 @@ public class NotificationHandlerTest {
         Map<String, Object> personalisation = Map.of("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
-                .sendText(
-                        TEST_PHONE_NUMBER,
-                        personalisation,
-                        PASSWORD_RESET_CONFIRMATION_SMS,
-                        SupportedLanguage.EN);
+                .sendText(TEST_PHONE_NUMBER, personalisation, PASSWORD_RESET_CONFIRMATION_SMS);
     }
 
     @Test
@@ -156,11 +147,7 @@ public class NotificationHandlerTest {
         personalisation.put("gov-uk-accounts-url", govUKAccountsUrl.toString());
 
         verify(notificationService)
-                .sendEmail(
-                        TEST_EMAIL_ADDRESS,
-                        personalisation,
-                        ACCOUNT_CREATED_CONFIRMATION,
-                        SupportedLanguage.EN);
+                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, ACCOUNT_CREATED_CONFIRMATION);
     }
 
     @Test
@@ -178,11 +165,7 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(
-                        notifyRequest.getDestination(),
-                        personalisation,
-                        VERIFY_PHONE_NUMBER,
-                        SupportedLanguage.EN);
+                .sendText(notifyRequest.getDestination(), personalisation, VERIFY_PHONE_NUMBER);
     }
 
     @Test
@@ -230,7 +213,7 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
-                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL, SupportedLanguage.EN);
+                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL);
 
         RuntimeException exception =
                 assertThrows(
@@ -256,11 +239,7 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
-                .sendText(
-                        TEST_PHONE_NUMBER,
-                        personalisation,
-                        VERIFY_PHONE_NUMBER,
-                        SupportedLanguage.EN);
+                .sendText(TEST_PHONE_NUMBER, personalisation, VERIFY_PHONE_NUMBER);
 
         RuntimeException exception =
                 assertThrows(
@@ -288,11 +267,7 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(
-                        notifyRequest.getDestination(),
-                        personalisation,
-                        VERIFY_PHONE_NUMBER,
-                        SupportedLanguage.EN);
+                .sendText(notifyRequest.getDestination(), personalisation, VERIFY_PHONE_NUMBER);
         var putObjectRequest =
                 PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
         verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
@@ -312,11 +287,7 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(
-                        notifyRequest.getDestination(),
-                        personalisation,
-                        MFA_SMS,
-                        SupportedLanguage.EN);
+                .sendText(notifyRequest.getDestination(), personalisation, MFA_SMS);
     }
 
     @Test
@@ -333,11 +304,7 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(
-                        notifyRequest.getDestination(),
-                        personalisation,
-                        MFA_SMS,
-                        SupportedLanguage.EN);
+                .sendText(notifyRequest.getDestination(), personalisation, MFA_SMS);
         var putObjectRequest =
                 PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
         verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
@@ -364,8 +331,7 @@ public class NotificationHandlerTest {
                 .sendEmail(
                         notifyRequest.getDestination(),
                         personalisation,
-                        ACCOUNT_CREATED_CONFIRMATION,
-                        SupportedLanguage.EN);
+                        ACCOUNT_CREATED_CONFIRMATION);
         var putObjectRequest =
                 PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
         verify(s3Client, times(0)).putObject(eq(putObjectRequest), any(RequestBody.class));
@@ -392,11 +358,7 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
-                .sendEmail(
-                        TEST_EMAIL_ADDRESS,
-                        personalisation,
-                        RESET_PASSWORD_WITH_CODE,
-                        SupportedLanguage.EN);
+                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, RESET_PASSWORD_WITH_CODE);
     }
 
     @Test
@@ -419,10 +381,7 @@ public class NotificationHandlerTest {
 
         verify(notificationService)
                 .sendEmail(
-                        TEST_EMAIL_ADDRESS,
-                        personalisation,
-                        VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
-                        SupportedLanguage.EN);
+                        TEST_EMAIL_ADDRESS, personalisation, VERIFY_CHANGE_HOW_GET_SECURITY_CODES);
     }
 
     private String buildContactUsUrl() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.frontendapi.services;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.entity.TemplateAware;
-import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.service.notify.NotificationClient;
@@ -29,12 +28,7 @@ class NotificationServiceTest {
         FAKE_EMAIL,
         FAKE_SMS;
 
-        public String getTemplateId() {
-            return name();
-        }
-
-        public String getTemplateId(
-                SupportedLanguage language, ConfigurationService configurationService) {
+        public String getTemplateId(ConfigurationService configurationService) {
             return name();
         }
     }
@@ -45,8 +39,7 @@ class NotificationServiceTest {
         emailPersonalisation.put("validation-code", "some-code");
         emailPersonalisation.put("email-address", TEST_EMAIL);
 
-        notificationService.sendEmail(
-                TEST_EMAIL, emailPersonalisation, FAKE_EMAIL, SupportedLanguage.EN);
+        notificationService.sendEmail(TEST_EMAIL, emailPersonalisation, FAKE_EMAIL);
 
         verify(notificationClient).sendEmail("FAKE_EMAIL", TEST_EMAIL, emailPersonalisation, "");
     }
@@ -55,8 +48,7 @@ class NotificationServiceTest {
     public void shouldCallNotifyClientToSendText() throws NotificationClientException {
         Map<String, Object> phonePersonalisation = new HashMap<>();
         phonePersonalisation.put("validation-code", "some-code");
-        notificationService.sendText(
-                TEST_PHONE_NUMBER, phonePersonalisation, FAKE_SMS, SupportedLanguage.EN);
+        notificationService.sendText(TEST_PHONE_NUMBER, phonePersonalisation, FAKE_SMS);
 
         verify(notificationClient).sendSms("FAKE_SMS", TEST_PHONE_NUMBER, phonePersonalisation, "");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/NotificationType.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/NotificationType.java
@@ -69,14 +69,7 @@ public enum NotificationType implements TemplateAware {
 
     public String getTemplateId(
             SupportedLanguage language, ConfigurationService configurationService) {
-        String templateId = configurationService.getNotifyTemplateId(getTemplateName(language));
-        if (!configurationService.isNotifyTemplatePerLanguage()
-                || templateId == null
-                || templateId.length() == 0) {
-            return configurationService.getNotifyTemplateId(templateName);
-        } else {
-            return templateId;
-        }
+        return configurationService.getNotifyTemplateId(templateName);
     }
 
     String getTemplateName(SupportedLanguage language) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/NotificationType.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/NotificationType.java
@@ -67,8 +67,7 @@ public enum NotificationType implements TemplateAware {
         this.languageSpecificTemplates = languageSpecificTemplates;
     }
 
-    public String getTemplateId(
-            SupportedLanguage language, ConfigurationService configurationService) {
+    public String getTemplateId(ConfigurationService configurationService) {
         return configurationService.getNotifyTemplateId(templateName);
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/TemplateAware.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/TemplateAware.java
@@ -1,8 +1,7 @@
 package uk.gov.di.orchestration.shared.entity;
 
-import uk.gov.di.orchestration.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
 public interface TemplateAware {
-    String getTemplateId(SupportedLanguage language, ConfigurationService configurationService);
+    String getTemplateId(ConfigurationService configurationService);
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -276,10 +276,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         }
     }
 
-    public boolean isNotifyTemplatePerLanguage() {
-        return System.getenv().getOrDefault("NOTIFY_TEMPLATE_PER_LANGUAGE", "false").equals("true");
-    }
-
     public long getIDTokenExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/NotificationTypeTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/NotificationTypeTest.java
@@ -49,9 +49,7 @@ class NotificationTypeTest {
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.EN, configurationService),
-                equalTo("12345"));
+        assertThat(VERIFY_EMAIL.getTemplateId(configurationService), equalTo("12345"));
     }
 
     @Test
@@ -60,9 +58,7 @@ class NotificationTypeTest {
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
-                equalTo("12345"));
+        assertThat(VERIFY_EMAIL.getTemplateId(configurationService), equalTo("12345"));
     }
 
     @Test
@@ -71,8 +67,6 @@ class NotificationTypeTest {
                 .thenReturn("");
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
-                equalTo("12345"));
+        assertThat(VERIFY_EMAIL.getTemplateId(configurationService), equalTo("12345"));
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/NotificationTypeTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/NotificationTypeTest.java
@@ -55,24 +55,11 @@ class NotificationTypeTest {
     }
 
     @Test
-    void shouldReturnCYTemplateForVerifyEmailWhenLanguageCYAndSingleTemplatePerLanguage() {
-        when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID_CY"))
-                .thenReturn("67890");
-        when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
-                .thenReturn("12345");
-        when(configurationService.isNotifyTemplatePerLanguage()).thenReturn(true);
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
-                equalTo("67890"));
-    }
-
-    @Test
     void shouldReturnENTemplateForVerifyEmailWhenLanguageCYAndNotSingleTemplatePerLanguage() {
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID_CY"))
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        when(configurationService.isNotifyTemplatePerLanguage()).thenReturn(false);
         assertThat(
                 VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
                 equalTo("12345"));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/DeliveryReceiptsNotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/DeliveryReceiptsNotificationType.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.shared.entity;
 
-import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 public enum DeliveryReceiptsNotificationType implements TemplateAware {
@@ -50,8 +49,7 @@ public enum DeliveryReceiptsNotificationType implements TemplateAware {
     }
 
     @Override
-    public String getTemplateId(
-            SupportedLanguage language, ConfigurationService configurationService) {
+    public String getTemplateId(ConfigurationService configurationService) {
         return null;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -78,8 +78,7 @@ public enum NotificationType implements TemplateAware {
         this.languageSpecificTemplates = languageSpecificTemplates;
     }
 
-    public String getTemplateId(
-            SupportedLanguage language, ConfigurationService configurationService) {
+    public String getTemplateId(ConfigurationService configurationService) {
         return configurationService.getNotifyTemplateId(templateName);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -80,14 +80,7 @@ public enum NotificationType implements TemplateAware {
 
     public String getTemplateId(
             SupportedLanguage language, ConfigurationService configurationService) {
-        String templateId = configurationService.getNotifyTemplateId(getTemplateName(language));
-        if (!configurationService.isNotifyTemplatePerLanguage()
-                || templateId == null
-                || templateId.length() == 0) {
-            return configurationService.getNotifyTemplateId(templateName);
-        } else {
-            return templateId;
-        }
+        return configurationService.getNotifyTemplateId(templateName);
     }
 
     String getTemplateName(SupportedLanguage language) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/TemplateAware.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/TemplateAware.java
@@ -1,8 +1,7 @@
 package uk.gov.di.authentication.shared.entity;
 
-import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 public interface TemplateAware {
-    String getTemplateId(SupportedLanguage language, ConfigurationService configurationService);
+    String getTemplateId(ConfigurationService configurationService);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -350,10 +350,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         }
     }
 
-    public boolean isNotifyTemplatePerLanguage() {
-        return System.getenv().getOrDefault("NOTIFY_TEMPLATE_PER_LANGUAGE", "false").equals("true");
-    }
-
     public long getIDTokenExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.shared.services;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.TemplateAware;
-import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -22,28 +21,16 @@ public class NotificationService {
         this.configurationService = configurationService;
     }
 
-    public void sendEmail(
-            String email,
-            Map<String, Object> personalisation,
-            TemplateAware type,
-            SupportedLanguage userLanguage)
+    public void sendEmail(String email, Map<String, Object> personalisation, TemplateAware type)
             throws NotificationClientException {
-        LOG.trace("sendEmail language {}", userLanguage);
         notifyClient.sendEmail(
-                type.getTemplateId(userLanguage, configurationService), email, personalisation, "");
+                type.getTemplateId(configurationService), email, personalisation, "");
     }
 
     public void sendText(
-            String phoneNumber,
-            Map<String, Object> personalisation,
-            TemplateAware type,
-            SupportedLanguage userLanguage)
+            String phoneNumber, Map<String, Object> personalisation, TemplateAware type)
             throws NotificationClientException {
-        LOG.trace("sendText language {}", userLanguage);
         notifyClient.sendSms(
-                type.getTemplateId(userLanguage, configurationService),
-                phoneNumber,
-                personalisation,
-                "");
+                type.getTemplateId(configurationService), phoneNumber, personalisation, "");
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/NotificationTypeTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/NotificationTypeTest.java
@@ -48,9 +48,7 @@ class NotificationTypeTest {
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.EN, configurationService),
-                equalTo("12345"));
+        assertThat(VERIFY_EMAIL.getTemplateId(configurationService), equalTo("12345"));
     }
 
     @Test
@@ -59,9 +57,7 @@ class NotificationTypeTest {
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
-                equalTo("12345"));
+        assertThat(VERIFY_EMAIL.getTemplateId(configurationService), equalTo("12345"));
     }
 
     @Test
@@ -70,8 +66,6 @@ class NotificationTypeTest {
                 .thenReturn("");
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
-                equalTo("12345"));
+        assertThat(VERIFY_EMAIL.getTemplateId(configurationService), equalTo("12345"));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/NotificationTypeTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/NotificationTypeTest.java
@@ -54,24 +54,11 @@ class NotificationTypeTest {
     }
 
     @Test
-    void shouldReturnCYTemplateForVerifyEmailWhenLanguageCYAndSingleTemplatePerLanguage() {
-        when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID_CY"))
-                .thenReturn("67890");
-        when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
-                .thenReturn("12345");
-        when(configurationService.isNotifyTemplatePerLanguage()).thenReturn(true);
-        assertThat(
-                VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
-                equalTo("67890"));
-    }
-
-    @Test
     void shouldReturnENTemplateForVerifyEmailWhenLanguageCYAndNotSingleTemplatePerLanguage() {
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID_CY"))
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
                 .thenReturn("12345");
-        when(configurationService.isNotifyTemplatePerLanguage()).thenReturn(false);
         assertThat(
                 VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
                 equalTo("12345"));

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
@@ -9,7 +9,6 @@ import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
 import uk.gov.di.authentication.shared.entity.BulkEmailUserSendMode;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.helpers.LocaleHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
@@ -190,11 +189,7 @@ public class BulkUserEmailSenderScheduledEventHandler
     private boolean sendNotifyEmail(String email) throws NotificationClientException {
         if (configurationService.isBulkUserEmailEmailSendingEnabled()) {
             LOG.info("Bulk user email sending email.");
-            notificationService.sendEmail(
-                    email,
-                    Map.of(),
-                    TERMS_AND_CONDITIONS_BULK_EMAIL,
-                    LocaleHelper.SupportedLanguage.EN);
+            notificationService.sendEmail(email, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
             return true;
         } else {
             LOG.info("Bulk user email email sending not enabled.");

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
@@ -11,7 +11,6 @@ import uk.gov.di.authentication.shared.entity.BulkEmailUser;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.helpers.LocaleHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -138,11 +137,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
 
         verify(notificationService, times(1))
-                .sendEmail(
-                        EMAIL,
-                        Map.of(),
-                        TERMS_AND_CONDITIONS_BULK_EMAIL,
-                        LocaleHelper.SupportedLanguage.EN);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.EMAIL_SENT);
         verify(auditService)
@@ -185,11 +180,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
 
         verify(notificationService, times(0))
-                .sendEmail(
-                        EMAIL,
-                        Map.of(),
-                        TERMS_AND_CONDITIONS_BULK_EMAIL,
-                        LocaleHelper.SupportedLanguage.EN);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.EMAIL_SENT);
         verify(auditService, never())
@@ -237,11 +228,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
 
         verify(notificationService, times(0))
-                .sendEmail(
-                        EMAIL,
-                        Map.of(),
-                        TERMS_AND_CONDITIONS_BULK_EMAIL,
-                        LocaleHelper.SupportedLanguage.EN);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.TERMS_ACCEPTED_RECENTLY);
         verify(auditService, never())
@@ -291,11 +278,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
                     ClientSubjectHelper.calculatePairwiseIdentifier(
                             TEST_SUBJECT_IDS[j], "test.account.gov.uk", SALT);
             verify(notificationService, times(1))
-                    .sendEmail(
-                            TEST_EMAILS[j],
-                            Map.of(),
-                            TERMS_AND_CONDITIONS_BULK_EMAIL,
-                            LocaleHelper.SupportedLanguage.EN);
+                    .sendEmail(TEST_EMAILS[j], Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
             verify(bulkEmailUsersService, times(1))
                     .updateUserStatus(TEST_SUBJECT_IDS[j], BulkEmailStatus.EMAIL_SENT);
             verify(auditService)
@@ -332,11 +315,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
 
         verify(notificationService, times(0))
-                .sendEmail(
-                        EMAIL,
-                        Map.of(),
-                        TERMS_AND_CONDITIONS_BULK_EMAIL,
-                        LocaleHelper.SupportedLanguage.EN);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.ACCOUNT_NOT_FOUND);
         verifyNoInteractions(auditService);
@@ -352,11 +331,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
                 .thenReturn(Optional.of(new UserProfile().withEmail(EMAIL)));
         doThrow(NotificationClientException.class)
                 .when(notificationService)
-                .sendEmail(
-                        EMAIL,
-                        Map.of(),
-                        TERMS_AND_CONDITIONS_BULK_EMAIL,
-                        LocaleHelper.SupportedLanguage.EN);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
         when(bulkEmailUsersService.updateUserStatus(
                         SUBJECT_ID, BulkEmailStatus.ERROR_SENDING_EMAIL))
                 .thenReturn(
@@ -368,11 +343,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
 
         verify(notificationService, times(1))
-                .sendEmail(
-                        EMAIL,
-                        Map.of(),
-                        TERMS_AND_CONDITIONS_BULK_EMAIL,
-                        LocaleHelper.SupportedLanguage.EN);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.ERROR_SENDING_EMAIL);
         verifyNoInteractions(auditService);
@@ -409,11 +380,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         verify(bulkEmailUsersService, never())
                 .getNSubjectIdsByStatus(anyInt(), eq(BulkEmailStatus.PENDING));
         verify(notificationService, times(1))
-                .sendEmail(
-                        EMAIL,
-                        Map.of(),
-                        TERMS_AND_CONDITIONS_BULK_EMAIL,
-                        LocaleHelper.SupportedLanguage.EN);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.EMAIL_SENT);
     }
@@ -451,11 +418,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
 
         verify(bulkEmailUsersService, never()).getNSubjectIdsByStatus(anyInt(), any());
         verify(notificationService, times(1))
-                .sendEmail(
-                        EMAIL,
-                        Map.of(),
-                        TERMS_AND_CONDITIONS_BULK_EMAIL,
-                        LocaleHelper.SupportedLanguage.EN);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.RETRY_EMAIL_SENT);
     }


### PR DESCRIPTION
## What

cleanup of unused feature flag **isNotifyTemplatePerLanguage**. There are 2 commits. The first removes the dependency on the feature flag. The second is subsequent cleanup of language dependent template ids that we may or may not want to keep for additional language support in future.

## How to review

Code Review

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

- [x] Impact on orch and auth mutual dependencies has been checked.
