### PR TITLE
AUT-2663: introduce auditcontext to make authenticatehandler easier to read

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.AuthenticateRequest;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
@@ -66,22 +67,25 @@ public class AuthenticateHandler
                 RequestHeaderHelper.getHeaderValueOrElse(input.getHeaders(), SESSION_ID_HEADER, "");
         attachSessionIdToLogs(sessionId);
         LOG.info("Request received to the AuthenticateHandler");
-
-        try {
-            AuthenticateRequest loginRequest =
-                    objectMapper.readValue(input.getBody(), AuthenticateRequest.class);
-            boolean userHasAccount = authenticationService.userExists(loginRequest.getEmail());
-            if (!userHasAccount) {
-                auditService.submitAuditEvent(
-                        AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
+        var auditContext =
+                new AuditContext(
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         sessionId,
                         AuditService.UNKNOWN,
-                        loginRequest.getEmail(),
+                        AuditService.UNKNOWN,
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+        try {
+            AuthenticateRequest loginRequest =
+                    objectMapper.readValue(input.getBody(), AuthenticateRequest.class);
+            auditContext.setEmail(loginRequest.getEmail());
+            boolean userHasAccount = authenticationService.userExists(loginRequest.getEmail());
+            if (!userHasAccount) {
+                auditService.submitAuditEvent(
+                        AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
+                        auditContext);
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
             }
             boolean hasValidCredentials =
@@ -90,41 +94,19 @@ public class AuthenticateHandler
             if (!hasValidCredentials) {
                 auditService.submitAuditEvent(
                         AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        sessionId,
-                        AuditService.UNKNOWN,
-                        loginRequest.getEmail(),
-                        IpAddressHelper.extractIpAddress(input),
-                        AuditService.UNKNOWN,
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                        auditContext);
                 return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
             }
             LOG.info("User has successfully Logged in. Generating successful AuthenticateResponse");
 
             auditService.submitAuditEvent(
-                    AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE,
-                    AuditService.UNKNOWN,
-                    AuditService.UNKNOWN,
-                    sessionId,
-                    AuditService.UNKNOWN,
-                    loginRequest.getEmail(),
-                    IpAddressHelper.extractIpAddress(input),
-                    AuditService.UNKNOWN,
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE, auditContext);
 
             return generateEmptySuccessApiGatewayResponse();
         } catch (JsonException e) {
             auditService.submitAuditEvent(
                     AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
-                    AuditService.UNKNOWN,
-                    AuditService.UNKNOWN,
-                    sessionId,
-                    AuditService.UNKNOWN,
-                    AuditService.UNKNOWN,
-                    IpAddressHelper.extractIpAddress(input),
-                    AuditService.UNKNOWN,
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    auditContext);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -29,7 +30,12 @@ class AuthenticateHandlerTest {
     private static final String PASSWORD = "joe.bloggs@test.com";
     private static final String PHONE_NUMBER = "01234567890";
     private static final String IP_ADDRESS = "123.123.123.123";
+    private static final String persistentIdValue = "some-persistent-session-id";
+    private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
+    private static final Map<String, String> headers =
+            Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue);
     private AuthenticateHandler handler;
+    private APIGatewayProxyRequestEvent event;
     private final Context context = mock(Context.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -37,114 +43,99 @@ class AuthenticateHandlerTest {
     @BeforeEach
     public void setUp() {
         handler = new AuthenticateHandler(authenticationService, auditService);
+        event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(headers);
+        event.setRequestContext(contextWithSourceIp(IP_ADDRESS));
+        event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
     }
 
     @Test
     public void shouldReturn204IfLoginIsSuccessful() {
-        String persistentIdValue = "some-persistent-session-id";
         when(authenticationService.userExists(EMAIL)).thenReturn(true);
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(true);
         when(authenticationService.getPhoneNumber(EMAIL)).thenReturn(Optional.of(PHONE_NUMBER));
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
-        event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
-
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        persistentIdValue);
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                EMAIL,
+                                IP_ADDRESS,
+                                AuditService.UNKNOWN,
+                                persistentIdValue));
     }
 
     @Test
     public void shouldReturn401IfUserHasInvalidCredentials() {
         when(authenticationService.userExists(EMAIL)).thenReturn(true);
-        String persistentIdValue = "some-persistent-session-id";
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
-        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1008));
-
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        persistentIdValue);
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                EMAIL,
+                                IP_ADDRESS,
+                                AuditService.UNKNOWN,
+                                persistentIdValue));
     }
 
     @Test
     public void shouldReturn400IfAnyRequestParametersAreMissing() {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        String persistentIdValue = "some-persistent-session-id";
         event.setBody(format("{ \"password\": \"%s\"}", PASSWORD));
-        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
-
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        persistentIdValue);
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                IP_ADDRESS,
+                                AuditService.UNKNOWN,
+                                persistentIdValue));
     }
 
     @Test
     public void shouldReturn400IfUserDoesNotHaveAnAccount() {
-        String persistentIdValue = "some-persistent-session-id";
         when(authenticationService.userExists(EMAIL)).thenReturn(false);
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
-        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));
-
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        persistentIdValue);
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                EMAIL,
+                                IP_ADDRESS,
+                                AuditService.UNKNOWN,
+                                persistentIdValue));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaRequest;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
@@ -174,16 +175,17 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT,
-                        "",
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        expectedCommonSubject,
-                        TEST_EMAIL_ADDRESS,
-                        "123.123.123.123",
-                        PHONE_NUMBER,
-                        persistentId,
-                        pair("journey-type", JourneyType.SIGN_IN),
-                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                CLIENT_SESSION_ID,
+                                session.getSessionId(),
+                                expectedCommonSubject,
+                                TEST_EMAIL_ADDRESS,
+                                "123.123.123.123",
+                                PHONE_NUMBER,
+                                persistentId,
+                                pair("journey-type", JourneyType.SIGN_IN),
+                                pair("mfa-type", MFAMethodType.SMS.getValue())));
     }
 
     @Test
