### PR TITLE
AUT-2663: Introduce additional parameter for audit service submission

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -81,7 +81,8 @@ public class AuthenticateHandler
                         loginRequest.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                        AuditService.RestrictedSection.empty);
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
             }
             boolean hasValidCredentials =
@@ -97,7 +98,8 @@ public class AuthenticateHandler
                         loginRequest.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                        AuditService.RestrictedSection.empty);
                 return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
             }
             LOG.info("User has successfully Logged in. Generating successful AuthenticateResponse");
@@ -111,7 +113,8 @@ public class AuthenticateHandler
                     loginRequest.getEmail(),
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty);
 
             return generateEmptySuccessApiGatewayResponse();
         } catch (JsonException e) {
@@ -124,7 +127,8 @@ public class AuthenticateHandler
                     AuditService.UNKNOWN,
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
     }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -292,6 +292,7 @@ public class SendOtpNotificationHandler
                 IpAddressHelper.extractIpAddress(input),
                 sendNotificationRequest.getPhoneNumber(),
                 PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                AuditService.RestrictedSection.empty,
                 pair("notification-type", sendNotificationRequest.getNotificationType()),
                 pair("test-user", isTestUserRequest));
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -177,6 +177,7 @@ public class UpdateEmailHandler
                     IpAddressHelper.extractIpAddress(input),
                     userProfile.getPhoneNumber(),
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty,
                     AuditService.MetadataPair.pair(
                             "replacedEmail", updateInfoRequest.getExistingEmailAddress(), true));
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -179,7 +179,8 @@ public class UpdatePasswordHandler
                     userProfile.getEmail(),
                     IpAddressHelper.extractIpAddress(input),
                     userProfile.getPhoneNumber(),
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty);
 
             return generateEmptySuccessApiGatewayResponse();
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -157,7 +157,8 @@ public class UpdatePhoneNumberHandler
                     userProfile.getEmail(),
                     IpAddressHelper.extractIpAddress(input),
                     updatePhoneNumberRequest.getPhoneNumber(),
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty);
 
             LOG.info("Message successfully added to queue. Generating successful gateway response");
             return generateEmptySuccessApiGatewayResponse();

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -101,7 +101,8 @@ public class AccountDeletionService {
                     userProfile.getEmail(),
                     AuditService.UNKNOWN,
                     userProfile.getPhoneNumber(),
-                    AuditService.UNKNOWN);
+                    AuditService.UNKNOWN,
+                    AuditService.RestrictedSection.empty);
         } catch (Exception e) {
             LOG.error("Failed to audit account deletion: ", e);
         }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -63,7 +63,8 @@ class AuthenticateHandlerTest {
                         EMAIL,
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
-                        persistentIdValue);
+                        persistentIdValue,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -91,7 +92,8 @@ class AuthenticateHandlerTest {
                         EMAIL,
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
-                        persistentIdValue);
+                        persistentIdValue,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -117,7 +119,8 @@ class AuthenticateHandlerTest {
                         AuditService.UNKNOWN,
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
-                        persistentIdValue);
+                        persistentIdValue,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -145,6 +148,7 @@ class AuthenticateHandlerTest {
                         EMAIL,
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
-                        persistentIdValue);
+                        persistentIdValue,
+                        AuditService.RestrictedSection.empty);
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -180,6 +180,7 @@ class SendOtpNotificationHandlerTest {
                                 "123.123.123.123",
                                 null,
                                 persistentIdValue,
+                                AuditService.RestrictedSection.empty,
                                 pair("notification-type", VERIFY_EMAIL),
                                 pair("test-user", false));
             }
@@ -262,6 +263,7 @@ class SendOtpNotificationHandlerTest {
                         "123.123.123.123",
                         TEST_PHONE_NUMBER,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", VERIFY_PHONE_NUMBER),
                         pair("test-user", false));
     }
