### PR TITLE
ATO-545: Allow cross-account access for auth callback userinfo table

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -387,6 +387,20 @@ data "aws_iam_policy_document" "dynamo_authentication_callback_userinfo_write_po
       "${data.aws_dynamodb_table.authentication_callback_userinfo_table.arn}/index/*"
     ]
   }
+
+  statement {
+    sid    = "AllowAccessToKms"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:CreateGrant",
+      "kms:DescribeKey",
+    ]
+    resources = [local.authentication_callback_userinfo_encryption_key_arn]
+  }
 }
 
 data "aws_iam_policy_document" "dynamo_authentication_callback_userinfo_read_policy_document" {
@@ -406,6 +420,20 @@ data "aws_iam_policy_document" "dynamo_authentication_callback_userinfo_read_pol
       data.aws_dynamodb_table.authentication_callback_userinfo_table.arn,
       "${data.aws_dynamodb_table.authentication_callback_userinfo_table.arn}/index/*",
     ]
+  }
+
+  statement {
+    sid    = "AllowAccessToKms"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:CreateGrant",
+      "kms:DescribeKey",
+    ]
+    resources = [local.authentication_callback_userinfo_encryption_key_arn]
   }
 }
 

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -536,6 +536,12 @@ resource "aws_dynamodb_table" "email-check-result" {
   tags = local.default_tags
 }
 
+resource "aws_dynamodb_resource_policy" "authentication_callback_userinfo_table_policy" {
+  count        = var.authentication_callback_userinfo_table_cross_account_access_enabled ? 1 : 0
+  resource_arn = aws_dynamodb_table.authentication_callback_userinfo.arn
+  policy       = data.aws_iam_policy_document.cross_account_table_resource_policy_document.json
+}
+
 resource "aws_dynamodb_resource_policy" "client_registry_table_policy" {
   count        = var.client_registry_table_cross_account_access_enabled ? 1 : 0
   resource_arn = aws_dynamodb_table.client_registry_table.arn

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -532,27 +532,63 @@ resource "aws_kms_key" "authentication_callback_userinfo_encryption_key" {
   key_usage                = "ENCRYPT_DECRYPT"
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
   enable_key_rotation      = true
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Id      = "key-policy-dynamodb",
-    Statement = [
-      {
-        Sid       = "Allow IAM to manage this key",
-        Effect    = "Allow",
-        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
-        Action = [
-          "kms:*"
-        ],
-        Resource = "*"
-      }
-    ]
-  })
-  tags = local.default_tags
+  policy                   = var.authentication_callback_userinfo_table_cross_account_access_enabled ? data.aws_iam_policy_document.authentication_callback_userinfo_encryption_key_access_policy_with_orch_access.json : data.aws_iam_policy_document.authentication_callback_userinfo_encryption_key_access_policy.json
+  tags                     = local.default_tags
 }
 
 resource "aws_kms_alias" "authentication_callback_userinfo_encryption_key_alias" {
   name          = "alias/${var.environment}-authentication-callback-userinfo-encryption-key-alias"
   target_key_id = aws_kms_key.authentication_callback_userinfo_encryption_key.key_id
+}
+
+data "aws_iam_policy_document" "authentication_callback_userinfo_encryption_key_access_policy" {
+  statement {
+    sid    = "key-policy-dynamodb"
+    effect = "Allow"
+    actions = [
+      "kms:*",
+    ]
+    principals {
+      identifiers = [data.aws_caller_identity.current.account_id]
+      type        = "AWS"
+    }
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "authentication_callback_userinfo_encryption_key_access_policy_with_orch_access" {
+  statement {
+    sid    = "key-policy-dynamodb"
+    effect = "Allow"
+    actions = [
+      "kms:*",
+    ]
+    principals {
+      identifiers = [data.aws_caller_identity.current.account_id]
+      type        = "AWS"
+    }
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow Orch access to KMS storage authentication callback userinfo encryption key"
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:CreateGrant",
+      "kms:DescribeKey",
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.orchestration_account_id]
+    }
+  }
 }
 
 resource "aws_kms_key" "account_modifiers_table_encryption_key" {

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -174,16 +174,16 @@ variable "dlq_alarm_threshold" {
   description = "The number of messages on a DLQ before a Cloudwatch alarm is generated"
 }
 
-variable "client_registry_table_cross_account_access_enabled" {
-  default     = false
-  type        = bool
-  description = "Whether the service should allow cross-account access to the client registry table"
-}
-
 variable "orch_privatesub_cidr_blocks" {
   type        = list(string)
   description = "Orchestration private subnet cidr blocks"
   default     = []
+}
+
+variable "authentication_callback_userinfo_table_cross_account_access_enabled" {
+  default     = false
+  type        = bool
+  description = "Whether the service should allow cross-account access to the authentication callback userinfo table"
 }
 
 variable "back_channel_logout_cross_account_access_enabled" {
@@ -192,14 +192,20 @@ variable "back_channel_logout_cross_account_access_enabled" {
   description = "Whether the service should allow cross-account access by orchestration to the back channel logout queue"
 }
 
-variable "kms_cross_account_access_enabled" {
+variable "client_registry_table_cross_account_access_enabled" {
   default     = false
   type        = bool
-  description = "Whether the service should allow cross-account access by the orchestration account to kms"
+  description = "Whether the service should allow cross-account access to the client registry table"
 }
 
 variable "doc_app_cross_account_access_enabled" {
   default     = false
   type        = bool
   description = "Feature flag to control cross-account access to the doc app signing key"
+}
+
+variable "kms_cross_account_access_enabled" {
+  default     = false
+  type        = bool
+  description = "Whether the service should allow cross-account access by the orchestration account to kms"
 }


### PR DESCRIPTION
## What

CMK is already set up for this
- Add the necessary policies to allow for cross-account access
- Slight reordering of flags in shared variables
- 
## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.