### PR TITLE
Auth-2737 change waf log subscription default behaviour 

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -368,7 +368,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_config_am_api" {
   resource_arn            = aws_wafv2_web_acl.wafregional_web_acl_am_api[count.index].arn
 
   logging_filter {
-    default_behavior = "DROP"
+    default_behavior = "KEEP"
 
     filter {
       behavior = "KEEP"

--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -336,7 +336,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_config_frontend_
   resource_arn            = aws_wafv2_web_acl.wafregional_web_acl_frontend_api[count.index].arn
 
   logging_filter {
-    default_behavior = "DROP"
+    default_behavior = "KEEP"
 
     filter {
       behavior = "KEEP"

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -640,7 +640,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_config_oidc_api"
   log_destination_configs = [aws_cloudwatch_log_group.oidc_waf_logs[count.index].arn]
   resource_arn            = aws_wafv2_web_acl.wafregional_web_acl_oidc_api[count.index].arn
   logging_filter {
-    default_behavior = "DROP"
+    default_behavior = "KEEP"
 
     filter {
       behavior = "KEEP"


### PR DESCRIPTION
## What

Auth-2737 change Waf log subscription default behaviour , ask from Security team DISEC-3686

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -o -a -p

Look for three changes to WAF log Subscription Like below 
  ```
# aws_wafv2_web_acl_logging_configuration.waf_logging_config_frontend_api[0] will be updated in-place
  ~ resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_config_frontend_api" {
        id                      = "arn:aws:wafv2:eu-west-2:761723964695:regional/webacl/sandpit-frontend-waf-web-acl/98d76397-08a0-4639-b5ca-4a678c144af7"
        # (2 unchanged attributes hidden)

      ~ logging_filter {
          ~ default_behavior = "DROP" -> "KEEP"

            # (1 unchanged block hidden)
        }
    }

```