### PR TITLE
ATO-411: Remove Usage SUPPORT_AUTH_ORCH_SPLIT- Auth - UserInfo

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -58,7 +58,7 @@ public class UserInfoHandler
         this.configurationService = configurationService;
         this.userInfoService =
                 new UserInfoService(new DynamoService(configurationService), configurationService);
-        this.accessTokenService = new AccessTokenService(configurationService);
+        this.accessTokenService = new AccessTokenService(configurationService, true);
         this.auditService = new AuditService(configurationService);
     }
 

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -25,12 +25,11 @@ module "auth_userinfo" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT             = var.environment
-    TXMA_AUDIT_QUEUE_URL    = module.auth_ext_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT     = null
-    DYNAMO_ENDPOINT         = null
-    INTERNAl_SECTOR_URI     = var.internal_sector_uri
-    SUPPORT_AUTH_ORCH_SPLIT = var.support_auth_orch_split
+    ENVIRONMENT          = var.environment
+    TXMA_AUDIT_QUEUE_URL = module.auth_ext_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT  = null
+    DYNAMO_ENDPOINT      = null
+    INTERNAl_SECTOR_URI  = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.external.lambda.UserInfoHandler::handleRequest"
   handler_runtime       = "java17"

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -58,11 +58,6 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                         configurationParameters) {
 
                     @Override
-                    public boolean isAuthOrchSplitEnabled() {
-                        return true;
-                    }
-
-                    @Override
                     public String getTxmaAuditQueueUrl() {
                         return txmaAuditQueue.getQueueUrl();
                     }


### PR DESCRIPTION
Remove usage of SUPPORT_AUTH_ORCH_SPLIT in Auth UserInfoHandler

- [x] Impact on orch and auth mutual dependencies has been checked.