### PR TITLE
ATO-588: SSE Client Registry Access in Integration

### DIFF
--- a/ci/terraform/shared/integration.tfvars
+++ b/ci/terraform/shared/integration.tfvars
@@ -4,3 +4,5 @@ di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:114407264696:/s
 tools_account_id                     = 706615647326
 orchestration_account_id             = "058264132019"
 dlq_alarm_threshold                  = 999999
+
+sse_account_ids = ["663985455444", "389946456390"]


### PR DESCRIPTION
## What
Extend #4442 to cover integration. Split to reduce deployment risk.
