### PR TITLE
ATO-534: temporarily disable snapstart

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -114,8 +114,6 @@ Globals:
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
     MemorySize: 1536
     Timeout: 30
-    SnapStart:
-      ApplyOn: PublishedVersions
     Runtime: java17
     Architectures:
       - x86_64


### PR DESCRIPTION
## What
Allow functions to deploy without VPC peering in build
