### PR TITLE
ATO-475: Tidying up use of cross account back channel logout feature flag

### DIFF
--- a/ci/terraform/oidc/rsa-signing-key.tf
+++ b/ci/terraform/oidc/rsa-signing-key.tf
@@ -4,7 +4,7 @@ resource "aws_kms_key" "id_token_signing_key_rsa" {
   key_usage                = "SIGN_VERIFY"
   customer_master_key_spec = "RSA_4096"
 
-  policy = var.back_channel_logout_cross_account_access_enabled ? data.aws_iam_policy_document.id_token_signing_key_rsa_access_policy_with_orch_access.json : data.aws_iam_policy_document.id_token_signing_key_rsa_access_policy.json
+  policy = var.kms_cross_account_access_enabled ? data.aws_iam_policy_document.id_token_signing_key_rsa_access_policy_with_orch_access.json : data.aws_iam_policy_document.id_token_signing_key_rsa_access_policy.json
 
   tags = local.default_tags
 }

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -59,7 +59,6 @@ orchestration_account_id = "816047645251"
 
 orch_privatesub_cidr_blocks = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
 
-back_channel_logout_cross_account_access_enabled = true
-kms_cross_account_access_enabled                 = true
-doc_app_cross_account_access_enabled             = true
-user_profile_table_cross_account_access_enabled  = true
+kms_cross_account_access_enabled                = true
+doc_app_cross_account_access_enabled            = true
+user_profile_table_cross_account_access_enabled = true

--- a/ci/terraform/shared/staging.tfvars
+++ b/ci/terraform/shared/staging.tfvars
@@ -3,8 +3,7 @@ common_state_bucket                  = "di-auth-staging-tfstate"
 di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:114407264696:/signing-profiles/di_auth_lambda_signing_20220215170204371800000001/zLiNn2Hi1I"
 tools_account_id                     = 706615647326
 
-orchestration_account_id                         = "590183975515"
-orch_privatesub_cidr_blocks                      = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
-back_channel_logout_cross_account_access_enabled = true
-kms_cross_account_access_enabled                 = true
-doc_app_cross_account_access_enabled             = true
+orchestration_account_id             = "590183975515"
+orch_privatesub_cidr_blocks          = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
+kms_cross_account_access_enabled     = true
+doc_app_cross_account_access_enabled = true

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -186,12 +186,6 @@ variable "authentication_callback_userinfo_table_cross_account_access_enabled" {
   description = "Whether the service should allow cross-account access to the authentication callback userinfo table"
 }
 
-variable "back_channel_logout_cross_account_access_enabled" {
-  default     = false
-  type        = bool
-  description = "Whether the service should allow cross-account access by orchestration to the back channel logout queue"
-}
-
 variable "client_registry_table_cross_account_access_enabled" {
   default     = false
   type        = bool


### PR DESCRIPTION
## What

One of the kms keys cross account access was behind the wrong feature flag, and there was also an unused feature flag in shared that has been removed
