### PR TITLE
INCIDEN-763: Add facility to restrict audit metadata pairs

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -178,7 +178,7 @@ public class UpdateEmailHandler
                     userProfile.getPhoneNumber(),
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
                     AuditService.MetadataPair.pair(
-                            "ReplacedEmail", updateInfoRequest.getExistingEmailAddress()));
+                            "ReplacedEmail", updateInfoRequest.getExistingEmailAddress(), true));
 
             LOG.info("Message successfully added to queue. Generating successful gateway response");
             return generateEmptySuccessApiGatewayResponse();

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -113,7 +113,8 @@ class UpdateEmailHandlerTest {
                         "123.123.123.123",
                         userProfile.getPhoneNumber(),
                         PERSISTENT_ID,
-                        AuditService.MetadataPair.pair("ReplacedEmail", EXISTING_EMAIL_ADDRESS));
+                        AuditService.MetadataPair.pair(
+                                "ReplacedEmail", EXISTING_EMAIL_ADDRESS, true));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -88,7 +88,9 @@ class AuditServiceTest {
                 "phone-number",
                 "persistent-session-id",
                 pair("key", "value"),
-                pair("key2", "value2"));
+                pair("key2", "value2"),
+                pair("restrictedKey1", "restrictedValue1", true),
+                pair("restrictedKey2", "restrictedValue2", true));
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
         var txmaMessage = asJson(txmaMessageCaptor.getValue());
@@ -100,6 +102,11 @@ class AuditServiceTest {
 
         assertThat(extensions, hasFieldWithValue("key", equalTo("value")));
         assertThat(extensions, hasFieldWithValue("key2", equalTo("value2")));
+
+        var restricted = txmaMessage.getAsJsonObject().get("restricted").getAsJsonObject();
+
+        assertThat(restricted, hasFieldWithValue("restrictedKey1", equalTo("restrictedValue1")));
+        assertThat(restricted, hasFieldWithValue("restrictedKey2", equalTo("restrictedValue2")));
     }
 
     @Test


### PR DESCRIPTION

## What

Add facility to restrict audit metadata pairs.

Some information sent for audit needs to be restricted.
Apply this to the UPDATE_EMAIL event in account management.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

