### PR TITLE
AUT-2640: Update audit event component id value to 'AUTH'

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -21,6 +21,7 @@ public class AuditService {
     private final Clock clock;
     private final ConfigurationService configurationService;
     private final AwsSqsClient txmaQueueClient;
+    private final String COMPONENT_ID = "AUTH";
 
     public AuditService(
             Clock clock, ConfigurationService configurationService, AwsSqsClient txmaQueueClient) {
@@ -47,7 +48,7 @@ public class AuditService {
         var txmaAuditEvent =
                 auditEventWithTime(event, () -> Date.from(clock.instant()))
                         .withClientId(clientId)
-                        .withComponentId(configurationService.getOidcApiBaseURL().orElse("UNKNOWN"))
+                        .withComponentId(COMPONENT_ID)
                         .withUser(user);
 
         Arrays.stream(metadataPairs)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.shared.services;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
@@ -8,13 +7,11 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.AuditServiceTest.TestEvents.TEST_EVENT_ONE;
 import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.asJson;
@@ -40,11 +37,6 @@ class AuditServiceTest {
         }
     }
 
-    @BeforeEach
-    void beforeEach() {
-        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of("oidc-base-url"));
-    }
-
     @Test
     void shouldLogAuditEvent() {
         var auditService = new AuditService(FIXED_CLOCK, configurationService, awsSqsClient);
@@ -67,7 +59,7 @@ class AuditServiceTest {
         assertThat(txmaMessage, hasFieldWithValue("event_name", equalTo("AUTH_TEST_EVENT_ONE")));
         assertThat(txmaMessage, hasNumericFieldWithValue("timestamp", equalTo(1630534200L)));
         assertThat(txmaMessage, hasFieldWithValue("client_id", equalTo("client-id")));
-        assertThat(txmaMessage, hasFieldWithValue("component_id", equalTo("oidc-base-url")));
+        assertThat(txmaMessage, hasFieldWithValue("component_id", equalTo("AUTH")));
 
         var userObject = txmaMessage.getAsJsonObject().get("user").getAsJsonObject();
 


### PR DESCRIPTION
## What
Changed componentId audit field assignment to have the value "AUTH".

Security require the component id field to be populated with a signifier that allows them to distinguish audit events from our service (or component) from audit events from other services. At least for the time being, "AUTH" has been chosen as an appropriate component id value.

Previously we were populating this field getting the env var OIDC_API_BASE_URL. This env var was not declared in our terraform and so was returning null anyway, but even if the correct value for OIDC_API_BASE_URL were returned, that would not be an appropriate componentId for auth as it is not our service uri.

## How to review

1. Code Review

