### PR TITLE
ATO-625/explicitly set orch lambda names

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -39,6 +39,6 @@ orch_client_id                     = "orchestrationAuth"
 orch_redirect_uri                  = "https://oidc.build.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
 
-orch_openid_configuration_name = "build-orch-be-deploy-OpenIdConfigurationFunction-EROoeGPLtVmV"
+orch_openid_configuration_name = "build-OpenIdConfigurationFunction"
 
 orch_account_id = "767397776536"

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -56,9 +56,9 @@ support_email_check_enabled = true
 
 
 orch_openid_configuration_enabled = true
-orch_openid_configuration_name    = "dev-orch-be-deploy-OpenIdConfigurationFunction-zDwyaSCWAbmi"
+orch_openid_configuration_name    = "dev-OpenIdConfigurationFunction"
 orch_doc_app_callback_enabled     = true
-orch_doc_app_callback_name        = "dev-orch-be-deploy-DocAppCallbackFunction-RVJSUW5JaiRv"
+orch_doc_app_callback_name        = "dev-DocAppCallbackFunction"
 
 
 orch_account_id                                  = "816047645251"

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -14,11 +14,11 @@ lockout_duration                     = 7200
 reduced_lockout_duration             = 900
 incorrect_password_lockout_count_ttl = 7200
 
-orch_openid_configuration_name = "staging-orch-be-deploy-OpenIdConfigurationFunction-wWh577dlDcFl"
+orch_openid_configuration_name = "staging-OpenIdConfigurationFunction"
 
 orch_account_id                                  = "590183975515"
 orch_doc_app_callback_enabled                    = true
-orch_doc_app_callback_name                       = "staging-orch-be-deploy-DocAppCallbackFunction-9CU8q80ZrDRZ"
+orch_doc_app_callback_name                       = "staging-DocAppCallbackFunction"
 back_channel_logout_cross_account_access_enabled = true
 kms_cross_account_access_enabled                 = true
 cmk_for_back_channel_logout_enabled              = true

--- a/template.yaml
+++ b/template.yaml
@@ -175,6 +175,7 @@ Resources:
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work
     Properties:
+      FunctionName: !Sub ${Environment}-OpenIdConfigurationFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api
       Handler: uk.gov.di.authentication.oidc.lambda.WellknownHandler::handleRequest
@@ -285,6 +286,7 @@ Resources:
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work
     Properties:
+      FunctionName: !Sub ${Environment}-TrustmarkFunction
       AutoPublishAlias: latest
       CodeUri: ./oidc-api
       Handler: uk.gov.di.authentication.oidc.lambda.TrustMarkHandler::handleRequest
@@ -394,6 +396,7 @@ Resources:
     Type: AWS::Serverless::Function
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     # checkov:skip=CKV_AWS_117: Lambda needs open egress so isn't in VPC
+    FunctionName: !Sub ${Environment}-BackChannelLogoutRequestFunction
     IgnoreGlobals: [VpcConfig]
     Properties:
       AutoPublishAlias: latest
@@ -510,6 +513,7 @@ Resources:
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
     # checkov:skip=CKV_AWS_117: VPC settings are global
     Properties:
+      FunctionName: !Sub ${Environment}-DocAppCallbackFunction
       AutoPublishAlias: latest
       CodeUri: ./doc-checking-app-api
       Handler: uk.gov.di.authentication.app.lambda.DocAppCallbackHandler::handleRequest

--- a/template.yaml
+++ b/template.yaml
@@ -566,10 +566,10 @@ Resources:
               - "ssm:GetParameter"
               - "ssm:GetParameters"
             Resource:
-              - !Sub "arn:aws:ssm:eu-west-2:816047645251:parameter/${Environment}-session-redis-master-host"
-              - !Sub "arn:aws:ssm:eu-west-2:816047645251:parameter/${Environment}-session-redis-tls"
-              - !Sub "arn:aws:ssm:eu-west-2:816047645251:parameter/${Environment}-session-redis-port"
-              - !Sub "arn:aws:ssm:eu-west-2:816047645251:parameter/${Environment}-session-redis-password"
+              - !Sub "arn:aws:ssm:eu-west-2:{AWS::AccountId}:parameter/${Environment}-session-redis-master-host"
+              - !Sub "arn:aws:ssm:eu-west-2:{AWS::AccountId}:parameter/${Environment}-session-redis-tls"
+              - !Sub "arn:aws:ssm:eu-west-2:{AWS::AccountId}:parameter/${Environment}-session-redis-port"
+              - !Sub "arn:aws:ssm:eu-west-2:{AWS::AccountId}:parameter/${Environment}-session-redis-password"
           - Sid: AllowDecryptOfParameters
             Effect: "Allow"
             Action: "kms:Decrypt"


### PR DESCRIPTION
## What

The random string appended to the end of the lambda names is causing a miss-match between auth and orch, causing deployment issues in sandpit.

## How to review

Check All lambda names have been correctly set and referenced

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
