### PR TITLE
AUT-2685: add ttl variable for lockout count and fix reduced lockout duration

### DIFF
--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -30,6 +30,7 @@ module "check_reauth_user" {
     INTERNAl_SECTOR_URI  = var.internal_sector_uri
     REDIS_KEY            = local.redis_key
     LOCKOUT_DURATION     = var.lockout_duration
+    LOCKOUT_COUNT_TTL    = var.lockout_count_ttl
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.CheckReAuthUserHandler::handleRequest"

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -40,6 +40,7 @@ module "login" {
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
     INTERNAl_SECTOR_URI      = var.internal_sector_uri
     LOCKOUT_DURATION         = var.lockout_duration
+    LOCKOUT_COUNT_TTL        = var.lockout_count_ttl
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.LoginHandler::handleRequest"
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -28,6 +28,7 @@ module "mfa" {
   handler_environment_variables = {
     ENVIRONMENT                            = var.environment
     LOCKOUT_DURATION                       = var.lockout_duration
+    LOCKOUT_COUNT_TTL                      = var.lockout_count_ttl
     DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
     EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
     EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -29,6 +29,7 @@ module "reset-password-request" {
     FRONTEND_BASE_URL    = "https://${local.frontend_fqdn}/"
     RESET_PASSWORD_ROUTE = var.reset_password_route
     LOCKOUT_DURATION     = var.lockout_duration
+    LOCKOUT_COUNT_TTL    = var.lockout_count_ttl
     SQS_ENDPOINT         = var.use_localstack ? "http://localhost:45678/" : null
     EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
     TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -30,6 +30,7 @@ module "send_notification" {
   handler_environment_variables = {
     ENVIRONMENT                            = var.environment
     LOCKOUT_DURATION                       = var.lockout_duration
+    LOCKOUT_COUNT_TTL                      = var.lockout_count_ttl
     EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id
     PENDING_EMAIL_CHECK_QUEUE_URL          = local.pending_email_check_queue_id
     SUPPORT_EMAIL_CHECK_ENABLED            = var.support_email_check_enabled

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -215,6 +215,11 @@ variable "lockout_duration" {
   default = 900
 }
 
+variable "lockout_count_ttl" {
+  type    = number
+  default = 900
+}
+
 variable "reduced_lockout_duration" {
   type    = number
   default = 900

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -43,6 +43,7 @@ module "verify_code" {
     REMOVE_RETRY_LIMIT_REGISTRATION_EMAIL_CODE = var.remove_retry_limit_registration_email_code
     CODE_MAX_RETRIES_INCREASED                 = var.code_max_retries_increased
     REDUCED_LOCKOUT_DURATION                   = var.reduced_lockout_duration
+    LOCKOUT_COUNT_TTL                          = var.lockout_count_ttl
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest"
 

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -31,6 +31,7 @@ module "verify_mfa_code" {
   handler_environment_variables = {
     ENVIRONMENT                         = var.environment
     LOCKOUT_DURATION                    = var.lockout_duration
+    LOCKOUT_COUNT_TTL                   = var.lockout_count_ttl
     TXMA_AUDIT_QUEUE_URL                = module.oidc_txma_audit.queue_url
     LOCALSTACK_ENDPOINT                 = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                           = local.redis_key

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -257,8 +257,15 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             return;
         }
 
-        codeStorageService.saveBlockedForEmail(
-                emailAddress, codeBlockedKeyPrefix, configurationService.getLockoutDuration());
+        boolean reducedLockout =
+                List.of(CodeRequestType.SMS_REGISTRATION, CodeRequestType.SMS_ACCOUNT_RECOVERY)
+                        .contains(CodeRequestType.getCodeRequestType(mfaMethodType, journeyType));
+        long blockDuration =
+                reducedLockout
+                        ? configurationService.getReducedLockoutDuration()
+                        : configurationService.getLockoutDuration();
+
+        codeStorageService.saveBlockedForEmail(emailAddress, codeBlockedKeyPrefix, blockDuration);
 
         if (mfaMethodType == MFAMethodType.SMS) {
             codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -178,7 +178,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         String sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         for (int i = 0; i < 5; i++) {
-            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, false);
+            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
         }
         var codeRequest = new VerifyCodeRequest(VERIFY_EMAIL, "123456", JourneyType.PASSWORD_RESET);
 
@@ -205,7 +205,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         String sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         for (int i = 0; i < 5; i++) {
-            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, false);
+            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
         }
         var codeRequest = new VerifyCodeRequest(VERIFY_EMAIL, "123456");
 
@@ -256,7 +256,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         String sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         for (int i = 0; i < 5; i++) {
-            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, false);
+            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
         }
         var codeRequest = new VerifyCodeRequest(VERIFY_CHANGE_HOW_GET_SECURITY_CODES, "123456");
 
@@ -282,7 +282,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         String sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         for (int i = 0; i < 5; i++) {
-            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, false);
+            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
         }
         var codeRequest = new VerifyCodeRequest(RESET_PASSWORD_WITH_CODE, "123456");
 
@@ -313,7 +313,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         String sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         for (int i = 0; i < 5; i++) {
-            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, false);
+            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
         }
         var codeRequest = new VerifyCodeRequest(MFA_SMS, "123456", journeyType);
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -256,8 +256,8 @@ public class RedisExtension
         codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email, mfaMethodType);
     }
 
-    public void increaseMfaCodeAttemptsCount(String email, boolean reducedLockout) {
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email, reducedLockout);
+    public void increaseMfaCodeAttemptsCount(String email) {
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email);
     }
 
     public void addToRedis(String key, String value, Long expiry) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -5,7 +5,6 @@ import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -155,11 +154,7 @@ public class ValidationHelper {
             return Optional.of(ErrorResponse.ERROR_1002);
         }
 
-        boolean reducedLockout =
-                List.of(CodeRequestType.SMS_REGISTRATION, CodeRequestType.SMS_ACCOUNT_RECOVERY)
-                        .contains(
-                                CodeRequestType.getCodeRequestType(notificationType, journeyType));
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(emailAddress, reducedLockout);
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(emailAddress);
 
         if (codeStorageService.getIncorrectMfaCodeAttemptsCount(emailAddress) > maxRetries) {
             switch (notificationType) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -60,13 +60,13 @@ public class CodeStorageService {
         return getCount(email, prefix);
     }
 
-    public void increaseIncorrectMfaCodeAttemptsCount(String email, boolean reducedLockout) {
-        increaseCount(email, MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX, reducedLockout);
+    public void increaseIncorrectMfaCodeAttemptsCount(String email) {
+        increaseCount(email, MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX);
     }
 
     public void increaseIncorrectMfaCodeAttemptsCount(String email, MFAMethodType mfaMethodType) {
         String prefix = MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX + mfaMethodType.getValue();
-        increaseCount(email, prefix, false);
+        increaseCount(email, prefix);
     }
 
     public void deleteIncorrectMfaCodeAttemptsCount(String email) {
@@ -79,29 +79,25 @@ public class CodeStorageService {
     }
 
     public void increaseIncorrectPasswordCount(String email) {
-        increaseCount(email, MULTIPLE_INCORRECT_PASSWORDS_PREFIX, false);
+        increaseCount(email, MULTIPLE_INCORRECT_PASSWORDS_PREFIX);
     }
 
     public void increaseIncorrectEmailCount(String email) {
-        increaseCount(email, MULTIPLE_INCORRECT_REAUTH_EMAIL_PREFIX, false);
+        increaseCount(email, MULTIPLE_INCORRECT_REAUTH_EMAIL_PREFIX);
     }
 
     public void increaseIncorrectPasswordCountReauthJourney(String email) {
-        increaseCount(email, MULTIPLE_INCORRECT_PASSWORDS_REAUTH_PREFIX, false);
+        increaseCount(email, MULTIPLE_INCORRECT_PASSWORDS_REAUTH_PREFIX);
     }
 
-    private void increaseCount(String email, String prefix, boolean reducedLockout) {
+    private void increaseCount(String email, String prefix) {
         String encodedHash = HashHelper.hashSha256String(email);
         String key = prefix + encodedHash;
         Optional<String> count = Optional.ofNullable(redisConnectionService.getValue(key));
         int newCount = count.map(t -> Integer.parseInt(t) + 1).orElse(1);
         try {
             redisConnectionService.saveWithExpiry(
-                    key,
-                    String.valueOf(newCount),
-                    reducedLockout
-                            ? configurationService.getReducedLockoutDuration()
-                            : configurationService.getLockoutDuration());
+                    key, String.valueOf(newCount), configurationService.getLockoutCountTTL());
             LOG.info("count increased from: {} to: {}", count, newCount);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -80,6 +80,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("AUTH_CODE_EXPIRY", "300"));
     }
 
+    public long getLockoutCountTTL() {
+        return Long.parseLong(System.getenv().getOrDefault("LOCKOUT_COUNT_TTL", "900"));
+    }
+
     public long getLockoutDuration() {
         return Long.parseLong(System.getenv().getOrDefault("LOCKOUT_DURATION", "900"));
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
@@ -73,7 +73,7 @@ class CodeStorageServiceTest {
 
     @BeforeAll
     static void init() {
-        when(configurationService.getLockoutDuration()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getLockoutCountTTL()).thenReturn(CODE_EXPIRY_TIME);
     }
 
     @Test
@@ -330,7 +330,7 @@ class CodeStorageServiceTest {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
                 .thenReturn(null);
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL, false);
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
 
         verify(redisConnectionService)
                 .saveWithExpiry(
@@ -360,7 +360,7 @@ class CodeStorageServiceTest {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
                 .thenReturn(String.valueOf(3));
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL, false);
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
 
         verify(redisConnectionService)
                 .saveWithExpiry(


### PR DESCRIPTION
## What

Lockout duration and lockout count TTL were mixed up so they have been separated and a new environment variable _lockout_count_ttl_ has been introduced.

## How to review

1. Code Review
2. Add _lockout_duration_ and _reduced_lockout_duration_ variables set
3. Deploy to sandpit with `./deploy-sandpit.sh -a`
4. Trigger lockout entering too many sms codes in account creation / mfa account recovery
5. verify time in _reduced_lockout_duration_ is used for lockout


## 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

- [x] Impact on orch and auth mutual dependencies has been checked.
