### PR TITLE
AUT-2663: account management api consumes encoded txma audit header

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 
@@ -101,6 +102,7 @@ public class RemoveAccountHandler
                     RequestHeaderHelper.getHeaderValueOrElse(
                             input.getHeaders(), SESSION_ID_HEADER, "");
             attachSessionIdToLogs(sessionId);
+            attachTxmaAuditFieldFromHeaders(input.getHeaders());
             LOG.info("RemoveAccountHandler received request");
             RemoveAccountRequest removeAccountRequest =
                     objectMapper.readValue(input.getBody(), RemoveAccountRequest.class);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -49,6 +49,7 @@ import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1002;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.getUserLanguageFromRequestHeaders;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.matchSupportedLanguage;
@@ -132,6 +133,7 @@ public class SendOtpNotificationHandler
                 RequestHeaderHelper.getHeaderValueOrElse(headers, CLIENT_SESSION_ID_HEADER, "");
         String persistentSessionId = PersistentIdHelper.extractPersistentIdFromHeaders(headers);
         attachSessionIdToLogs(sessionId);
+        attachTxmaAuditFieldFromHeaders(input.getHeaders());
         LOG.info("Request received in SendOtp Lambda");
 
         SendNotificationRequest sendNotificationRequest;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.getUserLanguageFromRequestHeaders;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.matchSupportedLanguage;
@@ -98,6 +99,7 @@ public class UpdateEmailHandler
         String sessionId =
                 RequestHeaderHelper.getHeaderValueOrElse(input.getHeaders(), SESSION_ID_HEADER, "");
         attachSessionIdToLogs(sessionId);
