### PR TITLE
ATO-585: Add information to the AUTH_LOG_OUT_SUCCESS audit event

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -100,14 +100,8 @@ public class LogoutHandler
                         () -> sessionService.getSessionFromSessionCookie(input.getHeaders()));
         attachSessionToLogsIfExists(sessionFromSessionCookie, input.getHeaders());
 
-        Optional<String> subjectId = Optional.empty();
-        Optional<String> sessionId = Optional.empty();
-        if (sessionFromSessionCookie.isPresent()) {
-            subjectId =
-                    Optional.ofNullable(
-                            sessionFromSessionCookie.get().getInternalCommonSubjectIdentifier());
-            sessionId = Optional.ofNullable(sessionFromSessionCookie.get().getSessionId());
-        }
+        var subjectId = sessionFromSessionCookie.map(Session::getInternalCommonSubjectIdentifier);
+        var sessionId = sessionFromSessionCookie.map(Session::getSessionId);
 
         var auditUser =
                 TxmaAuditUser.user()

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -8,8 +8,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
+import uk.gov.di.orchestration.shared.entity.UserProfile;
+import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -20,6 +23,7 @@ import static uk.gov.di.orchestration.shared.domain.LogoutAuditableEvent.LOG_OUT
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.orchestration.shared.helpers.IpAddressHelper.extractIpAddress;
 import static uk.gov.di.orchestration.shared.helpers.PersistentIdHelper.extractPersistentIdFromCookieHeader;
