### PR TITLE
AUT-2667: Add AUTH componentId to auth audit submission

### DIFF
--- a/shared/src/main/java/uk/gov/di/audit/TxmaAuditUser.java
+++ b/shared/src/main/java/uk/gov/di/audit/TxmaAuditUser.java
@@ -12,6 +12,7 @@ public class TxmaAuditUser {
     @Expose private String sessionId;
     @Expose private String persistentSessionId;
     @Expose private String govukSigninJourneyId;
+    @Expose private String componentId;
 
     public static TxmaAuditUser user() {
         return new TxmaAuditUser();
@@ -54,6 +55,11 @@ public class TxmaAuditUser {
 
     public TxmaAuditUser withGovukSigninJourneyId(String govukSigninJourneyId) {
         this.govukSigninJourneyId = govukSigninJourneyId;
+        return this;
+    }
+
+    public TxmaAuditUser withComponentId(String componentId) {
+        this.componentId = componentId;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -59,7 +59,8 @@ public class AuditService {
                         .withIpAddress(ipAddress)
                         .withSessionId(sessionId)
                         .withPersistentSessionId(persistentSessionId)
-                        .withGovukSigninJourneyId(clientSessionId);
+                        .withGovukSigninJourneyId(clientSessionId)
+                        .withComponentId("AUTH");
 
         var txmaAuditEvent =
                 auditEventWithTime(event, () -> Date.from(clock.instant()))


### PR DESCRIPTION
Security require auth submitted audit events to have a populated componentId field. This is so that they can quickly distinguish our audit events as having come from our service.

## What

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
