### PR TITLE
RFF-2: Migrate to new audit service style

### DIFF
--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.UpdateClientConfigRequest;
@@ -51,6 +52,7 @@ class UpdateClientConfigHandlerTest {
     private static final List<String> SCOPES = singletonList("openid");
     private static final String SERVICE_TYPE = String.valueOf(MANDATORY);
     private static final Json objectMapper = SerializationService.getInstance();
+    private static final TxmaAuditUser USER = TxmaAuditUser.user().withIpAddress("");
 
     private final Context context = mock(Context.class);
     private final ClientService clientService = mock(ClientService.class);
@@ -112,8 +114,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
-        verify(auditService)
-                .submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "", "", "", "", "", "", "", "");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "", USER);
     }
 
     @Test
@@ -125,8 +126,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
-        verify(auditService)
-                .submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "", "", "", "", "", "", "", "");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "", USER);
     }
 
     @Test
@@ -140,9 +140,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString()));
 
-        verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, CLIENT_ID, "", "", "", "", "", "", "");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, CLIENT_ID, USER);
     }
 
     @Test
@@ -163,9 +161,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_PUBLIC_KEY.toJSONObject().toJSONString()));
 
-        verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, CLIENT_ID, "", "", "", "", "", "", "");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, CLIENT_ID, USER);
     }
 
     @Test
@@ -183,9 +179,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_SCOPE.toJSONObject().toJSONString()));
 
-        verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, CLIENT_ID, "", "", "", "", "", "", "");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, CLIENT_ID, USER);
     }
 
     private ClientRegistry createClientRegistry() {
@@ -206,8 +200,7 @@ class UpdateClientConfigHandlerTest {
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
         var response = handler.handleRequest(event, context);
 
-        verify(auditService)
-                .submitAuditEvent(UPDATE_CLIENT_REQUEST_RECEIVED, "", "", "", "", "", "", "", "");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_RECEIVED, "", USER);
 
         return response;
     }

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.app.domain.DocAppAuditableEvent;
 import uk.gov.di.authentication.app.entity.DocAppAuthorisationResponse;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
@@ -158,13 +159,12 @@ class DocAppAuthorizeHandlerTest {
                 .submitAuditEvent(
                         DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
                         CLIENT_ID.getValue(),
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        DOC_APP_SUBJECT_ID.getValue(),
-                        AuditService.UNKNOWN,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        TxmaAuditUser.user()
+                                .withGovukSigninJourneyId(CLIENT_SESSION_ID)
+                                .withSessionId(SESSION_ID)
+                                .withUserId(DOC_APP_SUBJECT_ID.getValue())
+                                .withIpAddress("123.123.123.123")
+                                .withPersistentSessionId(PERSISTENT_SESSION_ID));
         verify(cloudwatchMetricsService)
                 .incrementCounter("DocAppHandoff", Map.of("Environment", ENVIRONMENT));
     }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.ipv.entity.IpvCallbackException;
 import uk.gov.di.authentication.ipv.entity.LogIds;
 import uk.gov.di.authentication.ipv.entity.SPOTClaims;
 import uk.gov.di.authentication.ipv.entity.SPOTRequest;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.IdentityClaims;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -122,13 +123,9 @@ public class IPVCallbackHelper {
         auditService.submitAuditEvent(
                 IPVAuditableEvent.IPV_UNSUCCESSFUL_AUTHORISATION_RESPONSE_RECEIVED,
                 authenticationRequest.getClientID().getValue(),
-                clientSessionId,
-                sessionId,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN);
+                TxmaAuditUser.user()
+                        .withGovukSigninJourneyId(clientSessionId)
+                        .withSessionId(sessionId));
         var errorResponse =
                 new AuthenticationErrorResponse(
                         authenticationRequest.getRedirectionURI(),
@@ -200,15 +197,15 @@ public class IPVCallbackHelper {
         auditService.submitAuditEvent(
                 IPVAuditableEvent.AUTH_CODE_ISSUED,
                 authRequest.getClientID().getValue(),
-                clientSessionId,
-                session.getSessionId(),
-                internalPairwiseSubjectId,
-                Objects.isNull(session.getEmailAddress())
-                        ? AuditService.UNKNOWN
-                        : session.getEmailAddress(),
-                ipAddress,
-                AuditService.UNKNOWN,
-                persistentSessionId,
+                TxmaAuditUser.user()
+                        .withGovukSigninJourneyId(clientSessionId)
+                        .withSessionId(session.getSessionId())
+                        .withUserId(internalPairwiseSubjectId)
+                        .withEmail(
+                                Optional.ofNullable(session.getEmailAddress())
+                                        .orElse(AuditService.UNKNOWN))
+                        .withIpAddress(ipAddress)
+                        .withPersistentSessionId(persistentSessionId),
                 pair("internalSubjectId", subjectId),
                 pair("isNewAccount", session.isNewAccount()),
                 pair("rpPairwiseId", rpPairwiseSubject.getValue()),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandler.java
@@ -6,11 +6,12 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.services.IPVCapacityService;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
+import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_CAPACITY_REQUESTED;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
 public class IPVCapacityHandler
@@ -40,15 +41,7 @@ public class IPVCapacityHandler
 
         LOG.info("Request received to IPVCapacityHandler");
         auditService.submitAuditEvent(
-                IPVAuditableEvent.IPV_CAPACITY_REQUESTED,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN);
+                IPV_CAPACITY_REQUESTED, AuditService.UNKNOWN, TxmaAuditUser.user());
         if (capacityService.isIPVCapacityAvailable()) {
             LOG.info("IPV Capacity available");
             return generateApiGatewayProxyResponse(200, "");

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.IpvCallbackException;
 import uk.gov.di.authentication.ipv.entity.LogIds;
 import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
@@ -197,13 +198,9 @@ class IPVCallbackHelperTest {
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_UNSUCCESSFUL_AUTHORISATION_RESPONSE_RECEIVED,
                         authRequest.getClientID().getValue(),
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN);
+                        TxmaAuditUser.user()
+                                .withGovukSigninJourneyId(CLIENT_SESSION_ID)
+                                .withSessionId(SESSION_ID));
         assertEquals(302, response.getStatusCode());
         assertEquals(expectedURI, response.getHeaders().get(ResponseHeaders.LOCATION));
     }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.IPVAuthorisationResponse;
 import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
@@ -229,17 +230,21 @@ public class IPVAuthorisationHandlerTest {
                         eq(EMAIL_ADDRESS),
                         eq(List.of("P0", "P2")),
                         any());
+
+        var user =
+                TxmaAuditUser.user()
+                        .withGovukSigninJourneyId(CLIENT_SESSION_ID)
+                        .withSessionId(SESSION_ID)
+                        .withUserId(expectedCommonSubject)
+                        .withEmail(EMAIL_ADDRESS)
+                        .withIpAddress("123.123.123.123")
+                        .withPersistentSessionId(PERSISTENT_SESSION_ID);
+
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
                         CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL_ADDRESS,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID,
+                        user,
                         pair("clientLandingPageUrl", LANDING_PAGE_URL),
                         pair("rpPairwiseId", expectedRpPairwiseId));
         verify(cloudwatchMetricsService)

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -40,6 +40,7 @@ import uk.gov.di.authentication.ipv.helpers.IPVCallbackHelper;
 import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.ipv.services.IPVTokenService;
 import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