@@ -308,6 +310,7 @@ class SendOtpNotificationHandlerTest {
                         "123.123.123.123",
                         null,
                         persistentIdValue,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", VERIFY_EMAIL),
                         pair("test-user", true));
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -113,6 +113,7 @@ class UpdateEmailHandlerTest {
                         "123.123.123.123",
                         userProfile.getPhoneNumber(),
                         PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty,
                         AuditService.MetadataPair.pair(
                                 "replacedEmail", EXISTING_EMAIL_ADDRESS, true));
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -117,7 +117,8 @@ class UpdatePasswordHandlerTest {
                         userProfile.getEmail(),
                         "123.123.123.123",
                         userProfile.getPhoneNumber(),
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -113,7 +113,8 @@ class UpdatePhoneNumberHandlerTest {
                         userProfile.getEmail(),
                         "123.123.123.123",
                         NEW_PHONE_NUMBER,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
@@ -199,7 +199,8 @@ class AccountDeletionServiceTest {
                         eq(expectedEmail),
                         eq(AuditService.UNKNOWN),
                         eq(expectedPhoneNumber),
-                        eq(AuditService.UNKNOWN));
+                        eq(AuditService.UNKNOWN),
+                        eq(AuditService.RestrictedSection.empty));
     }
 
     @Test
@@ -218,7 +219,8 @@ class AccountDeletionServiceTest {
                         anyString(),
                         anyString(),
                         anyString(),
-                        anyString());
+                        anyString(),
+                        any());
 
         // then
         assertDoesNotThrow(() -> underTest.removeAccount(Optional.of(input), userProfile));

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
@@ -179,7 +179,8 @@ public class TokenHandler
                     AuditService.UNKNOWN,
                     AuditService.UNKNOWN,
                     AuditService.UNKNOWN,
-                    AuditService.UNKNOWN);
+                    AuditService.UNKNOWN,
+                    AuditService.RestrictedSection.empty);
 
             Map<String, String> headers = new HashMap<>();
             headers.put("Content-Type", "application/json");

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -145,7 +145,8 @@ public class UserInfoHandler
                 Objects.isNull(userInfo.getPhoneNumber())
                         ? AuditService.UNKNOWN
                         : userInfo.getPhoneNumber(),
-                AuditService.UNKNOWN);
+                AuditService.UNKNOWN,
+                AuditService.RestrictedSection.empty);
 
         Optional<AccessTokenStore> updatedTokenStore =
                 accessTokenService.setAccessTokenStoreUsed(accessToken.getValue(), true);

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
@@ -239,6 +239,7 @@ class TokenHandlerTest {
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        AuditService.RestrictedSection.empty);
     }
 }

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
@@ -93,6 +93,7 @@ class UserInfoHandlerTest {
                         eq("test@test.com"),
                         any(),
                         eq("0123456789"),
+                        any(),
                         any());
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -241,7 +241,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                             .getUserProfile()
                             .map(UserProfile::getPhoneNumber)
                             .orElse(AuditService.UNKNOWN),
-                    persistentSessionID);
+                    persistentSessionID,
+                    AuditService.RestrictedSection.empty);
         } else {
             LOG.error(
                     "Unhandled account interventions state combination to calculate audit event: {}",

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandler.java
@@ -102,7 +102,8 @@ public class AccountRecoveryHandler extends BaseFrontendHandler<AccountRecoveryR
                             .orElse(AuditService.UNKNOWN),
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty);
             var accountRecoveryResponse = new AccountRecoveryResponse(accountRecoveryPermitted);
             LOG.info("Returning response back to frontend");
             return generateApiGatewayProxyResponse(200, accountRecoveryResponse);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -113,6 +113,7 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty,
                     e.getErrorResponse() == ErrorResponse.ERROR_1045
                             ? AuditService.MetadataPair.pair(
                                     "number_of_attempts_user_allowed_to_login",
@@ -152,7 +153,8 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                     userProfile.getEmail(),
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty);
             LOG.info("Successfully verified re-authentication");
             removeEmailCountLock(userProfile.getEmail());
             return Optional.of(rpPairwiseId);
@@ -187,7 +189,8 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                 email,
                 IpAddressHelper.extractIpAddress(input),
                 AuditService.UNKNOWN,
-                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                AuditService.RestrictedSection.empty);
         LOG.info("User not found or no match");
         codeStorageService.increaseIncorrectEmailCount(email);
         return generateApiGatewayProxyErrorResponse(404, ERROR_1056);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -115,7 +115,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                         emailAddress,
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
-                        persistentSessionId);
+                        persistentSessionId,
+                        AuditService.RestrictedSection.empty);
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
             }
 
