### PR TITLE
ATO-481: Add `auditLevel` field to AIS response pact 

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/contract/AccountInterventionServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/contract/AccountInterventionServiceTest.java
@@ -374,6 +374,7 @@ class AccountInterventionServiceTest {
                                         obj.booleanValue("reproveIdentity", reproveIdentity);
                                         obj.booleanValue("resetPassword", resetPassword);
                                     });
+                            body.stringValue("auditLevel", "standard");
                         })
                 .build();
     }


### PR DESCRIPTION
## What

Add `auditLevel` field to AIS response pact (on request from Bravo team).

## How to review

1. Code review only

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs
PR where contract tests were introduced: https://github.com/govuk-one-login/authentication-api/pull/4131
