### PR TITLE
ATO-619: cloudfront viewer ip

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelper.java
@@ -23,7 +23,11 @@ public class IpAddressHelper {
                         .map(APIGatewayProxyRequestEvent::getHeaders)
                         .orElse(emptyMap());
 
-        if (headersContainValidHeader(headers, "X-Forwarded-For", true)) {
+        if (headersContainValidHeader(headers, "CloudFront-Viewer-Address", true)) {
+            return getHeaderValueFromHeaders(headers, "CloudFront-Viewer-Address", true)
+                    .split(":")[0]
+                    .trim();
+        } else if (headersContainValidHeader(headers, "X-Forwarded-For", true)) {
             return getHeaderValueFromHeaders(headers, "X-Forwarded-For", true).split(",")[0].trim();
         }
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelperTest.java
@@ -15,6 +15,41 @@ import static uk.gov.di.orchestration.shared.helpers.IpAddressHelper.extractIpAd
 class IpAddressHelperTest {
 
     @Test
+    void shouldPreferCloudfrontViewerOverXForwarded() {
+        var request = new APIGatewayProxyRequestEvent();
+
+        request.setHeaders(
+                Map.of(
+                        "X-Forwarded-For",
+                        "234.234.234.234, 123.123.123.123, 111.111.111.111",
+                        "CloudFront-Viewer-Address",
+                        "222.222.222.222:222"));
+        request.setRequestContext(stubContextWithSourceIp());
+
+        assertThat(extractIpAddress(request), is("222.222.222.222"));
+    }
+
+    @Test
+    void shouldRetrieveCloudfrontViewerCaseInsensitively() {
+        var request = new APIGatewayProxyRequestEvent();
+
+        request.setHeaders(Map.of("cloudfront-viewer-address", "222.222.222.222:222"));
+        request.setRequestContext(stubContextWithSourceIp());
+
+        assertThat(extractIpAddress(request), is("222.222.222.222"));
+    }
+
+    @Test
+    void shouldAcceptCloudfrontViewerWithoutSourcePort() {
+        var request = new APIGatewayProxyRequestEvent();
+
+        request.setHeaders(Map.of("CloudFront-Viewer-Address", "222.222.222.222"));
+        request.setRequestContext(stubContextWithSourceIp());
+
+        assertThat(extractIpAddress(request), is("222.222.222.222"));
+    }
+
+    @Test
     void shouldPreferFirstXForwardedForHeader() {
         var request = new APIGatewayProxyRequestEvent();
 


### PR DESCRIPTION
## What

Per https://github.com/govuk-one-login/architecture/blob/main/rfc/0072-assets-via-cloudfront.md#application-changes---client-ip-address, we need to change how we retrieve viewer IP address when we introduce cloudfront. Use the new header value preferentially.

This is based on #4414 as that introduces header case insensitivity to this helper