@@ -139,6 +140,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         persistentSessionId,
+                        AuditService.RestrictedSection.empty,
                         pair(
                                 "number_of_attempts_user_allowed_to_login",
                                 configurationService.getMaxPasswordRetries()));
@@ -194,6 +196,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
                     persistentSessionId,
+                    AuditService.RestrictedSection.empty,
                     pair("rpPairwiseId", rpPairwiseId));
 
             var lockoutInformation =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -138,7 +138,10 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     authenticationService.getUserProfileByEmailMaybe(request.getEmail());
             if (userProfileMaybe.isEmpty() || userContext.getUserCredentials().isEmpty()) {
                 auditService.submitAuditEvent(
-                        FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL, clientId, auditUser);
+                        FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL,
+                        clientId,
+                        auditUser,
+                        AuditService.RestrictedSection.empty);
 
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
             }
@@ -174,6 +177,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
                         clientId,
                         auditUser,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()),
                         pair("number_of_attempts_user_allowed_to_login", incorrectPasswordCount));
@@ -194,6 +198,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
                         clientId,
                         auditUser,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("incorrectPasswordCount", updatedIncorrectPasswordCount),
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
@@ -205,6 +210,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                             FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
                             clientId,
                             auditUser,
+                            AuditService.RestrictedSection.empty,
                             pair("internalSubjectId", userProfile.getSubjectID()),
                             pair("attemptNoFailedAt", updatedIncorrectPasswordCount),
                             pair(
@@ -281,7 +287,12 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     userMfaDetail.getMfaMethodType().getValue(),
                     userMfaDetail.isMfaMethodVerified());
 
-            auditService.submitAuditEvent(LOG_IN_SUCCESS, clientId, auditUser, pairs);
+            auditService.submitAuditEvent(
+                    LOG_IN_SUCCESS,
+                    clientId,
+                    auditUser,
+                    AuditService.RestrictedSection.empty,
+                    pairs);
 
             if (!userMfaDetail.isMfaRequired()) {
                 cloudwatchMetricsService.incrementAuthenticationSuccess(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -157,6 +157,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         persistentSessionId,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", journeyType),
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
 
@@ -178,6 +179,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         persistentSessionId,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", journeyType),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
 
@@ -199,6 +201,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         persistentSessionId,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", journeyType),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType()));
 
@@ -254,6 +257,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     IpAddressHelper.extractIpAddress(input),
                     phoneNumber,
                     persistentSessionId,
+                    AuditService.RestrictedSection.empty,
                     pair("journey-type", journeyType),
                     pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
             LOG.info("Successfully processed request");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -198,7 +198,8 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                                 .getUserProfile()
                                 .map(UserProfile::getPhoneNumber)
                                 .orElse(AuditService.UNKNOWN),
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                        AuditService.RestrictedSection.empty);
             }
             auditService.submitAuditEvent(
                     auditableEvent,
@@ -212,7 +213,8 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                     userCredentials.getEmail(),
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty);
         } catch (ClientNotFoundException e) {
             LOG.warn("Client not found");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1015);
@@ -274,7 +276,8 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                     userCredentials.getEmail(),
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty);
         }
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -146,6 +146,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                     IpAddressHelper.extractIpAddress(input),
                     authenticationService.getPhoneNumber(request.getEmail()).orElse(null),
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty,
                     passwordResetCounterPair,
                     passwordResetTypePair);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -190,7 +190,8 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                         request.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
                         Optional.ofNullable(request.getPhoneNumber()).orElse(AuditService.UNKNOWN),
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                        AuditService.RestrictedSection.empty);
                 return generateApiGatewayProxyErrorResponse(400, codeRequestValid.get());
             }
             switch (request.getNotificationType()) {
@@ -322,7 +323,8 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                 request.getEmail(),
                 IpAddressHelper.extractIpAddress(input),
                 Optional.ofNullable(request.getPhoneNumber()).orElse(AuditService.UNKNOWN),
-                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                AuditService.RestrictedSection.empty);
         return generateEmptySuccessApiGatewayResponse();
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -116,7 +116,8 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                         request.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                        AuditService.RestrictedSection.empty);
 
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1009);
             }
