### PR TITLE
INC-760: Do not return an mfa method when none exists

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -63,7 +63,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         userStore.signUp(emailAddress, "password-1");
 
         if (MFAMethodType.SMS == mfaMethodType) {
-            userStore.addMfaMethod(emailAddress, mfaMethodType, false, true, "credential");
+            userStore.addMfaMethod(emailAddress, mfaMethodType, true, true, "credential");
             userStore.addVerifiedPhoneNumber(emailAddress, "+44987654321");
         } else {
             userStore.addMfaMethod(emailAddress, mfaMethodType, true, true, "credential");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
@@ -44,10 +44,9 @@ public class MfaHelper {
             String phoneNumber,
             boolean isPhoneNumberVerified) {
         var isMfaRequired = mfaRequired(userContext.getClientSession().getAuthRequestParams());
-        var mfaMethodVerified = isPhoneNumberVerified;
-
+        var mfaMethodVerified = false;
+        var mfaMethodType = MFAMethodType.NONE;
         var mfaMethod = getPrimaryMFAMethod(userCredentials);
-        var mfaMethodType = MFAMethodType.SMS;
         if (mfaMethod.filter(MFAMethod::isMethodVerified).isPresent()) {
             mfaMethodVerified = true;
             mfaMethodType = MFAMethodType.valueOf(mfaMethod.get().getMfaMethodType());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -458,7 +458,7 @@ public class DynamoService implements AuthenticationService {
         String dateTime = NowHelper.toTimestampString(NowHelper.now());
         MFAMethod mfaMethod =
                 new MFAMethod(
-                        MFAMethodType.AUTH_APP.getValue(),
+                        mfaMethodType.getValue(),
                         credentialValue,
                         methodVerified,
                         enabled,


### PR DESCRIPTION
We were defaulting to returning an MFA method of SMS even when none existed. This meant that when a user with a partially created account was going through a password reset journey, they were hitting an error (because we think they have an MFA method of SMS but actually they do not have a verified phone number.

