### PR TITLE
ATO-554: Remove read permission from spot queue from resource policy

### DIFF
--- a/ci/terraform/oidc/spot-sqs.tf
+++ b/ci/terraform/oidc/spot-sqs.tf
@@ -28,7 +28,7 @@ resource "aws_sqs_queue" "spot_request_dead_letter_queue" {
 }
 
 
-data "aws_iam_policy_document" "spot_request_queue_policy_document" {
+data "aws_iam_policy_document" "spot_request_queue_policy_document_with_ipv_callback" {
   statement {
     sid    = "SendSQS"
     effect = "Allow"
@@ -70,13 +70,36 @@ data "aws_iam_policy_document" "spot_request_queue_policy_document" {
   }
 }
 
+data "aws_iam_policy_document" "spot_request_queue_policy_document" {
+  statement {
+    sid    = "AllowSpotAccountToReceive"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${aws_ssm_parameter.spot_account_number.value}:root"]
+    }
+
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+    ]
+
+    resources = [
+      aws_sqs_queue.spot_request_queue.arn
+    ]
+  }
+}
+
 resource "aws_sqs_queue_policy" "spot_request_queue_policy" {
   depends_on = [
     data.aws_iam_policy_document.spot_request_queue_policy_document,
   ]
 
   queue_url = aws_sqs_queue.spot_request_queue.id
-  policy    = data.aws_iam_policy_document.spot_request_queue_policy_document.json
+  policy    = var.remove_ipv_callback_from_spot_queue_resource_policy ? data.aws_iam_policy_document.spot_request_queue_policy_document.json : data.aws_iam_policy_document.spot_request_queue_policy_document_with_ipv_callback.json
 }
 
 data "aws_iam_policy_document" "spot_request_dlq_queue_policy_document" {

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -21,3 +21,5 @@ orch_doc_app_callback_name                       = "staging-orch-be-deploy-DocAp
 back_channel_logout_cross_account_access_enabled = true
 kms_cross_account_access_enabled                 = true
 cmk_for_back_channel_logout_enabled              = true
+
+remove_ipv_callback_from_spot_queue_resource_policy = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -593,6 +593,12 @@ variable "oidc_origin_domain_enabled" {
   description = "Feature flag to control the creation of DNS records for the origin.oidc domain"
 }
 
+variable "remove_ipv_callback_from_spot_queue_resource_policy" {
+  type        = bool
+  default     = false
+  description = "Feature flag to control the removal of read permissions to the IPV callback lambda through a resource policy"
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What

We should move to identity policies for access to our queues. I have set up identity based access to the spot queue in the previous PR https://github.com/govuk-one-login/authentication-api/pull/4324 and this PR will start the rollout of removing the resource policies.

## How to review

Check it's feature flagged, and the logic is the correct way around
