### PR TITLE
AUT-2578: Retrieve X-Forwarded-For header as ip regardless of case

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
@@ -10,6 +10,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getOptionalHeaderValueFromHeaders;
 
 public class IpAddressHelper {
 
@@ -21,14 +22,13 @@ public class IpAddressHelper {
                         .map(APIGatewayProxyRequestEvent::getHeaders)
                         .orElse(emptyMap());
 
-        if (headers.containsKey("X-Forwarded-For")) {
-            return headers.get("X-Forwarded-For").split(",")[0].trim();
-        }
-
-        return Optional.ofNullable(input)
-                .map(APIGatewayProxyRequestEvent::getRequestContext)
-                .map(ProxyRequestContext::getIdentity)
-                .map(RequestIdentity::getSourceIp)
-                .orElse(AuditService.UNKNOWN);
+        return getOptionalHeaderValueFromHeaders(headers, "X-Forwarded-For", true)
+                .map(forwardedValue -> forwardedValue.split(",")[0].trim())
+                .orElse(
+                        Optional.ofNullable(input)
+                                .map(APIGatewayProxyRequestEvent::getRequestContext)
+                                .map(ProxyRequestContext::getIdentity)
+                                .map(RequestIdentity::getSourceIp)
+                                .orElse(AuditService.UNKNOWN));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/IpAddressHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/IpAddressHelperTest.java
@@ -36,6 +36,16 @@ class IpAddressHelperTest {
     }
 
     @Test
+    void shouldExtractFromXForwardedHeaderRegardlessOfCase() {
+        var request = new APIGatewayProxyRequestEvent();
+
+        request.setHeaders(Map.of("x-forwarded-for", "123.123.123.123"));
+        request.setRequestContext(stubContextWithSourceIp());
+
+        assertThat(extractIpAddress(request), is("123.123.123.123"));
+    }
+
+    @Test
     void shouldChooseSourceIpAsLastResort() {
         var request = new APIGatewayProxyRequestEvent();
         request.setRequestContext(stubContextWithSourceIp());


### PR DESCRIPTION
As part of setting common headers on all requests, we're going to start setting the forwarded for header from a common library instead of directly in our code, which uses lower casing. This commit allows case-insensitive retrieval of this header, to ensure that when we switch over our method of setting the method, we can still get the IP address from the header.

Depends on [refactor to request headers](https://github.com/govuk-one-login/authentication-api/pull/4406) - that needs merging first.
