### PR TITLE
ATO-591: Implement access to auth dynamo db's in permission boundary 

### DIFF
--- a/ci/stack-orchestration/README.md
+++ b/ci/stack-orchestration/README.md
@@ -36,6 +36,6 @@ the `configuration/[ENVIRONMENT]/[PIPELINE]/parameters.json` files.
 ## SSM Parameters
 
 The following parameters are not provisioned by CloudFormation, and instead are managed manually in Systems Manager Parameter Store:
-- `<envrionment>-ipv-capacity`
+- `<environment>-ipv-capacity`
 - `<environment>-auth-public-encryption-key`
 - `<environment>-ipv-public-encryption-key`

--- a/ci/stack-orchestration/configuration/dev/dev-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/dev-orch-be-pipeline/parameters.json
@@ -1,5 +1,25 @@
 [
   {
+    "ParameterKey": "AccessDynamoDBAccounts",
+    "ParameterValue": "761723964695"
+  },
+  {
+    "ParameterKey": "AllowedServiceOne",
+    "ParameterValue": "DynamoDB"
+  },
+  {
+    "ParameterKey": "AllowedServiceTwo",
+    "ParameterValue": "SSM"
+  },
+  {
+    "ParameterKey": "AllowedServiceThree",
+    "ParameterValue": "SQS"
+  },
+  {
+    "ParameterKey": "AllowedServiceFour",
+    "ParameterValue": "EC2"
+  },
+  {
     "ParameterKey": "AdditionalCodeSigningVersionArns",
     "ParameterValue": "arn:aws:signer:eu-west-2:216552277552:/signing-profiles/DynatraceSigner/5uwzCCGTPq"
   },
@@ -18,6 +38,10 @@
   {
     "ParameterKey": "OneLoginRepositoryName",
     "ParameterValue": "authentication-api"
+  },
+  {
+    "ParameterKey": "ProgrammaticPermissionsBoundary",
+    "ParameterValue": "True"
   },
   {
     "ParameterKey": "RequireManualApproval",


### PR DESCRIPTION
## What

Update the pipeline config so that we can access dynamo db's cross account - currently not permitted in permissions boundary
