### PR TITLE
ATO-627: Update AIS tests to cover case that fields are missing in AIS response

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -463,6 +463,25 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                                                             SESSION_ID, CLIENT_SESSION_ID))),
                                     constructQueryStringParameters()));
         }
+
+        @Test
+        void shouldRedirectToRpWhenFieldsAreMissingInResponse() throws Json.JsonException {
+            setupTestWithDefaultEnvVars();
+            accountInterventionApiStub.initWithoutOptionalFields(
+                    SUBJECT_ID.getValue(), false, false, false, false);
+
+            var session = redis.getSession(SESSION_ID);
+            assertNotNull(session);
+
+            var response =
+                    makeRequest(
+                            Optional.of(TEST_EMAIL_ADDRESS),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            constructQueryStringParameters());
+
+            assertUserInfoStoredAndRedirectedToRp(response);
+        }
     }
 
     @Nested

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/contract/AccountInterventionServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/contract/AccountInterventionServiceTest.java
@@ -39,8 +39,8 @@ class AccountInterventionServiceTest {
     private final HttpClient httpClient = HttpClient.newHttpClient();
     private AccountInterventionService accountInterventionService;
 
-    private static final String PROVIDER_NAME = "ExternalAccountInterventionService";
-    private static final String CONSUMER_NAME = "OrchestrationAccountInterventionService";
+    private static final String PROVIDER_NAME = "AccountInterventionServiceProvider";
+    private static final String CONSUMER_NAME = "OrchAccountInterventionServiceConsumer";
     private static final String INTERNAL_PAIRWISE_SUBJECT_ID = "internal-pairwise-subject-id";
     private static final String INVALID_INTERNAL_PAIRWISE_SUBJECT_ID =
             "invalid-internal-pairwise-subject-id";

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/contract/AccountInterventionServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/contract/AccountInterventionServiceTest.java
@@ -358,12 +358,7 @@ class AccountInterventionServiceTest {
                             body.object(
                                     "intervention",
                                     (obj) -> {
-                                        obj.numberType("updatedAt", TIME_NOW);
                                         obj.numberType("appliedAt", TIME_NOW);
-                                        obj.numberType("sentAt", TIME_NOW);
-                                        obj.stringType("description", "TEST_DESCRIPTION");
-                                        obj.numberType("reprovedIdentityAt", TIME_NOW);
-                                        obj.numberType("resetPasswordAt", TIME_NOW);
                                     });
                             body.object(
                                     "state",

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountInterventionsStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountInterventionsStubExtension.java
@@ -91,6 +91,39 @@ public class AccountInterventionsStubExtension extends HttpStubExtension {
                         + "}");
     }
 
+    public void initWithoutOptionalFields(
+            String userId,
+            boolean blocked,
+            boolean suspended,
+            boolean reproveIdentity,
+            boolean resetPassword) {
+        register(
+                "/v1/ais/" + userId,
+                200,
+                "application/json",
+                "{"
+                        + "  \"intervention\": {"
+                        + "    \"updatedAt\": 1696969322935,"
+                        + "    \"appliedAt\": 1696869005821,"
+                        + "    \"sentAt\": 1696869003456,"
+                        + "    \"description\": \"EXAMPLE_DESCRIPTION\""
+                        + "  },"
+                        + "  \"state\": {"
+                        + "    \"blocked\": "
+                        + blocked
+                        + ","
+                        + "    \"suspended\": "
+                        + suspended
+                        + ","
+                        + "    \"reproveIdentity\": "
+                        + reproveIdentity
+                        + ","
+                        + "    \"resetPassword\": "
+                        + resetPassword
+                        + "  }"
+                        + "}");
+    }
+
     public void initWithErrorResponse(String userId) {
         register("/v1/ais/" + userId, 500, "application/json", "{}");
     }


### PR DESCRIPTION
## What

AIS may not send us all the fields under "intervention" in the response. This PR modifies the contract test to let AIS know we do not need these fields, and adds unit and integration tests to cover this situation.

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