@@ -166,6 +167,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty,
                     pair("internalSubjectId", user.getUserProfile().getSubjectID()),
                     pair("rpPairwiseId", rpPairwiseId));
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -188,6 +188,7 @@ public class StartHandler
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    AuditService.RestrictedSection.empty,
                     pair("internalSubjectId", internalSubjectId));
 
             return generateApiGatewayProxyResponse(200, startResponse);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -86,7 +86,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
-                AuditService.UNKNOWN);
+                AuditService.UNKNOWN,
+                AuditService.RestrictedSection.empty);
     }
 
     @Override
@@ -100,7 +101,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
-                AuditService.UNKNOWN);
+                AuditService.UNKNOWN,
+                AuditService.RestrictedSection.empty);
     }
 
     @Override
@@ -231,7 +233,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 session.getEmailAddress(),
                 ipAddress,
                 auditablePhoneNumber,
-                persistentSessionId);
+                persistentSessionId,
+                AuditService.RestrictedSection.empty);
         return generateEmptySuccessApiGatewayResponse();
     }
 
@@ -288,7 +291,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 email,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
-                persistentSessionId);
+                persistentSessionId,
+                AuditService.RestrictedSection.empty);
         return generateApiGatewayProxyErrorResponse(400, errorResponse);
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -314,6 +314,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 IpAddressHelper.extractIpAddress(input),
                 AuditService.UNKNOWN,
                 extractPersistentIdFromHeaders(input.getHeaders()),
+                AuditService.RestrictedSection.empty,
                 metadataPairs);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -319,6 +319,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 IpAddressHelper.extractIpAddress(input),
                 AuditService.UNKNOWN,
                 extractPersistentIdFromHeaders(input.getHeaders()),
+                AuditService.RestrictedSection.empty,
                 metadataPairs.toArray(new AuditService.MetadataPair[0]));
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
@@ -81,6 +81,7 @@ public abstract class MfaCodeProcessor {
                 ipAddress,
                 phoneNumber,
                 persistentSessionId,
+                AuditService.RestrictedSection.empty,
                 pair("mfa-type", mfaMethodType.getValue()),
                 pair("account-recovery", accountRecovery));
     }
@@ -107,6 +108,7 @@ public abstract class MfaCodeProcessor {
                     ipAddress,
                     AuditService.UNKNOWN,
                     persistentSessionId,
+                    AuditService.RestrictedSection.empty,
                     pair("mfa-type", mfaMethodType.getValue()));
         }
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -327,7 +327,8 @@ public class AccountInterventionsHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         TEST_IP_ADDRESS,
                         AuditService.UNKNOWN,
-                        TEST_PERSISTENT_SESSION_ID);
+                        TEST_PERSISTENT_SESSION_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     private UserProfile generateUserProfile() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
@@ -109,7 +109,8 @@ class AccountRecoveryHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -142,7 +143,8 @@ class AccountRecoveryHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     private void usingValidSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -132,7 +132,8 @@ class CheckReAuthUserHandlerTest {
                         EMAIL_ADDRESS,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        PERSISTENT_SESSION_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -164,7 +165,8 @@ class CheckReAuthUserHandlerTest {
                         EMAIL_ADDRESS,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        PERSISTENT_SESSION_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -198,6 +200,7 @@ class CheckReAuthUserHandlerTest {
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID,
+                        AuditService.RestrictedSection.empty,
                         AuditService.MetadataPair.pair(
                                 "number_of_attempts_user_allowed_to_login", 5));
     }
@@ -253,7 +256,8 @@ class CheckReAuthUserHandlerTest {
                         EMAIL_ADDRESS,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        PERSISTENT_SESSION_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     private UserProfile generateUserProfile() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -188,6 +188,7 @@ class CheckUserExistsHandlerTest {
                             "123.123.123.123",
                             AuditService.UNKNOWN,
                             PERSISTENT_SESSION_ID,
+                            AuditService.RestrictedSection.empty,
                             AuditService.MetadataPair.pair("rpPairwiseId", expectedRpPairwiseId));
         }
 
@@ -260,6 +261,7 @@ class CheckUserExistsHandlerTest {
                             "123.123.123.123",
                             AuditService.UNKNOWN,
                             PERSISTENT_SESSION_ID,
+                            AuditService.RestrictedSection.empty,
                             AuditService.MetadataPair.pair(
                                     "number_of_attempts_user_allowed_to_login", 5));
         }
