### PR TITLE
Ato 483/dcmaw user info contract test

### DIFF
--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java
@@ -63,8 +63,6 @@ public class DcmawUserInfoTest {
     RequestResponsePact validRequestReturnsValidUserInfo(PactDslWithProvider builder) {
         return builder.given("accessToken is a valid access token")
                 .given("dummy-doc-app-subject-id is a valid subject")
-                .given("dummyDcmawComponentId is a valid issuer")
-                .given("the current time is 2099-01-01 00:00:00")
                 .uponReceiving("Valid access token")
                 .path("/" + DOC_APP_USER_INFO_PATH)
                 .method("POST")
@@ -114,8 +112,6 @@ public class DcmawUserInfoTest {
     RequestResponsePact validRequestReturnsAccessDenied(PactDslWithProvider builder) {
         return builder.given("accessToken is a valid access token")
                 .given("invalid-subject-id is a invalid subject")
-                .given("dummyDcmawComponentId is a valid issuer")
-                .given("the current time is 2099-01-01 00:00:00")
                 .uponReceiving("Valid access token")
                 .path("/" + DOC_APP_USER_INFO_PATH)
                 .method("POST")
@@ -160,8 +156,6 @@ public class DcmawUserInfoTest {
     RequestResponsePact invalidAccessTokenReturnsError(PactDslWithProvider builder) {
         return builder.given("accessToken is a invalid access token")
                 .given("invalid-subject-id is a invalid subject")
-                .given("dummyDcmawComponentId is a valid issuer")
-                .given("the current time is 2099-01-01 00:00:00")
                 .uponReceiving("Valid access token")
                 .path("/" + DOC_APP_USER_INFO_PATH)
                 .method("POST")

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java
@@ -1,0 +1,140 @@
+package uk.gov.di.authentication.app.contract;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit5.PactConsumerTest;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.PactSpecVersion;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.Tokens;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.app.services.DocAppCriService;
+import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
+import uk.gov.di.orchestration.shared.helpers.ConstructUriHelper;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
+import static com.nimbusds.common.contenttype.ContentType.APPLICATION_JSON;
+import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.POST;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.shared.entity.IdentityClaims.CREDENTIAL_JWT;
+
+@PactConsumerTest
+public class DcmawUserInfoTest {
+    private final ConfigurationService configService = mock(ConfigurationService.class);
+    private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
+    private DocAppCriService docAppCriService;
+    private Tokens tokens;
+
+    private final String DOC_APP_USER_INFO_PATH = "userinfo/v2";
+    private final String DOC_APP_SUBJECT_ID = "dummy-doc-app-subject-id";
+    private final String SUB_FIELD = "sub";
+    private final String CREDENTIALS_JWT_FIELD = "https://vocab.account.gov.uk/v1/credentialJWT";
+    private final String SUB_VALUE = DOC_APP_SUBJECT_ID;
+    private final String CREDENTIALS_JWT_VALUE =
+            "eyJraWQiOiIwNDEwZTQ0Mi1iNjJiLTQ1YzktOGNkNi00NTE4MGIxNmVmODUiLCJhbGciOiJFUzI1NiJ9.eyAgInN1YiI6ICJkdW1teS1kb2MtYXBwLXN1YmplY3QtaWQiLCAgIm5iZiI6IDQwNzA5MDg4MDAsICAiaXNzIjogImR1bW15RGNtYXdDb21wb25lbnRJZCIsICAiaWF0IjogNDA3MDkwODgwMCwgICJ2YyI6IHsgICAgIkBjb250ZXh0IjogWyAgICAgICJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsICAgICAgImh0dHBzOi8vdm9jYWIubG9uZG9uLmNsb3VkYXBwcy5kaWdpdGFsL2NvbnRleHRzL2lkZW50aXR5LXYxLmpzb25sZCIgICAgXSwgICAgInR5cGUiOiBbICAgICAgIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgICAgICAiQWRkcmVzc0NyZWRlbnRpYWwiICAgIF0sICAgICJjcmVkZW50aWFsU3ViamVjdCI6IHsgICAgfSAgfX0.QjbVNoAGZBFpkuE9RStPi5mAggMvSq0Kio6-EkyDxMJrColmcLPblF0ztgPdF5NEmMEPKst3Ug7AF1gXLW7jxg";
+    private final String ERROR_MESSAGE = "error message";
+
+    @BeforeEach
+    void setup() {
+        docAppCriService = new DocAppCriService(configService, kmsConnectionService);
+        tokens = new Tokens(new BearerAccessToken("accessToken"), null);
+        when(configService.getEnvironment()).thenReturn("not_build");
+    }
+
+    @Pact(consumer = "OrchUserInfoConsumer")
+    RequestResponsePact validRequestReturnsValidUserInfo(PactDslWithProvider builder) {
+        return builder.given("accessToken is a valid access token")
+                .given("dummy-doc-app-subject-id is a valid subject")
+                .given("dummyDcmawComponentId is a valid issuer")
+                .given("the current time is 2099-01-01 00:00:00")
+                .uponReceiving("Valid access token")
+                .path("/" + DOC_APP_USER_INFO_PATH)
+                .method("POST")
+                .matchHeader(
+                        "Authorization",
+                        "^(?i)Bearer (.*)(?-i)",
+                        tokens.getAccessToken().toAuthorizationHeader())
+                .willRespondWith()
+                .status(200)
+                .body(
+                        newJsonBody(
+                                        (body) -> {
+                                            body.stringType(SUB_FIELD, SUB_VALUE);
+                                            body.unorderedMinArray(
+                                                    CREDENTIALS_JWT_FIELD,
+                                                    1,
+                                                    (jwt) -> {
+                                                        jwt.stringType(CREDENTIALS_JWT_VALUE);
+                                                    });
+                                        })
+                                .build())
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(
+            providerName = "DcmawUserInfoProvider",
+            pactMethod = "validRequestReturnsValidUserInfo",
+            pactVersion = PactSpecVersion.V3)
+    void getIPVUserInfoSuccessResponse(MockServer mockServer)
+            throws UnsuccessfulCredentialResponseException,
+                    ParseException,
+                    java.text.ParseException {
+
+        var request =
+                new HTTPRequest(
+                        POST,
+                        ConstructUriHelper.buildURI(mockServer.getUrl(), DOC_APP_USER_INFO_PATH));
+        request.setAuthorization(tokens.getAccessToken().toAuthorizationHeader());
+
+        var userInfo = docAppCriService.sendCriDataRequest(request, DOC_APP_SUBJECT_ID);
+
+        assertThat(userInfo, equalTo(getUserInfoFromSuccessfulUserIdentityHttpResponse()));
+    }
+
+    private List<String> getUserInfoFromSuccessfulUserIdentityHttpResponse()
+            throws ParseException, java.text.ParseException {
+        var userInfoHTTPResponse = new HTTPResponse(200);
+        userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
+        userInfoHTTPResponse.setContent(
+                "{"
+                        + " \""
+                        + SUB_FIELD
+                        + "\": \""
+                        + SUB_VALUE
+                        + "\","
+                        + " \""
+                        + CREDENTIALS_JWT_FIELD
+                        + "\": ["
+                        + "     \""
+                        + CREDENTIALS_JWT_VALUE
+                        + "\""
+                        + "]"
+                        + "}");
+        var contentAsJSONObject = userInfoHTTPResponse.getContentAsJSONObject();
+        var serializedSignedJWTs =
+                (List<String>) contentAsJSONObject.get(CREDENTIAL_JWT.getValue());
+        List<SignedJWT> signedJWTs = new ArrayList<>();
+        for (String jwt : serializedSignedJWTs) {
+            signedJWTs.add(SignedJWT.parse(jwt));
+        }
+        return signedJWTs.stream().map(JWSObject::serialize).collect(Collectors.toList());
+    }
+}

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java
@@ -92,7 +92,7 @@ public class DcmawUserInfoTest {
             providerName = "DcmawUserInfoProvider",
             pactMethod = "validRequestReturnsValidUserInfo",
             pactVersion = PactSpecVersion.V3)
-    void getIPVUserInfoSuccessResponse(MockServer mockServer)
+    void getDocAppUserInfoSuccessResponse(MockServer mockServer)
             throws UnsuccessfulCredentialResponseException,
                     ParseException,
                     java.text.ParseException {
@@ -111,7 +111,6 @@ public class DcmawUserInfoTest {
     @Pact(consumer = "OrchUserInfoConsumer")
     RequestResponsePact validRequestReturnsAccessDenied(PactDslWithProvider builder) {
         return builder.given("accessToken is a valid access token")
-                .given("invalid-subject-id is a invalid subject")
                 .uponReceiving("Valid access token")
                 .path("/" + DOC_APP_USER_INFO_PATH)
                 .method("POST")
@@ -155,7 +154,6 @@ public class DcmawUserInfoTest {
     @Pact(consumer = "OrchUserInfoConsumer")
     RequestResponsePact invalidAccessTokenReturnsError(PactDslWithProvider builder) {
         return builder.given("accessToken is a invalid access token")
-                .given("invalid-subject-id is a invalid subject")
                 .uponReceiving("Valid access token")
                 .path("/" + DOC_APP_USER_INFO_PATH)
                 .method("POST")


### PR DESCRIPTION
## What
 
contract test for DCMA user info 

Looked at error paths for userInfo Response

will need ATO-482 merged in first

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
