### PR TITLE
ATO-520: Add CloudWatch alarms for TxMA failures

### DIFF
--- a/ci/stack-orchestration/manual-stacks/txma/template.yml
+++ b/ci/stack-orchestration/manual-stacks/txma/template.yml
@@ -81,6 +81,46 @@ Resources:
         - Key: 'ProducerType'
           Value: 'SQS'
 
+  TxMAAuditEventQueueMessageAgeCloudWatchAlarm:
+    Condition: TxMAIntegrationEnabled
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: txma-audit-event-queue-message-age-alarm
+      AlarmDescription: !Sub "${AWS::StackName}-AuditEventQueue contains message(s) older than 24 hours which means TxMA is failing to ingest events. ACCOUNT: di-orchestration-${Environment}."
+      Namespace: AWS/SQS
+      MetricName: ApproximateAgeOfOldestMessage
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt TxMASQSProducerAuditEventQueue.QueueName
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 86400 # 24 hours in seconds
+      EvaluationPeriods: 1
+      Period: 60
+      Statistic: Maximum
+      AlarmActions:
+        - !ImportValue
+          'Fn::Sub': '${Environment}-orch-be-deploy-SlackEventsArn'
+
+  TxMADeadLetterQueueCloudWatchAlarm:
+    Condition: TxMAIntegrationEnabled
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: txma-dead-letter-queue-alarm
+      AlarmDescription: !Sub "${AWS::StackName}-AuditEventDeadLetterQueue contains message(s) which means they have been rejected by TxMA. ACCOUNT: di-orchestration-${Environment}."
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt TxMAAuditEventDeadLetterQueue.QueueName
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      EvaluationPeriods: 1
+      Period: 60
+      Statistic: Maximum
+      AlarmActions:
+        - !ImportValue
+          'Fn::Sub': '${Environment}-orch-be-deploy-SlackEventsArn'
+
   TxMASQSProducerAuditEventQueueEncryptionKey:
     Type: AWS::KMS::Key
     Properties:

--- a/ci/stack-orchestration/manual-stacks/txma/template.yml
+++ b/ci/stack-orchestration/manual-stacks/txma/template.yml
@@ -98,8 +98,7 @@ Resources:
       Period: 60
       Statistic: Maximum
       AlarmActions:
-        - !ImportValue
-          'Fn::Sub': '${Environment}-orch-be-deploy-SlackEventsArn'
+        - !ImportValue '${Environment}-orch-be-deploy-SlackEventsArn'
 
   TxMADeadLetterQueueCloudWatchAlarm:
     Condition: TxMAIntegrationEnabled
@@ -118,8 +117,7 @@ Resources:
       Period: 60
       Statistic: Maximum
       AlarmActions:
-        - !ImportValue
-          'Fn::Sub': '${Environment}-orch-be-deploy-SlackEventsArn'
+        - !ImportValue '${Environment}-orch-be-deploy-SlackEventsArn'
 
   TxMASQSProducerAuditEventQueueEncryptionKey:
     Type: AWS::KMS::Key

--- a/template.yaml
+++ b/template.yaml
@@ -537,3 +537,10 @@ Resources:
     Properties:
       TopicName: !Sub ${Environment}-slack-events
       KmsMasterKeyId: !GetAtt MainKmsKey.Arn
+
+Outputs:
+  SlackEventsArn:
+    Description: 'ARN of the SlackEvents SNS topic'
+    Value: !Ref SlackEvents
+    Export:
+      Name: !Sub '${AWS::StackName}-SlackEventsArn'


### PR DESCRIPTION
## What
Add alarms based on the guidance from TxMA in their [onboarding documentation](https://govukverify.atlassian.net/wiki/spaces/TMA/pages/3603661028/2.+How+to+provision+the+infrastructure+on+your+end+and+understand+what+work+needs+to+happen+between+TxMA+and+your+team#Monitoring-and-Alerting)
- An alarm is triggered when there is at least one message in the audit queue for over 24 hours
- An alarm is triggered when there is at least one message in the dead letter queue at any time

Output the SlackEvents SNS topic ARN from the `{env}-orch-be-deploy` stack so it can be used in the `orchestration-{env}-txma` stack

The alarms are only provisioned in environments where TxMA ingest messages from the queue (staging, integration, and production).

## Testing
The alarms have been tested in the dev environment with dummy messages. Slack integration has not been tested.

## How to review

- Code review only

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs
PR that added TxMA infrastructure: https://github.com/govuk-one-login/authentication-api/pull/4199