@@ -289,6 +291,7 @@ class CheckUserExistsHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID,
+                        AuditService.RestrictedSection.empty,
                         AuditService.MetadataPair.pair("rpPairwiseId", AuditService.UNKNOWN));
     }
 
@@ -336,7 +339,8 @@ class CheckUserExistsHandlerTest {
                         "joe.bloggs",
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        PERSISTENT_SESSION_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     private void usingValidSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -232,6 +232,7 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
                         CLIENT_ID.getValue(),
                         auditUserWithAllUserInfo,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()));
 
         verify(cloudwatchMetricsService)
@@ -352,6 +353,7 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
                         CLIENT_ID.getValue(),
                         auditUserWithAllUserInfo,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("passwordResetType", PasswordResetType.FORCED_WEAK_PASSWORD));
         verifyNoInteractions(cloudwatchMetricsService);
@@ -415,6 +417,7 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
                         AuditService.UNKNOWN,
                         auditUserWithAllUserInfo,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("attemptNoFailedAt", maxRetriesAllowed),
                         pair("number_of_attempts_user_allowed_to_login", maxRetriesAllowed));
@@ -446,6 +449,7 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
                         AuditService.UNKNOWN,
                         auditUserWithAllUserInfo,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("incorrectPasswordCount", maxRetriesAllowed),
                         pair("attemptNoFailedAt", maxRetriesAllowed));
@@ -455,6 +459,7 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
                         AuditService.UNKNOWN,
                         auditUserWithAllUserInfo,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("attemptNoFailedAt", maxRetriesAllowed),
                         pair("number_of_attempts_user_allowed_to_login", maxRetriesAllowed));
@@ -485,6 +490,7 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
                         "",
                         auditUserWithAllUserInfo,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()),
                         pair(
@@ -537,6 +543,7 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
                         "",
                         auditUserWithAllUserInfo,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("incorrectPasswordCount", 1),
                         pair("attemptNoFailedAt", 6));
@@ -636,7 +643,10 @@ class LoginHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL, "", auditUserWithoutUserInfo);
+                        FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL,
+                        "",
+                        auditUserWithoutUserInfo,
+                        AuditService.RestrictedSection.empty);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -182,6 +182,7 @@ public class MfaHandlerTest {
                         "123.123.123.123",
                         PHONE_NUMBER,
                         persistentId,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", JourneyType.SIGN_IN),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }
@@ -231,6 +232,7 @@ public class MfaHandlerTest {
                         "123.123.123.123",
                         PHONE_NUMBER,
                         persistentId,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", JourneyType.SIGN_IN),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }
@@ -271,6 +273,7 @@ public class MfaHandlerTest {
                         "123.123.123.123",
                         PHONE_NUMBER,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", JourneyType.SIGN_IN),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }
@@ -347,6 +350,7 @@ public class MfaHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", JourneyType.SIGN_IN),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }
@@ -381,6 +385,7 @@ public class MfaHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", JourneyType.SIGN_IN),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType()));
     }
@@ -493,6 +498,7 @@ public class MfaHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", journeyType),
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
@@ -535,6 +541,7 @@ public class MfaHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", journeyType),
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
@@ -578,6 +585,7 @@ public class MfaHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", journeyType),
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
@@ -620,6 +628,7 @@ public class MfaHandlerTest {
                         "123.123.123.123",
                         PHONE_NUMBER,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("journey-type", JourneyType.SIGN_IN),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -169,7 +169,8 @@ class ResetPasswordHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -199,7 +200,8 @@ class ResetPasswordHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -230,7 +232,8 @@ class ResetPasswordHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
@@ -241,7 +244,8 @@ class ResetPasswordHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -272,7 +276,8 @@ class ResetPasswordHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -300,7 +305,8 @@ class ResetPasswordHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -369,7 +375,8 @@ class ResetPasswordHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -415,7 +422,8 @@ class ResetPasswordHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
@@ -426,7 +434,8 @@ class ResetPasswordHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     private APIGatewayProxyResponseEvent generateRequest(String password) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -265,6 +265,7 @@ class ResetPasswordRequestHandlerTest {
                             "123.123.123.123",
                             PHONE_NUMBER,
                             PERSISTENT_ID,
+                            AuditService.RestrictedSection.empty,
                             PASSWORD_RESET_COUNTER,
                             PASSWORD_RESET_TYPE_FORGOTTEN_PASSWORD);
         }
@@ -318,6 +319,7 @@ class ResetPasswordRequestHandlerTest {
                             "123.123.123.123",
                             PHONE_NUMBER,
                             PERSISTENT_ID,
+                            AuditService.RestrictedSection.empty,
                             PASSWORD_RESET_COUNTER,
                             PASSWORD_RESET_TYPE_FORGOTTEN_PASSWORD);
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -257,7 +257,8 @@ class SendNotificationHandlerTest {
                                 TEST_EMAIL_ADDRESS,
                                 "123.123.123.123",
                                 AuditService.UNKNOWN,
-                                PERSISTENT_ID);
+                                PERSISTENT_ID,
+                                AuditService.RestrictedSection.empty);
             }
         }
     }
