### PR TITLE
ATO-516: Bypass oidc origin rate limiting for requests containing cloudfront header

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -113,6 +113,8 @@ data "aws_region" "current" {
 
 locals {
   api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_api.id}/${var.environment}/_user_request_" : "https://${local.oidc_api_fqdn}/"
+
+  cloudfront_origin_cloaking_header_name = "origin-cloaking-secret"
 }
 
 resource "aws_api_gateway_deployment" "deployment" {
@@ -333,6 +335,49 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
       rate_based_statement {
         limit              = var.environment == "staging" ? 600000 : 3600
         aggregate_key_type = "IP"
+        scope_down_statement {
+          and_statement {
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      single_header {
+                        name = local.cloudfront_origin_cloaking_header_name
+                      }
+                    }
+                    positional_constraint = "EXACTLY"
+                    search_string         = var.oidc_origin_cloaking_header
+                    text_transformation {
+                      priority = 0
+                      type     = "NONE"
+                    }
+                  }
+                }
+              }
+            }
+
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      single_header {
+                        name = local.cloudfront_origin_cloaking_header_name
+                      }
+                    }
+                    positional_constraint = "EXACTLY"
+                    search_string         = var.previous_oidc_origin_cloaking_header
+                    text_transformation {
+                      priority = 0
+                      type     = "NONE"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
     visibility_config {

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -611,6 +611,16 @@ variable "txma_audit_encoded_enabled" {
   description = "Whether the service should pass cloudfront header to txma"
 }
 
+variable "oidc_origin_cloaking_header" {
+  type        = string
+  description = "Secret header to prove the origin request comes via cloudfront. Set using secrets manager and the read secrets script."
+}
+
+variable "previous_oidc_origin_cloaking_header" {
+  type        = string
+  description = "Used in rotation of the origin cloaking header. Set using secrets manager and the read secrets script."
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION

Once traffic is routed through cloudfront, all requests will be coming from a small pool of cloudfront IPs. It does not make sense to rate limit based on them. We are ratelimiting with a WAF at edge. This covers the origin for the transition to cloudfront.

I've set up deployment secrets in all environments for this