### PR TITLE
BAU: Force redeploy of check_reauth_user in api gateway on changes

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -81,6 +81,8 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.identity_progress.method_trigger_value,
       local.deploy_account_interventions_count == 1 ? module.account_interventions[0].integration_trigger_value : null,
       local.deploy_account_interventions_count == 1 ? module.account_interventions[0].method_trigger_value : null,
+      local.deploy_reauth_user_count == 1 ? module.check_reauth_user[0].integration_trigger_value : null,
+      local.deploy_reauth_user_count == 1 ? module.check_reauth_user[0].method_trigger_value : null,
       local.account_modifiers_encryption_policy_arn,
     ]))
   }
@@ -105,6 +107,7 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
     module.ipv-authorize,
     module.doc-app-authorize,
     module.orch_auth_code,
+    module.check_reauth_user,
   ]
 }
 
@@ -203,6 +206,7 @@ resource "aws_api_gateway_stage" "endpoint_frontend_stage" {
     module.processing-identity,
     module.doc-app-authorize,
     module.orch_auth_code,
+    module.check_reauth_user,
     aws_api_gateway_deployment.deployment,
   ]
 }


### PR DESCRIPTION
## What

Force redeploy of check_reauth_user in api gateway on changes

The endpoint is not being deployed in staging as it is missing these dependencies

Tested in sandpit to prove that the terraform works.

## How to review

1. Code Review

## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

#4229