@@ -327,7 +328,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -373,7 +375,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         TEST_PHONE_NUMBER,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @ParameterizedTest
@@ -417,7 +420,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @ParameterizedTest
@@ -592,7 +596,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         phoneNumber,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -723,7 +728,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -764,7 +770,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -806,7 +813,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         TEST_PHONE_NUMBER,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -837,7 +845,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -870,7 +879,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -905,7 +915,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         TEST_PHONE_NUMBER,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -936,7 +947,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -969,7 +981,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -1000,7 +1013,8 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty);
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -190,6 +190,7 @@ class SignUpHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         persistentId,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("rpPairwiseId", expectedRpPairwiseId));
 
@@ -279,7 +280,8 @@ class SignUpHandlerTest {
                         "joe.bloggs@test.com",
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty);
     }
 
     private void usingValidSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -180,6 +180,7 @@ class StartHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", AuditService.UNKNOWN));
     }
 
@@ -246,6 +247,7 @@ class StartHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", AuditService.UNKNOWN));
     }
 
@@ -290,6 +292,7 @@ class StartHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", AuditService.UNKNOWN));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -168,7 +168,8 @@ class UpdateProfileHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "",
                         PHONE_NUMBER,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -209,7 +210,8 @@ class UpdateProfileHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "",
                         PHONE_NUMBER,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -243,7 +245,8 @@ class UpdateProfileHandlerTest {
                         "",
                         "",
                         "",
-                        "");
+                        "",
+                        AuditService.RestrictedSection.empty);
     }
 
     private void usingValidSession() {
@@ -284,7 +287,8 @@ class UpdateProfileHandlerTest {
                         "",
                         "",
                         "",
-                        "");
+                        "",
+                        AuditService.RestrictedSection.empty);
 
         return response;
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -236,6 +236,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", emailNotificationType.name()),
                         pair(
                                 "account-recovery",
@@ -279,6 +280,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", emailNotificationType.name()),
                         pair(
                                 "account-recovery",
@@ -322,6 +324,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
@@ -363,6 +366,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
@@ -395,6 +399,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
@@ -474,6 +479,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", VERIFY_CHANGE_HOW_GET_SECURITY_CODES.name()),
                         pair("account-recovery", true),
                         pair("journey-type", "ACCOUNT_RECOVERY"));
@@ -511,6 +517,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", MFA_SMS.name()),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
@@ -530,6 +537,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
@@ -563,6 +571,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", MFA_SMS.name()),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
@@ -596,6 +605,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", MFA_SMS.name()),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
@@ -638,6 +648,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", MFA_SMS.name()),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
@@ -680,6 +691,7 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pair("notification-type", RESET_PASSWORD_WITH_CODE.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "PASSWORD_RESET"));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -740,6 +740,7 @@ class VerifyMfaCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        AuditService.RestrictedSection.empty,
                         pairs);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -203,6 +203,7 @@ class AuthAppCodeProcessorTest {
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
                         PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty,
                         pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                         pair("account-recovery", false));
     }
@@ -232,6 +233,7 @@ class AuthAppCodeProcessorTest {
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
                         PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty,
                         pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                         pair("account-recovery", true));
     }
@@ -258,6 +260,7 @@ class AuthAppCodeProcessorTest {
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
                         PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty,
                         pair("mfa-type", MFAMethodType.AUTH_APP.getValue()));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -226,6 +226,7 @@ class PhoneNumberCodeProcessorTest {
                         IP_ADDRESS,
                         PHONE_NUMBER,
                         PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty,
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false));
     }
