### PR TITLE
Rff 3 request header helper

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LocaleHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LocaleHelper.java
@@ -11,9 +11,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.USER_LANGUAGE_HEADER;
-import static uk.gov.di.authentication.shared.helpers.InputSanitiser.sanitiseBase64;
-import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
-import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getOptionalHeaderValueFromHeaders;
 
 public class LocaleHelper {
 
@@ -73,19 +71,15 @@ public class LocaleHelper {
 
     public static Optional<String> getUserLanguageFromRequestHeaders(
             Map<String, String> headers, ConfigurationService configurationService) {
-        if (!headersContainValidHeader(
-                headers, USER_LANGUAGE_HEADER, configurationService.getHeadersCaseInsensitive())) {
-            return Optional.empty();
-        }
-        String language =
-                getHeaderValueFromHeaders(
+        Optional<String> userLanguage =
+                getOptionalHeaderValueFromHeaders(
                         headers,
                         USER_LANGUAGE_HEADER,
                         configurationService.getHeadersCaseInsensitive());
-        if (language == null) {
+
+        if (userLanguage.isEmpty()) {
             LOG.warn("Value not found for User-Language header");
-            return Optional.empty();
         }
-        return sanitiseBase64(language);
+        return userLanguage.flatMap(InputSanitiser::sanitiseBase64);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
@@ -13,32 +13,7 @@ public final class RequestHeaderHelper {
 
     public static boolean headersContainValidHeader(
             Map<String, String> headers, String headerName, boolean matchLowerCase) {
-        if (headers == null || headers.isEmpty()) {
-            LOG.warn("All headers are missing or empty when looking for header {}", headerName);
-            return false;
-        } else if (!matchLowerCase && headers.containsKey(headerName)) {
-            LOG.trace("Found header {}, matchLowerCase={}", headerName, matchLowerCase);
-            return true;
-        } else if (matchLowerCase
-                && (headers.containsKey(headerName)
-                        && headers.containsKey(headerName.toLowerCase()))) {
-            LOG.warn(
-                    "Found both headers {} and lowercase version, matchLowerCase={}",
-                    headerName,
-                    matchLowerCase);
-            return false;
-        } else if (matchLowerCase
-                && (headers.containsKey(headerName)
-                        || headers.containsKey(headerName.toLowerCase()))) {
-            LOG.trace(
-                    "Found header {} lowercase version, matchLowerCase={}",
-                    headerName,
-                    matchLowerCase);
-            return true;
-        } else {
-            LOG.warn("Header {} is missing, matchLowerCase={}", headerName, matchLowerCase);
-            return false;
-        }
+        return getHeaderValueFromHeaders(headers, headerName, matchLowerCase) != null;
     }
 
     public static String getHeaderValueFromHeaders(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
@@ -12,11 +12,6 @@ public final class RequestHeaderHelper {
 
     private RequestHeaderHelper() {}
 
-    public static boolean headersContainValidHeader(
-            Map<String, String> headers, String headerName, boolean matchLowerCase) {
-        return getOptionalHeaderValueFromHeaders(headers, headerName, matchLowerCase).isPresent();
-    }
-
     public static String getHeaderValueFromHeaders(
             Map<String, String> headers, String headerName, boolean matchLowerCase) {
         return getOptionalHeaderValueFromHeaders(headers, headerName, matchLowerCase).orElse(null);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
+import java.util.Optional;
 
 public final class RequestHeaderHelper {
 
@@ -13,25 +14,29 @@ public final class RequestHeaderHelper {
 
     public static boolean headersContainValidHeader(
             Map<String, String> headers, String headerName, boolean matchLowerCase) {
-        return getHeaderValueFromHeaders(headers, headerName, matchLowerCase) != null;
+        return getOptionalHeaderValueFromHeaders(headers, headerName, matchLowerCase).isPresent();
     }
 
     public static String getHeaderValueFromHeaders(
             Map<String, String> headers, String headerName, boolean matchLowerCase) {
+        return getOptionalHeaderValueFromHeaders(headers, headerName, matchLowerCase).orElse(null);
+    }
+
+    public static Optional<String> getOptionalHeaderValueFromHeaders(
+            Map<String, String> headers, String headerName, boolean matchLowerCase) {
         if (headers == null || headers.isEmpty()) {
-            return null;
+            return Optional.empty();
         } else if (headers.containsKey(headerName)) {
-            return headers.get(headerName);
+            return Optional.of(headers.get(headerName));
         } else if (matchLowerCase && headers.containsKey(headerName.toLowerCase())) {
-            return headers.get(headerName.toLowerCase());
+            return Optional.of(headers.get(headerName.toLowerCase()));
         } else {
-            return null;
+            return Optional.empty();
         }
     }
 
     public static String getHeaderValueOrElse(
             Map<String, String> headers, String headerName, String orElse) {
-        String headerValue = getHeaderValueFromHeaders(headers, headerName, false);
-        return headerValue != null ? headerValue : orElse;
+        return getOptionalHeaderValueFromHeaders(headers, headerName, false).orElse(orElse);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
@@ -16,8 +16,7 @@ import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSI
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
-import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
-import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getOptionalHeaderValueFromHeaders;
 
 public class ClientSessionService {
 
@@ -95,25 +94,16 @@ public class ClientSessionService {
     }
 
     public Optional<ClientSession> getClientSessionFromRequestHeaders(Map<String, String> headers) {
-        if (!headersContainValidHeader(
-                headers,
-                CLIENT_SESSION_ID_HEADER,
-                configurationService.getHeadersCaseInsensitive())) {
-            return Optional.empty();
-        }
-        String clientSessionId =
-                getHeaderValueFromHeaders(
+        Optional<String> clientSessionId =
+                getOptionalHeaderValueFromHeaders(
                         headers,
                         CLIENT_SESSION_ID_HEADER,
                         configurationService.getHeadersCaseInsensitive());
-        if (clientSessionId == null) {
+
+        if (clientSessionId.isEmpty()) {
             LOG.warn("Value not found for Client-Session-Id header");
-            return Optional.empty();
         }
-        try {
-            return getClientSession(clientSessionId);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+
+        return clientSessionId.flatMap(this::getClientSession);
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelperTest.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueOrElse;
-import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
 
 class RequestHeaderHelperTest {
 
@@ -65,17 +64,6 @@ class RequestHeaderHelperTest {
                         true,
                         true,
                         "client-session-id-123"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("headersTestParameters")
-    void testHeadersContainValidHeader(
-            Map<String, String> headers,
-            String headerName,
-            boolean matchLowerCase,
-            boolean expectedValidity) {
-        assertEquals(
-                expectedValidity, headersContainValidHeader(headers, headerName, matchLowerCase));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What

Refactors the request header helper to reuse common logic, and removes a method that checks whether a request contains a header, since it's always then proceeded by retrieving that header, so can be replaced with the new helper method.

## How to review

1. Code Review commit by commit