### PR TITLE
ATO-NONE: Shorten branch name used on pact broker

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -4,7 +4,9 @@ env:
   PACT_USER: ${{ secrets.PACT_USER }}
   PACT_PASSWORD: ${{ secrets.PACT_PASSWORD }}
   PACT_URL: ${{ secrets.PACT_URL }}
-  GIT_BRANCH: ${{ github.head_ref }}
+  # The branch name for a pull request is in a property that only exists on pull request runs. If it doesn't exist
+  # fall back to the branch name property for pushes.
+  GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   CONSUMER_APP_VERSION: ${{ github.event.pull_request.head.sha }}
   PACT_BROKER_SOURCE_HEADER: ${{ secrets.PACT_BROKER_SOURCE_HEADER }}
 


### PR DESCRIPTION
## What

Shorten branch name used on pact broker for better readability

## Related PRs

https://github.com/govuk-one-login/ipv-core-back/pull/1824