+import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
 
 public class LogoutService {
 
@@ -32,6 +36,7 @@ public class LogoutService {
     private final AuditService auditService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final BackChannelLogoutService backChannelLogoutService;
+    private final DynamoService dynamoService;
 
     public LogoutService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
@@ -41,6 +46,7 @@ public class LogoutService {
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
         this.backChannelLogoutService = new BackChannelLogoutService(configurationService);
+        this.dynamoService = new DynamoService(configurationService);
     }
 
     public LogoutService(
@@ -50,7 +56,8 @@ public class LogoutService {
             ClientSessionService clientSessionService,
             AuditService auditService,
             CloudwatchMetricsService cloudwatchMetricsService,
-            BackChannelLogoutService backChannelLogoutService) {
+            BackChannelLogoutService backChannelLogoutService,
+            DynamoService dynamoService) {
         this.configurationService = configurationService;
         this.sessionService = sessionService;
         this.dynamoClientService = dynamoClientService;
@@ -58,6 +65,7 @@ public class LogoutService {
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.backChannelLogoutService = backChannelLogoutService;
+        this.dynamoService = dynamoService;
     }
 
     public APIGatewayProxyResponseEvent handleAccountInterventionLogout(
@@ -151,9 +159,7 @@ public class LogoutService {
             throw new RuntimeException("Unable to build URI");
         }
 
-        auditService.submitAuditEvent(
-                LOG_OUT_SUCCESS, clientId.orElse(AuditService.UNKNOWN), auditUser);
-
+        sendAuditEvent(clientId, auditUser);
         return generateApiGatewayProxyResponse(
                 302, "", Map.of(ResponseHeaders.LOCATION, uri.toString()), null);
     }
@@ -174,5 +180,49 @@ public class LogoutService {
         cloudwatchMetricsService.incrementLogout(Optional.of(clientId), Optional.of(intervention));
         return generateLogoutResponse(
                 redirectURI, Optional.empty(), Optional.empty(), auditUser, Optional.of(clientId));
+    }
+
+    public Optional<String> getRpPairwiseId(String subject, String clientId) {
+        try {
+            if (subject == null || clientId == null) {
+                LOG.warn("User or client ID is null while getting RP pairwise ID for audit event");
+                return Optional.empty();
+            }
+            UserProfile userProfile = dynamoService.getUserProfileFromSubject(subject);
+            Optional<ClientRegistry> client = dynamoClientService.getClient(clientId);
+            if (client.isEmpty()) {
+                LOG.warn("Client not found while getting RP pairwise ID for audit event");
+                return Optional.empty();
+            }
+            return Optional.of(
+                    ClientSubjectHelper.getSubject(
+                                    userProfile,
+                                    client.get(),
+                                    dynamoService,
+                                    configurationService.getInternalSectorUri())
+                            .getValue());
+        } catch (Exception e) {
+            LOG.warn("Exception caught while getting RP pairwise ID for audit event");
+            return Optional.empty();
+        }
+    }
+
+    private void sendAuditEvent(Optional<String> clientId, TxmaAuditUser auditUser) {
+        if (clientId.isPresent()) {
+            Optional<String> rpPairwiseId = getRpPairwiseId(auditUser.userId(), clientId.get());
+            if (rpPairwiseId.isPresent()) {
+                auditService.submitAuditEvent(
+                        LOG_OUT_SUCCESS,
+                        clientId.orElse(AuditService.UNKNOWN),
+                        auditUser,
+                        pair("rpPairwiseId", rpPairwiseId.get()));
+            } else {
+                auditService.submitAuditEvent(
+                        LOG_OUT_SUCCESS, clientId.orElse(AuditService.UNKNOWN), auditUser);
+            }
+        } else {
+            auditService.submitAuditEvent(
+                    LOG_OUT_SUCCESS, clientId.orElse(AuditService.UNKNOWN), auditUser);
+        }
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -167,10 +167,8 @@ public class LogoutServiceTest {
                         CLIENT_LOGOUT_URI,
                         Optional.of(STATE.getValue()),
                         Optional.empty(),
-                        event,
-                        Optional.of(audience.get()),
-                        Optional.of(SESSION_ID),
-                        Optional.of(SUBJECT.getValue()));
+                        auditUser,
+                        Optional.of(audience.get()));
 
         verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, CLIENT_ID, auditUser);
 
@@ -184,11 +182,7 @@ public class LogoutServiceTest {
     void successfullyReturnsDefaultLogoutResponseWithoutStateWhenStateIsAbsent() {
         APIGatewayProxyResponseEvent response =
                 logoutService.generateDefaultLogoutResponse(
-                        Optional.empty(),
-                        event,
-                        Optional.of(audience.get()),
-                        Optional.of(SESSION_ID),
-                        Optional.of(SUBJECT.getValue()));
+                        Optional.empty(), auditUser, Optional.of(audience.get()));
 
         verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, CLIENT_ID, auditUser);
         verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
@@ -203,11 +197,7 @@ public class LogoutServiceTest {
     void successfullyReturnsDefaultLogoutResponseWithStateWhenStateIsPresent() {
         APIGatewayProxyResponseEvent response =
                 logoutService.generateDefaultLogoutResponse(
-                        Optional.of(STATE.getValue()),
-                        event,
-                        Optional.of(audience.get()),
-                        Optional.of(SESSION_ID),
-                        Optional.of(SUBJECT.getValue()));
+                        Optional.of(STATE.getValue()), auditUser, Optional.of(audience.get()));
 
         verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, CLIENT_ID, auditUser);
         verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
@@ -224,10 +214,8 @@ public class LogoutServiceTest {
                 logoutService.generateErrorLogoutResponse(
                         Optional.empty(),
                         new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "invalid session"),
-                        event,
-                        Optional.empty(),
-                        Optional.of(SESSION_ID),
-                        Optional.of(SUBJECT.getValue()));
+                        auditUser,
+                        Optional.empty());
 
         verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, AuditService.UNKNOWN, auditUser);
         verifyNoInteractions(cloudwatchMetricsService);
@@ -300,9 +288,7 @@ public class LogoutServiceTest {
                 CLIENT_LOGOUT_URI,
                 Optional.of(STATE.getValue()),
                 Optional.empty(),
-                input,
-                Optional.empty(),
-                Optional.of(SESSION_ID),
+                auditUserWhenNoCookie,
                 Optional.empty());
 
         verify(sessionService, times(0)).deleteSessionFromRedis(SESSION_ID);


### PR DESCRIPTION
## What

- Add user ID (`subjectId`), when it is available, to the `AUTH_LOG_OUT_SUCCESS` event
- Add RP pairwise ID, when it is available, to the `AUTH_LOG_OUT_SUCCESS` event

I'd like to spend some time in the near future refactoring the logout flows as they are quite convoluted.

## How to review

1. Code review only, easiest commit by commit

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