+        attachTxmaAuditFieldFromHeaders(input.getHeaders());
         LOG.info("UpdateEmailHandler received request");
         SupportedLanguage userLanguage =
                 matchSupportedLanguage(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.getUserLanguageFromRequestHeaders;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.matchSupportedLanguage;
@@ -102,6 +103,7 @@ public class UpdatePasswordHandler
         String sessionId =
                 RequestHeaderHelper.getHeaderValueOrElse(input.getHeaders(), SESSION_ID_HEADER, "");
         attachSessionIdToLogs(sessionId);
+        attachTxmaAuditFieldFromHeaders(input.getHeaders());
         LOG.info("UpdatePasswordHandler received request");
         SupportedLanguage userLanguage =
                 matchSupportedLanguage(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.getUserLanguageFromRequestHeaders;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.matchSupportedLanguage;
@@ -96,6 +97,7 @@ public class UpdatePhoneNumberHandler
         String sessionId =
                 RequestHeaderHelper.getHeaderValueOrElse(input.getHeaders(), SESSION_ID_HEADER, "");
         attachSessionIdToLogs(sessionId);
+        attachTxmaAuditFieldFromHeaders(input.getHeaders());
         LOG.info("UpdatePhoneNumberHandler received request");
         SupportedLanguage userLanguage =
                 matchSupportedLanguage(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -3,10 +3,13 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.ThreadContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.helpers.AuditHelper.AuditField;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -16,6 +19,7 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,7 +33,16 @@ class AuthenticateHandlerTest {
     private static final String PASSWORD = "joe.bloggs@test.com";
     private static final String PHONE_NUMBER = "01234567890";
     private static final String IP_ADDRESS = "123.123.123.123";
+    private static final String persistentIdValue = "some-persistent-session-id";
+    private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
+    private static final Map<String, String> headers =
+            Map.of(
+                    PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
+                    persistentIdValue,
+                    AuditField.TXMA_ENCODED_HEADER.getHeaderName(),
+                    TXMA_ENCODED_HEADER_VALUE);
     private AuthenticateHandler handler;
+    private APIGatewayProxyRequestEvent event;
     private final Context context = mock(Context.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -37,114 +50,111 @@ class AuthenticateHandlerTest {
     @BeforeEach
     public void setUp() {
         handler = new AuthenticateHandler(authenticationService, auditService);
+        event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(headers);
+        event.setRequestContext(contextWithSourceIp(IP_ADDRESS));
+        event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
     }
 
     @Test
     public void shouldReturn204IfLoginIsSuccessful() {
-        String persistentIdValue = "some-persistent-session-id";
         when(authenticationService.userExists(EMAIL)).thenReturn(true);
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(true);
         when(authenticationService.getPhoneNumber(EMAIL)).thenReturn(Optional.of(PHONE_NUMBER));
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
-        event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
-
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        persistentIdValue);
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                EMAIL,
+                                IP_ADDRESS,
+                                AuditService.UNKNOWN,
+                                persistentIdValue));
+        assertEquals(
+                ThreadContext.get(AuditField.TXMA_ENCODED_HEADER.getFieldName()),
+                TXMA_ENCODED_HEADER_VALUE);
     }
 
     @Test
     public void shouldReturn401IfUserHasInvalidCredentials() {
         when(authenticationService.userExists(EMAIL)).thenReturn(true);
-        String persistentIdValue = "some-persistent-session-id";
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
-        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1008));
-
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        persistentIdValue);
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                EMAIL,
+                                IP_ADDRESS,
+                                AuditService.UNKNOWN,
+                                persistentIdValue));
+        assertEquals(
+                ThreadContext.get(AuditField.TXMA_ENCODED_HEADER.getFieldName()),
+                TXMA_ENCODED_HEADER_VALUE);
     }
 
     @Test
     public void shouldReturn400IfAnyRequestParametersAreMissing() {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        String persistentIdValue = "some-persistent-session-id";
         event.setBody(format("{ \"password\": \"%s\"}", PASSWORD));
-        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
-
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        persistentIdValue);
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                IP_ADDRESS,
+                                AuditService.UNKNOWN,
+                                persistentIdValue));
+        assertEquals(
+                ThreadContext.get(AuditField.TXMA_ENCODED_HEADER.getFieldName()),
+                TXMA_ENCODED_HEADER_VALUE);
     }
 
     @Test
     public void shouldReturn400IfUserDoesNotHaveAnAccount() {
-        String persistentIdValue = "some-persistent-session-id";
         when(authenticationService.userExists(EMAIL)).thenReturn(false);
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
-        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));
-
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        persistentIdValue);
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                EMAIL,
+                                IP_ADDRESS,
+                                AuditService.UNKNOWN,
+                                persistentIdValue));
+        assertEquals(
+                ThreadContext.get(AuditField.TXMA_ENCODED_HEADER.getFieldName()),
+                TXMA_ENCODED_HEADER_VALUE);
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import org.apache.logging.log4j.ThreadContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
@@ -11,6 +12,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.DynamoDeleteService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.AuditHelper.AuditField;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
@@ -26,6 +28,7 @@ import java.util.Optional;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -42,6 +45,7 @@ class RemoveAccountHandlerTest {
     private static final Subject PUBLIC_SUBJECT = new Subject();
     private static final Subject INTERNAL_SUBJECT = new Subject();
     private static final String PERSISTENT_ID = "some-persistent-session-id";
+    private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
@@ -86,6 +90,9 @@ class RemoveAccountHandlerTest {
 
         assertThat(result, hasStatus(204));
         verify(accountDeletionService).removeAccount(Optional.of(event), userProfile);
+        assertEquals(
+                ThreadContext.get(AuditField.TXMA_ENCODED_HEADER.getFieldName()),
+                TXMA_ENCODED_HEADER_VALUE);
     }
 
     @Test
@@ -110,6 +117,9 @@ class RemoveAccountHandlerTest {
         assertThat(expectedException.getMessage(), equalTo("Invalid Principal in request"));
         verifyNoInteractions(sqsClient);
         verifyNoInteractions(auditService);
+        assertEquals(
+                ThreadContext.get(AuditField.TXMA_ENCODED_HEADER.getFieldName()),
+                TXMA_ENCODED_HEADER_VALUE);
     }
 
     @Test
@@ -123,6 +133,9 @@ class RemoveAccountHandlerTest {
         verifyNoInteractions(auditService);
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));
+        assertEquals(
+                ThreadContext.get(AuditField.TXMA_ENCODED_HEADER.getFieldName()),
+                TXMA_ENCODED_HEADER_VALUE);
     }
 
     private APIGatewayProxyRequestEvent generateApiGatewayEvent(String principalId) {
@@ -135,8 +148,12 @@ class RemoveAccountHandlerTest {
         proxyRequestContext.setAuthorizer(authorizerParams);
         proxyRequestContext.setIdentity(identityWithSourceIp("123.123.123.123"));
         event.setRequestContext(proxyRequestContext);
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID));
-
+        event.setHeaders(
+                Map.of(
+                        PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
+                        PERSISTENT_ID,
+                        AuditField.TXMA_ENCODED_HEADER.getHeaderName(),
+                        TXMA_ENCODED_HEADER_VALUE));
         return event;
     }
 }

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -19,12 +19,13 @@ module "authenticate" {
   path_part       = "authenticate"
   endpoint_method = ["POST"]
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
-    REDIS_KEY            = local.redis_key
+    ENVIRONMENT                = var.environment
+    DYNAMO_ENDPOINT            = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    INTERNAl_SECTOR_URI        = var.internal_sector_uri
+    LOCALSTACK_ENDPOINT        = var.use_localstack ? var.localstack_endpoint : null
+    TXMA_AUDIT_QUEUE_URL       = module.account_management_txma_audit.queue_url
+    REDIS_KEY                  = local.redis_key
+    TXMA_AUDIT_ENCODED_ENABLED = var.txma_audit_encoded_enabled
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.AuthenticateHandler::handleRequest"
 

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -22,12 +22,13 @@ module "delete_account" {
   path_part       = "delete-account"
   endpoint_method = ["POST"]
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
-    TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    ENVIRONMENT                = var.environment
+    DYNAMO_ENDPOINT            = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT        = var.use_localstack ? var.localstack_endpoint : null
+    EMAIL_QUEUE_URL            = aws_sqs_queue.email_queue.id
+    TXMA_AUDIT_QUEUE_URL       = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI        = var.internal_sector_uri
+    TXMA_AUDIT_ENCODED_ENABLED = var.txma_audit_encoded_enabled
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.RemoveAccountHandler::handleRequest"
 

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -40,6 +40,7 @@ module "send_otp_notification" {
     TEST_CLIENT_VERIFY_EMAIL_OTP           = var.test_client_verify_email_otp
     TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP    = var.test_client_verify_phone_number_otp
     TEST_CLIENTS_ENABLED                   = var.test_clients_enabled
+    TXMA_AUDIT_ENCODED_ENABLED             = var.txma_audit_encoded_enabled
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler::handleRequest"
 

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -22,13 +22,14 @@ module "update_email" {
   path_part       = "update-email"
   endpoint_method = ["POST"]
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY            = local.redis_key
-    TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    ENVIRONMENT                = var.environment
+    DYNAMO_ENDPOINT            = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EMAIL_QUEUE_URL            = aws_sqs_queue.email_queue.id
+    LOCALSTACK_ENDPOINT        = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                  = local.redis_key
+    TXMA_AUDIT_QUEUE_URL       = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI        = var.internal_sector_uri
+    TXMA_AUDIT_ENCODED_ENABLED = var.txma_audit_encoded_enabled
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdateEmailHandler::handleRequest"
 

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -22,12 +22,13 @@ module "update_password" {
   path_part       = "update-password"
   endpoint_method = ["POST"]
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
-    TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    ENVIRONMENT                = var.environment
+    DYNAMO_ENDPOINT            = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT        = var.use_localstack ? var.localstack_endpoint : null
+    EMAIL_QUEUE_URL            = aws_sqs_queue.email_queue.id
+    TXMA_AUDIT_QUEUE_URL       = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI        = var.internal_sector_uri
+    TXMA_AUDIT_ENCODED_ENABLED = var.txma_audit_encoded_enabled
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdatePasswordHandler::handleRequest"
 

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -21,13 +21,14 @@ module "update_phone_number" {
   path_part       = "update-phone-number"
   endpoint_method = ["POST"]
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY            = local.redis_key
-    TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    ENVIRONMENT                = var.environment
+    DYNAMO_ENDPOINT            = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EMAIL_QUEUE_URL            = aws_sqs_queue.email_queue.id
+    LOCALSTACK_ENDPOINT        = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                  = local.redis_key
+    TXMA_AUDIT_QUEUE_URL       = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI        = var.internal_sector_uri
+    TXMA_AUDIT_ENCODED_ENABLED = var.txma_audit_encoded_enabled
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdatePhoneNumberHandler::handleRequest"
 

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -224,6 +224,12 @@ variable "support_email_check_enabled" {
   description = "Feature flag which toggles the Experian email check on and off"
 }
 
+variable "txma_audit_encoded_enabled" {
+  default     = false
+  type        = bool
+  description = "Feature flag which toggles submitting additional Txma headers for audit"
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -1,0 +1,160 @@
+package uk.gov.di.audit;
+
+import uk.gov.di.authentication.shared.services.AuditService.MetadataPair;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class AuditContext {
+    private String clientSessionId;
+    private String sessionId;
+    private String clientId;
+    private String subjectId;
+    private String email;
+    private String ipAddress;
+    private String phoneNumber;
+    private String persistentSessionId;
+    private MetadataPair[] metadataPairs = new MetadataPair[0];
+
+    public AuditContext(
+            String clientSessionId,
+            String sessionId,
+            String clientId,
+            String subjectId,
+            String email,
+            String ipAddress,
+            String phoneNumber,
+            String persistentSessionId) {
+        this.clientSessionId = clientSessionId;
+        this.sessionId = sessionId;
+        this.clientId = clientId;
+        this.subjectId = subjectId;
+        this.email = email;
+        this.ipAddress = ipAddress;
+        this.phoneNumber = phoneNumber;
+        this.persistentSessionId = persistentSessionId;
+    }
+
+    public AuditContext(
+            String clientSessionId,
+            String sessionId,
+            String clientId,
+            String subjectId,
+            String email,
+            String ipAddress,
+            String phoneNumber,
+            String persistentSessionId,
+            MetadataPair[] metadataPairs) {
+        this.clientSessionId = clientSessionId;
+        this.sessionId = sessionId;
+        this.clientId = clientId;
+        this.subjectId = subjectId;
+        this.email = email;
+        this.ipAddress = ipAddress;
+        this.phoneNumber = phoneNumber;
+        this.persistentSessionId = persistentSessionId;
+        this.metadataPairs = metadataPairs;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
+    public void setClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getSubjectId() {
+        return subjectId;
+    }
+
+    public void setSubjectId(String subjectId) {
+        this.subjectId = subjectId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getPersistentSessionId() {
+        return persistentSessionId;
+    }
+
+    public void setPersistentSessionId(String persistentSessionId) {
+        this.persistentSessionId = persistentSessionId;
+    }
+
+    public MetadataPair[] getMetadataPairs() {
+        return metadataPairs;
+    }
+
+    public void setMetadataPairs(MetadataPair[] metadataPairs) {
+        this.metadataPairs = metadataPairs;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuditContext that = (AuditContext) o;
+        return Objects.equals(clientSessionId, that.clientSessionId)
+                && Objects.equals(sessionId, that.sessionId)
+                && Objects.equals(clientId, that.clientId)
+                && Objects.equals(subjectId, that.subjectId)
+                && Objects.equals(email, that.email)
+                && Objects.equals(ipAddress, that.ipAddress)
+                && Objects.equals(phoneNumber, that.phoneNumber)
+                && Objects.equals(persistentSessionId, that.persistentSessionId)
+                && Arrays.equals(metadataPairs, that.metadataPairs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                clientSessionId,
+                sessionId,
+                clientId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                Arrays.hashCode(metadataPairs));
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/InvalidEncodingException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/InvalidEncodingException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class InvalidEncodingException extends Exception {
+
+    public InvalidEncodingException(String message) {
+        super(message);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/AuditHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/AuditHelper.java
@@ -1,0 +1,61 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.authentication.shared.exceptions.InvalidEncodingException;
+
+import java.util.Map;
+
+import static uk.gov.di.authentication.shared.helpers.InputSanitiser.sanitiseBase64;
+
+public class AuditHelper {
+
+    private static final Logger LOG = LogManager.getLogger(AuditHelper.class);
+
+    public enum AuditField {
+        TXMA_ENCODED_HEADER("txmaEncodedHeader", "txma-audit-encoded", true);
+
+        private final String fieldName;
+        private final String headerName;
+        private boolean isBase64;
+
+        AuditField(String fieldName, String headerName, boolean isBase64) {
+            this.fieldName = fieldName;
+            this.isBase64 = isBase64;
+            this.headerName = headerName;
+        }
+
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        public String getHeaderName() {
+            return headerName;
+        }
+    }
+
+    public static void attachTxmaAuditFieldFromHeaders(Map<String, String> headers) {
+        try {
+            var txmaEncoded =
+                    RequestHeaderHelper.getHeaderValueFromHeaders(
+                            headers, AuditField.TXMA_ENCODED_HEADER.getHeaderName(), false);
+            if (txmaEncoded != null) {
+                attachAuditField(AuditField.TXMA_ENCODED_HEADER, txmaEncoded);
+            }
+        } catch (InvalidEncodingException e) {
+            LOG.error(e.getMessage());
+        }
+    }
+
+    public static void attachAuditField(AuditField auditField, String value)
+            throws InvalidEncodingException {
+        if (value == null || value.isEmpty()) {
+            throw new InvalidEncodingException("Audit field cannot be empty");
+        } else if (auditField.isBase64 && sanitiseBase64(value).isEmpty()) {
+            throw new InvalidEncodingException("Audit field has invalid base64url encoding");
+        } else {
+            ThreadContext.put(auditField.getFieldName(), value);
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -647,4 +647,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     public String getAccountInterventionsErrorMetricName() {
         return System.getenv().getOrDefault("ACCOUNT_INTERVENTIONS_ERROR_METRIC_NAME", "");
     }
+
+    public boolean isTxmaAuditEncodedEnabled() {
+        return System.getenv().getOrDefault("TXMA_AUDIT_ENCODED_ENABLED", "false").equals("true");
+    }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/AuditHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/AuditHelperTest.java
@@ -1,0 +1,47 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.helpers.AuditHelper.AuditField;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AuditHelperTest {
+
+    @Test
+    void auditFieldAttachedToThreadContextWithValidValue() {
+        String auditValue = "validHeaderValue";
+        AuditHelper.attachTxmaAuditFieldFromHeaders(
+                Map.of(AuditField.TXMA_ENCODED_HEADER.getHeaderName(), auditValue));
+        assertEquals(ThreadContext.get(AuditField.TXMA_ENCODED_HEADER.getFieldName()), auditValue);
+    }
+
+    @Test
+    void auditFieldHeaderMissing() {
+        AuditHelper.attachTxmaAuditFieldFromHeaders(Map.of());
+        assertNull(ThreadContext.get(AuditField.TXMA_ENCODED_HEADER.getFieldName()));
+    }
+
+    @Test
+    void auditFieldValueNotSet() {
+        AuditHelper.attachTxmaAuditFieldFromHeaders(
+                Map.of(AuditField.TXMA_ENCODED_HEADER.getHeaderName(), ""));
+        assertNull(ThreadContext.get(AuditField.TXMA_ENCODED_HEADER.getFieldName()));
+    }
+
+    @Test
+    void auditFieldHasInvalidEncoding() {
+        AuditHelper.attachTxmaAuditFieldFromHeaders(
+                Map.of(AuditField.TXMA_ENCODED_HEADER.getHeaderName(), "AAAA\\0"));
+        assertNull(ThreadContext.get(AuditField.TXMA_ENCODED_HEADER.getFieldName()));
+    }
+
+    @AfterEach
+    public void cleanup() {
+        ThreadContext.clearMap();
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.services;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 import java.time.Clock;
@@ -43,14 +44,15 @@ class AuditServiceTest {
 
         auditService.submitAuditEvent(
                 TEST_EVENT_ONE,
-                "client-id",
-                "request-id",
-                "session-id",
-                "subject-id",
-                "email",
-                "ip-address",
-                "phone-number",
-                "persistent-session-id");
+                new AuditContext(
+                        "request-id",
+                        "session-id",
+                        "client-id",
+                        "subject-id",
+                        "email",
+                        "ip-address",
+                        "phone-number",
+                        "persistent-session-id"));
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
 


### PR DESCRIPTION
## What

Read the new CF TXMA encoded header in the account management api lambda handlers.  If present send to txma in each audit event submitted.
Value is being stored in ThreadContext (in line with Orch) similar to how we store session id. This is then read and the data is added to audit events.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

- [ ] Impact on orch and auth mutual dependencies has been checked.

