### PR TITLE
RFF-2: Refactor submitting audit messages

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -69,8 +69,8 @@ public class ClientRegistrationHandler
         String ipAddress = IpAddressHelper.extractIpAddress(input);
         auditService.submitAuditEvent(
                 REGISTER_CLIENT_REQUEST_RECEIVED,
-                context.getAwsRequestId(),
                 AuditService.UNKNOWN,
+                context.getAwsRequestId(),
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
@@ -91,8 +91,8 @@ public class ClientRegistrationHandler
                         errorResponse.get().getDescription());
                 auditService.submitAuditEvent(
                         REGISTER_CLIENT_REQUEST_ERROR,
-                        context.getAwsRequestId(),
                         AuditService.UNKNOWN,
+                        context.getAwsRequestId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -91,9 +91,9 @@ public class UpdateClientConfigHandler
             if (!clientService.isValidClient(clientId)) {
                 auditService.submitAuditEvent(
                         UPDATE_CLIENT_REQUEST_ERROR,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
                         clientId,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         ipAddress,
@@ -112,9 +112,9 @@ public class UpdateClientConfigHandler
                         errorResponse.get().getDescription());
                 auditService.submitAuditEvent(
                         UPDATE_CLIENT_REQUEST_ERROR,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
                         clientId,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         ipAddress,

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -238,7 +238,7 @@ class ClientRegistrationHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
+                        REGISTER_CLIENT_REQUEST_ERROR, "", "request-id", "", "", "", "", "", "");
     }
 
     @Test
@@ -256,7 +256,7 @@ class ClientRegistrationHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
+                        REGISTER_CLIENT_REQUEST_ERROR, "", "request-id", "", "", "", "", "", "");
     }
 
     private static Stream<String> clientTypes() {
@@ -300,7 +300,7 @@ class ClientRegistrationHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        REGISTER_CLIENT_REQUEST_RECEIVED, "request-id", "", "", "", "", "", "", "");
+                        REGISTER_CLIENT_REQUEST_RECEIVED, "", "request-id", "", "", "", "", "", "");
 
         return response;
     }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -142,7 +142,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "", "", CLIENT_ID, "", "", "", "", "");
+                        UPDATE_CLIENT_REQUEST_ERROR, CLIENT_ID, "", "", "", "", "", "", "");
     }
 
     @Test
@@ -165,7 +165,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "", "", CLIENT_ID, "", "", "", "", "");
+                        UPDATE_CLIENT_REQUEST_ERROR, CLIENT_ID, "", "", "", "", "", "", "");
     }
 
     @Test
