### PR TITLE
ATO-554: Remove spot queue feature flag

### DIFF
--- a/ci/terraform/oidc/spot-sqs.tf
+++ b/ci/terraform/oidc/spot-sqs.tf
@@ -27,49 +27,6 @@ resource "aws_sqs_queue" "spot_request_dead_letter_queue" {
   tags = local.default_tags
 }
 
-
-data "aws_iam_policy_document" "spot_request_queue_policy_document_with_ipv_callback" {
-  statement {
-    sid    = "SendSQS"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = [module.ipv_callback_role.arn]
-    }
-
-    actions = [
-      "sqs:SendMessage",
-      "sqs:ChangeMessageVisibility",
-      "sqs:GetQueueAttributes",
-    ]
-
-    resources = [
-      aws_sqs_queue.spot_request_queue.arn
-    ]
-  }
-  statement {
-    sid    = "AllowSpotAccountToReceive"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${aws_ssm_parameter.spot_account_number.value}:root"]
-    }
-
-    actions = [
-      "sqs:ReceiveMessage",
-      "sqs:ChangeMessageVisibility",
-      "sqs:DeleteMessage",
-      "sqs:GetQueueAttributes",
-    ]
-
-    resources = [
-      aws_sqs_queue.spot_request_queue.arn
-    ]
-  }
-}
-
 data "aws_iam_policy_document" "spot_request_queue_policy_document" {
   statement {
     sid    = "AllowSpotAccountToReceive"
@@ -99,7 +56,7 @@ resource "aws_sqs_queue_policy" "spot_request_queue_policy" {
   ]
 
   queue_url = aws_sqs_queue.spot_request_queue.id
-  policy    = var.remove_ipv_callback_from_spot_queue_resource_policy ? data.aws_iam_policy_document.spot_request_queue_policy_document.json : data.aws_iam_policy_document.spot_request_queue_policy_document_with_ipv_callback.json
+  policy    = data.aws_iam_policy_document.spot_request_queue_policy_document.json
 }
 
 data "aws_iam_policy_document" "spot_request_dlq_queue_policy_document" {

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -23,5 +23,3 @@ back_channel_logout_cross_account_access_enabled = true
 kms_cross_account_access_enabled                 = true
 cmk_for_back_channel_logout_enabled              = true
 txma_audit_encoded_enabled                       = true
-
-remove_ipv_callback_from_spot_queue_resource_policy = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -605,12 +605,6 @@ variable "oidc_origin_domain_enabled" {
   description = "Feature flag to control the creation of DNS records for the origin.oidc domain"
 }
 
-variable "remove_ipv_callback_from_spot_queue_resource_policy" {
-  type        = bool
-  default     = false
-  description = "Feature flag to control the removal of read permissions to the IPV callback lambda through a resource policy"
-}
-
 variable "txma_audit_encoded_enabled" {
   default     = false
   type        = bool


### PR DESCRIPTION
## What

Remove the feature flag around removing the resource policy to allow access to the spot queue from the ipv callback, since there is now an identity policy in place. This has been tested in staging