@@ -950,13 +951,13 @@ class IPVCallbackHandlerTest {
                 .submitAuditEvent(
                         auditableEvent,
                         CLIENT_ID.getValue(),
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        TEST_EMAIL_ADDRESS,
-                        AuditService.UNKNOWN,
-                        userProfile.getPhoneNumber(),
-                        PERSISTENT_SESSION_ID);
+                        TxmaAuditUser.user()
+                                .withGovukSigninJourneyId(CLIENT_SESSION_ID)
+                                .withSessionId(SESSION_ID)
+                                .withUserId(expectedCommonSubject)
+                                .withEmail(TEST_EMAIL_ADDRESS)
+                                .withPhone(userProfile.getPhoneNumber())
+                                .withPersistentSessionId(PERSISTENT_SESSION_ID));
     }
 
     private APIGatewayProxyRequestEvent getApiGatewayProxyRequestEvent(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandlerTest.java
@@ -2,15 +2,17 @@ package uk.gov.di.authentication.ipv.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.ipv.services.IPVCapacityService;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.services.AuditService;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_CAPACITY_REQUESTED;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVCapacityHandlerTest {
@@ -31,25 +33,19 @@ class IPVCapacityHandlerTest {
     void shouldReturn200WhenIPVCapacityAvailable() {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
 
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        APIGatewayProxyResponseEvent response = makeHandlerRequest(event);
+        var response = handler.handleRequest(new APIGatewayProxyRequestEvent(), context);
 
         assertThat(response, hasStatus(200));
+        verify(auditService).submitAuditEvent(IPV_CAPACITY_REQUESTED, "", TxmaAuditUser.user());
     }
 
     @Test
     void shouldReturn503WhenIPVCapacityUnavailable() {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(false);
 
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        APIGatewayProxyResponseEvent response = makeHandlerRequest(event);
+        var response = handler.handleRequest(new APIGatewayProxyRequestEvent(), context);
 
         assertThat(response, hasStatus(503));
-    }
-
-    private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
-        var response = handler.handleRequest(event, context);
-
-        return response;
+        verify(auditService).submitAuditEvent(IPV_CAPACITY_REQUESTED, "", TxmaAuditUser.user());
     }
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -5,7 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 
@@ -15,7 +15,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.ipv.lambda.ProcessingIdentityHandlerTest.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED;
+import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED;
 
 class SPOTResponseHandlerTest {
 
@@ -27,7 +28,14 @@ class SPOTResponseHandlerTest {
     private static final String REQUEST_ID = "request-id";
     private static final String SESSION_ID = "a-session-id";
     private static final String PERSISTENT_SESSION_ID = "a-persistent-id";
+    private static final String CLIENT_SESSION_ID = "known-client-session-id";
+
     private static final ClientID CLIENT_ID = new ClientID();
+    private static final TxmaAuditUser USER =
+            TxmaAuditUser.user()
+                    .withGovukSigninJourneyId(CLIENT_SESSION_ID)
+                    .withSessionId(SESSION_ID)
+                    .withPersistentSessionId(PERSISTENT_SESSION_ID);
 
     @BeforeEach
     void setup() {
@@ -58,15 +66,7 @@ class SPOTResponseHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        IPVAuditableEvent.IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED,
-                        CLIENT_ID.getValue(),
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED, CLIENT_ID.getValue(), USER);
     }
 
     @Test
@@ -97,15 +97,7 @@ class SPOTResponseHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        IPVAuditableEvent.IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED,
-                        CLIENT_ID.getValue(),
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED, CLIENT_ID.getValue(), USER);
     }
 
     private SQSEvent generateSQSEvent(String messageBody) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.exceptions.AccessTokenException;
@@ -143,13 +144,7 @@ public class UserInfoHandler
         auditService.submitAuditEvent(
                 OidcAuditableEvent.USER_INFO_RETURNED,
                 accessTokenInfo.getClientID(),
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                subjectForAudit,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
+                TxmaAuditUser.user().withUserId(subjectForAudit),
                 metadataPairs);
 
         return generateApiGatewayProxyResponse(200, userInfo.toJSONString());

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
@@ -111,13 +112,13 @@ public class InitiateIPVAuthorisationService {
         auditService.submitAuditEvent(
                 IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
                 rpClientID,
-                clientSessionId,
-                session.getSessionId(),
-                session.getInternalCommonSubjectIdentifier(),
-                userInfo.getEmailAddress(),
-                IpAddressHelper.extractIpAddress(input),
-                AuditService.UNKNOWN,
-                persistentSessionCookieId,
+                TxmaAuditUser.user()
+                        .withGovukSigninJourneyId(clientSessionId)
+                        .withSessionId(session.getSessionId())
+                        .withUserId(session.getInternalCommonSubjectIdentifier())
+                        .withEmail(userInfo.getEmailAddress())
+                        .withIpAddress(IpAddressHelper.extractIpAddress(input))
+                        .withPersistentSessionId(persistentSessionCookieId),
                 pair("clientLandingPageUrl", client.getLandingPageUrl()),
                 pair("rpPairwiseId", rpPairwiseId));
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AuthCodeResponse;
 import uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
@@ -289,17 +290,18 @@ class AuthCodeHandlerTest {
         var expectedRpPairwiseId =
                 ClientSubjectHelper.calculatePairwiseIdentifier(
                         SUBJECT.getValue(), "rp-sector-uri", SALT);
+
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTH_CODE_ISSUED,
                         CLIENT_ID.getValue(),
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID,
+                        TxmaAuditUser.user()
+                                .withGovukSigninJourneyId(CLIENT_SESSION_ID)
+                                .withSessionId(SESSION_ID)
+                                .withUserId(expectedCommonSubject)
+                                .withEmail(EMAIL)
+                                .withIpAddress("123.123.123.123")
+                                .withPersistentSessionId(PERSISTENT_SESSION_ID),
                         pair("internalSubjectId", SUBJECT.getValue()),
                         pair("isNewAccount", AccountState.NEW),
                         pair("rpPairwiseId", expectedRpPairwiseId),
@@ -398,13 +400,13 @@ class AuthCodeHandlerTest {
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTH_CODE_ISSUED,
                         CLIENT_ID.getValue(),
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        DOC_APP_SUBJECT_ID,
-                        AuditService.UNKNOWN,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID,
+                        TxmaAuditUser.user()
+                                .withGovukSigninJourneyId(CLIENT_SESSION_ID)
+                                .withSessionId(SESSION_ID)
+                                .withUserId(DOC_APP_SUBJECT_ID)
+                                .withEmail("")
+                                .withIpAddress("123.123.123.123")
+                                .withPersistentSessionId(PERSISTENT_SESSION_ID),
                         pair("internalSubjectId", AuditService.UNKNOWN),
                         pair("isNewAccount", AccountState.UNKNOWN),
                         pair("rpPairwiseId", AuditService.UNKNOWN),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -57,6 +57,7 @@ import uk.gov.di.authentication.oidc.exceptions.InvalidHttpMethodException;
 import uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService;
 import uk.gov.di.authentication.oidc.validators.QueryParamsAuthorizeValidator;
 import uk.gov.di.authentication.oidc.validators.RequestObjectAuthorizeValidator;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
@@ -200,6 +201,12 @@ class AuthorisationHandlerTest {
                     .serialize();
     private static final String ID_TOKEN_AUDIENCE = getIdTokenAudience();
     private static final String TXMA_ENCODED_HEADER_VALUE = "dGVzdAo=";
+    private static final TxmaAuditUser BASE_AUDIT_USER =
+            TxmaAuditUser.user()
+                    .withGovukSigninJourneyId(CLIENT_SESSION_ID)
+                    .withIpAddress("123.123.123.123")
+                    .withPersistentSessionId(EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP);
+
     private AuthorisationHandler handler;
 
     @RegisterExtension
@@ -280,13 +287,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
                             CLIENT_ID.getValue(),
-                            CLIENT_SESSION_ID,
-                            session.getSessionId(),
-                            AuditService.UNKNOWN,
-                            AuditService.UNKNOWN,
-                            "123.123.123.123",
-                            AuditService.UNKNOWN,
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER.withSessionId(session.getSessionId()),
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -424,13 +425,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
                             CLIENT_ID.getValue(),
-                            CLIENT_SESSION_ID,
-                            session.getSessionId(),
-                            AuditService.UNKNOWN,
-                            AuditService.UNKNOWN,
-                            "123.123.123.123",
-                            AuditService.UNKNOWN,
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER.withSessionId(session.getSessionId()),
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -469,13 +464,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
                             CLIENT_ID.getValue(),
-                            CLIENT_SESSION_ID,
-                            session.getSessionId(),
-                            AuditService.UNKNOWN,
-                            AuditService.UNKNOWN,
-                            "123.123.123.123",
-                            AuditService.UNKNOWN,
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER.withSessionId(session.getSessionId()),
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -544,13 +533,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
                             CLIENT_ID.getValue(),
-                            CLIENT_SESSION_ID,
-                            session.getSessionId(),
-                            AuditService.UNKNOWN,
-                            AuditService.UNKNOWN,
-                            "123.123.123.123",
-                            AuditService.UNKNOWN,
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER.withSessionId(session.getSessionId()),
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -591,13 +574,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
                             CLIENT_ID.getValue(),
-                            CLIENT_SESSION_ID,
-                            session.getSessionId(),
-                            AuditService.UNKNOWN,
-                            AuditService.UNKNOWN,
-                            "123.123.123.123",
-                            AuditService.UNKNOWN,
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER.withSessionId(session.getSessionId()),
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -641,13 +618,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
                             "",
-                            CLIENT_SESSION_ID,
-                            "",
-                            "",
-                            "",
-                            "123.123.123.123",
-                            "",
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER,
                             pair(
                                     "description",
                                     "Invalid request: Missing response_type parameter"));
@@ -684,13 +655,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
                             CLIENT_ID.getValue(),
-                            CLIENT_SESSION_ID,
-                            "",
-                            "",
-                            "",
-                            "123.123.123.123",
-                            "",
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER,
                             pair("description", OAuth2Error.INVALID_SCOPE.getDescription()));
         }
 
@@ -721,13 +686,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
                             CLIENT_ID.getValue(),
-                            CLIENT_SESSION_ID,
-                            "",
-                            "",
-                            "",
-                            "123.123.123.123",
-                            "",
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER,
                             pair("description", OAuth2Error.INVALID_SCOPE.getDescription()));
         }
 