@@ -255,6 +256,7 @@ class PhoneNumberCodeProcessorTest {
                         IP_ADDRESS,
                         PHONE_NUMBER,
                         PERSISTENT_ID,
+                        AuditService.RestrictedSection.empty,
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", true));
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -7,6 +7,7 @@ import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -61,6 +62,11 @@ public class AuditService {
                                 txmaAuditEvent.addExtension(pair.getKey(), pair.getValue());
                             }
                         });
+
+        restrictedSection.encoded.ifPresent(
+                encodedString ->
+                        txmaAuditEvent.addRestricted(
+                                "device_information", Map.of("encoded", encodedString)));
 
         Optional.ofNullable(user.getPhone())
                 .filter(not(String::isBlank))

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -71,6 +71,10 @@ public class AuditService {
         txmaQueueClient.send(txmaAuditEvent.serialize());
     }
 
+    public record RestrictedSection(Optional<String> encoded) {
+        public static RestrictedSection empty = new RestrictedSection(Optional.empty());
+    }
+
     public void submitAuditEvent(
             AuditableEvent event,
             String clientId,
@@ -81,6 +85,7 @@ public class AuditService {
             String ipAddress,
             String phoneNumber,
             String persistentSessionId,
+            RestrictedSection restrictedSection,
             MetadataPair... metadataPairs) {
 
         var user =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -44,6 +44,7 @@ public class AuditService {
             AuditableEvent event,
             String clientId,
             TxmaAuditUser user,
+            RestrictedSection restrictedSection,
             MetadataPair... metadataPairs) {
         var txmaAuditEvent =
                 auditEventWithTime(event, () -> Date.from(clock.instant()))
@@ -98,7 +99,7 @@ public class AuditService {
                         .withPersistentSessionId(persistentSessionId)
                         .withGovukSigninJourneyId(clientSessionId);
 
-        submitAuditEvent(event, clientId, user, metadataPairs);
+        submitAuditEvent(event, clientId, user, restrictedSection, metadataPairs);
     }
 
     public static class MetadataPair {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -51,7 +51,8 @@ class AuditServiceTest {
                 "email",
                 "ip-address",
                 "phone-number",
-                "persistent-session-id");
+                "persistent-session-id",
+                AuditService.RestrictedSection.empty);
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
 
@@ -97,6 +98,7 @@ class AuditServiceTest {
                 "ip-address",
                 "phone-number",
                 "persistent-session-id",
+                AuditService.RestrictedSection.empty,
                 pair("key", "value"),
                 pair("key2", "value2"),
                 pair("restrictedKey1", "restrictedValue1", true),
@@ -133,6 +135,7 @@ class AuditServiceTest {
                 "ip-address",
                 "07700900000",
                 "persistent-session-id",
+                AuditService.RestrictedSection.empty,
                 pair("key", "value"),
                 pair("key2", "value2"));
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -10,6 +10,7 @@ import java.time.ZoneId;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
@@ -56,21 +57,30 @@ class AuditServiceTest {
 
         var txmaMessage = asJson(txmaMessageCaptor.getValue());
 
-        assertThat(txmaMessage, hasFieldWithValue("event_name", equalTo("AUTH_TEST_EVENT_ONE")));
-        assertThat(txmaMessage, hasNumericFieldWithValue("timestamp", equalTo(1630534200L)));
-        assertThat(txmaMessage, hasFieldWithValue("client_id", equalTo("client-id")));
-        assertThat(txmaMessage, hasFieldWithValue("component_id", equalTo("AUTH")));
+        var expected =
+                """
+                {
+                "timestamp":1630534200,
+                "event_timestamp_ms":1630534200012,
+                "event_name":"AUTH_TEST_EVENT_ONE",
+                "client_id":"client-id",
+                "component_id":"AUTH",
+                "user": {
+                    "user_id":"subject-id",
+                    "transaction_id":null,
+                    "email":"email",
+                    "phone":"phone-number",
+                    "ip_address":"ip-address",
+                    "session_id":"session-id",
+                    "persistent_session_id":"persistent-session-id",
+                    "govuk_signin_journey_id":"request-id"
+                },
+                "platform":null,
+                "restricted":null,
+                "extensions":null}
+                """;
 
-        var userObject = txmaMessage.getAsJsonObject().get("user").getAsJsonObject();
-
-        assertThat(userObject, hasFieldWithValue("session_id", equalTo("session-id")));
-        assertThat(
-                userObject,
-                hasFieldWithValue("persistent_session_id", equalTo("persistent-session-id")));
-        assertThat(userObject, hasFieldWithValue("user_id", equalTo("subject-id")));
-        assertThat(userObject, hasFieldWithValue("email", equalTo("email")));
-        assertThat(userObject, hasFieldWithValue("phone", equalTo("phone-number")));
-        assertThat(userObject, hasFieldWithValue("ip_address", equalTo("ip-address")));
+        assertEquals(asJson(expected), txmaMessage);
     }
 
     @Test

--- a/test-services-api/src/main/java/uk/gov/di/authentication/testservices/lambda/DeleteSyntheticsUserHandler.java
+++ b/test-services-api/src/main/java/uk/gov/di/authentication/testservices/lambda/DeleteSyntheticsUserHandler.java
@@ -73,7 +73,8 @@ public class DeleteSyntheticsUserHandler
                                     userProfile.getEmail(),
                                     IpAddressHelper.extractIpAddress(input),
                                     AuditService.UNKNOWN,
-                                    AuditService.UNKNOWN);
+                                    AuditService.UNKNOWN,
+                                    AuditService.RestrictedSection.empty);
 
                             return generateApiGatewayProxyResponse(204, "");
                         })
