### PR TITLE
AUT-2162: Part 1: Create Code for new endpoint CheckEmailFraudBlock

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -83,6 +83,8 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       local.deploy_account_interventions_count == 1 ? module.account_interventions[0].method_trigger_value : null,
       local.deploy_reauth_user_count == 1 ? module.check_reauth_user[0].integration_trigger_value : null,
       local.deploy_reauth_user_count == 1 ? module.check_reauth_user[0].method_trigger_value : null,
+      local.deploy_check_email_fraud_block_count == 1 ? module.check_email_fraud_block[0].integration_trigger_value : null,
+      local.deploy_check_email_fraud_block_count == 1 ? module.check_email_fraud_block[0].method_trigger_value : null,
       local.account_modifiers_encryption_policy_arn,
     ]))
   }
@@ -207,6 +209,7 @@ resource "aws_api_gateway_stage" "endpoint_frontend_stage" {
     module.doc-app-authorize,
     module.orch_auth_code,
     module.check_reauth_user,
+    module.check_email_fraud_block,
     aws_api_gateway_deployment.deployment,
   ]
 }

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -74,4 +74,5 @@ locals {
   pending_email_check_queue_id                        = data.terraform_remote_state.shared.outputs.pending_email_check_queue_id
   pending_email_check_queue_access_policy_arn         = data.terraform_remote_state.shared.outputs.pending_email_check_queue_access_policy_arn
   user_profile_kms_key_arn                            = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
+  email_check_results_encryption_policy_arn           = data.terraform_remote_state.shared.outputs.email_check_results_encryption_policy_arn
 }

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -40,9 +40,10 @@ locals {
     application = "oidc-api"
   }
 
