### PR TITLE
AUT-2679: add internalPairwiseId to the session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -162,6 +162,10 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                                         configurationService.getInternalSectorUri(),
                                         authenticationService)
                                 .getValue();
+
+                LOG.info("Setting internal common subject identifier in user session");
+                userContext.getSession().setInternalCommonSubjectIdentifier(internalPairwiseId);
+
                 var isPhoneNumberVerified = userProfile.get().isPhoneNumberVerified();
                 var userCredentials =
                         authenticationService.getUserCredentialsFromEmail(emailAddress);


### PR DESCRIPTION
## What
After adding the new flow for the 2fa before password reset journey, we didn't have a place where we saved the internalPairwise id to a session. Thus, in VerifyCodeHandler.java and VerifyMfaCodeHandler.java we were auditing events without having a userId. This fixes it by adding it to the CheckUserExistsHandler, ensuring in the reset-password (and other journeys as well) we have the pairwiseId saved to the session

Cloudwatch log of pairwiseId being present in the resetPassword jouney:
![image](https://github.com/govuk-one-login/authentication-api/assets/146068663/63588a87-0293-46e5-b204-59b6974c07f0)

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

