### PR TITLE
Bugfix/fix password count audit logging in login handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -188,14 +188,13 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                 } else {
                     codeStorageService.increaseIncorrectPasswordCount(request.getEmail());
                 }
+                var updatedIncorrectPasswordCount = incorrectPasswordCount + 1;
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
                         clientId,
                         auditUser,
                         pair("internalSubjectId", userProfile.getSubjectID()),
-                        pair(
-                                "incorrectPasswordCount",
-                                codeStorageService.getIncorrectPasswordCount(request.getEmail())),
+                        pair("incorrectPasswordCount", updatedIncorrectPasswordCount),
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
 
                 if (incorrectPasswordCount + 1 >= configurationService.getMaxPasswordRetries()) {
@@ -206,7 +205,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                             clientId,
                             auditUser,
                             pair("internalSubjectId", userProfile.getSubjectID()),
-                            pair("attemptNoFailedAt", incorrectPasswordCount + 1),
+                            pair("attemptNoFailedAt", updatedIncorrectPasswordCount),
                             pair(
                                     "number_of_attempts_user_allowed_to_login",
                                     configurationService.getMaxPasswordRetries()));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -206,7 +206,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                             clientId,
                             auditUser,
                             pair("internalSubjectId", userProfile.getSubjectID()),
-                            pair("attemptNoFailedAt", incorrectPasswordCount),
+                            pair("attemptNoFailedAt", incorrectPasswordCount + 1),
                             pair(
                                     "number_of_attempts_user_allowed_to_login",
                                     configurationService.getMaxPasswordRetries()));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -109,8 +109,6 @@ class LoginHandlerTest {
                     .withMfaMethodType(MFAMethodType.AUTH_APP.getValue())
                     .withMethodVerified(true)
                     .withEnabled(true);
-    private static final AuditService.MetadataPair incorrectPasswordCountPair =
-            pair("incorrectPasswordCount", 0);
     private static final Json objectMapper = SerializationService.getInstance();
     private static final Session session =
             new Session(IdGenerator.generate()).setEmailAddress(EMAIL);
@@ -411,9 +409,7 @@ class LoginHandlerTest {
                         auditUserWithAllUserInfo,
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("attemptNoFailedAt", maxRetriesAllowed),
-                        pair(
-                                "number_of_attempts_user_allowed_to_login",
-                                maxRetriesAllowed));
+                        pair("number_of_attempts_user_allowed_to_login", maxRetriesAllowed));
     }
 
     @ParameterizedTest
@@ -424,7 +420,8 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
         var maxRetriesAllowed = configurationService.getMaxPasswordRetries();
-        when(codeStorageService.getIncorrectPasswordCountReauthJourney(EMAIL)).thenReturn(maxRetriesAllowed - 1);
+        when(codeStorageService.getIncorrectPasswordCountReauthJourney(EMAIL))
+                .thenReturn(maxRetriesAllowed - 1);
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
         usingDefaultVectorOfTrust();
@@ -435,6 +432,24 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(400));
 
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1028));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.INVALID_CREDENTIALS,
+                        AuditService.UNKNOWN,
+                        auditUserWithAllUserInfo,
+                        pair("internalSubjectId", userProfile.getSubjectID()),
+                        pair("incorrectPasswordCount", maxRetriesAllowed),
+                        pair("attemptNoFailedAt", maxRetriesAllowed));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
+                        AuditService.UNKNOWN,
+                        auditUserWithAllUserInfo,
+                        pair("internalSubjectId", userProfile.getSubjectID()),
+                        pair("attemptNoFailedAt", maxRetriesAllowed),
+                        pair("number_of_attempts_user_allowed_to_login", maxRetriesAllowed));
         verifyNoInteractions(cloudwatchMetricsService);
         verify(sessionService, never()).save(any());
     }
@@ -515,7 +530,7 @@ class LoginHandlerTest {
                         "",
                         auditUserWithAllUserInfo,
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
-                        incorrectPasswordCountPair,
+                        pair("incorrectPasswordCount", 1),
                         pair("attemptNoFailedAt", 6));
 
         assertThat(result, hasStatus(401));


### PR DESCRIPTION
## What

Fixes the numbers logged as `attemptNoFailedAt` and `incorrectPasswordCount` in the login handler (which as far as I can tell are actually the same thing so we should consolidate at some point once we've checked with analysts).

Previously, they were returning the count prior to the current request, which meant that the audit events could look incorrect in the case where we've blocked someone (since we record both the number of attempts made, and the number of attempts that can be made before blocking someone, and so a `TEMPORARILY_BLOCKED` event could say someone was blocked after 5 attempts when allowed 6.

## How to review

1. Code Review