### PR TITLE
ATO-NONE: Turn on consumer test upload to the pact broker

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -8,9 +8,16 @@ env:
   CONSUMER_APP_VERSION: ${{ github.event.pull_request.head.sha }}
   PACT_BROKER_SOURCE_HEADER: ${{ secrets.PACT_BROKER_SOURCE_HEADER }}
 
-# Set to workflow_dispatch as we do not want to run these as part of the pre-merge checks at this current point in time
 on:
-  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+  merge_group:
+    # merge main
+    branches: [ main ]
 
 jobs:
   contract-testing:
@@ -33,5 +40,5 @@ jobs:
         if: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
         run: ./gradlew pactPublish
 
-      - name: Verify pacts
-        run: ./gradlew pactProviderTests
+#      - name: Verify pacts
+#        run: ./gradlew pactProviderTests

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -52,13 +52,13 @@ task pactConsumerTests (type: Test, group: "verification") {
 pact {
     publish {
         pactDirectory = pactDir
-        pactBrokerUrl = "${System.env.PACT_URL}?testSource=${System.env.PACT_BROKER_SOURCE_HEADER}"
-        pactBrokerUsername = "${System.env.PACT_USER}"
-        pactBrokerPassword = "${System.env.PACT_PASSWORD}"
-        consumerVersion = "${System.env.CONSUMER_APP_VERSION}"
-        consumerBranch = "${System.env.GIT_BRANCH}"
+        pactBrokerUrl = "$System.env.PACT_URL".toString() + "?testSource=" + "$System.env.PACT_BROKER_SOURCE_HEADER".toString()
+        pactBrokerUsername = "$System.env.PACT_USER".toString()
+        pactBrokerPassword = "$System.env.PACT_PASSWORD".toString()
+        consumerVersion = "$System.env.CONSUMER_APP_VERSION".toString()
+        consumerBranch = "${System.env.GIT_BRANCH}".toString()
         tags = [
-            "${System.env.GIT_BRANCH}"
+            "${System.env.GIT_BRANCH}".toString()
         ]
     }
 }

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -55,13 +55,13 @@ task pactConsumerTests (type: Test, group: "verification") {
 pact {
     publish {
         pactDirectory = pactDir
-        pactBrokerUrl = "${System.env.PACT_URL}?testSource=${System.env.PACT_BROKER_SOURCE_HEADER}"
-        pactBrokerUsername = "${System.env.PACT_USER}"
-        pactBrokerPassword = "${System.env.PACT_PASSWORD}"
-        consumerVersion = "${System.env.CONSUMER_APP_VERSION}"
-        consumerBranch = "${System.env.GIT_BRANCH}"
+        pactBrokerUrl = "$System.env.PACT_URL".toString() + "?testSource=" + "$System.env.PACT_BROKER_SOURCE_HEADER".toString()
+        pactBrokerUsername = "$System.env.PACT_USER".toString()
+        pactBrokerPassword = "$System.env.PACT_PASSWORD".toString()
+        consumerVersion = "$System.env.CONSUMER_APP_VERSION".toString()
+        consumerBranch = "${System.env.GIT_BRANCH}".toString()
         tags = [
-            "${System.env.GIT_BRANCH}"
+            "${System.env.GIT_BRANCH}".toString()
         ]
     }
 }


### PR DESCRIPTION
## What
- Automatically upload pacts to the broker using GHA
- Comment out the provider tests as we only want consumer tests at the moment

## How to review

Ensure pipeline is running as expected and pacts are being uploaded to the broker

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.

