### PR TITLE
ATO-518: Enforce cloudfront for OIDC in sandpit and staging

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -703,7 +703,7 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
 }
 
 resource "aws_wafv2_web_acl_association" "oidc_waf_association" {
-  count        = var.use_localstack ? 0 : 1
+  count        = var.enforce_cloudfront ? 0 : 1
   resource_arn = aws_api_gateway_stage.endpoint_stage.arn
   web_acl_arn  = aws_wafv2_web_acl.wafregional_web_acl_oidc_api[count.index].arn
 
@@ -711,6 +711,16 @@ resource "aws_wafv2_web_acl_association" "oidc_waf_association" {
     aws_api_gateway_stage.endpoint_stage,
     aws_wafv2_web_acl.wafregional_web_acl_oidc_api
   ]
+}
+
+data "aws_cloudformation_export" "oidc_origin_cloaking_waf_arn" {
+  name = local.oidc_origin_cloaking_waf_export_name
+}
+
+resource "aws_wafv2_web_acl_association" "oidc_origin_cloaking_waf" {
+  count        = var.enforce_cloudfront ? 1 : 0
+  resource_arn = aws_api_gateway_stage.endpoint_stage.arn
+  web_acl_arn  = data.aws_cloudformation_export.oidc_origin_cloaking_waf_arn.value
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_config_oidc_api" {
@@ -853,6 +863,8 @@ data "aws_cloudformation_stack" "orch_frontend_stack" {
 locals {
   nlb_dns_name = length(data.aws_cloudformation_stack.orch_frontend_stack) > 0 ? data.aws_cloudformation_stack.orch_frontend_stack[0].outputs["OrchFrontendNlbDnsName"] : null
   nlb_arn      = length(data.aws_cloudformation_stack.orch_frontend_stack) > 0 ? data.aws_cloudformation_stack.orch_frontend_stack[0].outputs["OrchFrontendNlbArn"] : null
+
+  oidc_origin_cloaking_waf_export_name = var.environment == "sandpit" ? "dev-oidc-cloudfront-CloakingOriginWebACLArn" : "${var.environment}-oidc-cloudfront-CloakingOriginWebACLArn"
 }
 
 resource "aws_api_gateway_vpc_link" "orch_frontend_nlb_vpc_link" {

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -92,3 +92,4 @@ spot_request_queue_cross_account_access_enabled  = true
 
 oidc_origin_domain_enabled  = true
 oidc_cloudfront_dns_enabled = true
+enforce_cloudfront          = true

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -26,6 +26,7 @@ phone_checker_with_retry = false
 
 oidc_origin_domain_enabled  = true
 oidc_cloudfront_dns_enabled = true
+enforce_cloudfront          = true
 
 orch_openid_configuration_enabled    = true
 orch_openid_configuration_name       = "staging-OpenIdConfigurationFunction"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -754,6 +754,12 @@ variable "previous_oidc_origin_cloaking_header" {
   description = "Used in rotation of the origin cloaking header. Set using secrets manager and the read secrets script."
 }
 
+variable "enforce_cloudfront" {
+  type        = bool
+  default     = false
+  description = "Feature flag to switch the WAF on the OIDC API Gateway to the Origin Cloaking WAF to mandate CloudFront"
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What

Switch the WAF on the OIDC API Gateway to the one provided by dev platform that just blocks everything without the secret header that cloudfront sets
