### PR TITLE
Bau/refactor start handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ClientStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ClientStartInfo.java
@@ -7,80 +7,12 @@ import com.nimbusds.oauth2.sdk.id.State;
 import java.net.URI;
 import java.util.List;
 
-public class ClientStartInfo {
-
-    @SerializedName("clientName")
-    @Expose
-    private String clientName;
-
-    @SerializedName("scopes")
-    @Expose
-    private List<String> scopes;
-
-    @SerializedName("serviceType")
-    @Expose
-    private String serviceType;
-
-    @SerializedName("cookieConsentShared")
-    @Expose
-    private boolean cookieConsentShared;
-
-    @SerializedName("redirectUri")
-    @Expose
-    private URI redirectUri;
-
-    @SerializedName("state")
-    @Expose
-    private State state;
-
-    @SerializedName("isOneLoginService")
-    @Expose
-    private boolean oneLoginService;
-
-    public ClientStartInfo() {}
-
-    public ClientStartInfo(
-            String clientName,
-            List<String> scopes,
-            String serviceType,
-            boolean cookieConsentShared,
-            URI redirectUri,
-            State state,
-            boolean oneLoginService) {
-        this.clientName = clientName;
-        this.scopes = scopes;
-        this.serviceType = serviceType;
-        this.cookieConsentShared = cookieConsentShared;
-        this.redirectUri = redirectUri;
-        this.state = state;
-        this.oneLoginService = oneLoginService;
-    }
-
-    public String getClientName() {
-        return clientName;
-    }
-
-    public List<String> getScopes() {
-        return scopes;
-    }
-
-    public String getServiceType() {
-        return serviceType;
-    }
-
-    public boolean getCookieConsentShared() {
-        return cookieConsentShared;
-    }
-
-    public URI getRedirectUri() {
-        return redirectUri;
-    }
-
-    public State getState() {
-        return state;
-    }
-
-    public boolean isOneLoginService() {
-        return oneLoginService;
-    }
-}
+public record ClientStartInfo(
+        @SerializedName("clientName") @Expose String clientName,
+        @SerializedName("scopes") @Expose List<String> scopes,
+        @SerializedName("serviceType") @Expose String serviceType,
+        @SerializedName("cookieConsentShared") @Expose boolean cookieConsentShared,
+        @SerializedName("redirectUri") @Expose URI redirectUri,
+        @SerializedName("state") @Expose State state,
+        @SerializedName("isOneLoginService") @Expose boolean isOneLoginService) {}
+;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartResponse.java
@@ -4,30 +4,6 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.validation.Required;
 
-public class StartResponse {
-
-    @SerializedName("user")
-    @Required
-    @Expose
-    private UserStartInfo user;
-
-    @SerializedName("client")
-    @Required
-    @Expose
-    private ClientStartInfo client;
-
-    public StartResponse() {}
-
-    public StartResponse(UserStartInfo user, ClientStartInfo client) {
-        this.user = user;
-        this.client = client;
-    }
-
-    public UserStartInfo getUser() {
-        return user;
-    }
-
-    public ClientStartInfo getClient() {
-        return client;
-    }
-}
+public record StartResponse(
+        @SerializedName("user") @Required @Expose UserStartInfo user,
+        @SerializedName("client") @Required @Expose ClientStartInfo client) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
@@ -5,94 +5,12 @@ import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.validation.Required;
 
