### PR TITLE
Aut 1506: Fix create account smoke test in production and sandpit

### DIFF
--- a/ci/terraform/test-services/build.tfvars
+++ b/ci/terraform/test-services/build.tfvars
@@ -1,5 +1,4 @@
 logging_endpoint_arn              = ""
 logging_endpoint_arns             = []
 shared_state_bucket               = "digital-identity-dev-tfstate"
-synthetics_users                  = ""
 test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"

--- a/ci/terraform/test-services/dev.tfvars
+++ b/ci/terraform/test-services/dev.tfvars
@@ -1,5 +1,4 @@
 logging_endpoint_arn              = ""
 logging_endpoint_arns             = []
 shared_state_bucket               = "di-auth-development-tfstate"
-synthetics_users                  = ""
 test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"

--- a/ci/terraform/test-services/production.tfvars
+++ b/ci/terraform/test-services/production.tfvars
@@ -1,5 +1,4 @@
 logging_endpoint_arn              = ""
 logging_endpoint_arns             = []
 shared_state_bucket               = "digital-identity-prod-tfstate"
-synthetics_users                  = ""
 test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"

--- a/ci/terraform/test-services/sandpit.tfvars
+++ b/ci/terraform/test-services/sandpit.tfvars
@@ -1,7 +1,5 @@
 environment         = "sandpit"
 shared_state_bucket = "digital-identity-dev-tfstate"
 
-synthetics_users = "any.user@digital.cabinet-office.gov.uk"
-
 logging_endpoint_enabled = false
 logging_endpoint_arns    = []

--- a/ci/terraform/test-services/staging.tfvars
+++ b/ci/terraform/test-services/staging.tfvars
@@ -1,5 +1,4 @@
 logging_endpoint_arn              = ""
 logging_endpoint_arns             = []
 shared_state_bucket               = "di-auth-staging-tfstate"
-synthetics_users                  = ""
 test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"


### PR DESCRIPTION
## What

This removes tfvars for synthetics users, which were overriding a value set in secrets, and causing the create account smoke test to fail. The test was failing as it it depends on deleting the synthetics user. At the moment, due to the overriding value being empty, we don't set a synthetics user, meaning that the request to the test services api 404s (there is no user set in the environment variable to delete). This causes the smoke tests to fail as we attempt to create an account as a user where we have not deleted their account first.

Note that this variable is set as a secret for sandpit, build and production. Staging does not have the variable, but smoke tests are not run in this environment and it's OK therefore for it to default to this empty string.

The equivalent change has worked for integration.