### PR TITLE
ATO-517: Feature flag for Cloudfront DNS cutover

### DIFF
--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -67,3 +67,5 @@ kms_cross_account_access_enabled                 = true
 cmk_for_back_channel_logout_enabled              = true
 
 oidc_origin_domain_enabled = true
+
+oidc_cloudfront_dns_enabled = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -605,6 +605,12 @@ variable "oidc_origin_domain_enabled" {
   description = "Feature flag to control the creation of DNS records for the origin.oidc domain"
 }
 
+variable "oidc_cloudfront_dns_enabled" {
+  type        = bool
+  default     = false
+  description = "Feature flag controlling the DNS cutover between API Gateway and Cloudfront for the OIDC API"
+}
+
 variable "txma_audit_encoded_enabled" {
   default     = false
   type        = bool


### PR DESCRIPTION
## What
Feature flag to toggle DNS record for OIDC between API gateway and Cloudfront. Tested in sandpit.

To review ensure that this will only affect sandpit right now.