### PR TITLE
ATO-588: Grant SSE cross account access to client registry

### DIFF
--- a/ci/terraform/shared/staging.tfvars
+++ b/ci/terraform/shared/staging.tfvars
@@ -7,3 +7,5 @@ orchestration_account_id             = "590183975515"
 orch_privatesub_cidr_blocks          = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
 kms_cross_account_access_enabled     = true
 doc_app_cross_account_access_enabled = true
+
+sse_account_ids = ["494650018671", "399055180839", "325730373996"]

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -216,3 +216,9 @@ variable "user_profile_table_cross_account_access_enabled" {
   type        = bool
   description = "Whether the service should allow cross-account access to the user profile table"
 }
+
+variable "sse_account_ids" {
+  default     = []
+  type        = list(string)
+  description = "Account IDs of Self Service AWS accounts to grant read-only access to the Client Registry table"
+}


### PR DESCRIPTION
## What
update client registry policies to grant SSE cross account read access to the client registry in staging (integration to follow in separate PR).

Need to ensure that we're ready to go with CMK on this table before merging this