### PR TITLE
ATO-624: Include State param in error response from JAR authorize request

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthRequestError.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthRequestError.java
@@ -1,7 +1,8 @@
 package uk.gov.di.authentication.oidc.entity;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.id.State;
 
 import java.net.URI;
 
-public record AuthRequestError(ErrorObject errorObject, URI redirectURI) {}
+public record AuthRequestError(ErrorObject errorObject, URI redirectURI, State state) {}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -296,7 +296,7 @@ public class AuthorisationHandler
         if (authRequestError.isPresent()) {
             return generateErrorResponse(
                     authRequestError.get().redirectURI(),
-                    authRequest.getState(),
+                    authRequestError.get().state(),
                     authRequest.getResponseMode(),
                     authRequestError.get().errorObject(),
                     authRequest.getClientID().getValue(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -10,6 +10,7 @@ import com.nimbusds.langtag.LangTagUtils;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
 import uk.gov.di.authentication.oidc.services.IPVCapacityService;
@@ -85,35 +86,47 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
 
             var redirectURI = URI.create((String) jwtClaimsSet.getClaim("redirect_uri"));
 
+            if (Objects.isNull(jwtClaimsSet.getClaim("state"))) {
+                LOG.error("State is missing from authRequest");
+                return errorResponse(
+                        redirectURI,
+                        new ErrorObject(
+                                OAuth2Error.INVALID_REQUEST_CODE,
+                                "Request is missing state parameter"),
+                        null);
+            }
+
+            State state = new State(jwtClaimsSet.getStringClaim("state"));
+
             if (Arrays.stream(ClientType.values())
                     .noneMatch(type -> type.getValue().equals(client.getClientType()))) {
                 LOG.error("ClientType value of {} is not recognised", client.getClientType());
-                return errorResponse(redirectURI, OAuth2Error.UNAUTHORIZED_CLIENT);
+                return errorResponse(redirectURI, OAuth2Error.UNAUTHORIZED_CLIENT, state);
             }
 
             if (!CODE.toString().equals(authRequest.getResponseType().toString())) {
                 LOG.error(
                         "Unsupported responseType included in request. Expected responseType of code");
-                return errorResponse(redirectURI, OAuth2Error.UNSUPPORTED_RESPONSE_TYPE);
+                return errorResponse(redirectURI, OAuth2Error.UNSUPPORTED_RESPONSE_TYPE, state);
             }
 
             if (requestContainsInvalidScopes(authRequest.getScope(), client)) {
                 LOG.error(
                         "Invalid scopes in authRequest. Scopes in request: {}",
                         authRequest.getScope().toStringList());
-                return errorResponse(redirectURI, OAuth2Error.INVALID_SCOPE);
+                return errorResponse(redirectURI, OAuth2Error.INVALID_SCOPE, state);
             }
             if (Objects.isNull(jwtClaimsSet.getClaim("client_id"))
                     || !jwtClaimsSet
                             .getClaim("client_id")
                             .toString()
                             .equals(authRequest.getClientID().getValue())) {
-                return errorResponse(redirectURI, OAuth2Error.UNAUTHORIZED_CLIENT);
+                return errorResponse(redirectURI, OAuth2Error.UNAUTHORIZED_CLIENT, state);
             }
             if (Objects.nonNull(jwtClaimsSet.getClaim("request"))
                     || Objects.nonNull(jwtClaimsSet.getClaim("request_uri"))) {
                 LOG.error("request or request_uri claim should not be included in request JWT");
-                return errorResponse(redirectURI, OAuth2Error.INVALID_REQUEST);
+                return errorResponse(redirectURI, OAuth2Error.INVALID_REQUEST, state);
             }
             if (Objects.isNull(jwtClaimsSet.getAudience())
                     || !jwtClaimsSet
@@ -126,32 +139,24 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                                                     "/authorize")
                                             .toString())) {
                 LOG.error("Invalid or missing audience");
-                return errorResponse(redirectURI, OAuth2Error.ACCESS_DENIED);
+                return errorResponse(redirectURI, OAuth2Error.ACCESS_DENIED, state);
             }
             if (Objects.isNull(jwtClaimsSet.getIssuer())
                     || !jwtClaimsSet.getIssuer().equals(client.getClientID())) {
                 LOG.error("Invalid or missing issuer");
-                return errorResponse(redirectURI, OAuth2Error.UNAUTHORIZED_CLIENT);
+                return errorResponse(redirectURI, OAuth2Error.UNAUTHORIZED_CLIENT, state);
             }
 
             if (!CODE.toString().equals(jwtClaimsSet.getClaim("response_type"))) {
                 LOG.error(
                         "Unsupported responseType included in request JWT. Expected responseType of code");
-                return errorResponse(redirectURI, OAuth2Error.UNSUPPORTED_RESPONSE_TYPE);
+                return errorResponse(redirectURI, OAuth2Error.UNSUPPORTED_RESPONSE_TYPE, state);
             }
             if (Objects.isNull(jwtClaimsSet.getClaim("scope"))
                     || requestContainsInvalidScopes(
                             Scope.parse(jwtClaimsSet.getClaim("scope").toString()), client)) {
                 LOG.error("Invalid scopes in request JWT");
-                return errorResponse(redirectURI, OAuth2Error.INVALID_SCOPE);
-            }
-            if (Objects.isNull(jwtClaimsSet.getClaim("state"))) {
-                LOG.error("State is missing from authRequest");
-                return errorResponse(
-                        redirectURI,
-                        new ErrorObject(
-                                OAuth2Error.INVALID_REQUEST_CODE,
-                                "Request is missing state parameter"));
+                return errorResponse(redirectURI, OAuth2Error.INVALID_SCOPE, state);
             }
             if (Objects.isNull(jwtClaimsSet.getClaim("nonce"))) {
                 LOG.error("Nonce is missing from authRequest");
@@ -159,11 +164,12 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                         redirectURI,
                         new ErrorObject(
                                 OAuth2Error.INVALID_REQUEST_CODE,
-                                "Request is missing nonce parameter"));
+                                "Request is missing nonce parameter"),
+                        state);
             }
