### PR TITLE
ATO-608: Move backchannel logout lambda out of VPC

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -393,7 +393,8 @@ Resources:
   BackChannelLogoutRequestFunction:
     Type: AWS::Serverless::Function
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
-    # checkov:skip=CKV_AWS_117: VPC settings are global
+    # checkov:skip=CKV_AWS_117: Lambda needs open egress so isn't in VPC
+    IgnoreGlobals: [VpcConfig]
     Properties:
       AutoPublishAlias: latest
       CodeUri: ./oidc-api


### PR DESCRIPTION
## What

Back channel logout lambda should not be in a vpc, because it requires open egress.
