### PR TITLE
AUT-2637: add new fields for audit events

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
@@ -11,6 +11,8 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
+import java.util.Optional;
+
 public class ManuallyDeleteAccountHandler implements RequestHandler<String, String> {
     private final AuthenticationService authenticationService;
     private final AccountDeletionService accountDeletionService;
@@ -52,7 +54,8 @@ public class ManuallyDeleteAccountHandler implements RequestHandler<String, Stri
                         .orElseThrow(() -> new RuntimeException("User not found with given email"));
 
         try {
-            var userIdentifiers = accountDeletionService.removeAccount(userProfile);
+            var userIdentifiers =
+                    accountDeletionService.removeAccount(Optional.empty(), userProfile);
             return userIdentifiers.toString();
         } catch (Json.JsonException e) {
             throw new RuntimeException(e);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -115,7 +116,7 @@ public class RemoveAccountHandler
 
             authoriseRequest(input, userProfile);
 
-            accountDeletionService.removeAccount(userProfile);
+            accountDeletionService.removeAccount(Optional.of(input), userProfile);
 
             return generateEmptySuccessApiGatewayResponse();
         } catch (UserNotFoundException e) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
+import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
@@ -146,9 +147,12 @@ public class UpdatePhoneNumberHandler
 
             auditService.submitAuditEvent(
                     AccountManagementAuditableEvent.UPDATE_PHONE_NUMBER,
-                    AuditService.UNKNOWN,
+                    ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
                     sessionId,
-                    AuditService.UNKNOWN,
+                    input.getRequestContext()
+                            .getAuthorizer()
+                            .getOrDefault("clientId", AuditService.UNKNOWN)
+                            .toString(),
                     internalCommonSubjectIdentifier.getValue(),
                     userProfile.getEmail(),
                     IpAddressHelper.extractIpAddress(input),

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandlerTest.java
@@ -30,7 +30,7 @@ class ManuallyDeleteAccountHandlerTest {
         var userProfile = mock(UserProfile.class);
         when(authenticationService.getUserProfileByEmailMaybe(any()))
                 .thenReturn(Optional.ofNullable(userProfile));
-        when(accountDeletionService.removeAccount(any()))
+        when(accountDeletionService.removeAccount(any(), any()))
                 .thenReturn(mock(AccountDeletionService.DeletedAccountIdentifiers.class));
 
         // when
@@ -38,7 +38,7 @@ class ManuallyDeleteAccountHandlerTest {
 
         // then
         verify(authenticationService).getUserProfileByEmailMaybe(expectedEmail);
-        verify(accountDeletionService).removeAccount(userProfile);
+        verify(accountDeletionService).removeAccount(Optional.empty(), userProfile);
     }
 
     @Test
@@ -57,7 +57,8 @@ class ManuallyDeleteAccountHandlerTest {
         var userProfile = mock(UserProfile.class);
         when(authenticationService.getUserProfileByEmailMaybe(any()))
                 .thenReturn(Optional.ofNullable(userProfile));
-        when(accountDeletionService.removeAccount(any())).thenThrow(Json.JsonException.class);
+        when(accountDeletionService.removeAccount(any(), any()))
+                .thenThrow(Json.JsonException.class);
 
         // then
         assertThrows(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,8 +43,6 @@ class RemoveAccountHandlerTest {
     private static final Subject INTERNAL_SUBJECT = new Subject();
     private static final String PERSISTENT_ID = "some-persistent-session-id";
     private static final byte[] SALT = SaltHelper.generateNewSalt();
-    private final Json objectMapper = SerializationService.getInstance();
-
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT.getValue(), "test.account.gov.uk", SALT);
@@ -88,7 +85,7 @@ class RemoveAccountHandlerTest {
         var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
-        verify(accountDeletionService).removeAccount(userProfile);
+        verify(accountDeletionService).removeAccount(Optional.of(event), userProfile);
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
@@ -55,6 +56,7 @@ class UpdatePhoneNumberHandlerTest {
     private static final String OLD_PHONE_NUMBER = "09876543219";
     private static final String OTP = "123456";
     private static final String PERSISTENT_ID = "some-persistent-session-id";
+    private static final String CLIENT_SESSION_ID = "test-client-session-id";
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final Subject INTERNAL_SUBJECT = new Subject();
     private final String expectedCommonSubject =
@@ -104,7 +106,7 @@ class UpdatePhoneNumberHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.UPDATE_PHONE_NUMBER,
-                        AuditService.UNKNOWN,
+                        CLIENT_SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         expectedCommonSubject,
@@ -201,7 +203,12 @@ class UpdatePhoneNumberHandlerTest {
         proxyRequestContext.setAuthorizer(authorizerParams);
         proxyRequestContext.setIdentity(identityWithSourceIp("123.123.123.123"));
         event.setRequestContext(proxyRequestContext);
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID));
+        event.setHeaders(
+                Map.of(
+                        PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
+                        PERSISTENT_ID,
+                        ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
+                        CLIENT_SESSION_ID));
 
         return event;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -130,7 +130,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         userContext.getSession().getSessionId(),
                         clientId,
                         AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
+                        request.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         persistentSessionId);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -601,7 +601,7 @@ class LoginHandlerTest {
                         session.getSessionId(),
                         "",
                         "",
-                        "",
+                        EMAIL,
                         "123.123.123.123",
                         "",
                         PERSISTENT_ID);


### PR DESCRIPTION
## What

Added new fields to audit events in line with TxMAs requirements. See ticket [AUT-2637](https://govukverify.atlassian.net/browse/AUT-2637) for details

## How to review

1. Code Review
2. Check that audit events in handlers now have fields adder that are outlined in the ticket


[AUT-2637]: https://govukverify.atlassian.net/browse/AUT-2637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