### PR TITLE
Inc 760/add mfa verified to user exists

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
@@ -20,6 +20,10 @@ public class CheckUserExistsResponse {
     @Expose
     private MFAMethodType mfaMethodType;
 
+    @SerializedName("mfaMethodVerified")
+    @Expose
+    private Boolean mfaMethodVerified;
+
     @SerializedName("phoneNumberLastThree")
     @Expose
     private String phoneNumberLastThree;
@@ -53,12 +57,14 @@ public class CheckUserExistsResponse {
             boolean doesUserExist,
             MFAMethodType mfaMethodType,
             String phoneNumberLastThree,
-            List<LockoutInformation> lockoutInformation) {
+            List<LockoutInformation> lockoutInformation,
+            boolean mfaMethodVerified) {
         this.email = email;
         this.doesUserExist = doesUserExist;
         this.mfaMethodType = mfaMethodType;
         this.phoneNumberLastThree = phoneNumberLastThree;
         this.lockoutInformation = lockoutInformation;
+        this.mfaMethodVerified = mfaMethodVerified;
     }
 
     public String getEmail() {
@@ -71,6 +77,10 @@ public class CheckUserExistsResponse {
 
     public MFAMethodType getMfaMethodType() {
         return mfaMethodType;
+    }
+
+    public Boolean getMfaMethodVerified() {
+        return mfaMethodVerified;
     }
 
     public String getPhoneNumberLastThree() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -220,7 +220,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                             userExists,
                             userMfaDetail.getMfaMethodType(),
                             getLastDigitsOfPhoneNumber(userMfaDetail),
-                            lockoutInformation);
+                            lockoutInformation,
+                            userMfaDetail.isMfaMethodVerified());
             sessionService.save(userContext.getSession());
 
             LOG.info("Successfully processed request");

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -155,6 +155,7 @@ class CheckUserExistsHandlerTest {
                     {"email":%s,
                     "doesUserExist":true,
                     "mfaMethodType":"SMS",
+                    "mfaMethodVerified":true,
                     "phoneNumberLastThree":"321",
                     "lockoutInformation":[]}
                     """,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.frontendapi.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.google.gson.JsonParser;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -148,12 +149,19 @@ class CheckUserExistsHandlerTest {
             var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
 
             assertThat(result, hasStatus(200));
-            var checkUserExistsResponse =
-                    objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
-            assertEquals(EMAIL_ADDRESS, checkUserExistsResponse.getEmail());
-            assertEquals("321", checkUserExistsResponse.getPhoneNumberLastThree());
-            assertEquals(MFAMethodType.SMS, checkUserExistsResponse.getMfaMethodType());
-            assertTrue(checkUserExistsResponse.doesUserExist());
+            var expectedResponse =
+                    format(
+                            """
+                    {"email":%s,
+                    "doesUserExist":true,
+                    "mfaMethodType":"SMS",
+                    "phoneNumberLastThree":"321",
+                    "lockoutInformation":[]}
+                    """,
+                            EMAIL_ADDRESS);
+            assertEquals(
+                    JsonParser.parseString(result.getBody()),
+                    JsonParser.parseString(expectedResponse));
         }
 
         @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -11,6 +11,7 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
@@ -127,80 +128,133 @@ class CheckUserExistsHandlerTest {
         reset(authenticationService);
     }
 
-    @Test
-    void shouldReturn200IfUserExists() throws Json.JsonException {
-        usingValidSession();
-        var userProfile = generateUserProfile().withPhoneNumber(PHONE_NUMBER);
-        setupUserProfileAndClient(Optional.of(userProfile));
+    @Nested
+    class WhenUserExists {
+        @BeforeEach
+        void setup() {
+            usingValidSession();
+            var userProfile = generateUserProfile().withPhoneNumber(PHONE_NUMBER);
+            setupUserProfileAndClient(Optional.of(userProfile));
+        }
 
-        MFAMethod mfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, false);
-        MFAMethod mfaMethod2 = verifiedMfaMethod(MFAMethodType.SMS, true);
-        when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
-                .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod1, mfaMethod2)));
+        @Test
+        void shouldReturn200WithRelevantMfaMethod() throws Json.JsonException {
+            MFAMethod mfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, false);
+            MFAMethod mfaMethod2 = verifiedMfaMethod(MFAMethodType.SMS, true);
+            when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
+                    .thenReturn(
+                            new UserCredentials().withMfaMethods(List.of(mfaMethod1, mfaMethod2)));
 
-        var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
+            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
 
-        assertThat(result, hasStatus(200));
-        var checkUserExistsResponse =
-                objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
-        assertEquals(EMAIL_ADDRESS, checkUserExistsResponse.getEmail());
-        assertEquals("321", checkUserExistsResponse.getPhoneNumberLastThree());
-        assertEquals(MFAMethodType.SMS, checkUserExistsResponse.getMfaMethodType());
-        assertTrue(checkUserExistsResponse.doesUserExist());
-        var expectedRpPairwiseId =
-                ClientSubjectHelper.calculatePairwiseIdentifier(
-                        SUBJECT.getValue(), "sector-identifier", SALT.array());
-        var expectedInternalPairwiseId =
-                ClientSubjectHelper.calculatePairwiseIdentifier(
-                        SUBJECT.getValue(), "test.account.gov.uk", SALT.array());
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL,
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        CLIENT_ID,
-                        expectedInternalPairwiseId,
-                        EMAIL_ADDRESS,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID,
-                        AuditService.MetadataPair.pair("rpPairwiseId", expectedRpPairwiseId));
-    }
+            assertThat(result, hasStatus(200));
+            var checkUserExistsResponse =
+                    objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
+            assertEquals(EMAIL_ADDRESS, checkUserExistsResponse.getEmail());
+            assertEquals("321", checkUserExistsResponse.getPhoneNumberLastThree());
+            assertEquals(MFAMethodType.SMS, checkUserExistsResponse.getMfaMethodType());
+            assertTrue(checkUserExistsResponse.doesUserExist());
+        }
 
+        @Test
+        void shouldSubmitTheRelevantAuditEvent() {
+            when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
+                    .thenReturn(new UserCredentials().withMfaMethods(List.of()));
+            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
 
-    @Test
-    void shouldReturn200WithLockInformationIfUserExistsAndMfaIsAuthApp() {
-        usingValidSession();
-        var userProfile = generateUserProfile().withAccountVerified(1);
-        setupUserProfileAndClient(Optional.of(userProfile));
-        when(codeStorageService.getMfaCodeBlockTimeToLive(
-                EMAIL_ADDRESS, MFAMethodType.AUTH_APP, JourneyType.SIGN_IN))
-                .thenReturn(15L);
-        when(codeStorageService.getMfaCodeBlockTimeToLive(
-                EMAIL_ADDRESS, MFAMethodType.AUTH_APP, JourneyType.PASSWORD_RESET_MFA))
-                .thenReturn(15L);
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(
-                EMAIL_ADDRESS, MFAMethodType.AUTH_APP))
-                .thenReturn(6);
-        MFAMethod mfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, true);
-        when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
-                .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod1)));
-        var event = userExistsRequest(EMAIL_ADDRESS);
+            assertThat(result, hasStatus(200));
+            var expectedRpPairwiseId =
+                    ClientSubjectHelper.calculatePairwiseIdentifier(
+                            SUBJECT.getValue(), "sector-identifier", SALT.array());
+            var expectedInternalPairwiseId =
+                    ClientSubjectHelper.calculatePairwiseIdentifier(
+                            SUBJECT.getValue(), "test.account.gov.uk", SALT.array());
+            verify(auditService)
+                    .submitAuditEvent(
+                            FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL,
+                            CLIENT_SESSION_ID,
+                            session.getSessionId(),
+                            CLIENT_ID,
+                            expectedInternalPairwiseId,
+                            EMAIL_ADDRESS,
+                            "123.123.123.123",
+                            AuditService.UNKNOWN,
+                            PERSISTENT_SESSION_ID,
+                            AuditService.MetadataPair.pair("rpPairwiseId", expectedRpPairwiseId));
+        }
 
-        var result = handler.handleRequest(event, context);
-        assertThat(result, hasStatus(200));
-        assertTrue(
-                result.getBody()
-                        .contains(
-                                "\"lockoutInformation\":["
-                                        + "{\"lockType\":\"codeBlock\","
-                                        + "\"mfaMethodType\":\"AUTH_APP\","
-                                        + "\"lockTTL\":15,"
-                                        + "\"journeyType\":\"SIGN_IN\"},"
-                                        + "{\"lockType\":\"codeBlock\","
-                                        + "\"mfaMethodType\":\"AUTH_APP\","
-                                        + "\"lockTTL\":15,"
-                                        + "\"journeyType\":\"PASSWORD_RESET_MFA\"}]"));
+        @Test
+        void shouldReturn200WithLockInformationIfUserExistsAndMfaIsAuthApp() {
+            when(codeStorageService.getMfaCodeBlockTimeToLive(
+                            EMAIL_ADDRESS, MFAMethodType.AUTH_APP, JourneyType.SIGN_IN))
+                    .thenReturn(15L);
+            when(codeStorageService.getMfaCodeBlockTimeToLive(
+                            EMAIL_ADDRESS, MFAMethodType.AUTH_APP, JourneyType.PASSWORD_RESET_MFA))
+                    .thenReturn(15L);
+            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(
+                            EMAIL_ADDRESS, MFAMethodType.AUTH_APP))
+                    .thenReturn(6);
+            MFAMethod mfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, true);
+            when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
+                    .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod1)));
+            var event = userExistsRequest(EMAIL_ADDRESS);
+
+            var result = handler.handleRequest(event, context);
+            assertThat(result, hasStatus(200));
+            assertTrue(
+                    result.getBody()
+                            .contains(
+                                    "\"lockoutInformation\":["
+                                            + "{\"lockType\":\"codeBlock\","
+                                            + "\"mfaMethodType\":\"AUTH_APP\","
+                                            + "\"lockTTL\":15,"
+                                            + "\"journeyType\":\"SIGN_IN\"},"
+                                            + "{\"lockType\":\"codeBlock\","
+                                            + "\"mfaMethodType\":\"AUTH_APP\","
+                                            + "\"lockTTL\":15,"
+                                            + "\"journeyType\":\"PASSWORD_RESET_MFA\"}]"));
+        }
+
+        @Test
+        void shouldReturnNoRedactedPhoneNumberIfNotPresent() throws Json.JsonException {
+            setupUserProfileAndClient(Optional.of(generateUserProfile()));
+
+            MFAMethod mfaMethod = verifiedMfaMethod(MFAMethodType.SMS, true);
+            when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
+                    .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod)));
+
+            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
+
+            assertThat(result, hasStatus(200));
+            var checkUserExistsResponse =
+                    objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
+            assertEquals(EMAIL_ADDRESS, checkUserExistsResponse.getEmail());
+            assertNull(checkUserExistsResponse.getPhoneNumberLastThree());
+        }
+
+        @Test
+        void shouldReturn400AndSaveEmailInUserSessionIfUserAccountIsLocked() {
+            when(codeStorageService.getIncorrectPasswordCount(EMAIL_ADDRESS)).thenReturn(5);
+
+            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.ERROR_1045));
+            verify(sessionService, times(1)).save(any());
+            verify(auditService)
+                    .submitAuditEvent(
+                            ACCOUNT_TEMPORARILY_LOCKED,
+                            CLIENT_SESSION_ID,
+                            session.getSessionId(),
+                            CLIENT_ID,
+                            AuditService.UNKNOWN,
+                            EMAIL_ADDRESS,
+                            "123.123.123.123",
+                            AuditService.UNKNOWN,
+                            PERSISTENT_SESSION_ID,
+                            AuditService.MetadataPair.pair(
+                                    "number_of_attempts_user_allowed_to_login", 5));
+        }
     }
 
     @Test
@@ -228,25 +282,6 @@ class CheckUserExistsHandlerTest {
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID,
                         AuditService.MetadataPair.pair("rpPairwiseId", AuditService.UNKNOWN));
-    }
-
-    @Test
-    void shouldReturnNoRedactedPhoneNumberIfNotPresent() throws Json.JsonException {
-        usingValidSession();
-        setupUserProfileAndClient(Optional.of(generateUserProfile()));
-
-        MFAMethod mfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, false);
-        MFAMethod mfaMethod2 = verifiedMfaMethod(MFAMethodType.SMS, true);
-        when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
-                .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod1, mfaMethod2)));
-
-        var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
-
-        assertThat(result, hasStatus(200));
-        var checkUserExistsResponse =
-                objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
-        assertEquals(EMAIL_ADDRESS, checkUserExistsResponse.getEmail());
-        assertNull(checkUserExistsResponse.getPhoneNumberLastThree());
     }
 
     @Test
@@ -294,33 +329,6 @@ class CheckUserExistsHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID);
-    }
-
-    @Test
-    void shouldReturn400AndSaveEmailInUserSessionIfUserAccountIsLocked() {
-        usingValidSession();
-        setupUserProfileAndClient(Optional.of(generateUserProfile()));
-
-        when(codeStorageService.getIncorrectPasswordCount(EMAIL_ADDRESS)).thenReturn(5);
-
-        var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1045));
-        verify(sessionService, times(1)).save(any());
-        verify(auditService)
-                .submitAuditEvent(
-                        ACCOUNT_TEMPORARILY_LOCKED,
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        CLIENT_ID,
-                        AuditService.UNKNOWN,
-                        EMAIL_ADDRESS,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID,
-                        AuditService.MetadataPair.pair(
-                                "number_of_attempts_user_allowed_to_login", 5));
     }
 
     private void usingValidSession() {


### PR DESCRIPTION
## What

We need to know if a user's mfa method is verified when we get the user exists response, because in the case of a password reset journey we want to ensure that the user is not prompted to enter their mfa code before password reset, since this will result in an error.

This property is currently unused on the frontend.

## How to review

1. Code Review