### PR TITLE
BAU: Add check for if clientID is null in the access token

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
@@ -81,14 +81,18 @@ public class AccessTokenService {
                         "Unable to validate AccessToken signature", BearerTokenError.INVALID_TOKEN);
             }
             var clientID = signedJWT.getJWTClaimsSet().getStringClaim("client_id");
-            var client = clientService.getClient(clientID).orElse(null);
-
+            if (Objects.isNull(clientID)) {
+                LOG.warn("ClientID is null");
+                throw new AccessTokenException("ClientID is null", BearerTokenError.INVALID_TOKEN);
+            }
             attachLogFieldToLogs(CLIENT_ID, clientID);
 
+            var client = clientService.getClient(clientID).orElse(null);
             if (Objects.isNull(client)) {
                 LOG.warn("Client not found");
                 throw new AccessTokenException("Client not found", BearerTokenError.INVALID_TOKEN);
             }
+
             var scopes =
                     JSONArrayUtils.parse(
                                     new Gson()


### PR DESCRIPTION
## What

Add a check for the `clientID` in the AccessToken, to make sure that if it is `null` it throws an exception instead of querying the database with a null clientID and erroring.

https://gds.slack.com/archives/C02HCLREVV5/p1714570226681109