### PR TITLE
ATP-563: Create SNS topic to publish cloudfront alerts to

### DIFF
--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -34,6 +34,17 @@ provider "aws" {
   }
 }
 
+
+provider "aws" {
+  alias = "cloudfront"
+
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = var.deployer_role_arn
+  }
+}
+
 locals {
   // Using a local rather than the default_tags option on the AWS provider, as the latter has known issues which produce errors on apply.
   default_tags = var.use_localstack ? null : {

--- a/ci/terraform/shared/sns-cloudfront.tf
+++ b/ci/terraform/shared/sns-cloudfront.tf
@@ -1,0 +1,37 @@
+resource "aws_sns_topic" "cloudfront_alerts" {
+  name = "${var.environment}-cloudfront-alerts"
+  # checkov:skip=CKV_AWS_26:No encryption needed on alerts topic
+}
+
+data "aws_iam_policy_document" "cloudfront_alerts" {
+  version = "2012-10-17"
+
+  statement {
+    actions = [
+      "sns:Publish"
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:SourceAccount"
+    }
+
+    resources = [
+      aws_sns_topic.cloudfront_alerts.arn,
+    ]
+  }
+}
+
+resource "aws_sns_topic_policy" "cloudfront_alerts" {
+  arn = aws_sns_topic.cloudfront_alerts.arn
+
+  policy = data.aws_iam_policy_document.cloudfront_alerts.json
+}


### PR DESCRIPTION


## What

Create SNS topic to publish cloudfront alerts to
Must be in us-east-1 as this is where the metrics are emitted so where the alert will be
