### PR TITLE
ATO-413: Remove Usage SUPPORT_AUTH_ORCH_SPLIT - Auth - TokenHandler

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
@@ -71,7 +71,7 @@ public class TokenHandler
     public TokenHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
         this.authorisationCodeService = new DynamoAuthCodeService(configurationService);
-        this.accessTokenStoreService = new AccessTokenService(configurationService);
+        this.accessTokenStoreService = new AccessTokenService(configurationService, true);
         this.tokenUtilityService = new TokenService();
 
         String orchestratorCallbackRedirectUri =

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -35,7 +35,6 @@ module "auth_token" {
     ORCH_CLIENT_ID                            = var.orch_client_id
     AUTHENTICATION_BACKEND_URI                = "https://${aws_api_gateway_rest_api.di_auth_ext_api.id}-${data.aws_vpc_endpoint.auth_api_vpc_endpoint.id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
     ORCH_TO_AUTH_TOKEN_SIGNING_PUBLIC_KEY     = var.orch_to_auth_public_signing_key
-    SUPPORT_AUTH_ORCH_SPLIT                   = var.support_auth_orch_split
     INTERNAl_SECTOR_URI                       = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.external.lambda.TokenHandler::handleRequest"

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
@@ -220,11 +220,6 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
         }
 
         @Override
-        public boolean isAuthOrchSplitEnabled() {
-            return true;
-        }
-
-        @Override
         public String getTxmaAuditQueueUrl() {
             return txmaAuditQueue.getQueueUrl();
         }


### PR DESCRIPTION
Remove usage of SUPPORT_AUTH_ORCH_SPLIT in Auth TokenHandler
- [x] Impact on orch and auth mutual dependencies has been checked.