-            var vtrError = validateVtr(jwtClaimsSet, redirectURI);
+            var vtrError = validateVtr(jwtClaimsSet);
             if (vtrError.isPresent()) {
-                return vtrError;
+                return errorResponse(redirectURI, vtrError.get(), state);
             }
             if (Objects.nonNull(jwtClaimsSet.getClaim("ui_locales"))) {
                 try {
@@ -175,7 +181,8 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                             redirectURI,
                             new ErrorObject(
                                     OAuth2Error.INVALID_REQUEST_CODE,
-                                    "ui_locales parameter is invalid"));
+                                    "ui_locales parameter is invalid"),
+                            state);
                 }
             }
             LOG.info("RequestObject has passed initial validation");
@@ -214,27 +221,25 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
         }
     }
 
-    private Optional<AuthRequestError> validateVtr(JWTClaimsSet jwtClaimsSet, URI redirectURI) {
+    private Optional<ErrorObject> validateVtr(JWTClaimsSet jwtClaimsSet) {
         List<String> authRequestVtr = new ArrayList<>();
         try {
             authRequestVtr = getRequestObjectVtrAsList(jwtClaimsSet);
             var vtrList = VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
             if (vtrList.get(0).containsLevelOfConfidence()
                     && !ipvCapacityService.isIPVCapacityAvailable()) {
-                return errorResponse(redirectURI, OAuth2Error.TEMPORARILY_UNAVAILABLE);
+                return Optional.of(OAuth2Error.TEMPORARILY_UNAVAILABLE);
             }
         } catch (IllegalArgumentException e) {
             LOG.error(
                     "vtr in AuthRequest is not valid. vtr in request: {}. IllegalArgumentException: {}",
                     authRequestVtr,
                     e);
-            return errorResponse(
-                    redirectURI,
+            return Optional.of(
                     new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
         } catch (ParseException | Json.JsonException e) {
             LOG.error("Parse exception thrown when validating vtr", e);
-            return errorResponse(
-                    redirectURI,
+            return Optional.of(
                     new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
         }
         return Optional.empty();
@@ -256,7 +261,8 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
         throw new ParseException("vtr is in an invalid format. Could not be parsed.", 0);
     }
 
-    private static Optional<AuthRequestError> errorResponse(URI uri, ErrorObject error) {
-        return Optional.of(new AuthRequestError(error, uri));
+    private static Optional<AuthRequestError> errorResponse(
+            URI uri, ErrorObject error, State state) {
+        return Optional.of(new AuthRequestError(error, uri, state));
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
@@ -47,6 +47,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -139,6 +140,7 @@ class QueryParamsAuthorizeValidatorTest {
                 equalTo(
                         new ErrorObject(
                                 OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid")));
+        assertEquals(STATE, errorObject.get().state());
     }
 
     @Test
@@ -216,6 +218,7 @@ class QueryParamsAuthorizeValidatorTest {
                         new ErrorObject(
                                 OAuth2Error.INVALID_REQUEST_CODE,
                                 "Request contains invalid claims")));
+        assertEquals(STATE, errorObject.get().state());
     }
 
     @Test
@@ -270,6 +273,7 @@ class QueryParamsAuthorizeValidatorTest {
 
         assertTrue(errorObject.isPresent());
         assertThat(errorObject.get().errorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
+        assertEquals(STATE, errorObject.get().state());
     }
 
     @Test
@@ -308,6 +312,7 @@ class QueryParamsAuthorizeValidatorTest {
 
         assertTrue(errorObject.isPresent());
         assertThat(errorObject.get().errorObject(), equalTo(OAuth2Error.UNSUPPORTED_RESPONSE_TYPE));
+        assertEquals(STATE, errorObject.get().state());
     }
 
     @Test
@@ -327,6 +332,7 @@ class QueryParamsAuthorizeValidatorTest {
 
         assertTrue(errorObject.isPresent());
         assertThat(errorObject.get().errorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
+        assertEquals(STATE, errorObject.get().state());
     }
 
     @Test
@@ -353,6 +359,7 @@ class QueryParamsAuthorizeValidatorTest {
                         new ErrorObject(
                                 OAuth2Error.INVALID_REQUEST_CODE,
                                 "Request is missing state parameter")));
+        assertNull(errorObject.get().state());
     }
 
     @Test
@@ -368,7 +375,7 @@ class QueryParamsAuthorizeValidatorTest {
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(
                                 responseType, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
-                        .state(new State())
+                        .state(STATE)
                         .build();
         var errorObject = queryParamsAuthorizeValidator.validate(authRequest);
 
@@ -379,6 +386,7 @@ class QueryParamsAuthorizeValidatorTest {
                         new ErrorObject(
                                 OAuth2Error.INVALID_REQUEST_CODE,
                                 "Request is missing nonce parameter")));
+        assertEquals(STATE, errorObject.get().state());
     }
 
     @Test
@@ -393,7 +401,7 @@ class QueryParamsAuthorizeValidatorTest {
                                         REDIRECT_URI.toString(), CLIENT_ID.toString())));
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
-                        .state(new State())
+                        .state(STATE)
                         .nonce(new Nonce())
                         .customParameter("vtr", jsonArrayOf("Cm"))
                         .build();
@@ -405,6 +413,7 @@ class QueryParamsAuthorizeValidatorTest {
                 equalTo(
                         new ErrorObject(
                                 OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid")));
+        assertEquals(STATE, errorObject.get().state());
     }
 
     @Test
@@ -419,7 +428,7 @@ class QueryParamsAuthorizeValidatorTest {
                                         REDIRECT_URI.toString(), CLIENT_ID.toString())));
         var authRequest =
                 new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
-                        .state(new State())
+                        .state(STATE)
                         .nonce(new Nonce())
                         .customParameter("vtr", jsonArrayOf("P2.Cl.Cm"))
                         .build();
@@ -427,6 +436,7 @@ class QueryParamsAuthorizeValidatorTest {
 
         assertTrue(errorObject.isPresent());
         assertThat(errorObject.get().errorObject(), equalTo(OAuth2Error.TEMPORARILY_UNAVAILABLE));
+        assertEquals(STATE, errorObject.get().state());
     }
 
     @Test
@@ -492,6 +502,7 @@ class QueryParamsAuthorizeValidatorTest {
                                 CLIENT_ID,
                                 REDIRECT_URI)
                         .requestURI(URI.create("https://localhost/redirect-uri"))
+                        .state(STATE)
                         .build();
 
         var authRequestError = queryParamsAuthorizeValidator.validate(authenticationRequest);
@@ -500,6 +511,7 @@ class QueryParamsAuthorizeValidatorTest {
         assertThat(
                 authRequestError.get().errorObject(),
                 equalTo(OAuth2Error.REQUEST_URI_NOT_SUPPORTED));
+        assertEquals(STATE, authRequestError.get().state());
     }
 
     private ClientRegistry generateClientRegistry(String redirectURI, String clientID) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -33,6 +33,8 @@ import java.util.Optional;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -200,7 +202,6 @@ class RequestObjectAuthorizeValidatorTest {
                         .claim("scope", SCOPE)
                         .claim("nonce", NONCE.getValue())
                         .claim("state", STATE.toString())
-                        .claim("state", new State())
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
@@ -212,6 +213,7 @@ class RequestObjectAuthorizeValidatorTest {
         assertThat(
                 requestObjectError.get().errorObject(), equalTo(OAuth2Error.UNAUTHORIZED_CLIENT));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -235,6 +237,7 @@ class RequestObjectAuthorizeValidatorTest {
                 requestObjectError.get().errorObject(),
                 equalTo(OAuth2Error.UNSUPPORTED_RESPONSE_TYPE));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -268,6 +271,7 @@ class RequestObjectAuthorizeValidatorTest {
                 requestObjectError.get().errorObject(),
                 equalTo(OAuth2Error.UNSUPPORTED_RESPONSE_TYPE));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -290,6 +294,7 @@ class RequestObjectAuthorizeValidatorTest {
         assertThat(
                 requestObjectError.get().errorObject(), equalTo(OAuth2Error.UNAUTHORIZED_CLIENT));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -311,6 +316,7 @@ class RequestObjectAuthorizeValidatorTest {
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().errorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -339,6 +345,7 @@ class RequestObjectAuthorizeValidatorTest {
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().errorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -364,6 +371,7 @@ class RequestObjectAuthorizeValidatorTest {
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().errorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -385,6 +393,7 @@ class RequestObjectAuthorizeValidatorTest {
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().errorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -407,6 +416,7 @@ class RequestObjectAuthorizeValidatorTest {
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().errorObject(), equalTo(OAuth2Error.ACCESS_DENIED));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -429,6 +439,7 @@ class RequestObjectAuthorizeValidatorTest {
         assertThat(
                 requestObjectError.get().errorObject(), equalTo(OAuth2Error.UNAUTHORIZED_CLIENT));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -452,6 +463,7 @@ class RequestObjectAuthorizeValidatorTest {
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().errorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -474,6 +486,7 @@ class RequestObjectAuthorizeValidatorTest {
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().errorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -520,6 +533,7 @@ class RequestObjectAuthorizeValidatorTest {
                 requestObjectError.get().errorObject().getDescription(),
                 equalTo("Request is missing state parameter"));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertNull(requestObjectError.get().state());
     }
 
     @Test
@@ -544,6 +558,7 @@ class RequestObjectAuthorizeValidatorTest {
                 requestObjectError.get().errorObject().getDescription(),
                 equalTo("Request is missing nonce parameter"));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     @Test
@@ -566,6 +581,7 @@ class RequestObjectAuthorizeValidatorTest {
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().errorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        assertEquals(STATE, requestObjectError.get().state());
     }
 
     private ClientRegistry generateClientRegistry(String clientType, Scope scope) {


### PR DESCRIPTION
## What
Mobile noticed that we do not include state in error responses from authorize made with JAR requests. This is not spec compliant. 

To review ensure no backwards incompatible changes have been made