### PR TITLE
BAU: DO NOT MERGE: Set persistent cookie age to 18 months

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -380,7 +380,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public int getPersistentCookieMaxAge() {
         return Integer.parseInt(
-                System.getenv().getOrDefault("PERSISTENT_COOKIE_MAX_AGE", "34190000"));
+                System.getenv().getOrDefault("PERSISTENT_COOKIE_MAX_AGE", "47340000"));
     }
 
     public int getLanguageCookieMaxAge() {


### PR DESCRIPTION
## What

Set persistent cookie age to 18 months.

It is currently set to 13 months.

## How to review

1. Code Review

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3453
