### PR TITLE
ATO-595: Add journey ID to AUTH_USER_INFO_RETURNED audit event

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -81,6 +81,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final Subject PUBLIC_SUBJECT = new Subject();
     private static final Subject INTERNAL_SUBJECT = new Subject();
     private static final Subject INTERNAL_PAIRWISE_SUBJECT = new Subject();
+    private static final String JOURNEY_ID = "client-session-id";
     private static final Scope DOC_APP_SCOPES =
             new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);
     private static final Subject DOC_APP_PUBLIC_SUBJECT = new Subject();
@@ -149,7 +150,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new AccessTokenStore(
                         accessToken.getValue(),
                         INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue());
+                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                        JOURNEY_ID);
         var accessTokenStoreString = objectMapper.writeValueAsString(accessTokenStore);
         redis.addToRedis(
                 ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT,
@@ -395,7 +397,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new AccessTokenStore(
                         accessToken.getValue(),
                         INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue());
+                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                        JOURNEY_ID);
         redis.addToRedis(
                 ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT,
                 objectMapper.writeValueAsString(accessTokenStore),
@@ -424,7 +427,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new AccessTokenStore(
                         accessToken.getValue(),
                         INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue());
+                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                        JOURNEY_ID);
         var accessTokenStoreString = objectMapper.writeValueAsString(accessTokenStore);
         redis.addToRedis(
                 ACCESS_TOKEN_PREFIX + APP_CLIENT_ID + "." + DOC_APP_PUBLIC_SUBJECT,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -144,7 +144,10 @@ public class UserInfoHandler
         auditService.submitAuditEvent(
                 OidcAuditableEvent.USER_INFO_RETURNED,
                 accessTokenInfo.getClientID(),
-                TxmaAuditUser.user().withUserId(subjectForAudit),
+                TxmaAuditUser.user()
+                        .withUserId(subjectForAudit)
+                        .withGovukSigninJourneyId(
+                                accessTokenInfo.getAccessTokenStore().getJourneyId()),
                 metadataPairs);
 
         return generateApiGatewayProxyResponse(200, userInfo.toJSONString());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
+import uk.gov.di.orchestration.shared.entity.AccessTokenStore;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.exceptions.AccessTokenException;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
@@ -42,6 +43,10 @@ class UserInfoHandlerTest {
     private static final String EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String PHONE_NUMBER = "01234567890";
     private static final Subject SUBJECT = new Subject();
+    private static final String TOKEN = "token";
+    private static final String INTERNAL_SUBJECT_ID = "internal-subject-id";
+    private static final String INTERNAL_PAIRWISE_ID = "internal-pairwise-subject-id";
+    private static final String JOURNEY_ID = "client-session-id";
     private static final Subject AUDIT_SUBJECT_ID = new Subject();
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
@@ -62,6 +67,10 @@ class UserInfoHandlerTest {
         when(context.getAwsRequestId()).thenReturn("aws-request-id");
         when(accessTokenInfo.getClientID()).thenReturn("client-id");
         when(accessTokenInfo.getSubject()).thenReturn(SUBJECT.getValue());
+        when(accessTokenInfo.getAccessTokenStore())
+                .thenReturn(
+                        new AccessTokenStore(
+                                TOKEN, INTERNAL_SUBJECT_ID, INTERNAL_PAIRWISE_ID, JOURNEY_ID));
     }
 
     @Test
@@ -95,7 +104,9 @@ class UserInfoHandlerTest {
                 .submitAuditEvent(
                         OidcAuditableEvent.USER_INFO_RETURNED,
                         "client-id",
-                        TxmaAuditUser.user().withUserId(AUDIT_SUBJECT_ID.getValue()));
+                        TxmaAuditUser.user()
+                                .withUserId(AUDIT_SUBJECT_ID.getValue())
+                                .withGovukSigninJourneyId(JOURNEY_ID));
     }
 
     @Test
@@ -118,7 +129,9 @@ class UserInfoHandlerTest {
                 .submitAuditEvent(
                         OidcAuditableEvent.USER_INFO_RETURNED,
                         "client-id",
-                        TxmaAuditUser.user().withUserId(AUDIT_SUBJECT_ID.getValue()),
+                        TxmaAuditUser.user()
+                                .withUserId(AUDIT_SUBJECT_ID.getValue())
+                                .withGovukSigninJourneyId(JOURNEY_ID),
                         AuditService.MetadataPair.pair("return-code", RETURN_CODE));
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -58,6 +58,7 @@ class AccessTokenServiceTest {
     private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
     private static final Subject INTERNAL_PAIRWISE_SUBJECT = new Subject();
     private static final Subject SUBJECT = new Subject("some-subject");
+    private static final String JOURNEY_ID = "client-session-id";
     private static final List<String> SCOPES =
             List.of(
                     OIDCScopeValue.OPENID.getValue(),
@@ -123,7 +124,8 @@ class AccessTokenServiceTest {
                                 new AccessTokenStore(
                                         accessToken.getValue(),
                                         INTERNAL_SUBJECT.getValue(),
-                                        INTERNAL_PAIRWISE_SUBJECT.getValue())));
+                                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                                        JOURNEY_ID)));
 
         var accessTokenInfo =
                 validationService.parse(accessToken.toAuthorizationHeader(), identityEnabled);
