### PR TITLE
ATO-541: scripts and configuration to deploy cloudfront tls stack

### DIFF
--- a/ci/cloudfront-orchestration/tls-certificate/README.md
+++ b/ci/cloudfront-orchestration/tls-certificate/README.md
@@ -1,0 +1,32 @@
+# Cloudfront TLS Certificate stack
+
+This script deploys a cloudformation stack in the us-east-1 region which creates an ACM certificate for the `oidc.`
+domain for use with Cloudfront.
+
+The template deployed is maintained by the Dev Platform team and can be found
+at https://github.com/govuk-one-login/devplatform-deploy/tree/main/certificate
+
+## Usage
+
+The parameters for the template should be configured in a file at `<env>/parameters.json`. The tags to apply to created
+resources should be configured in a file at `<env>/tags.json`.
+
+The list of permitted environments is set up in the script. The script will automatically log in to the correct AWS
+account and then create or update the Cloudformation stack using the parameters and tags provided.
+
+If you have not done so already, your AWS profiles will need to be configured using the
+script [here](../../../scripts/export_aws_creds.sh).
+
+Note that the `dev` environment refers to the `oidc.sandpit.account.gov.uk` domain.
+
+### Create stack
+
+```
+./deploy.sh <env> --create
+```
+
+### Update stack
+
+```
+./deploy.sh <env>
+```

--- a/ci/cloudfront-orchestration/tls-certificate/deploy.sh
+++ b/ci/cloudfront-orchestration/tls-certificate/deploy.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export AWS_PAGER=""
+
+function loginAws() {
+  export AWS_REGION=us-east-1
+  case $1 in
+  dev)
+    export AWS_PROFILE=gds-di-development-admin
+    ;;
+  build)
+    export AWS_PROFILE=gds-di-development-admin
+    ;;
+  staging)
+    export AWS_PROFILE=di-auth-staging-admin
+    ;;
+  integration)
+    export AWS_PROFILE=gds-di-development-admin
+    ;;
+  production)
+    export AWS_PROFILE=gds-di-production-admin
+    ;;
+  esac
+
+  # shellcheck disable=SC1091
+  source "../../../scripts/export_aws_creds.sh"
+}
+
+PERMITTED_ENVIRONMENTS="dev build staging integration production"
+
+if  [[ $# == 0 ]] || ! [[ $PERMITTED_ENVIRONMENTS =~ ( |^)$1( |$) ]]; then
+  echo "Call ./deploy <env>, where <env> is one of $PERMITTED_ENVIRONMENTS"
+fi
+
+ENVIRONMENT=$1
+
+PARAMETERS_FILE=${PARAMETERS_FILE:=./$ENVIRONMENT/parameters.json}
+TAGS_FILE=${TAGS_FILE:=./$ENVIRONMENT/tags.json}
+
+if  [ ! -f "$PARAMETERS_FILE" ]; then
+  echo "Configuration file not found. Please see README.md"
+  exit 1
+fi
+
+if  [ ! -f "$TAGS_FILE" ]; then
+  echo "Tags file not found. Please see README.md"
+  exit 1
+fi
+
+loginAws "$ENVIRONMENT"
+
+TEMPLATE_URL="https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/certificate/template.yaml"
+
+if [[ $# == 2 ]] && [[ $2 == "--create" ]]; then
+  aws cloudformation create-stack \
+      --region us-east-1 \
+      --enable-termination-protection \
+      --stack-name="$ENVIRONMENT-oidc-cloudfront-tls" \
+      --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+      --template-url ${TEMPLATE_URL} \
+      --parameters="$(jq '. | tojson' -r "${PARAMETERS_FILE}")" \
+      --tags="$(jq '. | tojson' -r "${TAGS_FILE}")"
+else
+    aws cloudformation update-stack \
+        --region us-east-1 \
+        --stack-name="$ENVIRONMENT-oidc-cloudfront-tls" \
+        --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+        --template-url ${TEMPLATE_URL} \
+        --parameters="$(jq '. | tojson' -r "${PARAMETERS_FILE}")" \
+        --tags="$(jq '. | tojson' -r "${TAGS_FILE}")"
+fi

--- a/ci/cloudfront-orchestration/tls-certificate/dev/parameters.json
+++ b/ci/cloudfront-orchestration/tls-certificate/dev/parameters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey": "HostedZoneID",
+    "ParameterValue": "Z04812572XHS4OV4NR9AM"
+  },
+  {
+    "ParameterKey": "DomainName",
+    "ParameterValue": "oidc.sandpit.account.gov.uk"
+  }
+]

--- a/ci/cloudfront-orchestration/tls-certificate/dev/tags.json
+++ b/ci/cloudfront-orchestration/tls-certificate/dev/tags.json
@@ -1,0 +1,22 @@
+[
+  {
+    "Key": "Product",
+    "Value": "GOV.UK Sign In"
+  },
+  {
+    "Key": "System",
+    "Value": "Orchestration"
+  },
+  {
+    "Key": "Environment",
+    "Value": "sandpit"
+  },
+  {
+    "Key": "Owner",
+    "Value": "di-orchestration@digital.cabinet-office.gov.uk"
+  },
+  {
+    "Key": "Repository",
+    "Value": "govuk-one-login/authentication-api"
+  }
+]


### PR DESCRIPTION
## What

Create a script to deploy the tls stack for cloudfront. Currently only configured for dev/sandpit, others will be added in a followup
