### PR TITLE
ATO-564: Update lambda references to ensure zero downtime deployments

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -177,6 +177,9 @@ resource "aws_api_gateway_deployment" "deployment" {
     module.ipv-callback,
     module.ipv-capacity,
     module.doc-app-callback,
+    aws_api_gateway_integration.orch_openid_configuration_integration,
+    aws_api_gateway_integration.orch_trustmark_integration,
+    aws_api_gateway_integration.orch_doc_app_callback_integration
   ]
 }
 
@@ -777,6 +780,9 @@ resource "aws_api_gateway_resource" "orch_trustmark_resource" {
   rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
   parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   path_part   = "trustmark"
+  depends_on = [
+    module.trustmarks
+  ]
 }
 
 resource "aws_api_gateway_method" "orch_trustmark_method" {
@@ -809,6 +815,9 @@ resource "aws_api_gateway_resource" "orch_doc_app_callback_resource" {
   rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
   parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   path_part   = "doc-app-callback"
+  depends_on = [
+    module.doc-app-callback
+  ]
 }
 
 resource "aws_api_gateway_method" "orch_doc_app_callback_method" {

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -19,7 +19,7 @@ module "doc_app_callback_role" {
 
 module "doc-app-callback" {
   source          = "../modules/endpoint-module"
-  endpoint_name   = var.orch_doc_app_callback_enabled ? "doc-app-callback-auth" : "doc-app-callback"
+  endpoint_name   = "doc-app-callback"
   path_part       = var.orch_doc_app_callback_enabled ? "doc-app-callback-auth" : "doc-app-callback"
   endpoint_method = ["GET"]
   environment     = var.environment

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -55,8 +55,8 @@ authorize_protected_subnet_enabled = true
 support_email_check_enabled = true
 
 
-orch_openid_configuration_enabled = false
-orch_openid_configuration_name    = "dev-orch-be-deploy-OpenIdConfigurationFunction-6Abl5SEjt8kV"
+orch_openid_configuration_enabled = true
+orch_openid_configuration_name    = "dev-orch-be-deploy-OpenIdConfigurationFunction-zDwyaSCWAbmi"
 orch_doc_app_callback_enabled     = true
 orch_doc_app_callback_name        = "dev-orch-be-deploy-DocAppCallbackFunction-RVJSUW5JaiRv"
 

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -9,7 +9,7 @@ module "oidc_trustmarks_role" {
 module "trustmarks" {
   source = "../modules/endpoint-module"
 
-  endpoint_name   = var.orch_trustmark_enabled ? "trustmark-auth" : "trustmark"
+  endpoint_name   = "trustmark"
   path_part       = var.orch_trustmark_enabled ? "trustmark-auth" : "trustmark"
   endpoint_method = ["GET"]
   environment     = var.environment

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -9,7 +9,7 @@ module "openid_configuration_role" {
 module "openid_configuration_discovery" {
   source = "../modules/endpoint-module"
 
-  endpoint_name   = var.orch_openid_configuration_enabled ? "openid-configuration-auth" : "openid-configuration"
+  endpoint_name   = "openid-configuration"
   path_part       = var.orch_openid_configuration_enabled ? "openid-configuration-auth" : "openid-configuration"
   endpoint_method = ["GET"]
   environment     = var.environment
@@ -52,6 +52,7 @@ module "openid_configuration_discovery" {
     aws_api_gateway_rest_api.di_authentication_api,
     aws_api_gateway_resource.connect_resource,
     aws_api_gateway_resource.wellknown_resource,
-    module.openid_configuration_role
+    module.openid_configuration_role,
+
   ]
 }


### PR DESCRIPTION
- Changing the endpoint-name causes the lambda to be deleted, which would cause downtime. We don't need this, just the path-part change
- Explicit depends on in the new resources because the existing module needs to update first to make the path available
- Explicit depends on in the gateway deployment because we want to ensure all gateway integrations have been finalised before deploying

