### PR TITLE
INC-760 Do not return SMS mfa type if a phone number is not verified

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -40,6 +40,7 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.MFAMethodType.AUTH_APP;
+import static uk.gov.di.authentication.shared.entity.MFAMethodType.NONE;
 import static uk.gov.di.authentication.shared.entity.MFAMethodType.SMS;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
@@ -129,7 +130,9 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 loginResponse.getLatestTermsAndConditionsAccepted(),
                 equalTo(termsAndConditionsVersion.equals(CURRENT_TERMS_AND_CONDITIONS)));
 
-        assertThat(loginResponse.getMfaMethodType(), equalTo(mfaMethodType));
+        var expectedMfaType =
+                (mfaMethodType.equals(SMS) && !mfaMethodVerified) ? NONE : mfaMethodType;
+        assertThat(loginResponse.getMfaMethodType(), equalTo(expectedMfaType));
         assertThat(loginResponse.isMfaMethodVerified(), equalTo(mfaMethodVerified));
         assertTrue(
                 Objects.nonNull(redis.getSession(sessionId).getInternalCommonSubjectIdentifier()));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
@@ -45,9 +45,9 @@ public class MfaHelper {
             boolean isPhoneNumberVerified) {
         var isMfaRequired = mfaRequired(userContext.getClientSession().getAuthRequestParams());
         var mfaMethodVerified = isPhoneNumberVerified;
+        var mfaMethodType = isPhoneNumberVerified ? MFAMethodType.SMS : MFAMethodType.NONE;
 
         var mfaMethod = getPrimaryMFAMethod(userCredentials);
-        var mfaMethodType = MFAMethodType.SMS;
         if (mfaMethod.filter(MFAMethod::isMethodVerified).isPresent()) {
             mfaMethodVerified = true;
             mfaMethodType = MFAMethodType.valueOf(mfaMethod.get().getMfaMethodType());


### PR DESCRIPTION
## What

We were previously assuming in the mfa helper that a user had SMS mfa by default. This made sense at some point, since we were only using this method once a user had successfully logged in, so they must have had MFA. However, we're now returning this information from the check user exists endpoint, at which point a user might not have fully set up 2fa.

Basing the MFA method on whether a user has a verified phone number or not means that for users with no verified phone number, we return a none as a 2fa method. This fixes a bug in the password reset journey, where a user without a fully set up account cannot reset their password because they hit an error screen on the 2fa step. They were hitting this 2fa step since the backend was returning that they had SMS MFA setup, so we were routing them through that journey without them actually having a verified phone number.

It should be noted that the logic for this MFA helper is slightly confusing to look at at first glance, because depending on MFA type we store this information in different ways - if an Auth app, we store this information in the user credentials table, but if SMS we do not store this information in the same table, but instead base it on whether the user has a verified number, and no auth app set up. Future work on MFA method management should fix this oddity.

## How to review

This is currently deployed to sandpit. Through the stub, you should be able to:

* partially create an account (stop at the stage where you're being asked to set up 2fa), then go through a new password reset journey, and observe that you're able to reset password and then prompted to set up 2fa
* Once 2fa is set up, your 2fa method continues to be respected

Then:
* Code review
