### PR TITLE
ATO-442: Add support for vpc peering

### DIFF
--- a/ci/stack-orchestration/configuration/dev/vpc/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/vpc/parameters.json
@@ -2,5 +2,9 @@
   {
     "ParameterKey": "DynatraceApiEnabled",
     "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "10.1.0.0/16"
   }
 ]

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -766,5 +766,5 @@ resource "aws_api_gateway_integration" "orch_openid_configuration_integration" {
   ]
   type                    = "AWS_PROXY"
   integration_http_method = "POST"
-  uri                     = var.orch_openid_configuration_uri
+  uri                     = "arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-2:${var.orch_account_id}:function:${var.orch_openid_configuration_name}:latest/invocations"
 }

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -34,6 +34,6 @@ orch_redirect_uri                  = "https://oidc.build.account.gov.uk/orchestr
 authorize_protected_subnet_enabled = true
 
 orch_backend_api_gateway_integration_enabled = false
-orch_openid_configuration_uri                = "arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-2:767397776536:function:build-orch-be-deploy-OpenIdConfigurationFunction-EROoeGPLtVmV:latest/invocations"
+orch_openid_configuration_name               = "build-orch-be-deploy-OpenIdConfigurationFunction-EROoeGPLtVmV"
 
 orch_account_id = "767397776536"

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -60,6 +60,6 @@ authorize_protected_subnet_enabled = true
 support_email_check_enabled = true
 
 orch_backend_api_gateway_integration_enabled = true
-orch_openid_configuration_uri                = "arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-2:767397776536:function:build-orch-be-deploy-OpenIdConfigurationFunction-EROoeGPLtVmV:latest/invocations"
+orch_openid_configuration_name               = "dev-orch-be-deploy-OpenIdConfigurationFunction-5vYKOtKeTBRw"
 
 orch_account_id = "816047645251"

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -15,6 +15,6 @@ lockout_duration                           = 60
 reduced_lockout_duration                   = 30
 
 orch_backend_api_gateway_integration_enabled = false
-orch_openid_configuration_uri                = "arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-2:590183975515:function:staging-orch-be-deploy-OpenIdConfigurationFunction-wWh577dlDcFl:latest/invocations"
+orch_openid_configuration_name               = "staging-orch-be-deploy-OpenIdConfigurationFunction-wWh577dlDcFl"
 
 orch_account_id = "590183975515"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -523,7 +523,7 @@ variable "orch_backend_api_gateway_integration_enabled" {
   default     = false
 }
 
-variable "orch_openid_configuration_uri" {
+variable "orch_openid_configuration_name" {
   type    = string
   default = ""
 }


### PR DESCRIPTION
## What

- Change orch vpc cidr block
- Update api-gateway terraform to use new orch vars

Click-ops for orch side can be found at:
https://govukverify.atlassian.net/wiki/spaces/Orch/pages/4097867900/Enabling+vpc-peering|

## How to review

Ensure orch account id's and vpc-id's are corrrect
Ensure feature flag is correctly set

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

[580](https://github.com/alphagov/di-infrastructure/pull/580)
This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