-public class UserStartInfo {
-
-    @SerializedName("consentRequired")
-    @Expose
-    @Required
-    private boolean consentRequired;
-
-    @SerializedName("upliftRequired")
-    @Expose
-    @Required
-    private boolean upliftRequired;
-
-    @SerializedName("identityRequired")
-    @Expose
-    @Required
-    private boolean identityRequired;
-
-    @SerializedName("authenticated")
-    @Expose
-    @Required
-    private boolean authenticated;
-
-    @SerializedName("cookieConsent")
-    @Expose
-    private String cookieConsent;
-
-    @SerializedName("gaCrossDomainTrackingId")
-    @Expose
-    private String gaCrossDomainTrackingId;
-
-    @SerializedName("docCheckingAppUser")
-    @Expose
-    private boolean docCheckingAppUser;
-
-    @SerializedName("mfaMethodType")
-    @Expose
-    private MFAMethodType mfaMethodType;
-
-    public UserStartInfo() {}
-
-    public UserStartInfo(
-            boolean consentRequired,
-            boolean upliftRequired,
-            boolean identityRequired,
-            boolean authenticated,
-            String cookieConsent,
-            String gaCrossDomainTrackingId,
-            boolean docCheckingAppUser,
-            MFAMethodType mfaMethodType) {
-        this.consentRequired = consentRequired;
-        this.upliftRequired = upliftRequired;
-        this.identityRequired = identityRequired;
-        this.authenticated = authenticated;
-        this.cookieConsent = cookieConsent;
-        this.gaCrossDomainTrackingId = gaCrossDomainTrackingId;
-        this.docCheckingAppUser = docCheckingAppUser;
-        this.mfaMethodType = mfaMethodType;
-    }
-
-    public boolean isConsentRequired() {
-        return consentRequired;
-    }
-
-    public boolean isUpliftRequired() {
-        return upliftRequired;
-    }
-
-    public boolean isIdentityRequired() {
-        return identityRequired;
-    }
-
-    public boolean isAuthenticated() {
-        return authenticated;
-    }
-
-    public String getCookieConsent() {
-        return cookieConsent;
-    }
-
-    public String getGaCrossDomainTrackingId() {
-        return gaCrossDomainTrackingId;
-    }
-
-    public boolean isDocCheckingAppUser() {
-        return docCheckingAppUser;
-    }
-
-    public MFAMethodType getMfaMethodType() {
-        return mfaMethodType;
-    }
-}
+public record UserStartInfo(
+        @SerializedName("consentRequired") @Expose @Required boolean isConsentRequired,
+        @SerializedName("upliftRequired") @Expose @Required boolean isUpliftRequired,
+        @SerializedName("identityRequired") @Expose @Required boolean isIdentityRequired,
+        @SerializedName("authenticated") @Expose @Required boolean isAuthenticated,
+        @SerializedName("cookieConsent") @Expose String cookieConsent,
+        @SerializedName("gaCrossDomainTrackingId") @Expose String gaCrossDomainTrackingId,
+        @SerializedName("docCheckingAppUser") @Expose boolean isDocCheckingAppUser,
+        @SerializedName("mfaMethodType") @Expose MFAMethodType mfaMethodType) {}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -161,26 +161,21 @@ class StartHandlerTest {
         StartResponse response = objectMapper.readValue(result.getBody(), StartResponse.class);
 
         assertThat(
-                response.getClient().getClientName(),
-                equalTo(getClientStartInfo().getClientName()));
-        assertThat(response.getClient().getScopes(), equalTo(getClientStartInfo().getScopes()));
+                response.client().getClientName(), equalTo(getClientStartInfo().getClientName()));
+        assertThat(response.client().getScopes(), equalTo(getClientStartInfo().getScopes()));
         assertThat(
-                response.getClient().getServiceType(),
-                equalTo(getClientStartInfo().getServiceType()));
+                response.client().getServiceType(), equalTo(getClientStartInfo().getServiceType()));
         assertThat(
-                response.getClient().getCookieConsentShared(),
+                response.client().getCookieConsentShared(),
                 equalTo(getClientStartInfo().getCookieConsentShared()));
