### PR TITLE
AUT-2488: Create request & response for TICF CRI stub

### DIFF
--- a/ticf-cri-stub/build.gradle
+++ b/ticf-cri-stub/build.gradle
@@ -9,7 +9,8 @@ version = 'unspecified'
 dependencies {
     compileOnly configurations.lambda
 
-    implementation project(":shared")
+    implementation project(":shared"),
+            configurations.gson
 
     testImplementation configurations.tests,
             configurations.lambda

--- a/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandler.java
+++ b/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandler.java
@@ -4,15 +4,40 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.SerializationService;
+import uk.gov.di.authentication.ticf.cri.stub.lambda.entity.TICFCRIRequest;
+import uk.gov.di.authentication.ticf.cri.stub.lambda.entity.TICFCRIStubResponse;
+
+import java.util.List;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
 public class TICFCRIStubHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
+    private final Json objectMapper = SerializationService.getInstance();
+
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        return generateApiGatewayProxyResponse(200, "Hello world");
+        try {
+            var request = objectMapper.readValue(input.getBody(), TICFCRIRequest.class);
+        } catch (Json.JsonException e) {
+            throw new RuntimeException(e);
+        }
+        String testInternalPairwiseId = "urn:fdc:gov.uk:2022:test";
+        String testJourneyId = "44444444-4444-4444-4444-444444444444";
+        List<String> testCi = List.of("D03", "F01");
+        TICFCRIStubResponse.Intervention testIntervention =
+                new TICFCRIStubResponse.Intervention("01", "01");
+        try {
+            return generateApiGatewayProxyResponse(
+                    200,
+                    new TICFCRIStubResponse(
+                            testIntervention, testInternalPairwiseId, testJourneyId, testCi));
+        } catch (Json.JsonException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/entity/TICFCRIRequest.java
+++ b/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/entity/TICFCRIRequest.java
@@ -1,0 +1,14 @@
+package uk.gov.di.authentication.ticf.cri.stub.lambda.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public record TICFCRIRequest(
+        @Expose @SerializedName("sub") String internalPairwiseId,
+        @Expose @SerializedName("vtr") List<String> vtr,
+        @Expose @SerializedName("govuk_signin_journey_id") String journeyId,
+        @Expose @SerializedName("authenticated") String authenticated,
+        @Expose @SerializedName("initial_registration") String initialRegistration,
+        @Expose @SerializedName("password_reset") String passwordReset) {}

--- a/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/entity/TICFCRIStubResponse.java
+++ b/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/entity/TICFCRIStubResponse.java
@@ -1,0 +1,16 @@
+package uk.gov.di.authentication.ticf.cri.stub.lambda.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public record TICFCRIStubResponse(
+        @Expose @SerializedName("intervention") Intervention intervention,
+        @Expose @SerializedName("sub") String internalPairwiseId,
+        @Expose @SerializedName("govuk_signin_journey_id") String journeyId,
+        @Expose @SerializedName("ci") List<String> ci) {
+    public record Intervention(
+            @Expose @SerializedName("interventionCode") String interventionCode,
+            @Expose @SerializedName("interventionReason") String interventionReason) {}
+}

--- a/ticf-cri-stub/src/test/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandlerTest.java
+++ b/ticf-cri-stub/src/test/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandlerTest.java
@@ -8,14 +8,24 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 class TICFCRIStubHandlerTest {
-    @Test
-    void shouldReturn200ForSuccessfulRequest() {
-        var handler = new TICFCRIStubHandler();
-        var context = mock(Context.class);
-        var event = new APIGatewayProxyRequestEvent();
+    private static final Context context = mock(Context.class);
 
+    @Test
+    void shouldReturn200ForSuccessfulValidRequest() {
+        TICFCRIStubHandler handler = new TICFCRIStubHandler();
+        var event = new APIGatewayProxyRequestEvent();
+        event.setBody(
+                "{\"sub\":\"urn:fdc:gov.uk:2022:test\","
+                        + "\"vtr\":[\"Cl.Cm\"],"
+                        + "\"govuk_signin_journey_id\":\"44444444-4444-4444-4444-444444444444\","
+                        + "\"authenticated\":\"Y\"}\n");
         var result = handler.handleRequest(event, context);
+        String expectedResponse =
+                "{\"intervention\":{\"interventionCode\":\"01\",\"interventionReason\":\"01\"},"
+                        + "\"sub\":\"urn:fdc:gov.uk:2022:test\","
+                        + "\"govuk_signin_journey_id\":\"44444444-4444-4444-4444-444444444444\","
+                        + "\"ci\":[\"D03\",\"F01\"]}";
+        assertEquals(result.getBody(), expectedResponse);
         assertEquals(200, result.getStatusCode());
-        assertEquals("Hello world", result.getBody());
     }
 }


### PR DESCRIPTION
## What

Created request and response classes for the TICF CRI Stub. Also added ability for the handler to to process requests, currently giving back a default response with logic to be implemented in future PRs.

## How to review

1. Code Review
2. Check that the request and response bodies match those outlined in the following links respectively:
https://github.com/govuk-one-login/architecture/blob/main/rfc/0063-auth-ticf-risk-assessment-interface.md#authentication-risk-assessment
and 
https://github.com/govuk-one-login/architecture/blob/main/rfc/0063-auth-ticf-risk-assessment-interface.md#no-interventions-or-warnings-or-has-timed-out
