### PR TITLE
ATO-NONE: Update vpc endpoint id

### DIFF
--- a/ci/terraform/auth-external-api/sandpit.tfvars
+++ b/ci/terraform/auth-external-api/sandpit.tfvars
@@ -9,4 +9,4 @@ endpoint_memory_size   = 1536
 
 orch_client_id                  = "orchestrationAuth"
 orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5Px78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ=="
-orch_api_vpc_endpoint_id        = "vpce-0ba3e33c40ed354b0"
+orch_api_vpc_endpoint_id        = "vpce-0028f62dad635589a"


### PR DESCRIPTION
## What

the orch vpc stack got redeployed without the parameter to make the vpc endpoint, and redeployed again with it so the vpc endpoint was recreated. Sandpit deployment errors with the wrong vpc endpoint id
