### PR TITLE
AUT-2578: Retrieve X-Forwarded-For header as ip regardless of case

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelper.java
@@ -3,6 +3,8 @@ package uk.gov.di.orchestration.shared.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent.ProxyRequestContext;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent.RequestIdentity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.services.AuditService;
 
 import java.util.Optional;
@@ -13,6 +15,8 @@ import static uk.gov.di.orchestration.shared.helpers.RequestHeaderHelper.headers
 
 public class IpAddressHelper {
 
+    private static final Logger LOG = LogManager.getLogger(IpAddressHelper.class);
+
     public static String extractIpAddress(APIGatewayProxyRequestEvent input) {
         var headers =
                 Optional.ofNullable(input)
@@ -22,6 +26,9 @@ public class IpAddressHelper {
         if (headersContainValidHeader(headers, "X-Forwarded-For", true)) {
             return getHeaderValueFromHeaders(headers, "X-Forwarded-For", true).split(",")[0].trim();
         }
+
+        LOG.warn(
+                "No IP address present in x-forwarded-for header, attempting to retrieve from request context");
 
         return Optional.ofNullable(input)
                 .map(APIGatewayProxyRequestEvent::getRequestContext)

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelper.java
@@ -8,6 +8,8 @@ import uk.gov.di.orchestration.shared.services.AuditService;
 import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
+import static uk.gov.di.orchestration.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
+import static uk.gov.di.orchestration.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
 
 public class IpAddressHelper {
 
@@ -17,8 +19,8 @@ public class IpAddressHelper {
                         .map(APIGatewayProxyRequestEvent::getHeaders)
                         .orElse(emptyMap());
 
-        if (headers.containsKey("X-Forwarded-For")) {
-            return headers.get("X-Forwarded-For").split(",")[0].trim();
+        if (headersContainValidHeader(headers, "X-Forwarded-For", true)) {
+            return getHeaderValueFromHeaders(headers, "X-Forwarded-For", true).split(",")[0].trim();
         }
 
         return Optional.ofNullable(input)

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelperTest.java
@@ -36,6 +36,16 @@ class IpAddressHelperTest {
     }
 
     @Test
+    void shouldExtractFromXForwardedHeaderRegardlessOfCase() {
+        var request = new APIGatewayProxyRequestEvent();
+
+        request.setHeaders(Map.of("x-forwarded-for", "123.123.123.123"));
+        request.setRequestContext(stubContextWithSourceIp());
+
+        assertThat(extractIpAddress(request), is("123.123.123.123"));
+    }
+
+    @Test
     void shouldChooseSourceIpAsLastResort() {
         var request = new APIGatewayProxyRequestEvent();
         request.setRequestContext(stubContextWithSourceIp());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
@@ -3,8 +3,6 @@ package uk.gov.di.authentication.shared.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent.ProxyRequestContext;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent.RequestIdentity;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.services.AuditService;
 
 import java.util.Optional;
@@ -13,8 +11,6 @@ import static java.util.Collections.emptyMap;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getOptionalHeaderValueFromHeaders;
 
 public class IpAddressHelper {
-
-    private static final Logger LOG = LogManager.getLogger(IpAddressHelper.class);
 
     public static String extractIpAddress(APIGatewayProxyRequestEvent input) {
         var headers =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
@@ -25,7 +25,7 @@ public class IpAddressHelper {
 
         var maybeIpAddressFromHeaders =
                 getOptionalHeaderValueFromHeaders(headers, IP_HEADER_NAME, true)
-                        .map(forwardedValue -> forwardedValue.split(",")[0].trim());
+                        .map(IpAddressHelper::getFirstValueFromHeaderString);
 
         return maybeIpAddressFromHeaders.orElseGet(
                 () -> {
@@ -37,5 +37,9 @@ public class IpAddressHelper {
                             .map(RequestIdentity::getSourceIp)
                             .orElse(AuditService.UNKNOWN);
                 });
+    }
+
+    private static String getFirstValueFromHeaderString(String headerString) {
+        return headerString.split(",")[0].trim();
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
@@ -10,6 +10,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getOptionalHeaderValueFromHeaders;
 
 public class IpAddressHelper {
 
@@ -21,14 +22,13 @@ public class IpAddressHelper {
                         .map(APIGatewayProxyRequestEvent::getHeaders)
                         .orElse(emptyMap());
 
-        if (headers.containsKey("X-Forwarded-For")) {
-            return headers.get("X-Forwarded-For").split(",")[0].trim();
-        }
-
-        return Optional.ofNullable(input)
-                .map(APIGatewayProxyRequestEvent::getRequestContext)
-                .map(ProxyRequestContext::getIdentity)
-                .map(RequestIdentity::getSourceIp)
-                .orElse(AuditService.UNKNOWN);
+        return getOptionalHeaderValueFromHeaders(headers, "X-Forwarded-For", true)
+                .map(forwardedValue -> forwardedValue.split(",")[0].trim())
+                .orElse(
+                        Optional.ofNullable(input)
+                                .map(APIGatewayProxyRequestEvent::getRequestContext)
+                                .map(ProxyRequestContext::getIdentity)
+                                .map(RequestIdentity::getSourceIp)
+                                .orElse(AuditService.UNKNOWN));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
@@ -12,13 +12,15 @@ import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getOpt
 
 public class IpAddressHelper {
 
+    private static String IP_HEADER_NAME = "X-Forwarded-For";
+
     public static String extractIpAddress(APIGatewayProxyRequestEvent input) {
         var headers =
                 Optional.ofNullable(input)
                         .map(APIGatewayProxyRequestEvent::getHeaders)
                         .orElse(emptyMap());
 
-        return getOptionalHeaderValueFromHeaders(headers, "X-Forwarded-For", true)
+        return getOptionalHeaderValueFromHeaders(headers, IP_HEADER_NAME, true)
                 .map(forwardedValue -> forwardedValue.split(",")[0].trim())
                 .orElse(
                         Optional.ofNullable(input)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/IpAddressHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/IpAddressHelperTest.java
@@ -36,6 +36,16 @@ class IpAddressHelperTest {
     }
 
     @Test
+    void shouldExtractFromXForwardedHeaderRegardlessOfCase() {
+        var request = new APIGatewayProxyRequestEvent();
+
+        request.setHeaders(Map.of("x-forwarded-for", "123.123.123.123"));
+        request.setRequestContext(stubContextWithSourceIp());
+
+        assertThat(extractIpAddress(request), is("123.123.123.123"));
+    }
+
+    @Test
     void shouldChooseSourceIpAsLastResort() {
         var request = new APIGatewayProxyRequestEvent();
         request.setRequestContext(stubContextWithSourceIp());


### PR DESCRIPTION
As part of setting common headers on all requests, we're going to start setting the forwarded for header from a common library instead of directly in our code, which uses lower casing. This commit allows case-insensitive retrieval of this header, to ensure that when we switch over our method of setting the method, we can still get the IP address from the header.

Depends on [refactor to request headers](https://github.com/govuk-one-login/authentication-api/pull/4406) - that needs merging first ✅ 