@@ -223,16 +225,17 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT,
-                        "",
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        expectedCommonSubject,
-                        TEST_EMAIL_ADDRESS,
-                        "123.123.123.123",
-                        PHONE_NUMBER,
-                        persistentId,
-                        pair("journey-type", JourneyType.SIGN_IN),
-                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                CLIENT_SESSION_ID,
+                                session.getSessionId(),
+                                expectedCommonSubject,
+                                TEST_EMAIL_ADDRESS,
+                                "123.123.123.123",
+                                PHONE_NUMBER,
+                                persistentId,
+                                pair("journey-type", JourneyType.SIGN_IN),
+                                pair("mfa-type", MFAMethodType.SMS.getValue())));
     }
 
     @Test
@@ -263,16 +266,17 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT,
-                        "",
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        expectedCommonSubject,
-                        TEST_EMAIL_ADDRESS,
-                        "123.123.123.123",
-                        PHONE_NUMBER,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("journey-type", JourneyType.SIGN_IN),
-                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                CLIENT_SESSION_ID,
+                                session.getSessionId(),
+                                expectedCommonSubject,
+                                TEST_EMAIL_ADDRESS,
+                                "123.123.123.123",
+                                PHONE_NUMBER,
+                                PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                                pair("journey-type", JourneyType.SIGN_IN),
+                                pair("mfa-type", MFAMethodType.SMS.getValue())));
     }
 
     @Test
@@ -339,16 +343,17 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISMATCHED_EMAIL,
-                        "",
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        expectedCommonSubject,
-                        "wrong.email@gov.uk",
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("journey-type", JourneyType.SIGN_IN),
-                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                CLIENT_SESSION_ID,
+                                session.getSessionId(),
+                                expectedCommonSubject,
+                                "wrong.email@gov.uk",
+                                "123.123.123.123",
+                                AuditService.UNKNOWN,
+                                PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                                pair("journey-type", JourneyType.SIGN_IN),
+                                pair("mfa-type", MFAMethodType.SMS.getValue())));
     }
 
     @Test
