### PR TITLE
ATO-618: Enable OIDC origin domain in staging

### DIFF
--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -23,3 +23,5 @@ back_channel_logout_cross_account_access_enabled = true
 kms_cross_account_access_enabled                 = true
 cmk_for_back_channel_logout_enabled              = true
 txma_audit_encoded_enabled                       = true
+
+oidc_origin_domain_enabled = true


### PR DESCRIPTION
## What

Create the `origin.oidc.staging.account.gov.uk` domain