### PR TITLE
ATO-511: Add DNS records for the origin oidc domain

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -307,6 +307,13 @@ resource "aws_api_gateway_base_path_mapping" "api" {
   domain_name = local.oidc_api_fqdn
 }
 
+resource "aws_api_gateway_base_path_mapping" "api_origin" {
+  count       = var.oidc_origin_domain_enabled ? 1 : 0
+  api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  stage_name  = aws_api_gateway_stage.endpoint_stage.stage_name
+  domain_name = local.oidc_origin_api_fqdn
+}
+
 module "dashboard" {
   source           = "../modules/dashboards"
   api_gateway_name = aws_api_gateway_rest_api.di_authentication_api.name

--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -60,3 +60,5 @@ orch_redirect_uri = "https://oidc.authdev1.sandpit.account.gov.uk/orchestration-
 authorize_protected_subnet_enabled = true
 
 support_email_check_enabled = true
+
+oidc_origin_domain_enabled = true

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -56,3 +56,6 @@ orch_redirect_uri                  = "https://oidc.authdev2.sandpit.account.gov.
 authorize_protected_subnet_enabled = true
 
 support_email_check_enabled = true
+
+
+oidc_origin_domain_enabled = true

--- a/ci/terraform/oidc/dns.tf
+++ b/ci/terraform/oidc/dns.tf
@@ -9,6 +9,7 @@ locals {
   frontend_fqdn               = "signin.${local.service_domain}"
   frontend_api_fqdn           = "auth.${local.service_domain}"
   oidc_api_fqdn               = "oidc.${local.service_domain}"
+  oidc_origin_api_fqdn        = "origin.${local.oidc_api_fqdn}"
 }
 
 # TODO: delete
@@ -99,6 +100,64 @@ resource "aws_route53_record" "oidc_api" {
 
 output "oidc_api_name_servers" {
   value = aws_route53_zone.oidc_api_zone.name_servers
+}
+
+resource "aws_acm_certificate" "oidc_origin_api" {
+  count             = var.oidc_origin_domain_enabled ? 1 : 0
+  domain_name       = local.oidc_origin_api_fqdn
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "oidc_origin_api_certificate_validation" {
+  for_each = var.oidc_origin_domain_enabled ? {
+    for dvo in aws_acm_certificate.oidc_origin_api[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.oidc_api_zone.zone_id
+}
+
+resource "aws_acm_certificate_validation" "oidc_origin_api" {
+  count                   = var.oidc_origin_domain_enabled ? 1 : 0
+  certificate_arn         = aws_acm_certificate.oidc_origin_api[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.oidc_origin_api_certificate_validation : record.fqdn]
+}
+
+resource "aws_api_gateway_domain_name" "oidc_origin_api" {
+  count                    = var.oidc_origin_domain_enabled ? 1 : 0
+  regional_certificate_arn = aws_acm_certificate_validation.oidc_origin_api[0].certificate_arn
+  domain_name              = local.oidc_origin_api_fqdn
+
+  security_policy = "TLS_1_2"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
+resource "aws_route53_record" "oidc_origin_api" {
+  count   = var.oidc_origin_domain_enabled ? 1 : 0
+  name    = local.oidc_origin_api_fqdn
+  type    = "A"
+  zone_id = aws_route53_zone.oidc_api_zone.zone_id
+
+  alias {
+    evaluate_target_health = true
+    name                   = aws_api_gateway_domain_name.oidc_origin_api[0].regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.oidc_origin_api[0].regional_zone_id
+  }
 }
 
 resource "aws_route53_zone" "frontend_api_zone" {

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -70,3 +70,5 @@ orch_account_id                                  = "816047645251"
 back_channel_logout_cross_account_access_enabled = true
 kms_cross_account_access_enabled                 = true
 cmk_for_back_channel_logout_enabled              = true
+
+oidc_origin_domain_enabled = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -611,6 +611,12 @@ variable "kms_cross_account_access_enabled" {
   description = "Whether the service should allow cross-account access by the orchestration account to kms"
 }
 
+variable "oidc_origin_domain_enabled" {
+  type        = bool
+  default     = false
+  description = "Feature flag to control the creation of DNS records for the origin.oidc domain"
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What
Add DNS for origin.oidc domain. This is needed for cloudfront

## How to review
Ensure all resources feature flagged