@@ -792,13 +751,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
                             "",
-                            CLIENT_SESSION_ID,
-                            "",
-                            "",
-                            "",
-                            "123.123.123.123",
-                            "",
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER,
                             pair(
                                     "description",
                                     "Invalid request: Invalid prompt parameter: Unknown prompt type: unrecognised"));
@@ -964,13 +917,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
                             CLIENT_ID.getValue(),
-                            CLIENT_SESSION_ID,
-                            session.getSessionId(),
-                            AuditService.UNKNOWN,
-                            AuditService.UNKNOWN,
-                            "123.123.123.123",
-                            AuditService.UNKNOWN,
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER.withSessionId(SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -1014,13 +961,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
                             CLIENT_ID.getValue(),
-                            CLIENT_SESSION_ID,
-                            session.getSessionId(),
-                            AuditService.UNKNOWN,
-                            AuditService.UNKNOWN,
-                            "123.123.123.123",
-                            AuditService.UNKNOWN,
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER.withSessionId(SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME));
         }
 
@@ -1307,13 +1248,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
                             CLIENT_ID.getValue(),
-                            CLIENT_SESSION_ID,
-                            "",
-                            "",
-                            "",
-                            "123.123.123.123",
-                            "",
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER.withSessionId(SESSION_ID),
                             pair("description", expectedErrorObject.getDescription()));
         }
 
