### PR TITLE
Adding lifecycle ignore for provisioned_concurrent_executions

### DIFF
--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -79,7 +79,7 @@ resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrenc
   provisioned_concurrent_executions = local.authorizer_provisioned_concurrency
 
   lifecycle {
-    ignore_changes = [provisioned_concurrent_executions]
+    ignore_changes = [provisioned_concurrent_executions] # Ignoring as this is targeted by aws_app_autoscaling_target.lambda_target resource
   }
 
 }

--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -77,6 +77,11 @@ resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrenc
   qualifier     = aws_lambda_alias.authorizer_alias.name
 
   provisioned_concurrent_executions = local.authorizer_provisioned_concurrency
+
+  lifecycle {
+    ignore_changes = [provisioned_concurrent_executions]
+  }
+
 }
 
 resource "aws_appautoscaling_target" "lambda_target" {

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -78,7 +78,7 @@ resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrenc
   provisioned_concurrent_executions = var.provisioned_concurrency
 
   lifecycle {
-    ignore_changes = [provisioned_concurrent_executions]
+    ignore_changes = [provisioned_concurrent_executions] # Ignoring as this is targeted by aws_app_autoscaling_target.lambda_target resource
   }
 
 }

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -76,6 +76,11 @@ resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrenc
   qualifier     = aws_lambda_alias.endpoint_lambda.name
 
   provisioned_concurrent_executions = var.provisioned_concurrency
+
+  lifecycle {
+    ignore_changes = [provisioned_concurrent_executions]
+  }
+
 }
 
 resource "aws_appautoscaling_target" "lambda_target" {

--- a/ci/terraform/modules/stub-endpoint-module/lambda.tf
+++ b/ci/terraform/modules/stub-endpoint-module/lambda.tf
@@ -78,7 +78,7 @@ resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrenc
   provisioned_concurrent_executions = var.provisioned_concurrency
 
   lifecycle {
-    ignore_changes = [provisioned_concurrent_executions]
+    ignore_changes = [provisioned_concurrent_executions] # Ignoring as this is targeted by aws_app_autoscaling_target.lambda_target resource
   }
 
 }

--- a/ci/terraform/modules/stub-endpoint-module/lambda.tf
+++ b/ci/terraform/modules/stub-endpoint-module/lambda.tf
@@ -76,6 +76,11 @@ resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrenc
   qualifier     = aws_lambda_alias.endpoint_lambda.name
 
   provisioned_concurrent_executions = var.provisioned_concurrency
+
+  lifecycle {
+    ignore_changes = [provisioned_concurrent_executions]
+  }
+
 }
 
 resource "aws_appautoscaling_target" "lambda_target" {

--- a/ci/terraform/utils/email_check_results_writer_lambda.tf
+++ b/ci/terraform/utils/email_check_results_writer_lambda.tf
@@ -74,6 +74,11 @@ resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrenc
   qualifier     = aws_lambda_alias.email_check_results_writer_lambda.name
 
   provisioned_concurrent_executions = var.email_check_results_writer_provisioned_concurrency
+
+  lifecycle {
+    ignore_changes = [provisioned_concurrent_executions]
+  }
+
 }
 
 resource "aws_cloudwatch_log_group" "lambda_log_group" {


### PR DESCRIPTION
## What

Adding lifecycle ignore for provisioned_concurrent_executions

## Why
We are experiencing lambda throttling during lambda running in scaled   provisioned concurrent. while deployment in happing which is try to re provision  the provisioned concurrent from scaled 10 to 3 
Evidence below
![image](https://github.com/govuk-one-login/authentication-api/assets/144677445/9b50be6a-b151-43b2-b933-431d0d6fdfcb)