@@ -185,7 +185,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "", "", CLIENT_ID, "", "", "", "", "");
+                        UPDATE_CLIENT_REQUEST_ERROR, CLIENT_ID, "", "", "", "", "", "", "");
     }
 
     private ClientRegistry createClientRegistry() {

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -170,9 +170,9 @@ public class DocAppAuthorizeHandler
             noSessionOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
             auditService.submitAuditEvent(
                     DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
+                    clientRegistry.getClientID(),
                     clientSessionId,
                     session.getSessionId(),
-                    clientRegistry.getClientID(),
                     clientSession.getDocAppSubjectId().toString(),
                     AuditService.UNKNOWN,
                     IpAddressHelper.extractIpAddress(input),

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -205,9 +205,9 @@ public class DocAppCallbackHandler
 
             auditService.submitAuditEvent(
                     DocAppAuditableEvent.DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
+                    clientId,
                     clientSessionId,
                     session.getSessionId(),
-                    clientId,
                     clientSession.getDocAppSubjectId().getValue(),
                     AuditService.UNKNOWN,
                     AuditService.UNKNOWN,
@@ -222,9 +222,9 @@ public class DocAppCallbackHandler
                 LOG.info("TokenResponse was successful");
                 auditService.submitAuditEvent(
                         DocAppAuditableEvent.DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        clientId,
                         clientSessionId,
                         session.getSessionId(),
-                        clientId,
                         clientSession.getDocAppSubjectId().getValue(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -237,9 +237,9 @@ public class DocAppCallbackHandler
                 incrementDocAppCallbackErrorCounter(false, "UnsuccessfulTokenResponse");
                 auditService.submitAuditEvent(
                         DocAppAuditableEvent.DOC_APP_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        clientId,
                         clientSessionId,
                         session.getSessionId(),
-                        clientId,
                         clientSession.getDocAppSubjectId().getValue(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -269,9 +269,9 @@ public class DocAppCallbackHandler
                                 request, clientSession.getDocAppSubjectId().getValue());
                 auditService.submitAuditEvent(
                         DocAppAuditableEvent.DOC_APP_SUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED,
+                        clientId,
                         clientSessionId,
                         session.getSessionId(),
-                        clientId,
                         clientSession.getDocAppSubjectId().getValue(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -305,9 +305,9 @@ public class DocAppCallbackHandler
 
                 auditService.submitAuditEvent(
                         AUTH_CODE_ISSUED,
+                        clientId,
                         clientSessionId,
                         session.getSessionId(),
-                        clientId,
                         clientSession.getDocAppSubjectId().getValue(),
                         session.getEmailAddress(),
                         IpAddressHelper.extractIpAddress(input),
@@ -338,9 +338,9 @@ public class DocAppCallbackHandler
                     incrementDocAppCallbackErrorCounter(false, "UnsuccessfulCredentialResponse");
                     auditService.submitAuditEvent(
                             DocAppAuditableEvent.DOC_APP_UNSUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED,
+                            clientId,
                             clientSessionId,
                             session.getSessionId(),
-                            clientId,
                             clientSession.getDocAppSubjectId().getValue(),
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
@@ -378,9 +378,9 @@ public class DocAppCallbackHandler
         incrementDocAppCallbackErrorCounter(noSessionErrorResponse, errorObject.getCode());
         auditService.submitAuditEvent(
                 DocAppAuditableEvent.DOC_APP_UNSUCCESSFUL_AUTHORISATION_RESPONSE_RECEIVED,
+                authenticationRequest.getClientID().getValue(),
                 clientSessionId,
                 sessionId,
-                authenticationRequest.getClientID().getValue(),
                 docAppSubjectId,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
@@ -157,9 +157,9 @@ class DocAppAuthorizeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        CLIENT_ID.getValue(),
                         DOC_APP_SUBJECT_ID.getValue(),
                         AuditService.UNKNOWN,
                         "123.123.123.123",

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -181,9 +181,9 @@ class DocAppCallbackHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         DocAppAuditableEvent.AUTH_CODE_ISSUED,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        CLIENT_ID.getValue(),
                         PAIRWISE_SUBJECT_ID.getValue(),
                         TEST_EMAIL_ADDRESS,
                         AuditService.UNKNOWN,
@@ -430,9 +430,9 @@ class DocAppCallbackHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         DocAppAuditableEvent.DOC_APP_UNSUCCESSFUL_AUTHORISATION_RESPONSE_RECEIVED,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         AuditService.UNKNOWN,
-                        CLIENT_ID.getValue(),
                         PAIRWISE_SUBJECT_ID.getValue(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -580,9 +580,9 @@ class DocAppCallbackHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         docAppAuditableEvent,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        CLIENT_ID.getValue(),
                         PAIRWISE_SUBJECT_ID.getValue(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -121,9 +121,9 @@ public class IPVCallbackHelper {
                 noSessionErrorResponse);
         auditService.submitAuditEvent(
                 IPVAuditableEvent.IPV_UNSUCCESSFUL_AUTHORISATION_RESPONSE_RECEIVED,
+                authenticationRequest.getClientID().getValue(),
                 clientSessionId,
                 sessionId,
-                authenticationRequest.getClientID().getValue(),
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
@@ -199,9 +199,9 @@ public class IPVCallbackHelper {
         var subjectId = authCodeResponseService.getSubjectId(session);
         auditService.submitAuditEvent(
                 IPVAuditableEvent.AUTH_CODE_ISSUED,
+                authRequest.getClientID().getValue(),
                 clientSessionId,
                 session.getSessionId(),
-                authRequest.getClientID().getValue(),
                 internalPairwiseSubjectId,
                 Objects.isNull(session.getEmailAddress())
                         ? AuditService.UNKNOWN

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -188,9 +188,9 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
 
             auditService.submitAuditEvent(
                     IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
+                    rpClientID.orElse(AuditService.UNKNOWN),
                     clientSessionId,
                     userContext.getSession().getSessionId(),
-                    rpClientID.orElse(AuditService.UNKNOWN),
                     userContext.getSession().getInternalCommonSubjectIdentifier(),
                     request.getEmail(),
                     IpAddressHelper.extractIpAddress(input),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -271,9 +271,9 @@ public class IPVCallbackHandler
 
             auditService.submitAuditEvent(
                     IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED,
+                    clientId,
                     clientSessionId,
                     session.getSessionId(),
-                    clientId,
                     internalPairwiseSubjectId,
                     userProfile.getEmail(),
                     AuditService.UNKNOWN,
@@ -292,9 +292,9 @@ public class IPVCallbackHandler
                         tokenResponse.toErrorResponse().toJSONObject());
                 auditService.submitAuditEvent(
                         IPVAuditableEvent.IPV_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        clientId,
                         clientSessionId,
                         session.getSessionId(),
-                        clientId,
                         internalPairwiseSubjectId,
                         userProfile.getEmail(),
                         AuditService.UNKNOWN,
@@ -305,9 +305,9 @@ public class IPVCallbackHandler
             }
             auditService.submitAuditEvent(
                     IPVAuditableEvent.IPV_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                    clientId,
                     clientSessionId,
                     session.getSessionId(),
-                    clientId,
                     internalPairwiseSubjectId,
                     userProfile.getEmail(),
                     AuditService.UNKNOWN,
@@ -327,9 +327,9 @@ public class IPVCallbackHandler
 
             auditService.submitAuditEvent(
                     IPVAuditableEvent.IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED,
+                    clientId,
                     clientSessionId,
                     session.getSessionId(),
-                    clientId,
                     internalPairwiseSubjectId,
                     userProfile.getEmail(),
                     AuditService.UNKNOWN,
@@ -423,9 +423,9 @@ public class IPVCallbackHandler
 
             auditService.submitAuditEvent(
                     IPVAuditableEvent.IPV_SPOT_REQUESTED,
+                    clientId,
                     clientSessionId,
                     session.getSessionId(),
-                    clientId,
                     internalPairwiseSubjectId,
                     userProfile.getEmail(),
                     AuditService.UNKNOWN,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -147,11 +147,11 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
 
             auditService.submitAuditEvent(
                     IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST,
-                    userSession.getClientSessionId(),
-                    userSession.getSession().getSessionId(),
                     userSession.getClientId() != null
                             ? userSession.getClientId()
                             : AuditService.UNKNOWN,
+                    userSession.getClientSessionId(),
+                    userSession.getSession().getSessionId(),
                     AuditService.UNKNOWN,
                     AuditService.UNKNOWN,
                     IpAddressHelper.extractIpAddress(input),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -105,9 +105,9 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
     private void submitAuditEvent(AuditableEvent auditableEvent, LogIds logIds) {
         auditService.submitAuditEvent(
                 auditableEvent,
+                logIds.getClientId(),
                 logIds.getClientSessionId(),
                 logIds.getSessionId(),
-                logIds.getClientId(),
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -196,9 +196,9 @@ class IPVCallbackHelperTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_UNSUCCESSFUL_AUTHORISATION_RESPONSE_RECEIVED,
+                        authRequest.getClientID().getValue(),
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        authRequest.getClientID().getValue(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -232,9 +232,9 @@ public class IPVAuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
+                        CLIENT_ID,
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        CLIENT_ID,
                         expectedCommonSubject,
                         EMAIL_ADDRESS,
                         "123.123.123.123",

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -949,9 +949,9 @@ class IPVCallbackHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         auditableEvent,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        CLIENT_ID.getValue(),
                         expectedCommonSubject,
                         TEST_EMAIL_ADDRESS,
                         AuditService.UNKNOWN,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -59,9 +59,9 @@ class SPOTResponseHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -98,9 +98,9 @@ class SPOTResponseHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -213,9 +213,9 @@ public class AuthCodeHandler
 
             auditService.submitAuditEvent(
                     OidcAuditableEvent.AUTH_CODE_ISSUED,
+                    clientID.getValue(),
                     clientSessionId,
                     session.getSessionId(),
-                    clientID.getValue(),
                     internalCommonPairwiseSubjectId,
                     Objects.isNull(session.getEmailAddress())
                             ? AuditService.UNKNOWN

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -227,9 +227,9 @@ public class AuthenticationCallbackHandler
 
             auditService.submitAuditEvent(
                     OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                    clientId,
                     clientSessionId,
                     userSession.getSessionId(),
-                    clientId,
                     AuditService.UNKNOWN,
                     AuditService.UNKNOWN,
                     AuditService.UNKNOWN,
@@ -244,9 +244,9 @@ public class AuthenticationCallbackHandler
                 LOG.info("TokenResponse was successful");
                 auditService.submitAuditEvent(
                         OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        clientId,
                         clientSessionId,
                         userSession.getSessionId(),
-                        clientId,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -258,9 +258,9 @@ public class AuthenticationCallbackHandler
                         tokenResponse.toErrorResponse().toJSONObject());
                 auditService.submitAuditEvent(
                         OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        clientId,
                         clientSessionId,
                         userSession.getSessionId(),
-                        clientId,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -288,9 +288,9 @@ public class AuthenticationCallbackHandler
 
                 auditService.submitAuditEvent(
                         OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
+                        clientId,
                         clientSessionId,
                         userSession.getSessionId(),
-                        clientId,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -328,9 +328,9 @@ public class AuthenticationCallbackHandler
 
                 auditService.submitAuditEvent(
                         OidcAuditableEvent.AUTHENTICATION_COMPLETE,
+                        clientId,
                         clientSessionId,
                         userSession.getSessionId(),
-                        clientId,
                         userInfo.getSubject().getValue(),
                         Objects.isNull(userSession.getEmailAddress())
                                 ? AuditService.UNKNOWN
@@ -436,9 +436,9 @@ public class AuthenticationCallbackHandler
 
                 auditService.submitAuditEvent(
                         OidcAuditableEvent.AUTH_CODE_ISSUED,
+                        clientId,
                         clientSessionId,
                         userSession.getSessionId(),
-                        clientId,
                         userInfo.getSubject().getValue(),
                         Objects.isNull(userSession.getEmailAddress())
                                 ? AuditService.UNKNOWN
@@ -463,9 +463,9 @@ public class AuthenticationCallbackHandler
             } catch (UnsuccessfulCredentialResponseException e) {
                 auditService.submitAuditEvent(
                         OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
+                        clientId,
                         clientSessionId,
                         userSession.getSessionId(),
-                        clientId,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -543,9 +543,9 @@ public class AuthenticationCallbackHandler
                 errorObject.getDescription());
         auditService.submitAuditEvent(
                 OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED,
+                authenticationRequest.getClientID().getValue(),
                 clientSessionId,
                 sessionId,
-                authenticationRequest.getClientID().getValue(),
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService
 import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
 import uk.gov.di.authentication.oidc.services.InitiateIPVAuthorisationService;
 import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.conditions.MfaHelper;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
@@ -66,6 +67,7 @@ import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.GET;
 import static java.lang.String.format;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import static uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED;
 import static uk.gov.di.orchestration.shared.conditions.DocAppUserHelper.isDocCheckingAppUserWithSubjectId;
 import static uk.gov.di.orchestration.shared.conditions.IdentityHelper.identityRequired;
 import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING;
@@ -206,6 +208,12 @@ public class AuthenticationCallbackHandler
                     PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders());
             attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentSessionId);
 
+            var user =
+                    TxmaAuditUser.user()
+                            .withGovukSigninJourneyId(clientSessionId)
+                            .withSessionId(userSession.getSessionId())
+                            .withPersistentSessionId(persistentSessionId);
+
             var authenticationRequest =
                     AuthenticationRequest.parse(clientSession.getAuthRequestParams());
 
@@ -218,23 +226,11 @@ public class AuthenticationCallbackHandler
 
             if (!requestValid) {
                 return generateAuthenticationErrorResponse(
-                        authenticationRequest,
-                        OAuth2Error.SERVER_ERROR,
-                        clientSessionId,
-                        userSession.getSessionId(),
-                        persistentSessionId);
+                        authenticationRequest, OAuth2Error.SERVER_ERROR, user);
             }
 
             auditService.submitAuditEvent(
-                    OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
-                    clientId,
-                    clientSessionId,
-                    userSession.getSessionId(),
-                    AuditService.UNKNOWN,
-                    AuditService.UNKNOWN,
-                    AuditService.UNKNOWN,
-                    AuditService.UNKNOWN,
-                    persistentSessionId);
+                    OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED, clientId, user);
 
             var tokenRequest =
                     tokenService.constructTokenRequest(
@@ -245,13 +241,7 @@ public class AuthenticationCallbackHandler
                 auditService.submitAuditEvent(
                         OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                         clientId,
-                        clientSessionId,
-                        userSession.getSessionId(),
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        persistentSessionId);
+                        user);
             } else {
                 LOG.error(
                         "Authentication TokenResponse was not successful: {}",
@@ -259,13 +249,7 @@ public class AuthenticationCallbackHandler
                 auditService.submitAuditEvent(
                         OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                         clientId,
-                        clientSessionId,
-                        userSession.getSessionId(),
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        persistentSessionId);
+                        user);
                 return RedirectService.redirectToFrontendErrorPage(
                         configurationService.getLoginURI().toString(), ERROR_PAGE_REDIRECT_PATH);
             }
@@ -289,13 +273,7 @@ public class AuthenticationCallbackHandler
                 auditService.submitAuditEvent(
                         OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
                         clientId,
-                        clientSessionId,
-                        userSession.getSessionId(),
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        persistentSessionId);
+                        user);
                 LOG.info("Adding Authentication userinfo to dynamo");
                 userInfoStorageService.addAuthenticationUserInfoData(
                         userInfo.getSubject().getValue(), userInfo);
@@ -462,15 +440,7 @@ public class AuthenticationCallbackHandler
 
             } catch (UnsuccessfulCredentialResponseException e) {
                 auditService.submitAuditEvent(
-                        OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
-                        clientId,
-                        clientSessionId,
-                        userSession.getSessionId(),
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        persistentSessionId);
+                        AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED, clientId, user);
                 LOG.error(
                         "Orchestration to Authentication userinfo request was not successful: {}",
                         e.getMessage());
@@ -534,9 +504,7 @@ public class AuthenticationCallbackHandler
     private APIGatewayProxyResponseEvent generateAuthenticationErrorResponse(
             AuthenticationRequest authenticationRequest,
             ErrorObject errorObject,
-            String clientSessionId,
-            String sessionId,
-            String persistentSessionId) {
+            TxmaAuditUser user) {
         LOG.warn(
                 "Error in Authentication Authorisation Response. ErrorCode: {}. ErrorDescription: {}",
                 errorObject.getCode(),
@@ -544,13 +512,7 @@ public class AuthenticationCallbackHandler
         auditService.submitAuditEvent(
                 OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED,
                 authenticationRequest.getClientID().getValue(),
-                clientSessionId,
-                sessionId,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                persistentSessionId);
+                user);
         var errorResponse =
                 new AuthenticationErrorResponse(
                         authenticationRequest.getRedirectionURI(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -198,8 +198,8 @@ public class AuthorisationHandler
 
         auditService.submitAuditEvent(
                 OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED,
-                clientSessionId,
                 AuditService.UNKNOWN,
+                clientSessionId,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
@@ -327,9 +327,9 @@ public class AuthorisationHandler
                         configurationService.isIdentityEnabled());
         auditService.submitAuditEvent(
                 OidcAuditableEvent.AUTHORISATION_REQUEST_PARSED,
+                authRequest.getClientID().getValue(),
                 clientSessionId,
                 AuditService.UNKNOWN,
-                authRequest.getClientID().getValue(),
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 ipAddress,
@@ -462,9 +462,9 @@ public class AuthorisationHandler
 
         auditService.submitAuditEvent(
                 DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
+                client.getClientID(),
                 clientSessionId,
                 session.getSessionId(),
-                client.getClientID(),
                 clientSession.getDocAppSubjectId().toString(),
                 AuditService.UNKNOWN,
                 ipAddress,
@@ -529,9 +529,9 @@ public class AuthorisationHandler
 
         auditService.submitAuditEvent(
                 OidcAuditableEvent.AUTHORISATION_INITIATED,
+                authenticationRequest.getClientID().getValue(),
                 clientSessionId,
                 session.getSessionId(),
-                authenticationRequest.getClientID().getValue(),
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 ipAddress,
@@ -678,9 +678,9 @@ public class AuthorisationHandler
 
         auditService.submitAuditEvent(
                 OidcAuditableEvent.AUTHORISATION_REQUEST_ERROR,
+                clientId,
                 clientSessionId,
                 AuditService.UNKNOWN,
-                clientId,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 ipAddress,
@@ -706,8 +706,8 @@ public class AuthorisationHandler
 
         auditService.submitAuditEvent(
                 OidcAuditableEvent.AUTHORISATION_REQUEST_ERROR,
-                clientSessionId,
                 AuditService.UNKNOWN,
+                clientSessionId,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -142,9 +142,9 @@ public class UserInfoHandler
 
         auditService.submitAuditEvent(
                 OidcAuditableEvent.USER_INFO_RETURNED,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
                 accessTokenInfo.getClientID(),
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
                 subjectForAudit,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
@@ -110,9 +110,9 @@ public class InitiateIPVAuthorisationService {
 
         auditService.submitAuditEvent(
                 IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
+                rpClientID,
                 clientSessionId,
                 session.getSessionId(),
-                rpClientID,
                 session.getInternalCommonSubjectIdentifier(),
                 userInfo.getEmailAddress(),
                 IpAddressHelper.extractIpAddress(input),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -292,9 +292,9 @@ class AuthCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTH_CODE_ISSUED,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        CLIENT_ID.getValue(),
                         expectedCommonSubject,
                         EMAIL,
                         "123.123.123.123",
@@ -397,9 +397,9 @@ class AuthCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTH_CODE_ISSUED,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        CLIENT_ID.getValue(),
                         DOC_APP_SUBJECT_ID,
                         AuditService.UNKNOWN,
                         "123.123.123.123",

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
 import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
 import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
 import uk.gov.di.authentication.oidc.services.InitiateIPVAuthorisationService;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.conditions.IdentityHelper;
 import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 import uk.gov.di.orchestration.shared.entity.*;
@@ -662,13 +663,11 @@ class AuthenticationCallbackHandlerTest {
                     .submitAuditEvent(
                             eq(event),
                             eq(CLIENT_ID.getValue()),
-                            eq(CLIENT_SESSION_ID),
-                            eq(SESSION_ID),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            eq(PERSISTENT_SESSION_ID));
+                            eq(
+                                    TxmaAuditUser.user()
+                                            .withSessionId(SESSION_ID)
+                                            .withPersistentSessionId(PERSISTENT_SESSION_ID)
+                                            .withGovukSigninJourneyId(CLIENT_SESSION_ID)));
         }
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -197,9 +197,9 @@ class AuthenticationCallbackHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         eq(OidcAuditableEvent.AUTHENTICATION_COMPLETE),
+                        eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(SESSION_ID),
-                        eq(CLIENT_ID.getValue()),
                         any(),
                         any(),
                         any(),
@@ -210,9 +210,9 @@ class AuthenticationCallbackHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         eq(OidcAuditableEvent.AUTH_CODE_ISSUED),
+                        eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(SESSION_ID),
-                        eq(CLIENT_ID.getValue()),
                         any(),
                         any(),
                         any(),
@@ -661,9 +661,9 @@ class AuthenticationCallbackHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             eq(event),
+                            eq(CLIENT_ID.getValue()),
                             eq(CLIENT_SESSION_ID),
                             eq(SESSION_ID),
-                            eq(CLIENT_ID.getValue()),
                             any(),
                             any(),
                             any(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -279,9 +279,9 @@ class AuthorisationHandlerTest {
             inOrder.verify(auditService)
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
+                            CLIENT_ID.getValue(),
                             CLIENT_SESSION_ID,
                             session.getSessionId(),
-                            CLIENT_ID.getValue(),
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
                             "123.123.123.123",
@@ -423,9 +423,9 @@ class AuthorisationHandlerTest {
             inOrder.verify(auditService)
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
+                            CLIENT_ID.getValue(),
                             CLIENT_SESSION_ID,
                             session.getSessionId(),
-                            CLIENT_ID.getValue(),
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
                             "123.123.123.123",
@@ -468,9 +468,9 @@ class AuthorisationHandlerTest {
             inOrder.verify(auditService)
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
+                            CLIENT_ID.getValue(),
                             CLIENT_SESSION_ID,
                             session.getSessionId(),
-                            CLIENT_ID.getValue(),
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
                             "123.123.123.123",
@@ -543,9 +543,9 @@ class AuthorisationHandlerTest {
             inOrder.verify(auditService)
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
+                            CLIENT_ID.getValue(),
                             CLIENT_SESSION_ID,
                             session.getSessionId(),
-                            CLIENT_ID.getValue(),
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
                             "123.123.123.123",
@@ -590,9 +590,9 @@ class AuthorisationHandlerTest {
             inOrder.verify(auditService)
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
+                            CLIENT_ID.getValue(),
                             CLIENT_SESSION_ID,
                             session.getSessionId(),
-                            CLIENT_ID.getValue(),
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
                             "123.123.123.123",
@@ -641,8 +641,8 @@ class AuthorisationHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
-                            CLIENT_SESSION_ID,
                             "",
+                            CLIENT_SESSION_ID,
                             "",
                             "",
                             "",
@@ -685,9 +685,9 @@ class AuthorisationHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
+                            CLIENT_ID.getValue(),
                             CLIENT_SESSION_ID,
                             "",
-                            CLIENT_ID.getValue(),
                             "",
                             "",
                             "123.123.123.123",
@@ -723,9 +723,9 @@ class AuthorisationHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
+                            CLIENT_ID.getValue(),
                             CLIENT_SESSION_ID,
                             "",
-                            CLIENT_ID.getValue(),
                             "",
                             "",
                             "123.123.123.123",
@@ -796,8 +796,8 @@ class AuthorisationHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
-                            CLIENT_SESSION_ID,
                             "",
+                            CLIENT_SESSION_ID,
                             "",
                             "",
                             "",
@@ -973,9 +973,9 @@ class AuthorisationHandlerTest {
             inOrder.verify(auditService)
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
+                            CLIENT_ID.getValue(),
                             CLIENT_SESSION_ID,
                             session.getSessionId(),
-                            CLIENT_ID.getValue(),
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
                             "123.123.123.123",
@@ -1024,9 +1024,9 @@ class AuthorisationHandlerTest {
             inOrder.verify(auditService)
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
+                            CLIENT_ID.getValue(),
                             CLIENT_SESSION_ID,
                             session.getSessionId(),
-                            CLIENT_ID.getValue(),
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
                             "123.123.123.123",
@@ -1317,9 +1317,9 @@ class AuthorisationHandlerTest {
             inOrder.verify(auditService)
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
+                            CLIENT_ID.getValue(),
                             CLIENT_SESSION_ID,
                             "",
-                            CLIENT_ID.getValue(),
                             "",
                             "",
                             "123.123.123.123",
@@ -1379,9 +1379,9 @@ class AuthorisationHandlerTest {
             inOrder.verify(auditService)
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
+                            CLIENT_ID.getValue(),
                             CLIENT_SESSION_ID,
                             "",
-                            CLIENT_ID.getValue(),
                             "",
                             "",
                             "123.123.123.123",
@@ -1541,9 +1541,9 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         "",
-                        CLIENT_ID.getValue(),
                         "",
                         "",
                         "123.123.123.123",
@@ -1574,9 +1574,9 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         "",
-                        CLIENT_ID.getValue(),
                         "",
                         "",
                         "123.123.123.123",
@@ -1591,8 +1591,8 @@ class AuthorisationHandlerTest {
         inOrder.verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED,
-                        CLIENT_SESSION_ID,
                         "",
+                        CLIENT_SESSION_ID,
                         "",
                         "",
                         "",
@@ -1742,8 +1742,8 @@ class AuthorisationHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             eq(event),
-                            eq(CLIENT_SESSION_ID),
                             any(),
+                            eq(CLIENT_SESSION_ID),
                             any(),
                             any(),
                             any(),
@@ -1786,9 +1786,9 @@ class AuthorisationHandlerTest {
         inOrder.verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTHORISATION_REQUEST_PARSED,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         AuditService.UNKNOWN,
-                        CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         "123.123.123.123",

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -93,9 +93,9 @@ class UserInfoHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.USER_INFO_RETURNED,
+                        "client-id",
                         AuditService.UNKNOWN,
                         "",
-                        "client-id",
                         AUDIT_SUBJECT_ID.getValue(),
                         "",
                         "",
@@ -122,9 +122,9 @@ class UserInfoHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.USER_INFO_RETURNED,
+                        "client-id",
                         AuditService.UNKNOWN,
                         "",
-                        "client-id",
                         AUDIT_SUBJECT_ID.getValue(),
                         "",
                         "",

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -218,9 +218,9 @@ public class InitiateIPVAuthorisationServiceTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
+                        CLIENT_ID,
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        CLIENT_ID,
                         expectedCommonSubject,
                         EMAIL_ADDRESS,
                         IP_ADDRESS,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/audit/TxmaAuditUser.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/audit/TxmaAuditUser.java
@@ -1,6 +1,9 @@
 package uk.gov.di.orchestration.audit;
 
 import com.google.gson.annotations.Expose;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class TxmaAuditUser {
 
@@ -59,5 +62,53 @@ public class TxmaAuditUser {
 
     public String getPhone() {
         return phone;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TxmaAuditUser that = (TxmaAuditUser) o;
+
+        return new EqualsBuilder()
+                .append(userId, that.userId)
+                .append(transactionId, that.transactionId)
+                .append(email, that.email)
+                .append(phone, that.phone)
+                .append(ipAddress, that.ipAddress)
+                .append(sessionId, that.sessionId)
+                .append(persistentSessionId, that.persistentSessionId)
+                .append(govukSigninJourneyId, that.govukSigninJourneyId)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(userId)
+                .append(transactionId)
+                .append(email)
+                .append(phone)
+                .append(ipAddress)
+                .append(sessionId)
+                .append(persistentSessionId)
+                .append(govukSigninJourneyId)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("userId", userId)
+                .append("transactionId", transactionId)
+                .append("email", email)
+                .append("phone", phone)
+                .append("ipAddress", ipAddress)
+                .append("sessionId", sessionId)
+                .append("persistentSessionId", persistentSessionId)
+                .append("govukSigninJourneyId", govukSigninJourneyId)
+                .toString();
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/audit/TxmaAuditUser.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/audit/TxmaAuditUser.java
@@ -56,4 +56,8 @@ public class TxmaAuditUser {
         this.govukSigninJourneyId = govukSigninJourneyId;
         return this;
     }
+
+    public String getPhone() {
+        return phone;
+    }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
@@ -43,9 +43,9 @@ public class AuditService {
     public void submitAuditEvent(AuditableEvent event, AuditContext auditContext) {
         submitAuditEvent(
                 event,
+                auditContext.clientId(),
                 auditContext.clientSessionId(),
                 auditContext.sessionId(),
-                auditContext.clientId(),
                 auditContext.subjectId(),
                 auditContext.email(),
                 auditContext.ipAddress(),
@@ -56,9 +56,9 @@ public class AuditService {
 
     public void submitAuditEvent(
             AuditableEvent event,
+            String clientId,
             String clientSessionId,
             String sessionId,
-            String clientId,
             String subjectId,
             String email,
             String ipAddress,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
@@ -76,6 +76,14 @@ public class AuditService {
                         .withPersistentSessionId(persistentSessionId)
                         .withGovukSigninJourneyId(clientSessionId);
 
+        submitAuditEvent(event, clientId, user, metadataPairs);
+    }
+
+    public void submitAuditEvent(
+            AuditableEvent event,
+            String clientId,
+            TxmaAuditUser user,
+            MetadataPair... metadataPairs) {
         var txmaAuditEvent =
                 auditEventWithTime(event, () -> Date.from(clock.instant()))
                         .withClientId(clientId)
@@ -89,7 +97,7 @@ public class AuditService {
         Arrays.stream(metadataPairs)
                 .forEach(pair -> txmaAuditEvent.addExtension(pair.getKey(), pair.getValue()));
 
-        Optional.ofNullable(phoneNumber)
+        Optional.ofNullable(user.getPhone())
                 .filter(not(String::isBlank))
                 .flatMap(PhoneNumberHelper::maybeGetCountry)
                 .ifPresent(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -148,9 +148,9 @@ public class LogoutService {
         }
         auditService.submitAuditEvent(
                 LogoutAuditableEvent.LOG_OUT_SUCCESS,
+                clientId.orElse(AuditService.UNKNOWN),
                 AuditService.UNKNOWN,
                 sessionId.orElse(AuditService.UNKNOWN),
-                clientId.orElse(AuditService.UNKNOWN),
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 IpAddressHelper.extractIpAddress(input),

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuditServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuditServiceTest.java
@@ -51,9 +51,9 @@ class AuditServiceTest {
 
         auditService.submitAuditEvent(
                 TEST_EVENT_ONE,
+                "client-id",
                 "request-id",
                 "session-id",
-                "client-id",
                 "subject-id",
                 "email",
                 "ip-address",
@@ -88,9 +88,9 @@ class AuditServiceTest {
 
         auditService.submitAuditEvent(
                 TEST_EVENT_ONE,
+                "client-id",
                 "request-id",
                 "session-id",
-                "client-id",
                 "subject-id",
                 "email",
                 "ip-address",
@@ -117,9 +117,9 @@ class AuditServiceTest {
 
         auditService.submitAuditEvent(
                 TEST_EVENT_ONE,
+                "client-id",
                 "request-id",
                 "session-id",
-                "client-id",
                 "subject-id",
                 "email",
                 "ip-address",

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -158,9 +158,9 @@ public class LogoutServiceTest {
         verify(auditService)
                 .submitAuditEvent(
                         LogoutAuditableEvent.LOG_OUT_SUCCESS,
+                        CLIENT_ID,
                         AuditService.UNKNOWN,
                         SESSION_ID,
-                        CLIENT_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         IP_ADDRESS,
@@ -185,9 +185,9 @@ public class LogoutServiceTest {
         verify(auditService)
                 .submitAuditEvent(
                         LogoutAuditableEvent.LOG_OUT_SUCCESS,
+                        CLIENT_ID,
                         AuditService.UNKNOWN,
                         SESSION_ID,
-                        CLIENT_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         IP_ADDRESS,
@@ -213,9 +213,9 @@ public class LogoutServiceTest {
         verify(auditService)
                 .submitAuditEvent(
                         LogoutAuditableEvent.LOG_OUT_SUCCESS,
+                        CLIENT_ID,
                         AuditService.UNKNOWN,
                         SESSION_ID,
-                        CLIENT_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         IP_ADDRESS,
@@ -243,8 +243,8 @@ public class LogoutServiceTest {
                 .submitAuditEvent(
                         LogoutAuditableEvent.LOG_OUT_SUCCESS,
                         AuditService.UNKNOWN,
-                        SESSION_ID,
                         AuditService.UNKNOWN,
+                        SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         IP_ADDRESS,
@@ -277,9 +277,9 @@ public class LogoutServiceTest {
         verify(auditService)
                 .submitAuditEvent(
                         LogoutAuditableEvent.LOG_OUT_SUCCESS,
+                        CLIENT_ID,
                         AuditService.UNKNOWN,
                         SESSION_ID,
-                        CLIENT_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         IP_ADDRESS,
@@ -308,9 +308,9 @@ public class LogoutServiceTest {
         verify(auditService)
                 .submitAuditEvent(
                         LogoutAuditableEvent.LOG_OUT_SUCCESS,
+                        CLIENT_ID,
                         AuditService.UNKNOWN,
                         SESSION_ID,
-                        CLIENT_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         IP_ADDRESS,


### PR DESCRIPTION
This PR refactors the `submitAuditMessage` method to take fewer parameters, so we avoid large callsites in the application code.