@@ -1369,13 +1304,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
                             CLIENT_ID.getValue(),
-                            CLIENT_SESSION_ID,
-                            "",
-                            "",
-                            "",
-                            "123.123.123.123",
-                            "",
-                            EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                            BASE_AUDIT_USER.withSessionId(SESSION_ID),
                             pair("description", expectedErrorObject.getDescription()));
         }
     }
@@ -1465,11 +1394,16 @@ class AuthorisationHandlerTest {
 
             verify(cloudwatchMetricsService).incrementCounter(eq("DocAppHandoff"), any());
 
-            verifyAuditEvents(
-                    List.of(
-                            OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED,
-                            DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED),
-                    auditService);
+            verify(auditService)
+                    .submitAuditEvent(
+                            OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED, "", BASE_AUDIT_USER);
+            verify(auditService)
+                    .submitAuditEvent(
+                            DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
+                            CLIENT_ID.getValue(),
+                            BASE_AUDIT_USER
+                                    .withSessionId(SESSION_ID)
+                                    .withUserId("test-subject-id"));
         }
     }
 
@@ -1531,13 +1465,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         CLIENT_ID.getValue(),
-                        CLIENT_SESSION_ID,
-                        "",
-                        "",
-                        "",
-                        "123.123.123.123",
-                        "",
-                        EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                        BASE_AUDIT_USER,
                         pair("description", errorObject.getDescription()));
     }
 
