### PR TITLE
ATO-524: Pass txma-audit-encoded header in AuthenticationCallbackHandler

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -72,6 +72,7 @@ import static uk.gov.di.orchestration.shared.conditions.DocAppUserHelper.isDocCh
 import static uk.gov.di.orchestration.shared.conditions.IdentityHelper.identityRequired;
 import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.orchestration.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
 import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
@@ -175,6 +176,7 @@ public class AuthenticationCallbackHandler
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
         LOG.info("Request received to AuthenticationCallbackHandler");
+        attachTxmaAuditFieldFromHeaders(input.getHeaders());
         try {
             CookieHelper.SessionCookieIds sessionCookiesIds =
                     cookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);


### PR DESCRIPTION
## What

 Pass txma-audit-encoded header in AuthenticationCallbackHandler, using attachTxmaAuditFieldFromHeaders()
