### PR TITLE
ATO-567/fix test not defaulting es256

### DIFF
--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
@@ -34,7 +34,6 @@ import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 
 import java.io.IOException;
 import java.net.URI;
-import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPrivateKey;
@@ -167,9 +166,8 @@ class DocAppCriServiceTest {
                     JOSEException,
                     NoSuchAlgorithmException,
                     UnsuccessfulCredentialResponseException {
-        var keyPair = KeyPairGenerator.getInstance("EC").generateKeyPair();
-        var signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build(), keyPair);
-        var signedJwtTwo = generateSignedJWT(new JWTClaimsSet.Builder().build(), keyPair);
+        var signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build());
+        var signedJwtTwo = generateSignedJWT(new JWTClaimsSet.Builder().build());
 
         var userInfoHTTPResponseContent =
                 format(
@@ -200,9 +198,8 @@ class DocAppCriServiceTest {
                     JOSEException,
                     IOException,
                     UnsuccessfulCredentialResponseException {
-        var keyPair = KeyPairGenerator.getInstance("EC").generateKeyPair();
-        var signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build(), keyPair);
-        var signedJwtTwo = generateSignedJWT(new JWTClaimsSet.Builder().build(), keyPair);
+        var signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build());
+        var signedJwtTwo = generateSignedJWT(new JWTClaimsSet.Builder().build());
 
         var userInfoHTTPResponseContent =
                 format(
@@ -231,9 +228,8 @@ class DocAppCriServiceTest {
     @Test
     void shouldThrowWhenClientSessionAndUserInfoEndpointDocAppIdDoesNotMatch()
             throws IOException, JOSEException, NoSuchAlgorithmException {
-        var keyPair = KeyPairGenerator.getInstance("EC").generateKeyPair();
-        var signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build(), keyPair);
-        var signedJwtTwo = generateSignedJWT(new JWTClaimsSet.Builder().build(), keyPair);
+        var signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build());
+        var signedJwtTwo = generateSignedJWT(new JWTClaimsSet.Builder().build());
 
         var userInfoHTTPResponseContent =
                 format(
@@ -292,11 +288,16 @@ class DocAppCriServiceTest {
         when(kmsService.sign(any(SignRequest.class))).thenReturn(signResult);
     }
 
-    public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet, KeyPair keyPair)
-            throws JOSEException {
+    public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet)
+            throws JOSEException, NoSuchAlgorithmException {
         var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
         var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+
+        var keyPairGenerator = KeyPairGenerator.getInstance("EC");
+        keyPairGenerator.initialize(256);
+        var keyPair = keyPairGenerator.generateKeyPair();
         var ecdsaSigner = new ECDSASigner((ECPrivateKey) keyPair.getPrivate());
+
         signedJWT.sign(ecdsaSigner);
         return signedJWT;
     }

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
@@ -20,6 +20,7 @@ import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.JWTID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
@@ -82,238 +83,225 @@ class DocAppCriServiceTest {
         when(configService.getDocAppJwksUri()).thenReturn(DOC_APP_JWKS_URI);
     }
 
-    @Test
-    void shouldConstructTokenRequest() throws JOSEException {
-        signJWTWithKMS();
-        when(kmsService.getPublicKey(any(GetPublicKeyRequest.class)))
-                .thenReturn(GetPublicKeyResponse.builder().keyId("789789789789789").build());
-        TokenRequest tokenRequest = docAppCriService.constructTokenRequest(AUTH_CODE.getValue());
-        assertThat(tokenRequest.getEndpointURI().toString(), equalTo(CRI_URI + "token"));
-        assertThat(
-                tokenRequest.getClientAuthentication().getMethod().getValue(),
-                equalTo("private_key_jwt"));
-        assertThat(
-                tokenRequest.toHTTPRequest().getQueryParameters().get("redirect_uri").get(0),
-                equalTo(REDIRECT_URI.toString()));
-        assertThat(
-                tokenRequest.toHTTPRequest().getQueryParameters().get("grant_type").get(0),
-                equalTo(GrantType.AUTHORIZATION_CODE.getValue()));
-        assertThat(
-                tokenRequest.toHTTPRequest().getQueryParameters().get("client_id").get(0),
-                equalTo(CLIENT_ID.getValue()));
+    @Nested
+    class TokenTests {
+        @Test
+        void shouldConstructTokenRequest() throws JOSEException {
+            signJWTWithKMS();
+            when(kmsService.getPublicKey(any(GetPublicKeyRequest.class)))
+                    .thenReturn(GetPublicKeyResponse.builder().keyId("789789789789789").build());
+            TokenRequest tokenRequest =
+                    docAppCriService.constructTokenRequest(AUTH_CODE.getValue());
+            assertThat(tokenRequest.getEndpointURI().toString(), equalTo(CRI_URI + "token"));
+            assertThat(
+                    tokenRequest.getClientAuthentication().getMethod().getValue(),
+                    equalTo("private_key_jwt"));
+            assertThat(
+                    tokenRequest.toHTTPRequest().getQueryParameters().get("redirect_uri").get(0),
+                    equalTo(REDIRECT_URI.toString()));
+            assertThat(
+                    tokenRequest.toHTTPRequest().getQueryParameters().get("grant_type").get(0),
+                    equalTo(GrantType.AUTHORIZATION_CODE.getValue()));
+            assertThat(
+                    tokenRequest.toHTTPRequest().getQueryParameters().get("client_id").get(0),
+                    equalTo(CLIENT_ID.getValue()));
+        }
+
+        @Test
+        void shouldUseNewDocAppAud() throws JOSEException {
+            Audience newAudience = new Audience("https://www.review-b.test.account.gov.uk");
+            when(configService.isDocAppNewAudClaimEnabled()).thenReturn(true);
+            when(configService.getDocAppAudClaim()).thenReturn(newAudience);
+
+            signJWTWithKMS();
+            when(kmsService.getPublicKey(any(GetPublicKeyRequest.class)))
+                    .thenReturn(GetPublicKeyResponse.builder().keyId("789789789789789").build());
+
+            TokenRequest tokenRequest =
+                    docAppCriService.constructTokenRequest(AUTH_CODE.getValue());
+
+            var clientAuth = (PrivateKeyJWT) tokenRequest.getClientAuthentication();
+            assertThat(
+                    clientAuth.getJWTAuthenticationClaimsSet().getAudience(),
+                    contains(newAudience));
+        }
+
+        @Test
+        void shouldCallTokenEndpointAndReturn200() throws IOException {
+            var tokenRequest = mock(TokenRequest.class);
+            when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
+            when(tokenRequest.toHTTPRequest().send()).thenReturn(getSuccessfulTokenHttpResponse());
+
+            var tokenResponse = docAppCriService.sendTokenRequest(tokenRequest);
+
+            assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
+        }
+
+        @Test
+        void shouldRetryCallToTokenIfFirstCallFails() throws IOException {
+            var tokenRequest = mock(TokenRequest.class);
+            when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
+
+            when(tokenRequest.toHTTPRequest().send())
+                    .thenReturn(new HTTPResponse(500))
+                    .thenReturn(getSuccessfulTokenHttpResponse());
+
+            var tokenResponse = docAppCriService.sendTokenRequest(tokenRequest);
+
+            assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
+            verify(tokenRequest.toHTTPRequest(), times(2)).send();
+        }
+
+        @Test
+        void shouldReturnUnsuccessfulTokenResponseIf2CallsToTokenFail() throws IOException {
+            var tokenRequest = mock(TokenRequest.class);
+            when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
+
+            when(tokenRequest.toHTTPRequest().send())
+                    .thenReturn(new HTTPResponse(500))
+                    .thenReturn(new HTTPResponse(500));
+
+            var tokenResponse = docAppCriService.sendTokenRequest(tokenRequest);
+
+            assertThat(tokenResponse.indicatesSuccess(), equalTo(false));
+            verify(tokenRequest.toHTTPRequest(), times(2)).send();
+        }
+
+        private void signJWTWithKMS() throws JOSEException {
+            var ecSigningKey =
+                    new ECKeyGenerator(Curve.P_256)
+                            .keyID(SIGNING_KID)
+                            .algorithm(JWSAlgorithm.ES256)
+                            .generate();
+            var claimsSet =
+                    new JWTAuthenticationClaimsSet(
+                            new ClientID(CLIENT_ID),
+                            singletonList(new Audience(buildURI(CRI_URI.toString(), "token"))),
+                            NowHelper.nowPlus(5, ChronoUnit.MINUTES),
+                            null,
+                            NowHelper.now(),
+                            new JWTID());
+            var ecdsaSigner = new ECDSASigner(ecSigningKey);
+            var jwsHeader =
+                    new JWSHeader.Builder(JWSAlgorithm.ES256)
+                            .keyID(ecSigningKey.getKeyID())
+                            .build();
+            var signedJWT = new SignedJWT(jwsHeader, claimsSet.toJWTClaimsSet());
+            unchecked(signedJWT::sign).accept(ecdsaSigner);
+            byte[] idTokenSignatureDer =
+                    ECDSA.transcodeSignatureToDER(signedJWT.getSignature().decode());
+            var signResult =
+                    SignResponse.builder()
+                            .signature(SdkBytes.fromByteArray(idTokenSignatureDer))
+                            .keyId(SIGNING_KID)
+                            .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
+                            .build();
+
+            when(kmsService.sign(any(SignRequest.class))).thenReturn(signResult);
+        }
+
+        public HTTPResponse getSuccessfulTokenHttpResponse() {
+            var tokenResponseContent =
+                    "{"
+                            + "  \"access_token\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
+                            + "  \"token_type\": \"bearer\","
+                            + "  \"expires_in\": \"3600\","
+                            + "  \"uri\": \"https://localhost\""
+                            + "}";
+            var tokenHTTPResponse = new HTTPResponse(200);
+            tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
+            tokenHTTPResponse.setContent(tokenResponseContent);
+
+            return tokenHTTPResponse;
+        }
     }
 
-    @Test
-    void shouldUseNewDocAppAud() throws JOSEException {
-        Audience newAudience = new Audience("https://www.review-b.test.account.gov.uk");
-        when(configService.isDocAppNewAudClaimEnabled()).thenReturn(true);
-        when(configService.getDocAppAudClaim()).thenReturn(newAudience);
+    @Nested
+    class UserInfoTests {
 
-        signJWTWithKMS();
-        when(kmsService.getPublicKey(any(GetPublicKeyRequest.class)))
-                .thenReturn(GetPublicKeyResponse.builder().keyId("789789789789789").build());
+        SignedJWT signedJwtOne;
+        SignedJWT signedJwtTwo;
+        String userInfoHTTPResponseContent;
 
-        TokenRequest tokenRequest = docAppCriService.constructTokenRequest(AUTH_CODE.getValue());
+        @BeforeEach
+        void setupUserInfo() throws NoSuchAlgorithmException, JOSEException {
+            signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build());
+            signedJwtTwo = generateSignedJWT(new JWTClaimsSet.Builder().build());
+            userInfoHTTPResponseContent =
+                    format(
+                            "{"
+                                    + " \"sub\": \"%s\","
+                                    + " \"https://vocab.account.gov.uk/v1/credentialJWT\": ["
+                                    + "     \"%s\","
+                                    + "     \"%s\""
+                                    + "]"
+                                    + "}",
+                            DOC_APP_SUBJECT_ID, signedJwtOne.serialize(), signedJwtTwo.serialize());
+        }
 
-        var clientAuth = (PrivateKeyJWT) tokenRequest.getClientAuthentication();
-        assertThat(clientAuth.getJWTAuthenticationClaimsSet().getAudience(), contains(newAudience));
-    }
+        @Test
+        void shouldCallUserInfoEndpointAndReturn200()
+                throws IOException, UnsuccessfulCredentialResponseException {
+            var userInfoHTTPResponse = new HTTPResponse(200);
+            userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
+            userInfoHTTPResponse.setContent(userInfoHTTPResponseContent);
+            when(httpRequest.send()).thenReturn(userInfoHTTPResponse);
 
-    @Test
-    void shouldCallTokenEndpointAndReturn200() throws IOException {
-        var tokenRequest = mock(TokenRequest.class);
-        when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
-        when(tokenRequest.toHTTPRequest().send()).thenReturn(getSuccessfulTokenHttpResponse());
+            var response = docAppCriService.sendCriDataRequest(httpRequest, DOC_APP_SUBJECT_ID);
 
-        var tokenResponse = docAppCriService.sendTokenRequest(tokenRequest);
+            assertThat(response.size(), equalTo(2));
+            assertTrue(response.contains(signedJwtOne.serialize()));
+            assertTrue(response.contains(signedJwtTwo.serialize()));
+        }
 
-        assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
-    }
+        @Test
+        void shouldRetryCallToUserInfoAndReturn200IfFirstCallFails()
+                throws IOException, UnsuccessfulCredentialResponseException {
+            var userInfoHTTPResponse = new HTTPResponse(200);
+            userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
+            userInfoHTTPResponse.setContent(userInfoHTTPResponseContent);
+            when(httpRequest.send())
+                    .thenReturn(new HTTPResponse(500))
+                    .thenReturn(userInfoHTTPResponse);
 
-    @Test
-    void shouldRetryCallToTokenIfFirstCallFails() throws IOException {
-        var tokenRequest = mock(TokenRequest.class);
-        when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
+            var response = docAppCriService.sendCriDataRequest(httpRequest, DOC_APP_SUBJECT_ID);
 
-        when(tokenRequest.toHTTPRequest().send())
-                .thenReturn(new HTTPResponse(500))
-                .thenReturn(getSuccessfulTokenHttpResponse());
+            assertThat(response.size(), equalTo(2));
+            assertTrue(response.contains(signedJwtOne.serialize()));
+            assertTrue(response.contains(signedJwtTwo.serialize()));
+            verify(httpRequest, times(2)).send();
+        }
 
-        var tokenResponse = docAppCriService.sendTokenRequest(tokenRequest);
+        @Test
+        void shouldThrowWhenClientSessionAndUserInfoEndpointDocAppIdDoesNotMatch()
+                throws IOException {
+            var userInfoHTTPResponse = new HTTPResponse(200);
+            userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
+            userInfoHTTPResponse.setContent(userInfoHTTPResponseContent);
+            when(httpRequest.send()).thenReturn(userInfoHTTPResponse);
 
-        assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
-        verify(tokenRequest.toHTTPRequest(), times(2)).send();
-    }
+            UnsuccessfulCredentialResponseException thrown =
+                    assertThrows(
+                            UnsuccessfulCredentialResponseException.class,
+                            () -> docAppCriService.sendCriDataRequest(httpRequest, "different-id"));
 
-    @Test
-    void shouldReturnUnsuccessfulTokenResponseIf2CallsToTokenFail() throws IOException {
-        var tokenRequest = mock(TokenRequest.class);
-        when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
+            assertEquals(
+                    "Sub in CRI response does not match docAppSubjectId in client session",
+                    thrown.getMessage());
+        }
 
-        when(tokenRequest.toHTTPRequest().send())
-                .thenReturn(new HTTPResponse(500))
-                .thenReturn(new HTTPResponse(500));
+        public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet)
+                throws JOSEException, NoSuchAlgorithmException {
+            var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
+            var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
 
-        var tokenResponse = docAppCriService.sendTokenRequest(tokenRequest);
+            var keyPairGenerator = KeyPairGenerator.getInstance("EC");
+            keyPairGenerator.initialize(256);
+            var keyPair = keyPairGenerator.generateKeyPair();
+            var ecdsaSigner = new ECDSASigner((ECPrivateKey) keyPair.getPrivate());
 
-        assertThat(tokenResponse.indicatesSuccess(), equalTo(false));
-        verify(tokenRequest.toHTTPRequest(), times(2)).send();
-    }
-
-    @Test
-    void shouldCallUserInfoEndpointAndReturn200()
-            throws IOException,
-                    JOSEException,
-                    NoSuchAlgorithmException,
-                    UnsuccessfulCredentialResponseException {
-        var signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build());
-        var signedJwtTwo = generateSignedJWT(new JWTClaimsSet.Builder().build());
-
-        var userInfoHTTPResponseContent =
-                format(
-                        "{"
-                                + " \"sub\": \"%s\","
-                                + " \"https://vocab.account.gov.uk/v1/credentialJWT\": ["
-                                + "     \"%s\","
-                                + "     \"%s\""
-                                + "]"
-                                + "}",
-                        DOC_APP_SUBJECT_ID, signedJwtOne.serialize(), signedJwtTwo.serialize());
-
-        var userInfoHTTPResponse = new HTTPResponse(200);
-        userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        userInfoHTTPResponse.setContent(userInfoHTTPResponseContent);
-        when(httpRequest.send()).thenReturn(userInfoHTTPResponse);
-
-        var response = docAppCriService.sendCriDataRequest(httpRequest, DOC_APP_SUBJECT_ID);
-
-        assertThat(response.size(), equalTo(2));
-        assertTrue(response.contains(signedJwtOne.serialize()));
-        assertTrue(response.contains(signedJwtTwo.serialize()));
-    }
-
-    @Test
-    void shouldRetryCallToUserInfoAndReturn200IfFirstCallFails()
-            throws NoSuchAlgorithmException,
-                    JOSEException,
-                    IOException,
-                    UnsuccessfulCredentialResponseException {
-        var signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build());
-        var signedJwtTwo = generateSignedJWT(new JWTClaimsSet.Builder().build());
-
-        var userInfoHTTPResponseContent =
-                format(
-                        "{"
-                                + " \"sub\": \"%s\","
-                                + " \"https://vocab.account.gov.uk/v1/credentialJWT\": ["
-                                + "     \"%s\","
-                                + "     \"%s\""
-                                + "]"
-                                + "}",
-                        DOC_APP_SUBJECT_ID, signedJwtOne.serialize(), signedJwtTwo.serialize());
-
-        var userInfoHTTPResponse = new HTTPResponse(200);
-        userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        userInfoHTTPResponse.setContent(userInfoHTTPResponseContent);
-        when(httpRequest.send()).thenReturn(new HTTPResponse(500)).thenReturn(userInfoHTTPResponse);
-
-        var response = docAppCriService.sendCriDataRequest(httpRequest, DOC_APP_SUBJECT_ID);
-
-        assertThat(response.size(), equalTo(2));
-        assertTrue(response.contains(signedJwtOne.serialize()));
-        assertTrue(response.contains(signedJwtTwo.serialize()));
-        verify(httpRequest, times(2)).send();
-    }
-
-    @Test
-    void shouldThrowWhenClientSessionAndUserInfoEndpointDocAppIdDoesNotMatch()
-            throws IOException, JOSEException, NoSuchAlgorithmException {
-        var signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build());
-        var signedJwtTwo = generateSignedJWT(new JWTClaimsSet.Builder().build());
-
-        var userInfoHTTPResponseContent =
-                format(
-                        "{"
-                                + " \"sub\": \"%s\","
-                                + " \"https://vocab.account.gov.uk/v1/credentialJWT\": ["
-                                + "     \"%s\","
-                                + "     \"%s\""
-                                + "]"
-                                + "}",
-                        DOC_APP_SUBJECT_ID, signedJwtOne.serialize(), signedJwtTwo.serialize());
-
-        var userInfoHTTPResponse = new HTTPResponse(200);
-        userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        userInfoHTTPResponse.setContent(userInfoHTTPResponseContent);
-        when(httpRequest.send()).thenReturn(userInfoHTTPResponse);
-
-        UnsuccessfulCredentialResponseException thrown =
-                assertThrows(
-                        UnsuccessfulCredentialResponseException.class,
-                        () -> docAppCriService.sendCriDataRequest(httpRequest, "different-id"));
-
-        assertEquals(
-                "Sub in CRI response does not match docAppSubjectId in client session",
-                thrown.getMessage());
-    }
-
-    private void signJWTWithKMS() throws JOSEException {
-        var ecSigningKey =
-                new ECKeyGenerator(Curve.P_256)
-                        .keyID(SIGNING_KID)
-                        .algorithm(JWSAlgorithm.ES256)
-                        .generate();
-        var claimsSet =
-                new JWTAuthenticationClaimsSet(
-                        new ClientID(CLIENT_ID),
-                        singletonList(new Audience(buildURI(CRI_URI.toString(), "token"))),
-                        NowHelper.nowPlus(5, ChronoUnit.MINUTES),
-                        null,
-                        NowHelper.now(),
-                        new JWTID());
-        var ecdsaSigner = new ECDSASigner(ecSigningKey);
-        var jwsHeader =
-                new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(ecSigningKey.getKeyID()).build();
-        var signedJWT = new SignedJWT(jwsHeader, claimsSet.toJWTClaimsSet());
-        unchecked(signedJWT::sign).accept(ecdsaSigner);
-        byte[] idTokenSignatureDer =
-                ECDSA.transcodeSignatureToDER(signedJWT.getSignature().decode());
-        var signResult =
-                SignResponse.builder()
-                        .signature(SdkBytes.fromByteArray(idTokenSignatureDer))
-                        .keyId(SIGNING_KID)
-                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
-                        .build();
-
-        when(kmsService.sign(any(SignRequest.class))).thenReturn(signResult);
-    }
-
-    public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet)
-            throws JOSEException, NoSuchAlgorithmException {
-        var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
-        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
-
-        var keyPairGenerator = KeyPairGenerator.getInstance("EC");
-        keyPairGenerator.initialize(256);
-        var keyPair = keyPairGenerator.generateKeyPair();
-        var ecdsaSigner = new ECDSASigner((ECPrivateKey) keyPair.getPrivate());
-
-        signedJWT.sign(ecdsaSigner);
-        return signedJWT;
-    }
-
-    public HTTPResponse getSuccessfulTokenHttpResponse() {
-        var tokenResponseContent =
-                "{"
-                        + "  \"access_token\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
-                        + "  \"token_type\": \"bearer\","
-                        + "  \"expires_in\": \"3600\","
-                        + "  \"uri\": \"https://localhost\""
-                        + "}";
-        var tokenHTTPResponse = new HTTPResponse(200);
-        tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        tokenHTTPResponse.setContent(tokenResponseContent);
-
-        return tokenHTTPResponse;
+            signedJWT.sign(ecdsaSigner);
+            return signedJWT;
+        }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -125,9 +125,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 };
 
         handler = new UserInfoHandler(configuration);
-        var keyPair = KeyPairGenerator.getInstance("EC").generateKeyPair();
-        DOC_APP_CREDENTIAL =
-                generateSignedJWT(new JWTClaimsSet.Builder().build(), keyPair).serialize();
+        DOC_APP_CREDENTIAL = generateSignedJWT(new JWTClaimsSet.Builder().build()).serialize();
 
         userInfoStorageExtension.addAuthenticationUserInfoData(
                 INTERNAL_PAIRWISE_SUBJECT.getValue(), AUTH_USER_INFO);
@@ -346,11 +344,16 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
-    public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet, KeyPair keyPair)
-            throws JOSEException {
+    public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet)
+            throws JOSEException, NoSuchAlgorithmException {
         var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
         var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+
+        var keyPairGenerator = KeyPairGenerator.getInstance("EC");
+        keyPairGenerator.initialize(256);
+        var keyPair = keyPairGenerator.generateKeyPair();
         var ecdsaSigner = new ECDSASigner((ECPrivateKey) keyPair.getPrivate());
+
         signedJWT.sign(ecdsaSigner);
         return signedJWT;
     }


### PR DESCRIPTION
## What

Add to use es256 in ec key pair generation instead of using system default.
Refactor the DocAppCriService test to use nesting