@@ -1564,13 +1492,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         CLIENT_ID.getValue(),
-                        CLIENT_SESSION_ID,
-                        "",
-                        "",
-                        "",
-                        "123.123.123.123",
-                        "",
-                        EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                        BASE_AUDIT_USER,
                         pair("description", expectedError.getDescription()));
     }
 
@@ -1579,15 +1501,7 @@ class AuthorisationHandlerTest {
 
         inOrder.verify(auditService)
                 .submitAuditEvent(
-                        OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED,
-                        "",
-                        CLIENT_SESSION_ID,
-                        "",
-                        "",
-                        "",
-                        "123.123.123.123",
-                        "",
-                        EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP);
+                        OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED, "", BASE_AUDIT_USER);
 
         LogEvent logEvent = logging.events().get(0);
 
@@ -1672,7 +1586,7 @@ class AuthorisationHandlerTest {
 
     private ClientRegistry generateClientRegistry() {
         return new ClientRegistry()
-                .withClientID(new ClientID().getValue())
+                .withClientID("test-id")
                 .withConsentRequired(IS_COOKIE_CONSENT_SHARED)
                 .withClientName(RP_CLIENT_NAME)
                 .withSectorIdentifierUri("https://test.com")
@@ -1729,17 +1643,7 @@ class AuthorisationHandlerTest {
     private static void verifyAuditEvents(
             List<AuditableEvent> auditEvents, AuditService auditService) {
         for (AuditableEvent event : auditEvents) {
-            verify(auditService)
-                    .submitAuditEvent(
-                            eq(event),
-                            any(),
-                            eq(CLIENT_SESSION_ID),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any());
+            verify(auditService).submitAuditEvent(eq(event), any(), eq(BASE_AUDIT_USER));
         }
     }
 
@@ -1777,13 +1681,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTHORISATION_REQUEST_PARSED,
                         CLIENT_ID.getValue(),
-                        CLIENT_SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP,
+                        BASE_AUDIT_USER,
                         pair("rpSid", rpSid),
                         pair("identityRequested", identityRequested),
                         pair("reauthRequested", reauthRequested));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.exceptions.AccessTokenException;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
@@ -94,13 +95,7 @@ class UserInfoHandlerTest {
                 .submitAuditEvent(
                         OidcAuditableEvent.USER_INFO_RETURNED,
                         "client-id",
-                        AuditService.UNKNOWN,
-                        "",
-                        AUDIT_SUBJECT_ID.getValue(),
-                        "",
-                        "",
-                        "",
-                        "");
+                        TxmaAuditUser.user().withUserId(AUDIT_SUBJECT_ID.getValue()));
     }
 
     @Test
@@ -123,13 +118,7 @@ class UserInfoHandlerTest {
                 .submitAuditEvent(
                         OidcAuditableEvent.USER_INFO_RETURNED,
                         "client-id",
-                        AuditService.UNKNOWN,
-                        "",
-                        AUDIT_SUBJECT_ID.getValue(),
-                        "",
-                        "",
-                        "",
-                        "",
+                        TxmaAuditUser.user().withUserId(AUDIT_SUBJECT_ID.getValue()),
                         AuditService.MetadataPair.pair("return-code", RETURN_CODE));
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
@@ -219,13 +220,13 @@ public class InitiateIPVAuthorisationServiceTest {
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
                         CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL_ADDRESS,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID,
+                        TxmaAuditUser.user()
+                                .withGovukSigninJourneyId(CLIENT_SESSION_ID)
+                                .withSessionId(SESSION_ID)
+                                .withUserId(expectedCommonSubject)
+                                .withEmail(EMAIL_ADDRESS)
+                                .withIpAddress(IP_ADDRESS)
+                                .withPersistentSessionId(PERSISTENT_SESSION_ID),
                         pair("clientLandingPageUrl", LANDING_PAGE_URL),
                         pair("rpPairwiseId", RP_PAIRWISE_ID));
         verify(cloudwatchMetricsService)

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/audit/TxmaAuditUser.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/audit/TxmaAuditUser.java
@@ -1,114 +1,114 @@
 package uk.gov.di.orchestration.audit;
 
 import com.google.gson.annotations.Expose;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
-public class TxmaAuditUser {
-
-    @Expose private String userId;
-    @Expose private String transactionId;
-    @Expose private String email;
-    @Expose private String phone;
-    @Expose private String ipAddress;
-    @Expose private String sessionId;
-    @Expose private String persistentSessionId;
-    @Expose private String govukSigninJourneyId;
+public record TxmaAuditUser(
+        @Expose String userId,
+        @Expose String transactionId,
+        @Expose String email,
+        @Expose String phone,
+        @Expose String ipAddress,
+        @Expose String sessionId,
+        @Expose String persistentSessionId,
+        @Expose String govukSigninJourneyId) {
 
     public static TxmaAuditUser user() {
-        return new TxmaAuditUser();
+        return new TxmaAuditUser(null, null, null, null, null, null, null, null);
     }
 
     public TxmaAuditUser withUserId(String userId) {
-        this.userId = userId;
-        return this;
+        return new TxmaAuditUser(
+                userId,
+                transactionId,
+                email,
+                phone,
+                ipAddress,
+                sessionId,
+                persistentSessionId,
+                govukSigninJourneyId);
     }
 
     public TxmaAuditUser withTransactionId(String transactionId) {
-        this.transactionId = transactionId;
-        return this;
+        return new TxmaAuditUser(
+                userId,
+                transactionId,
+                email,
+                phone,
+                ipAddress,
+                sessionId,
+                persistentSessionId,
+                govukSigninJourneyId);
     }
 
     public TxmaAuditUser withEmail(String email) {
-        this.email = email;
-        return this;
+        return new TxmaAuditUser(
+                userId,
+                transactionId,
+                email,
+                phone,
+                ipAddress,
+                sessionId,
+                persistentSessionId,
+                govukSigninJourneyId);
     }
 
     public TxmaAuditUser withPhone(String phone) {
-        this.phone = phone;
-        return this;
+        return new TxmaAuditUser(
+                userId,
+                transactionId,
+                email,
+                phone,
+                ipAddress,
+                sessionId,
+                persistentSessionId,
+                govukSigninJourneyId);
     }
 
     public TxmaAuditUser withIpAddress(String ipAddress) {
-        this.ipAddress = ipAddress;
-        return this;
+        return new TxmaAuditUser(
+                userId,
+                transactionId,
+                email,
+                phone,
+                ipAddress,
+                sessionId,
+                persistentSessionId,
+                govukSigninJourneyId);
     }
 
     public TxmaAuditUser withSessionId(String sessionId) {
-        this.sessionId = sessionId;
-        return this;
+        return new TxmaAuditUser(
+                userId,
+                transactionId,
+                email,
+                phone,
+                ipAddress,
+                sessionId,
+                persistentSessionId,
+                govukSigninJourneyId);
     }
 
     public TxmaAuditUser withPersistentSessionId(String persistentSessionId) {
-        this.persistentSessionId = persistentSessionId;
-        return this;
+        return new TxmaAuditUser(
+                userId,
+                transactionId,
+                email,
+                phone,
+                ipAddress,
+                sessionId,
+                persistentSessionId,
+                govukSigninJourneyId);
     }
 
     public TxmaAuditUser withGovukSigninJourneyId(String govukSigninJourneyId) {
-        this.govukSigninJourneyId = govukSigninJourneyId;
-        return this;
-    }
-
-    public String getPhone() {
-        return phone;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-
-        if (o == null || getClass() != o.getClass()) return false;
-
-        TxmaAuditUser that = (TxmaAuditUser) o;
-
-        return new EqualsBuilder()
-                .append(userId, that.userId)
-                .append(transactionId, that.transactionId)
-                .append(email, that.email)
-                .append(phone, that.phone)
-                .append(ipAddress, that.ipAddress)
-                .append(sessionId, that.sessionId)
-                .append(persistentSessionId, that.persistentSessionId)
-                .append(govukSigninJourneyId, that.govukSigninJourneyId)
-                .isEquals();
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-                .append(userId)
-                .append(transactionId)
-                .append(email)
-                .append(phone)
-                .append(ipAddress)
-                .append(sessionId)
-                .append(persistentSessionId)
-                .append(govukSigninJourneyId)
-                .toHashCode();
-    }
-
-    @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .append("userId", userId)
-                .append("transactionId", transactionId)
-                .append("email", email)
-                .append("phone", phone)
-                .append("ipAddress", ipAddress)
-                .append("sessionId", sessionId)
-                .append("persistentSessionId", persistentSessionId)
-                .append("govukSigninJourneyId", govukSigninJourneyId)
-                .toString();
+        return new TxmaAuditUser(
+                userId,
+                transactionId,
+                email,
+                phone,
+                ipAddress,
+                sessionId,
+                persistentSessionId,
+                govukSigninJourneyId);
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
@@ -107,7 +107,7 @@ public class AuditService {
         Arrays.stream(metadataPairs)
                 .forEach(pair -> txmaAuditEvent.addExtension(pair.getKey(), pair.getValue()));
 
-        Optional.ofNullable(user.getPhone())
+        Optional.ofNullable(user.phone())
                 .filter(not(String::isBlank))
                 .flatMap(PhoneNumberHelper::maybeGetCountry)
                 .ifPresent(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuditService.java
@@ -44,42 +44,18 @@ public class AuditService {
     }
 
     public void submitAuditEvent(AuditableEvent event, AuditContext auditContext) {
-        submitAuditEvent(
-                event,
-                auditContext.clientId(),
-                auditContext.clientSessionId(),
-                auditContext.sessionId(),
-                auditContext.subjectId(),
-                auditContext.email(),
-                auditContext.ipAddress(),
-                auditContext.phoneNumber(),
-                auditContext.persistentSessionId(),
-                auditContext.metadataPairs());
-    }
-
-    public void submitAuditEvent(
-            AuditableEvent event,
-            String clientId,
-            String clientSessionId,
-            String sessionId,
-            String subjectId,
-            String email,
-            String ipAddress,
-            String phoneNumber,
-            String persistentSessionId,
-            MetadataPair... metadataPairs) {
 
         var user =
                 TxmaAuditUser.user()
-                        .withUserId(subjectId)
-                        .withPhone(phoneNumber)
-                        .withEmail(email)
-                        .withIpAddress(ipAddress)
-                        .withSessionId(sessionId)
-                        .withPersistentSessionId(persistentSessionId)
-                        .withGovukSigninJourneyId(clientSessionId);
+                        .withUserId(auditContext.subjectId())
+                        .withPhone(auditContext.phoneNumber())
+                        .withEmail(auditContext.email())
+                        .withIpAddress(auditContext.ipAddress())
+                        .withSessionId(auditContext.sessionId())
+                        .withPersistentSessionId(auditContext.persistentSessionId())
+                        .withGovukSigninJourneyId(auditContext.clientSessionId());
 
-        submitAuditEvent(event, clientId, user, metadataPairs);
+        submitAuditEvent(event, auditContext.clientId(), user, auditContext.metadataPairs());
     }
 
     public void submitAuditEvent(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuditServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuditServiceTest.java
@@ -56,16 +56,17 @@ class AuditServiceTest {
     void shouldLogAuditEvent() {
         var auditService = new AuditService(FIXED_CLOCK, configurationService, awsSqsClient);
 
-        auditService.submitAuditEvent(
-                TEST_EVENT_ONE,
-                "client-id",
-                "request-id",
-                "session-id",
-                "subject-id",
-                "email",
-                "ip-address",
-                "phone-number",
-                "persistent-session-id");
+        var user =
+                TxmaAuditUser.user()
+                        .withUserId("subject-id")
+                        .withPhone("phone-number")
+                        .withEmail("email")
+                        .withIpAddress("ip-address")
+                        .withSessionId("session-id")
+                        .withPersistentSessionId("persistent-session-id")
+                        .withGovukSigninJourneyId("request-id");
+
+        auditService.submitAuditEvent(TEST_EVENT_ONE, "client-id", user);
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
 
@@ -93,18 +94,18 @@ class AuditServiceTest {
     void shouldLogAuditEventWithMetadataPairsAttached() {
         var auditService = new AuditService(FIXED_CLOCK, configurationService, awsSqsClient);
 
+        var user =
+                TxmaAuditUser.user()
+                        .withUserId("subject-id")
+                        .withPhone("phone-number")
+                        .withEmail("email")
+                        .withIpAddress("ip-address")
+                        .withSessionId("session-id")
+                        .withPersistentSessionId("persistent-session-id")
+                        .withGovukSigninJourneyId("request-id");
+
         auditService.submitAuditEvent(
-                TEST_EVENT_ONE,
-                "client-id",
-                "request-id",
-                "session-id",
-                "subject-id",
-                "email",
-                "ip-address",
-                "phone-number",
-                "persistent-session-id",
-                pair("key", "value"),
-                pair("key2", "value2"));
+                TEST_EVENT_ONE, "client-id", user, pair("key", "value"), pair("key2", "value2"));
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
         var txmaMessage = asJson(txmaMessageCaptor.getValue());
@@ -122,18 +123,18 @@ class AuditServiceTest {
     void shouldAddCountryCodeExtensionToPhoneNumberEvents() {
         var auditService = new AuditService(FIXED_CLOCK, configurationService, awsSqsClient);
 
+        var user =
+                TxmaAuditUser.user()
+                        .withUserId("subject-id")
+                        .withPhone("07700900000")
+                        .withEmail("email")
+                        .withIpAddress("ip-address")
+                        .withSessionId("session-id")
+                        .withPersistentSessionId("persistent-session-id")
+                        .withGovukSigninJourneyId("request-id");
+
         auditService.submitAuditEvent(
-                TEST_EVENT_ONE,
-                "client-id",
-                "request-id",
-                "session-id",
-                "subject-id",
-                "email",
-                "ip-address",
-                "07700900000",
-                "persistent-session-id",
-                pair("key", "value"),
-                pair("key2", "value2"));
+                TEST_EVENT_ONE, "client-id", user, pair("key", "value"), pair("key2", "value2"));
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
 
@@ -170,7 +171,7 @@ class AuditServiceTest {
     }
 
     @Test
-    void TxmaHeaderNotAddedWhenNotSet() throws JOSEException, InvalidEncodingException {
+    void TxmaHeaderNotAddedWhenNotSet() {
         var auditService = new AuditService(FIXED_CLOCK, configurationService, awsSqsClient);
         when(configurationService.isTxmaAuditEncodedEnabled()).thenReturn(true);
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.MockedStatic;
-import uk.gov.di.orchestration.shared.domain.LogoutAuditableEvent;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.shared.domain.LogoutAuditableEvent.LOG_OUT_SUCCESS;
 import static uk.gov.di.orchestration.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -101,6 +102,11 @@ public class LogoutServiceTest {
     private Optional<String> audience;
     private Session session;
     private LogoutService logoutService;
+    private final TxmaAuditUser user =
+            TxmaAuditUser.user()
+                    .withIpAddress(IP_ADDRESS)
+                    .withSessionId(SESSION_ID)
+                    .withPersistentSessionId(PERSISTENT_SESSION_ID);
 
     @BeforeEach
     void setup() throws JOSEException, ParseException {
@@ -155,17 +161,7 @@ public class LogoutServiceTest {
                         Optional.of(audience.get()),
                         Optional.of(SESSION_ID));
 
-        verify(auditService)
-                .submitAuditEvent(
-                        LogoutAuditableEvent.LOG_OUT_SUCCESS,
-                        CLIENT_ID,
-                        AuditService.UNKNOWN,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+        verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, CLIENT_ID, user);
 
         assertThat(response, hasStatus(302));
         assertThat(
@@ -182,17 +178,7 @@ public class LogoutServiceTest {
                         Optional.of(audience.get()),
                         Optional.of(SESSION_ID));
 
-        verify(auditService)
-                .submitAuditEvent(
-                        LogoutAuditableEvent.LOG_OUT_SUCCESS,
-                        CLIENT_ID,
-                        AuditService.UNKNOWN,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+        verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, CLIENT_ID, user);
         verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
@@ -210,17 +196,7 @@ public class LogoutServiceTest {
                         Optional.of(audience.get()),
                         Optional.of(SESSION_ID));
 
-        verify(auditService)
-                .submitAuditEvent(
-                        LogoutAuditableEvent.LOG_OUT_SUCCESS,
-                        CLIENT_ID,
-                        AuditService.UNKNOWN,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+        verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, CLIENT_ID, user);
         verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
@@ -239,17 +215,7 @@ public class LogoutServiceTest {
                         Optional.empty(),
                         Optional.of(SESSION_ID));
 
-        verify(auditService)
-                .submitAuditEvent(
-                        LogoutAuditableEvent.LOG_OUT_SUCCESS,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+        verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, AuditService.UNKNOWN, user);
         verifyNoInteractions(cloudwatchMetricsService);
 
         assertThat(response, hasStatus(302));
@@ -274,17 +240,7 @@ public class LogoutServiceTest {
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
         verify(sessionService).deleteSessionFromRedis(session.getSessionId());
-        verify(auditService)
-                .submitAuditEvent(
-                        LogoutAuditableEvent.LOG_OUT_SUCCESS,
-                        CLIENT_ID,
-                        AuditService.UNKNOWN,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+        verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, CLIENT_ID, user);
         verify(cloudwatchMetricsService)
                 .incrementLogout(Optional.of(CLIENT_ID), Optional.of(intervention));
 
@@ -305,17 +261,7 @@ public class LogoutServiceTest {
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
         verify(sessionService).deleteSessionFromRedis(session.getSessionId());
-        verify(auditService)
-                .submitAuditEvent(
-                        LogoutAuditableEvent.LOG_OUT_SUCCESS,
-                        CLIENT_ID,
-                        AuditService.UNKNOWN,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+        verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, CLIENT_ID, user);
         verify(cloudwatchMetricsService)
                 .incrementLogout(Optional.of(CLIENT_ID), Optional.of(intervention));
 


### PR DESCRIPTION
This moves the orchestration code to use the new style of audit service method calling, as set up in #4319 