### PR TITLE
Revert "INC-760: Add mfa method verified to Check User Exists response"

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
@@ -20,10 +20,6 @@ public class CheckUserExistsResponse {
     @Expose
     private MFAMethodType mfaMethodType;
 
-    @SerializedName("mfaMethodVerified")
-    @Expose
-    private Boolean mfaMethodVerified;
-
     @SerializedName("phoneNumberLastThree")
     @Expose
     private String phoneNumberLastThree;
@@ -57,14 +53,12 @@ public class CheckUserExistsResponse {
             boolean doesUserExist,
             MFAMethodType mfaMethodType,
             String phoneNumberLastThree,
-            List<LockoutInformation> lockoutInformation,
-            boolean mfaMethodVerified) {
+            List<LockoutInformation> lockoutInformation) {
         this.email = email;
         this.doesUserExist = doesUserExist;
         this.mfaMethodType = mfaMethodType;
         this.phoneNumberLastThree = phoneNumberLastThree;
         this.lockoutInformation = lockoutInformation;
-        this.mfaMethodVerified = mfaMethodVerified;
     }
 
     public String getEmail() {
@@ -77,10 +71,6 @@ public class CheckUserExistsResponse {
 
     public MFAMethodType getMfaMethodType() {
         return mfaMethodType;
-    }
-
-    public Boolean getMfaMethodVerified() {
-        return mfaMethodVerified;
     }
 
     public String getPhoneNumberLastThree() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -220,8 +220,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                             userExists,
                             userMfaDetail.getMfaMethodType(),
                             getLastDigitsOfPhoneNumber(userMfaDetail),
-                            lockoutInformation,
-                            userMfaDetail.isMfaMethodVerified());
+                            lockoutInformation);
             sessionService.save(userContext.getSession());
 
             LOG.info("Successfully processed request");

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -155,7 +155,6 @@ class CheckUserExistsHandlerTest {
                     {"email":%s,
                     "doesUserExist":true,
                     "mfaMethodType":"SMS",
-                    "mfaMethodVerified":true,
                     "phoneNumberLastThree":"321",
                     "lockoutInformation":[]}
                     """,


### PR DESCRIPTION
This reverts commit 5a337ee8c0b0bdd0277c0b9eccc7b62636b6b60a.

This was introduced as a fix for an incident, but in the end we [didn't use this](https://github.com/govuk-one-login/authentication-frontend/blob/0af4c5ef7135bbf26f6c1edf71f865d707249657/src/components/enter-email/types.ts#L4-L8) (it would have needed a PR in authentication-frontend to use this response and there ended up being a simpler way) and fixed in a different way - see commit 19bcc8c35d48aa88942a4e0ceb4b18b91b50b446

Reverting this commit so as not to have additional unneeded code.

## Related PRs

[PR](https://github.com/govuk-one-login/authentication-api/pull/4369) that contains the fix that we ended up using