@@ -133,6 +135,7 @@ class AccessTokenServiceTest {
         assertThat(
                 accessTokenInfo.getAccessTokenStore().getInternalSubjectId(),
                 equalTo(INTERNAL_SUBJECT.getValue()));
+        assertThat(accessTokenInfo.getAccessTokenStore().getJourneyId(), equalTo(JOURNEY_ID));
         assertThat(accessTokenInfo.getSubject(), equalTo(SUBJECT.getValue()));
         assertThat(accessTokenInfo.getScopes(), equalTo(SCOPES));
         assertThat(accessTokenInfo.getIdentityClaims(), equalTo(expectedIdentityClaims));
@@ -151,7 +154,8 @@ class AccessTokenServiceTest {
                                 new AccessTokenStore(
                                         accessToken.getValue(),
                                         INTERNAL_SUBJECT.getValue(),
-                                        INTERNAL_PAIRWISE_SUBJECT.getValue())));
+                                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                                        JOURNEY_ID)));
 
         var accessTokenInfo = validationService.parse(accessToken.toAuthorizationHeader(), true);
 
@@ -160,6 +164,7 @@ class AccessTokenServiceTest {
         assertThat(
                 accessTokenInfo.getAccessTokenStore().getInternalSubjectId(),
                 equalTo(INTERNAL_SUBJECT.getValue()));
+        assertThat(accessTokenInfo.getAccessTokenStore().getJourneyId(), equalTo(JOURNEY_ID));
         assertThat(accessTokenInfo.getSubject(), equalTo(SUBJECT.getValue()));
         assertThat(accessTokenInfo.getScopes(), equalTo(SCOPES));
         assertThat(accessTokenInfo.getIdentityClaims(), equalTo(null));
@@ -255,7 +260,8 @@ class AccessTokenServiceTest {
                                 new AccessTokenStore(
                                         accessToken.getValue(),
                                         INTERNAL_SUBJECT.getValue(),
-                                        INTERNAL_PAIRWISE_SUBJECT.getValue())));
+                                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                                        JOURNEY_ID)));
 
         var accessTokenException =
                 assertThrows(
@@ -307,7 +313,8 @@ class AccessTokenServiceTest {
                                 new AccessTokenStore(
                                         createSignedAccessToken(null, false).getValue(),
                                         INTERNAL_SUBJECT.getValue(),
-                                        INTERNAL_PAIRWISE_SUBJECT.getValue())));
+                                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                                        JOURNEY_ID)));
 
         var accessTokenException =
                 assertThrows(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -77,6 +77,7 @@ class UserInfoServiceTest {
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
     private static final Subject INTERNAL_PAIRWISE_SUBJECT = new Subject("test-subject");
+    private static final String JOURNEY_ID = "client-session-id";
     private static final Subject SUBJECT = new Subject("some-subject");
     private static final Subject DOC_APP_SUBJECT = new Subject("some-subject");
     private static final List<String> SCOPES =
@@ -139,7 +140,8 @@ class UserInfoServiceTest {
                 new AccessTokenStore(
                         accessToken.getValue(),
                         INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue());
+                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                        JOURNEY_ID);
         var accessTokenInfo =
                 new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
         givenThereIsUserInfo();
@@ -183,7 +185,8 @@ class UserInfoServiceTest {
                 new AccessTokenStore(
                         accessToken.getValue(),
                         INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue());
+                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                        JOURNEY_ID);
         var accessTokenInfo =
                 new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), scopes, null, CLIENT_ID);
 