@@ -373,16 +378,17 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISSING_PHONE_NUMBER,
-                        "",
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        expectedCommonSubject,
-                        TEST_EMAIL_ADDRESS,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("journey-type", JourneyType.SIGN_IN),
-                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType()));
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                CLIENT_SESSION_ID,
+                                session.getSessionId(),
+                                expectedCommonSubject,
+                                TEST_EMAIL_ADDRESS,
+                                "123.123.123.123",
+                                AuditService.UNKNOWN,
+                                PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                                pair("journey-type", JourneyType.SIGN_IN),
+                                pair("mfa-type", MFAMethodType.SMS.getValue())));
     }
 
     @Test
@@ -485,16 +491,17 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        "",
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        expectedCommonSubject,
-                        TEST_EMAIL_ADDRESS,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("journey-type", journeyType),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()));
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                CLIENT_SESSION_ID,
+                                session.getSessionId(),
+                                expectedCommonSubject,
+                                TEST_EMAIL_ADDRESS,
+                                "123.123.123.123",
+                                AuditService.UNKNOWN,
+                                PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                                pair("journey-type", journeyType),
+                                pair("mfa-type", MFAMethodType.SMS.getValue())));
     }
 
     @ParameterizedTest
@@ -527,16 +534,17 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        "",
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        expectedCommonSubject,
-                        TEST_EMAIL_ADDRESS,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("journey-type", journeyType),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()));
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                CLIENT_SESSION_ID,
+                                session.getSessionId(),
+                                expectedCommonSubject,
+                                TEST_EMAIL_ADDRESS,
+                                "123.123.123.123",
+                                AuditService.UNKNOWN,
+                                PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                                pair("journey-type", journeyType),
+                                pair("mfa-type", MFAMethodType.SMS.getValue())));
     }
 
     @ParameterizedTest
@@ -570,16 +578,17 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        "",
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        expectedCommonSubject,
-                        TEST_EMAIL_ADDRESS,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("journey-type", journeyType),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()));
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                CLIENT_SESSION_ID,
+                                session.getSessionId(),
+                                expectedCommonSubject,
+                                TEST_EMAIL_ADDRESS,
+                                "123.123.123.123",
+                                AuditService.UNKNOWN,
+                                PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                                pair("journey-type", journeyType),
+                                pair("mfa-type", MFAMethodType.SMS.getValue())));
     }
 
     @Test