-  request_tracing_allowed            = contains(["build", "sandpit"], var.environment)
-  deploy_account_interventions_count = 1
-  deploy_reauth_user_count           = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
+  request_tracing_allowed              = contains(["build", "sandpit"], var.environment)
+  deploy_account_interventions_count   = 1
+  deploy_reauth_user_count             = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
+  deploy_check_email_fraud_block_count = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
 
   access_logging_template = jsonencode({
     requestId            = "$context.requestId"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckEmailFraudBlockRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckEmailFraudBlockRequest.java
@@ -1,0 +1,5 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+
+public class CheckEmailFraudBlockRequest extends BaseFrontendRequest {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckEmailFraudBlockResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckEmailFraudBlockResponse.java
@@ -1,0 +1,9 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+
+public record CheckEmailFraudBlockResponse(
+        @SerializedName("email") @Expose @Required String email,
+        @SerializedName("isBlockedStatus") @Expose String isBlockedStatus) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
@@ -1,0 +1,95 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockRequest;
+import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
+import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
+import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+
+public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailFraudBlockRequest> {
+
+    private static final Logger LOG = LogManager.getLogger(CheckEmailFraudBlockRequest.class);
+
+    private final AuditService auditService;
+    private final DynamoEmailCheckResultService dynamoEmailCheckResultService;
+
+    protected CheckEmailFraudBlockHandler(
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
+            AuthenticationService authenticationService,
+            DynamoEmailCheckResultService dynamoEmailCheckResultService,
+            AuditService auditService) {
+        super(
+                CheckEmailFraudBlockRequest.class,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
+        this.dynamoEmailCheckResultService = dynamoEmailCheckResultService;
+        this.auditService = auditService;
+    }
+
+    public CheckEmailFraudBlockHandler(ConfigurationService configurationService) {
+        super(CheckEmailFraudBlockRequest.class, configurationService);
+        this.dynamoEmailCheckResultService =
+                new DynamoEmailCheckResultService(configurationService);
+        this.auditService = new AuditService(configurationService);
+    }
+
+    public CheckEmailFraudBlockHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        return super.handleRequest(input, context);
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            CheckEmailFraudBlockRequest request,
+            UserContext userContext) {
+        try {
+            LOG.info("Request received to CheckEmailFraudBlockHandler");
+            LOG.info("Checking if block is present");
+
+            var emailCheckResult =
+                    dynamoEmailCheckResultService.getEmailCheckStore(request.getEmail());
+
+            if (emailCheckResult.isPresent()) {
+                var checkEmailFraudBlockResponse =
+                        new CheckEmailFraudBlockResponse(
+                                request.getEmail(), emailCheckResult.get().getStatus().getValue());
+                return generateApiGatewayProxyResponse(200, checkEmailFraudBlockResponse);
+            }
+            return generateApiGatewayProxyResponse(
+                    200,
+                    new CheckEmailFraudBlockResponse(
+                            request.getEmail(), EmailCheckResultStatus.PENDING.getValue()));
+        } catch (Json.JsonException e) {
+            LOG.error("Unable to serialize check email fraud block response", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
@@ -1,0 +1,129 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
+import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
+import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.helpers.SaltHelper;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
+import uk.gov.di.authentication.shared.services.SessionService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
+import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class CheckEmailFraudBlockHandlerTest {
+
+    private static final byte[] SALT = SaltHelper.generateNewSalt();
+    private static final String EMAIL = "joe.bloggs@test.com";
+    private static final String PERSISTENT_ID = "some-persistent-id-value";
+    private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
+    private static final String CLIENT_SESSION_ID = "known-client-session-id";
+    private static final Subject INTERNAL_SUBJECT_ID = new Subject();
+
+    private static AuditService auditServiceMock;
+    private static AuthenticationService authenticationServiceMock;
+    private static Context contextMock;
+    private static ConfigurationService configurationServiceMock;
+    private static ClientService clientServiceMock;
+    private static ClientSessionService clientSessionServiceMock;
+    private static DynamoEmailCheckResultService dbMock;
+    private static SessionService sessionServiceMock;
+
+    private final Session session = new Session(IdGenerator.generate()).setEmailAddress(EMAIL);
+    private CheckEmailFraudBlockHandler handler;
+
+    @BeforeAll
+    static void init() {
+        contextMock = mock(Context.class);
+        dbMock = mock(DynamoEmailCheckResultService.class);
+        clientServiceMock = mock(ClientService.class);
+        auditServiceMock = mock(AuditService.class);
+        configurationServiceMock = mock(ConfigurationService.class);
+        authenticationServiceMock = mock(AuthenticationService.class);
+        sessionServiceMock = mock(SessionService.class);
+        clientSessionServiceMock = mock(ClientSessionService.class);
+    }
+
+    @BeforeEach
+    void setup() {
+        var userProfile = generateUserProfile();
+
+        when(configurationServiceMock.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
+        when(authenticationServiceMock.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+        when(authenticationServiceMock.getUserProfileFromEmail(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+
+        handler =
+                new CheckEmailFraudBlockHandler(
+                        configurationServiceMock,
+                        sessionServiceMock,
+                        clientSessionServiceMock,
+                        clientServiceMock,
+                        authenticationServiceMock,
+                        dbMock,
+                        auditServiceMock);
+    }
+
+    @ParameterizedTest
+    @EnumSource(EmailCheckResultStatus.class)
+    void shouldReturnCorrectStatusBasedOnDbResult(EmailCheckResultStatus status) {
+        var resultStore = new EmailCheckResultStore();
+        resultStore.setStatus(status);
+        when(dbMock.getEmailCheckStore(EMAIL)).thenReturn(Optional.of(resultStore));
+
+        usingValidSession();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
+        headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
+
+        var event = new APIGatewayProxyRequestEvent();
+        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+        event.setHeaders(headers);
+        event.setBody(format("{ \"email\": \"%s\" }", EMAIL.toUpperCase()));
+
+        var expectedResponse = new CheckEmailFraudBlockResponse(EMAIL, status.getValue());
+        var result = handler.handleRequest(event, contextMock);
+
+        assertThat(result, hasStatus(200));
+        assertThat(result, hasJsonBody(expectedResponse));
+    }
+
+    private void usingValidSession() {
+        when(sessionServiceMock.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(session));
+    }
+
+    private UserProfile generateUserProfile() {
+        return new UserProfile()
+                .withEmail(EMAIL)
+                .withEmailVerified(true)
+                .withSubjectID(INTERNAL_SUBJECT_ID.getValue());
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
@@ -1,0 +1,100 @@
+package uk.gov.di.authentication.api;
+
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
+import uk.gov.di.authentication.frontendapi.lambda.CheckEmailFraudBlockHandler;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
+    public static final String CLIENT_SESSION_ID = "some-client-session-id";
+    private static final String INTERNAl_SECTOR_URI = "https://test.account.gov.uk";
+    private static final String INTERNAl_SECTOR_HOST = "test.account.gov.uk";
+    private static final Subject SUBJECT = new Subject();
+
+    DynamoEmailCheckResultService dynamoEmailCheckResultService =
+            new DynamoEmailCheckResultService(TEST_CONFIGURATION_SERVICE);
+
+    @RegisterExtension
+    protected static final EmailCheckResultExtension emailCheckResultExtension =
+            new EmailCheckResultExtension();
+
+    @BeforeEach
+    void setup() {
+        handler = new CheckEmailFraudBlockHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
+    }
+
+    @Test
+    void shouldReturnCorrectStatusBasedOnDbResult() throws Json.JsonException {
+        userStore.signUp(EMAIL, "password-1", SUBJECT);
+        var sessionId = redis.createSession();
+        dynamoEmailCheckResultService.saveEmailCheckResult(
+                EMAIL, EmailCheckResultStatus.ALLOW, unixTimePlusNDays(), "test-reference");
+        redis.addEmailToSession(sessionId, EMAIL);
+        redis.createClientSession(CLIENT_SESSION_ID, createClientSession());
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Session-Id", sessionId);
+        headers.put("X-API-Key", FRONTEND_API_KEY);
+        headers.put("Client-Session-Id", CLIENT_SESSION_ID);
+        var response =
+                makeRequest(Optional.of(format("{ \"email\": \"%s\"}", EMAIL)), headers, Map.of());
+
+        assertThat(response, hasStatus(200));
+        assertThat(
+                response,
+                hasJsonBody(
+                        new CheckEmailFraudBlockResponse(
+                                EMAIL, EmailCheckResultStatus.ALLOW.getValue())));
+    }
+
+    private ClientSession createClientSession() {
+        var authRequestBuilder =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                new Scope(OIDCScopeValue.OPENID),
+                                new ClientID("test-client-id"),
+                                URI.create("http://localhost/redirect"))
+                        .state(new State())
+                        .nonce(new Nonce());
+        return new ClientSession(
+                authRequestBuilder.build().toParameters(),
+                LocalDateTime.now(),
+                VectorOfTrust.getDefaults(),
+                "test-client-name");
+    }
+
+    private long unixTimePlusNDays() {
+        return NowHelper.nowPlus(1, ChronoUnit.DAYS).toInstant().getEpochSecond();
+    }
+}


### PR DESCRIPTION
# What

- Create new `CheckEmailFraudBlock` handler that takes `email` as a request and returns a response containing the email check status
- The check status can either be `ALLOW`, `DENY`, `PENDING` 
- The email check status is stored in the `<env>-email-check-result` dynamodb table
- This lambda will be called during the Create Account journey
- Implement necessary Iac Terraform scripts to create CheckEmailFraud lambda
- Deployed and tested in `authdev1`

# How to review
1. Code Review