@@ -214,7 +217,8 @@ class UserInfoServiceTest {
                     new AccessTokenStore(
                             accessToken.getValue(),
                             INTERNAL_SUBJECT.getValue(),
-                            INTERNAL_PAIRWISE_SUBJECT.getValue());
+                            INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                            JOURNEY_ID);
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
@@ -263,7 +267,8 @@ class UserInfoServiceTest {
                     new AccessTokenStore(
                             accessToken.getValue(),
                             INTERNAL_SUBJECT.getValue(),
-                            INTERNAL_PAIRWISE_SUBJECT.getValue());
+                            INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                            JOURNEY_ID);
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore,
@@ -319,7 +324,8 @@ class UserInfoServiceTest {
                     new AccessTokenStore(
                             accessToken.getValue(),
                             INTERNAL_SUBJECT.getValue(),
-                            INTERNAL_PAIRWISE_SUBJECT.getValue());
+                            INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                            JOURNEY_ID);
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), scopes, null, CLIENT_ID);
@@ -349,7 +355,8 @@ class UserInfoServiceTest {
                     new AccessTokenStore(
                             accessToken.getValue(),
                             INTERNAL_SUBJECT.getValue(),
-                            INTERNAL_PAIRWISE_SUBJECT.getValue());
+                            INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                            JOURNEY_ID);
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), scopes, null, CLIENT_ID);
@@ -386,7 +393,8 @@ class UserInfoServiceTest {
                     new AccessTokenStore(
                             accessToken.getValue(),
                             INTERNAL_SUBJECT.getValue(),
-                            INTERNAL_PAIRWISE_SUBJECT.getValue());
+                            INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                            JOURNEY_ID);
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore,
@@ -439,7 +447,8 @@ class UserInfoServiceTest {
                     new AccessTokenStore(
                             accessToken.getValue(),
                             INTERNAL_SUBJECT.getValue(),
-                            INTERNAL_PAIRWISE_SUBJECT.getValue());
+                            INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                            JOURNEY_ID);
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
@@ -462,7 +471,8 @@ class UserInfoServiceTest {
                     new AccessTokenStore(
                             accessToken.getValue(),
                             DOC_APP_SUBJECT.getValue(),
-                            DOC_APP_SUBJECT.getValue());
+                            DOC_APP_SUBJECT.getValue(),
+                            JOURNEY_ID);
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore,
@@ -492,7 +502,8 @@ class UserInfoServiceTest {
                     new AccessTokenStore(
                             accessToken.getValue(),
                             INTERNAL_SUBJECT.getValue(),
-                            INTERNAL_PAIRWISE_SUBJECT.getValue());
+                            INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                            JOURNEY_ID);
             var accessTokenInfo =
                     new AccessTokenInfo(
                             accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccessTokenStore.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AccessTokenStore.java
@@ -10,13 +10,19 @@ public class AccessTokenStore {
 
     @Expose private String internalPairwiseSubjectId = "missing";
 
+    @Expose private String journeyId;
+
     public AccessTokenStore() {}
 
     public AccessTokenStore(
-            String token, String internalSubjectId, String internalPairwiseSubjectId) {
+            String token,
+            String internalSubjectId,
+            String internalPairwiseSubjectId,
+            String journeyId) {
         this.token = token;
         this.internalSubjectId = internalSubjectId;
         this.internalPairwiseSubjectId = internalPairwiseSubjectId;
+        this.journeyId = journeyId;
     }
 
     public String getToken() {
@@ -29,5 +35,9 @@ public class AccessTokenStore {
 
     public String getInternalPairwiseSubjectId() {
         return internalPairwiseSubjectId;
+    }
+
+    public String getJourneyId() {
+        return journeyId;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -113,7 +113,8 @@ public class TokenService {
                                         rpPairwiseSubject,
                                         internalPairwiseSubject,
                                         claimsRequest,
-                                        signingAlgorithm));
+                                        signingAlgorithm,
+                                        journeyId));
         AccessTokenHash accessTokenHash =
                 segmentedFunctionCall(
                         "AccessTokenHash.compute",
@@ -165,7 +166,8 @@ public class TokenService {
                         rpPaiwiseSubject,
                         internalPairwiseSubject,
                         null,
-                        signingAlgorithm);
+                        signingAlgorithm,
+                        null);
         RefreshToken refreshToken =
                 generateAndStoreRefreshToken(
                         clientID,
@@ -322,7 +324,8 @@ public class TokenService {
             Subject rpPairwiseSubject,
             Subject internalPairwiseSubject,
             OIDCClaimsRequest claimsRequest,
-            JWSAlgorithm signingAlgorithm) {
+            JWSAlgorithm signingAlgorithm,
+            String journeyId) {
 
         LOG.info("Generating AccessToken");
         Date expiryDate =
@@ -338,6 +341,7 @@ public class TokenService {
                         .expirationTime(expiryDate)
                         .issueTime(NowHelper.now())
                         .claim("client_id", clientId)
+                        .claim("sid", journeyId)
                         .subject(rpPairwiseSubject.getValue())
                         .jwtID(jwtID);
 
@@ -366,7 +370,8 @@ public class TokenService {
                             new AccessTokenStore(
                                     accessToken.getValue(),
                                     internalSubject.getValue(),
-                                    internalPairwiseSubject.getValue())),
+                                    internalPairwiseSubject.getValue(),
+                                    journeyId)),
                     configService.getAccessTokenExpiry());
         } catch (JsonException e) {
             LOG.error("Unable to save access token to Redis");

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
@@ -92,6 +92,7 @@ class TokenServiceTest {
     private static final Subject PUBLIC_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Subject INTERNAL_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Subject INTERNAL_PAIRWISE_SUBJECT = SubjectHelper.govUkSignInSubject();
+    private static final String JOURNEY_ID = "client-session-id";
     private static final Scope SCOPES =
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PHONE);
     private static final String VOT = CredentialTrustLevel.MEDIUM_LEVEL.getValue();
@@ -165,7 +166,7 @@ class TokenServiceTest {
                         null,
                         false,
                         JWSAlgorithm.ES256,
-                        "client-session-id",
+                        JOURNEY_ID,
                         VOT);
 
         assertSuccessfulTokenResponse(tokenResponse);
@@ -239,7 +240,7 @@ class TokenServiceTest {
                         oidcClaimsRequest,
                         false,
                         JWSAlgorithm.ES256,
-                        "client-session-id",
+                        JOURNEY_ID,
                         VOT);
 
         assertSuccessfulTokenResponse(tokenResponse);
@@ -312,7 +313,7 @@ class TokenServiceTest {
                         null,
                         false,
                         JWSAlgorithm.ES256,
-                        "client-session-id",
+                        JOURNEY_ID,
                         VOT);
 
         assertSuccessfulTokenResponse(tokenResponse);
@@ -347,7 +348,7 @@ class TokenServiceTest {
                         null,
                         false,
                         JWSAlgorithm.ES256,
-                        "client-session-id",
+                        JOURNEY_ID,
                         VOT);
 
         var parsedAccessToken =
@@ -559,7 +560,8 @@ class TokenServiceTest {
                 new AccessTokenStore(
                         tokenResponse.getOIDCTokens().getAccessToken().getValue(),
                         INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue());
+                        INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                        JOURNEY_ID);
         verify(redisConnectionService)
                 .saveWithExpiry(
                         accessTokenKey, objectMapper.writeValueAsString(accessTokenStore), 300L);
@@ -595,6 +597,6 @@ class TokenServiceTest {
 
         assertThat(
                 tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getStringClaim("sid"),
-                is("client-session-id"));
+                is(JOURNEY_ID));
     }
 }


### PR DESCRIPTION
_Co-authored by Isaac Au (@isaac-GDS)_

## What

Add journey ID (aka client session ID) to AUTH_USER_INFO_RETURNED audit event

## How to review

1. Code review only

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