@@ -612,16 +621,17 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT_FOR_TEST_CLIENT,
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        expectedCommonSubject,
-                        TEST_EMAIL_ADDRESS,
-                        "123.123.123.123",
-                        PHONE_NUMBER,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("journey-type", JourneyType.SIGN_IN),
-                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
+                        new AuditContext(
+                                TEST_CLIENT_ID,
+                                CLIENT_SESSION_ID,
+                                session.getSessionId(),
+                                expectedCommonSubject,
+                                TEST_EMAIL_ADDRESS,
+                                "123.123.123.123",
+                                PHONE_NUMBER,
+                                PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                                pair("journey-type", JourneyType.SIGN_IN),
+                                pair("mfa-type", MFAMethodType.SMS.getValue())));
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -1,0 +1,160 @@
+package uk.gov.di.audit;
+
+import uk.gov.di.authentication.shared.services.AuditService.MetadataPair;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class AuditContext {
+    private String clientId;
+    private String clientSessionId;
+    private String sessionId;
+    private String subjectId;
+    private String email;
+    private String ipAddress;
+    private String phoneNumber;
+    private String persistentSessionId;
+    private MetadataPair[] metadataPairs = new MetadataPair[0];
+
+    public AuditContext(
+            String clientId,
+            String clientSessionId,
+            String sessionId,
+            String subjectId,
+            String email,
+            String ipAddress,
+            String phoneNumber,
+            String persistentSessionId) {
+        this.clientId = clientId;
+        this.clientSessionId = clientSessionId;
+        this.sessionId = sessionId;
+        this.subjectId = subjectId;
+        this.email = email;
+        this.ipAddress = ipAddress;
+        this.phoneNumber = phoneNumber;
+        this.persistentSessionId = persistentSessionId;
+    }
+
+    public AuditContext(
+            String clientId,
+            String clientSessionId,
+            String sessionId,
+            String subjectId,
+            String email,
+            String ipAddress,
+            String phoneNumber,
+            String persistentSessionId,
+            MetadataPair... metadataPairs) {
+        this.clientId = clientId;
+        this.clientSessionId = clientSessionId;
+        this.sessionId = sessionId;
+        this.subjectId = subjectId;
+        this.email = email;
+        this.ipAddress = ipAddress;
+        this.phoneNumber = phoneNumber;
+        this.persistentSessionId = persistentSessionId;
+        this.metadataPairs = metadataPairs;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
+    public void setClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getSubjectId() {
+        return subjectId;
+    }
+
+    public void setSubjectId(String subjectId) {
+        this.subjectId = subjectId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getPersistentSessionId() {
+        return persistentSessionId;
+    }
+
+    public void setPersistentSessionId(String persistentSessionId) {
+        this.persistentSessionId = persistentSessionId;
+    }
+
+    public MetadataPair[] getMetadataPairs() {
+        return metadataPairs;
+    }
+
+    public void setMetadataPairs(MetadataPair[] metadataPairs) {
+        this.metadataPairs = metadataPairs;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuditContext that = (AuditContext) o;
+        return Objects.equals(clientId, that.clientId)
+                && Objects.equals(clientSessionId, that.clientSessionId)
+                && Objects.equals(sessionId, that.sessionId)
+                && Objects.equals(subjectId, that.subjectId)
+                && Objects.equals(email, that.email)
+                && Objects.equals(ipAddress, that.ipAddress)
+                && Objects.equals(phoneNumber, that.phoneNumber)
+                && Objects.equals(persistentSessionId, that.persistentSessionId)
+                && Arrays.equals(metadataPairs, that.metadataPairs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                clientId,
+                clientSessionId,
+                sessionId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                Arrays.hashCode(metadataPairs));
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.services;
 
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.audit.TxmaAuditUser;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
@@ -38,6 +39,20 @@ public class AuditService {
                         configurationService.getAwsRegion(),
                         configurationService.getTxmaAuditQueueUrl(),
                         configurationService.getLocalstackEndpointUri());
+    }
+
+    public void submitAuditEvent(AuditableEvent event, AuditContext auditContext) {
+        submitAuditEvent(
+                event,
+                auditContext.getClientId(),
+                auditContext.getClientSessionId(),
+                auditContext.getSessionId(),
+                auditContext.getSubjectId(),
+                auditContext.getEmail(),
+                auditContext.getIpAddress(),
+                auditContext.getPhoneNumber(),
+                auditContext.getPersistentSessionId(),
+                auditContext.getMetadataPairs());
     }
 
     public void submitAuditEvent(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.services;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 import java.time.Clock;
@@ -43,14 +44,15 @@ class AuditServiceTest {
 
         auditService.submitAuditEvent(
                 TEST_EVENT_ONE,
-                "client-id",
-                "request-id",
-                "session-id",
-                "subject-id",
-                "email",
-                "ip-address",
-                "phone-number",
-                "persistent-session-id");
+                new AuditContext(
+                        "client-id",
+                        "request-id",
+                        "session-id",
+                        "subject-id",
+                        "email",
+                        "ip-address",
+                        "phone-number",
+                        "persistent-session-id"));
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
 


### PR DESCRIPTION
## What

All 4 audit requests in AuthenticateHandler were almost identical. Created a context object that is created initially and gets updated as required before being submitted in an audit event.

## How to review

1. Code Review

## Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.