### PR TITLE
BAU: Fix name of staging log group

### DIFF
--- a/ci/terraform/oidc/doc-app-alerts.tf
+++ b/ci/terraform/oidc/doc-app-alerts.tf
@@ -1,6 +1,6 @@
 data "aws_cloudwatch_log_group" "doc_app_callback_lambda_log_group" {
   count = var.use_localstack ? 0 : 1
-  name  = var.orch_doc_app_callback_enabled ? replace("/aws/lambda/${var.environment}-doc-app-callback-auth-lambda", ".", "") : replace("/aws/lambda/${var.environment}-doc-app-callback-lambda", ".", "")
+  name  = replace("/aws/lambda/${var.environment}-doc-app-callback-lambda", ".", "")
 
   depends_on = [
     module.doc-app-callback


### PR DESCRIPTION
## What
Missed from e5d8fb7be2068d4dfbbb4bb0c1afb8540a602317 where I changed the name of the lambda and log group back