-        assertThat(response.getClient().getRedirectUri(), equalTo(REDIRECT_URL));
-        assertFalse(response.getClient().isOneLoginService());
+        assertThat(response.client().getRedirectUri(), equalTo(REDIRECT_URL));
+        assertFalse(response.client().isOneLoginService());
+        assertThat(response.user().isConsentRequired(), equalTo(userStartInfo.isConsentRequired()));
         assertThat(
-                response.getUser().isConsentRequired(), equalTo(userStartInfo.isConsentRequired()));
-        assertThat(
-                response.getUser().isIdentityRequired(),
-                equalTo(userStartInfo.isIdentityRequired()));
-        assertThat(
-                response.getUser().isUpliftRequired(), equalTo(userStartInfo.isUpliftRequired()));
-        assertThat(response.getUser().getCookieConsent(), equalTo(cookieConsentValue));
-        assertThat(response.getUser().getGaCrossDomainTrackingId(), equalTo(gaTrackingId));
+                response.user().isIdentityRequired(), equalTo(userStartInfo.isIdentityRequired()));
+        assertThat(response.user().isUpliftRequired(), equalTo(userStartInfo.isUpliftRequired()));
+        assertThat(response.user().getCookieConsent(), equalTo(cookieConsentValue));
+        assertThat(response.user().getGaCrossDomainTrackingId(), equalTo(gaTrackingId));
 
         verify(auditService)
                 .submitAuditEvent(
@@ -234,19 +229,18 @@ class StartHandlerTest {
 
         var response = objectMapper.readValue(result.getBody(), StartResponse.class);
 
-        assertThat(response.getClient().getClientName(), equalTo(TEST_CLIENT_NAME));
-        assertThat(response.getClient().getScopes(), equalTo(DOC_APP_SCOPE.toStringList()));
-        assertThat(
-                response.getClient().getServiceType(), equalTo(ServiceType.MANDATORY.toString()));
-        assertThat(response.getClient().getRedirectUri(), equalTo(REDIRECT_URL));
-        assertFalse(response.getClient().getCookieConsentShared());
-        assertTrue(response.getUser().isDocCheckingAppUser());
-        assertFalse(response.getUser().isIdentityRequired());
-        assertFalse(response.getUser().isUpliftRequired());
-        assertFalse(response.getUser().isAuthenticated());
-        assertFalse(response.getUser().isConsentRequired());
-        assertThat(response.getUser().getCookieConsent(), equalTo(null));
-        assertThat(response.getUser().getGaCrossDomainTrackingId(), equalTo(null));
+        assertThat(response.client().getClientName(), equalTo(TEST_CLIENT_NAME));
+        assertThat(response.client().getScopes(), equalTo(DOC_APP_SCOPE.toStringList()));
+        assertThat(response.client().getServiceType(), equalTo(ServiceType.MANDATORY.toString()));
+        assertThat(response.client().getRedirectUri(), equalTo(REDIRECT_URL));
+        assertFalse(response.client().getCookieConsentShared());
+        assertTrue(response.user().isDocCheckingAppUser());
+        assertFalse(response.user().isIdentityRequired());
+        assertFalse(response.user().isUpliftRequired());
+        assertFalse(response.user().isAuthenticated());
+        assertFalse(response.user().isConsentRequired());
+        assertThat(response.user().getCookieConsent(), equalTo(null));
+        assertThat(response.user().getGaCrossDomainTrackingId(), equalTo(null));
         verify(clientSessionService).updateStoredClientSession(anyString(), any());
 
         verify(auditService)
@@ -291,7 +285,7 @@ class StartHandlerTest {
 
         var response = objectMapper.readValue(result.getBody(), StartResponse.class);
 
-        assertFalse(response.getUser().isAuthenticated());
+        assertFalse(response.user().isAuthenticated());
 
         verify(auditService)
                 .submitAuditEvent(
@@ -335,7 +329,7 @@ class StartHandlerTest {
 
         var response = objectMapper.readValue(result.getBody(), StartResponse.class);
 
-        assertTrue(response.getUser().isAuthenticated());
+        assertTrue(response.user().isAuthenticated());
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -166,8 +166,8 @@ class StartHandlerTest {
         assertThat(
                 response.user().isIdentityRequired(), equalTo(userStartInfo.isIdentityRequired()));
         assertThat(response.user().isUpliftRequired(), equalTo(userStartInfo.isUpliftRequired()));
-        assertThat(response.user().getCookieConsent(), equalTo(cookieConsentValue));
-        assertThat(response.user().getGaCrossDomainTrackingId(), equalTo(gaTrackingId));
+        assertThat(response.user().cookieConsent(), equalTo(cookieConsentValue));
+        assertThat(response.user().gaCrossDomainTrackingId(), equalTo(gaTrackingId));
 
         verify(auditService)
                 .submitAuditEvent(
@@ -231,8 +231,8 @@ class StartHandlerTest {
         assertFalse(response.user().isUpliftRequired());
         assertFalse(response.user().isAuthenticated());
         assertFalse(response.user().isConsentRequired());
-        assertThat(response.user().getCookieConsent(), equalTo(null));
-        assertThat(response.user().getGaCrossDomainTrackingId(), equalTo(null));
+        assertThat(response.user().cookieConsent(), equalTo(null));
+        assertThat(response.user().gaCrossDomainTrackingId(), equalTo(null));
         verify(clientSessionService).updateStoredClientSession(anyString(), any());
 
         verify(auditService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -160,15 +160,7 @@ class StartHandlerTest {
 
         StartResponse response = objectMapper.readValue(result.getBody(), StartResponse.class);
 
-        assertThat(
-                response.client().getClientName(), equalTo(getClientStartInfo().getClientName()));
-        assertThat(response.client().getScopes(), equalTo(getClientStartInfo().getScopes()));
-        assertThat(
-                response.client().getServiceType(), equalTo(getClientStartInfo().getServiceType()));
-        assertThat(
-                response.client().getCookieConsentShared(),
-                equalTo(getClientStartInfo().getCookieConsentShared()));
-        assertThat(response.client().getRedirectUri(), equalTo(REDIRECT_URL));
+        assertThat(response.client(), equalTo(getClientStartInfo()));
         assertFalse(response.client().isOneLoginService());
         assertThat(response.user().isConsentRequired(), equalTo(userStartInfo.isConsentRequired()));
         assertThat(
@@ -229,11 +221,11 @@ class StartHandlerTest {
 
         var response = objectMapper.readValue(result.getBody(), StartResponse.class);
 
-        assertThat(response.client().getClientName(), equalTo(TEST_CLIENT_NAME));
-        assertThat(response.client().getScopes(), equalTo(DOC_APP_SCOPE.toStringList()));
-        assertThat(response.client().getServiceType(), equalTo(ServiceType.MANDATORY.toString()));
-        assertThat(response.client().getRedirectUri(), equalTo(REDIRECT_URL));
-        assertFalse(response.client().getCookieConsentShared());
+        assertThat(response.client().clientName(), equalTo(TEST_CLIENT_NAME));
+        assertThat(response.client().scopes(), equalTo(DOC_APP_SCOPE.toStringList()));
+        assertThat(response.client().serviceType(), equalTo(ServiceType.MANDATORY.toString()));
+        assertThat(response.client().redirectUri(), equalTo(REDIRECT_URL));
+        assertFalse(response.client().cookieConsentShared());
         assertTrue(response.user().isDocCheckingAppUser());
         assertFalse(response.user().isIdentityRequired());
         assertFalse(response.user().isUpliftRequired());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -198,8 +198,8 @@ class StartServiceTest {
         assertThat(userStartInfo.isUpliftRequired(), equalTo(false));
         assertThat(userStartInfo.isIdentityRequired(), equalTo(false));
         assertThat(userStartInfo.isConsentRequired(), equalTo(false));
-        assertThat(userStartInfo.getCookieConsent(), equalTo(cookieConsent));
-        assertThat(userStartInfo.getGaCrossDomainTrackingId(), equalTo(gaTrackingId));
+        assertThat(userStartInfo.cookieConsent(), equalTo(cookieConsent));
+        assertThat(userStartInfo.gaCrossDomainTrackingId(), equalTo(gaTrackingId));
         assertThat(userStartInfo.isDocCheckingAppUser(), equalTo(false));
         assertThat(userStartInfo.isAuthenticated(), equalTo(isAuthenticated));
     }
@@ -244,8 +244,8 @@ class StartServiceTest {
         assertThat(userStartInfo.isUpliftRequired(), equalTo(false));
         assertThat(userStartInfo.isIdentityRequired(), equalTo(expectedIdentityRequiredValue));
         assertThat(userStartInfo.isConsentRequired(), equalTo(false));
-        assertThat(userStartInfo.getCookieConsent(), equalTo("some-cookie-consent"));
-        assertThat(userStartInfo.getGaCrossDomainTrackingId(), equalTo("some-ga-tracking-id"));
+        assertThat(userStartInfo.cookieConsent(), equalTo("some-cookie-consent"));
+        assertThat(userStartInfo.gaCrossDomainTrackingId(), equalTo("some-ga-tracking-id"));
         assertThat(userStartInfo.isDocCheckingAppUser(), equalTo(false));
     }
 
@@ -278,8 +278,8 @@ class StartServiceTest {
         assertThat(userStartInfo.isIdentityRequired(), equalTo(false));
         assertThat(userStartInfo.isAuthenticated(), equalTo(false));
         assertThat(userStartInfo.isConsentRequired(), equalTo(false));
-        assertThat(userStartInfo.getCookieConsent(), equalTo("some-cookie-consent"));
-        assertThat(userStartInfo.getGaCrossDomainTrackingId(), equalTo("some-ga-tracking-id"));
+        assertThat(userStartInfo.cookieConsent(), equalTo("some-cookie-consent"));
+        assertThat(userStartInfo.gaCrossDomainTrackingId(), equalTo("some-ga-tracking-id"));
         assertThat(userStartInfo.isDocCheckingAppUser(), equalTo(true));
     }
 
@@ -462,10 +462,10 @@ class StartServiceTest {
         assertThat(userStartInfo.isUpliftRequired(), equalTo(expectedUpliftRequiredValue));
         assertThat(userStartInfo.isIdentityRequired(), equalTo(expectedIdentityRequiredValue));
         assertThat(userStartInfo.isConsentRequired(), equalTo(false));
-        assertThat(userStartInfo.getCookieConsent(), equalTo("some-cookie-consent"));
-        assertThat(userStartInfo.getGaCrossDomainTrackingId(), equalTo("some-ga-tracking-id"));
+        assertThat(userStartInfo.cookieConsent(), equalTo("some-cookie-consent"));
+        assertThat(userStartInfo.gaCrossDomainTrackingId(), equalTo("some-ga-tracking-id"));
         assertThat(userStartInfo.isDocCheckingAppUser(), equalTo(false));
-        assertThat(userStartInfo.getMfaMethodType(), equalTo(expectedMfaMethodType));
+        assertThat(userStartInfo.mfaMethodType(), equalTo(expectedMfaMethodType));
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -491,17 +491,17 @@ class StartServiceTest {
 
         var clientStartInfo = startService.buildClientStartInfo(userContext);
 
-        assertThat(clientStartInfo.getCookieConsentShared(), equalTo(cookieConsentShared));
-        assertThat(clientStartInfo.getClientName(), equalTo(CLIENT_NAME));
-        assertThat(clientStartInfo.getRedirectUri(), equalTo(REDIRECT_URI));
-        assertThat(clientStartInfo.getState().getValue(), equalTo(STATE.getValue()));
+        assertThat(clientStartInfo.cookieConsentShared(), equalTo(cookieConsentShared));
+        assertThat(clientStartInfo.clientName(), equalTo(CLIENT_NAME));
+        assertThat(clientStartInfo.redirectUri(), equalTo(REDIRECT_URI));
+        assertThat(clientStartInfo.state().getValue(), equalTo(STATE.getValue()));
         assertThat(clientStartInfo.isOneLoginService(), equalTo(oneLoginService));
 
         var expectedScopes = SCOPES;
         if (Objects.nonNull(signedJWT)) {
             expectedScopes = DOC_APP_SCOPES;
         }
-        assertThat(clientStartInfo.getScopes(), equalTo(expectedScopes.toStringList()));
+        assertThat(clientStartInfo.scopes(), equalTo(expectedScopes.toStringList()));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -354,12 +354,12 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private void verifyStandardClientInformationSetOnResponse(
             ClientStartInfo clientStartInfo, Scope scope, State state) {
-        assertThat(clientStartInfo.getClientName(), equalTo(TEST_CLIENT_NAME));
-        assertThat(clientStartInfo.getServiceType(), equalTo(ServiceType.MANDATORY.toString()));
-        assertFalse(clientStartInfo.getCookieConsentShared());
-        assertThat(clientStartInfo.getScopes(), equalTo(scope.toStringList()));
-        assertThat(clientStartInfo.getRedirectUri(), equalTo(REDIRECT_URI));
-        assertThat(clientStartInfo.getState().getValue(), equalTo(state.getValue()));
+        assertThat(clientStartInfo.clientName(), equalTo(TEST_CLIENT_NAME));
+        assertThat(clientStartInfo.serviceType(), equalTo(ServiceType.MANDATORY.toString()));
+        assertFalse(clientStartInfo.cookieConsentShared());
+        assertThat(clientStartInfo.scopes(), equalTo(scope.toStringList()));
+        assertThat(clientStartInfo.redirectUri(), equalTo(REDIRECT_URI));
+        assertThat(clientStartInfo.state().getValue(), equalTo(state.getValue()));
     }
 
     private void verifyStandardUserInformationSetOnResponse(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -221,7 +221,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         StartResponse startResponse =
                 objectMapper.readValue(response.getBody(), StartResponse.class);
 
-        assertThat(startResponse.user().getMfaMethodType(), equalTo(mfaMethodType));
+        assertThat(startResponse.user().mfaMethodType(), equalTo(mfaMethodType));
         verifyStandardClientInformationSetOnResponse(startResponse.client(), scope, state);
         verifyStandardUserInformationSetOnResponse(startResponse.user(), true);
         assertThat(startResponse.user().isAuthenticated(), equalTo(true));
@@ -366,8 +366,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             UserStartInfo userStartInfo, Boolean consentRequired) {
         assertFalse(userStartInfo.isConsentRequired());
         assertThat(userStartInfo.isUpliftRequired(), equalTo(false));
-        assertThat(userStartInfo.getCookieConsent(), equalTo(null));
-        assertThat(userStartInfo.getGaCrossDomainTrackingId(), equalTo(null));
+        assertThat(userStartInfo.cookieConsent(), equalTo(null));
+        assertThat(userStartInfo.gaCrossDomainTrackingId(), equalTo(null));
     }
 
     private Map<String, String> standardHeadersWithSessionId(String sessionId) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -174,7 +174,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         StartResponse startResponse =
                 objectMapper.readValue(response.getBody(), StartResponse.class);
 
-        assertThat(startResponse.getUser().isAuthenticated(), equalTo(false));
+        assertThat(startResponse.user().isAuthenticated(), equalTo(false));
 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(START_INFO_FOUND));
     }
@@ -221,10 +221,10 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         StartResponse startResponse =
                 objectMapper.readValue(response.getBody(), StartResponse.class);
 
-        assertThat(startResponse.getUser().getMfaMethodType(), equalTo(mfaMethodType));
-        verifyStandardClientInformationSetOnResponse(startResponse.getClient(), scope, state);
-        verifyStandardUserInformationSetOnResponse(startResponse.getUser(), true);
-        assertThat(startResponse.getUser().isAuthenticated(), equalTo(true));
+        assertThat(startResponse.user().getMfaMethodType(), equalTo(mfaMethodType));
+        verifyStandardClientInformationSetOnResponse(startResponse.client(), scope, state);
+        verifyStandardUserInformationSetOnResponse(startResponse.user(), true);
+        assertThat(startResponse.user().isAuthenticated(), equalTo(true));
 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(START_INFO_FOUND));
     }
@@ -267,11 +267,11 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         var startResponse = objectMapper.readValue(response.getBody(), StartResponse.class);
 
-        assertTrue(startResponse.getUser().isDocCheckingAppUser());
-        assertFalse(startResponse.getUser().isAuthenticated());
-        assertFalse(startResponse.getUser().isIdentityRequired());
-        verifyStandardClientInformationSetOnResponse(startResponse.getClient(), scope, state);
-        verifyStandardUserInformationSetOnResponse(startResponse.getUser(), false);
+        assertTrue(startResponse.user().isDocCheckingAppUser());
+        assertFalse(startResponse.user().isAuthenticated());
+        assertFalse(startResponse.user().isIdentityRequired());
+        verifyStandardClientInformationSetOnResponse(startResponse.client(), scope, state);
+        verifyStandardUserInformationSetOnResponse(startResponse.user(), false);
 
         var clientSession = redis.getClientSession(CLIENT_SESSION_ID);
 
@@ -305,9 +305,9 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(redis.getSession(sessionId).isAuthenticated(), equalTo(false));
         var startResponse = objectMapper.readValue(response.getBody(), StartResponse.class);
 
-        assertThat(startResponse.getUser().isAuthenticated(), equalTo(false));
-        verifyStandardUserInformationSetOnResponse(startResponse.getUser(), false);
-        verifyStandardClientInformationSetOnResponse(startResponse.getClient(), scope, STATE);
+        assertThat(startResponse.user().isAuthenticated(), equalTo(false));
+        verifyStandardUserInformationSetOnResponse(startResponse.user(), false);
+        verifyStandardClientInformationSetOnResponse(startResponse.client(), scope, STATE);
 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(START_INFO_FOUND));
     }


### PR DESCRIPTION
## What

Converts response types used in the start handler from classes to records to take advantage of the reduced boilerplate as introduced in more recent java versions. This may also allow for future test refactorings, as it's easier to check equality across two equivalent records.

## How to review

1. Code Review commit by commit