@@ -91,7 +92,8 @@ public class DeleteSyntheticsUserHandler
                                     email,
                                     IpAddressHelper.extractIpAddress(input),
                                     AuditService.UNKNOWN,
-                                    AuditService.UNKNOWN);
+                                    AuditService.UNKNOWN,
+                                    AuditService.RestrictedSection.empty);
 
                             return generateApiGatewayProxyErrorResponse(
                                     404, ErrorResponse.ERROR_1010);

--- a/test-services-api/src/test/java/uk/gov/di/authentication/testservices/DeleteSyntheticsUserHandlerTest.java
+++ b/test-services-api/src/test/java/uk/gov/di/authentication/testservices/DeleteSyntheticsUserHandlerTest.java
@@ -71,7 +71,8 @@ class DeleteSyntheticsUserHandlerTest {
                         userProfile.getEmail(),
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -106,7 +107,8 @@ class DeleteSyntheticsUserHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        AuditService.RestrictedSection.empty);
     }
 
     private APIGatewayProxyRequestEvent generateApiGatewayEvent() {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
@@ -268,6 +268,7 @@ public class BulkUserEmailSenderScheduledEventHandler
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
+                AuditService.RestrictedSection.empty,
                 pair("internalSubjectId", userProfile.getSubjectID()),
                 pair("bulk-email-type", BulkEmailType.VC_EXPIRY_BULK_EMAIL.name()));
     }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
@@ -151,6 +151,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", SUBJECT_ID),
                         pair("bulk-email-type", "VC_EXPIRY_BULK_EMAIL"));
     }
@@ -194,6 +195,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", SUBJECT_ID),
                         pair("bulk-email-type", "VC_EXPIRY_BULK_EMAIL"));
     }
@@ -242,6 +244,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
+                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", SUBJECT_ID),
                         pair("bulk-email-type", "VC_EXPIRY_BULK_EMAIL"));
     }
@@ -292,6 +295,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
+                            AuditService.RestrictedSection.empty,
                             pair("internalSubjectId", TEST_SUBJECT_IDS[j]),
                             pair("bulk-email-type", "VC_EXPIRY_BULK_EMAIL"));
         }


### PR DESCRIPTION
This PR is part of a set of work to send through additional security headers on audit events, which will eventually be passed through from the cloudfront proxy on frontend. 

This is a preparatory step in this, and puts in place some common unused functionality to allow us to start passing through this information to the audit service in individual handlers.

This PR should have no observable behaviour change - no existing audit events should be modified as a result of this.

* Introduces a new `restrictedSection` parameter for the auth service
* When this parameter is populated with an encoded string, adds this to the restricted section of the audit event
* Updates all calls to reflect this new parameter (although all calls use the empty version of the restricted section, meaning that this should result in no observable change).
 

## How to review


1. Code Review commit by commit