### PR TITLE
ATO-610: Turn on network firewall in dev

### DIFF
--- a/ci/stack-orchestration/configuration/dev/vpc/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/vpc/parameters.json
@@ -1,5 +1,9 @@
 [
   {
+    "ParameterKey": "AllowedDomains",
+    "ParameterValue": "*.account.gov.uk"
+  },
+  {
     "ParameterKey": "DynatraceApiEnabled",
     "ParameterValue": "Yes"
   },


### PR DESCRIPTION
## What

Turn on network firewall in dev. The suricata rules that we need are already included in the template by dev platform, but we need to provide a value for AllowedDomain or AllowRules for the network firewall to deploy. Documentation can be found [here](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3531735041/VPC)
