### PR TITLE
ATO-538: Reduce batch processing size of SPOT responses from 10 (default) to 1

### DIFF
--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -64,6 +64,7 @@ resource "aws_lambda_event_source_mapping" "spot_response_lambda_sqs_mapping" {
   count            = var.spot_enabled ? 1 : 0
   event_source_arn = aws_ssm_parameter.spot_response_queue_arn.value
   function_name    = aws_lambda_function.spot_response_lambda.arn
+  batch_size       = 1
 
   depends_on = [
     aws_lambda_function.spot_response_lambda,


### PR DESCRIPTION
## What

`SPOTResponseHandler` handles processing SPOT responses taken from an SQS queue. It does so in batches, and currently the handler is configured with a batch size of 10 (the Terraform default). However, the handler returns after processing the first item in the batch, which means responses may be lost. 

In order to prevent loss of responses, batch size is set to 1.

When load is increased, a batch size of 1 may create a bottleneck, in which case the handler can be modified to process larger batches of messages correctly. Care should be taken when increasing the batch size to ensure messages can be processed idempotently, as a failure in processing one message would cause the entire batch to be replayed.

## How to review

1. Code review only


## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

