### PR TITLE
ATO-592: Add cross account access to the auth external api to orch in sandpit

### DIFF
--- a/ci/stack-orchestration/README.md
+++ b/ci/stack-orchestration/README.md
@@ -18,7 +18,7 @@ terminal, run `aws configure sso` and enter the start URL and region from AWS on
 profile that you can set as an environment variable, by running `export AWS_PROFILE=<profile>`.
 
 After this you can then run the below, replacing `<environment>`with one
-of `sandpit`, `build`, `stage`, `int`, `prod`:
+of `dev`, `build`, `stage`, `int`, `prod`:
 
 ```shell
 ./provision_all.sh <environment>

--- a/ci/stack-orchestration/configuration/dev/vpc/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/vpc/parameters.json
@@ -8,6 +8,10 @@
     "ParameterValue": "10.1.0.0/16"
   },
   {
+    "ParameterKey": "ExecuteApiGatewayEnabled",
+    "ParameterValue": "Yes"
+  },
+  {
     "ParameterKey": "SSMApiEnabled",
     "ParameterValue": "Yes"
   },

--- a/ci/terraform/auth-external-api/sandpit.tfvars
+++ b/ci/terraform/auth-external-api/sandpit.tfvars
@@ -9,3 +9,4 @@ endpoint_memory_size   = 1536
 
 orch_client_id                  = "orchestrationAuth"
 orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5Px78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ=="
+orch_api_vpc_endpoint_id        = "vpce-0ba3e33c40ed354b0"

--- a/ci/terraform/auth-external-api/variables.tf
+++ b/ci/terraform/auth-external-api/variables.tf
@@ -110,6 +110,12 @@ variable "orch_to_auth_public_signing_key" {
   description = "A hardcoded value for the public key corresponding to the KMS created in the OIDC module. It is used to validate the signature of a client_assertion JWT (orch<->auth token endpoint)"
 }
 
+variable "orch_api_vpc_endpoint_id" {
+  default     = ""
+  type        = string
+  description = "The ID of the Execute API Gateway vpc endpoint in the orchestration account"
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What

Auth external api is a private api, so we need to add the orch vpc endpoint id to allow it access to call the api, but also with backwards compatibility
