### PR TITLE
ATO-387: Remove consent from oidc-api

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -487,10 +487,7 @@ public class AuthorisationHandler
             List<VectorOfTrust> vtrList,
             TxmaAuditUser user) {
         if (Objects.nonNull(authenticationRequest.getPrompt())
-                && (authenticationRequest.getPrompt().contains(Prompt.Type.CONSENT)
-                        || authenticationRequest
-                                .getPrompt()
-                                .contains(Prompt.Type.SELECT_ACCOUNT))) {
+                && authenticationRequest.getPrompt().contains(Prompt.Type.SELECT_ACCOUNT)) {
             return generateErrorResponse(
                     authenticationRequest.getRedirectionURI(),
                     authenticationRequest.getState(),
@@ -612,7 +609,6 @@ public class AuthorisationHandler
                         .claim("rp_state", authenticationRequest.getState().getValue())
                         .claim("client_name", client.getClientName())
                         .claim("cookie_consent_shared", client.isCookieConsentShared())
-                        .claim("consent_required", client.isConsentRequired())
                         .claim("is_one_login_service", client.isOneLoginService())
                         .claim("service_type", client.getServiceType())
                         .claim("govuk_signin_journey_id", clientSessionId)

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -357,8 +357,6 @@ public class TokenHandler
 
         final OIDCClaimsRequest finalClaimsRequest = getClaimsRequest(vtr, authRequest);
 
-        var isConsentRequired =
-                clientRegistry.isConsentRequired() && !vtr.containsLevelOfConfidence();
         OIDCTokenResponse tokenResponse;
         if (isDocCheckingAppUserWithSubjectId(clientSession)) {
             tokenResponse =
@@ -372,8 +370,6 @@ public class TokenHandler
                                             additionalTokenClaims,
                                             clientSession.getDocAppSubjectId(),
                                             clientSession.getDocAppSubjectId(),
-                                            null,
-                                            false,
                                             finalClaimsRequest,
                                             true,
                                             signingAlgorithm,
@@ -404,8 +400,6 @@ public class TokenHandler
                                             additionalTokenClaims,
                                             rpPairwiseSubject,
                                             internalPairwiseSubject,
-                                            userProfile.getClientConsent(),
-                                            isConsentRequired,
                                             finalClaimsRequest,
                                             false,
                                             signingAlgorithm,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -47,7 +47,6 @@ import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.RefreshTokenStore;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
-import uk.gov.di.orchestration.shared.entity.ValidScopes;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
@@ -81,7 +80,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
@@ -616,7 +614,6 @@ public class TokenHandlerTest {
     }
 
     private UserProfile generateUserProfile() {
-        Set<String> claims = ValidScopes.getClaimsForListOfScopes(SCOPES.toStringList());
         return new UserProfile()
                 .withEmail(TEST_EMAIL)
                 .withEmailVerified(true)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -620,7 +620,6 @@ class RequestObjectAuthorizeValidatorTest {
                 .withClientID(CLIENT_ID.getValue())
                 .withPublicKey(
                         Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()))
-                .withConsentRequired(false)
                 .withClientName("test-client")
                 .withScopes(scope.toStringList())
                 .withRedirectUrls(singletonList(REDIRECT_URI))

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -89,19 +89,12 @@ public class TokenService {
             Map<String, Object> additionalTokenClaims,
             Subject rpPairwiseSubject,
             Subject internalPairwiseSubject,
-            List<ClientConsent> clientConsents,
-            boolean isConsentRequired,
             OIDCClaimsRequest claimsRequest,
             boolean isDocAppJourney,
             JWSAlgorithm signingAlgorithm,
             String journeyId,
             String vot) {
-        List<String> scopesForToken;
-        if (isConsentRequired) {
-            scopesForToken = calculateScopesForToken(clientConsents, clientID, authRequestScopes);
-        } else {
-            scopesForToken = authRequestScopes.toStringList();
-        }
+        List<String> scopesForToken = authRequestScopes.toStringList();
         AccessToken accessToken =
                 segmentedFunctionCall(
                         "generateAndStoreAccessToken",
@@ -209,6 +202,7 @@ public class TokenService {
         return Optional.empty();
     }
 
+    // TODO: Remove once all uses have been deleted
     private List<String> calculateScopesForToken(
             List<ClientConsent> clientConsents, String clientID, Scope authRequestScopes) {
         ClientConsent clientConsent =

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -34,9 +34,7 @@ import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.orchestration.shared.entity.AccessTokenStore;
-import uk.gov.di.orchestration.shared.entity.ClientConsent;
 import uk.gov.di.orchestration.shared.entity.RefreshTokenStore;
-import uk.gov.di.orchestration.shared.entity.ValidScopes;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.helpers.RequestBodyHelper;
@@ -51,9 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.orchestration.shared.helpers.HashHelper.hashSha256String;
@@ -200,31 +196,6 @@ public class TokenService {
             return validateRefreshRequestParams(requestBody);
         }
         return Optional.empty();
-    }
-
-    // TODO: Remove once all uses have been deleted
-    private List<String> calculateScopesForToken(
-            List<ClientConsent> clientConsents, String clientID, Scope authRequestScopes) {
-        ClientConsent clientConsent =
-                clientConsents.stream()
-                        .filter(consent -> consent.getClientId().equals(clientID))
-                        .findFirst()
-                        .orElse(null);
-        if (clientConsent == null) {
-            LOG.warn("Client consent is empty for user");
-            throw new RuntimeException("Client consent is empty for user");
-        }
-        Set<String> claimsFromAuthRequest =
-                ValidScopes.getClaimsForListOfScopes(authRequestScopes.toStringList());
-        Set<String> claims =
-                clientConsent.getClaims().stream()
-                        .filter(t -> claimsFromAuthRequest.stream().anyMatch(t::equals))
-                        .collect(Collectors.toSet());
-        List<String> scopesForIdToken = ValidScopes.getScopesForListOfClaims(claims);
-        if (authRequestScopes.contains(OIDCScopeValue.OFFLINE_ACCESS.getValue())) {
-            scopesForIdToken.add(OIDCScopeValue.OFFLINE_ACCESS.getValue());
-        }
-        return scopesForIdToken;
     }
 
     private Optional<ErrorObject> validateRefreshRequestParams(Map<String, String> requestBody) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
@@ -39,10 +39,8 @@ import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.orchestration.shared.entity.AccessTokenStore;
-import uk.gov.di.orchestration.shared.entity.ClientConsent;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.RefreshTokenStore;
-import uk.gov.di.orchestration.shared.entity.ValidScopes;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.sharedtest.helper.SubjectHelper;
@@ -51,8 +49,6 @@ import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
 import java.text.ParseException;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Date;
@@ -60,7 +56,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -146,8 +141,6 @@ class TokenServiceTest {
         createSignedAccessToken();
         Map<String, Object> additionalTokenClaims = new HashMap<>();
         additionalTokenClaims.put("nonce", nonce);
-        Set<String> claimsForListOfScopes =
-                ValidScopes.getClaimsForListOfScopes(SCOPES_OFFLINE_ACCESS.toStringList());
 
         OIDCTokenResponse tokenResponse =
                 tokenService.generateTokenResponse(
@@ -157,12 +150,6 @@ class TokenServiceTest {
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
                         INTERNAL_PAIRWISE_SUBJECT,
-                        Collections.singletonList(
-                                new ClientConsent(
-                                        CLIENT_ID,
-                                        claimsForListOfScopes,
-                                        LocalDateTime.now(ZoneId.of("UTC")).toString())),
-                        false,
                         null,
                         false,
                         JWSAlgorithm.ES256,
@@ -220,8 +207,6 @@ class TokenServiceTest {
         createSignedAccessToken();
         Map<String, Object> additionalTokenClaims = new HashMap<>();
         additionalTokenClaims.put("nonce", nonce);
-        Set<String> claimsForListOfScopes =
-                ValidScopes.getClaimsForListOfScopes(SCOPES_OFFLINE_ACCESS.toStringList());
 
         OIDCTokenResponse tokenResponse =
                 tokenService.generateTokenResponse(
@@ -231,12 +216,6 @@ class TokenServiceTest {
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
                         INTERNAL_PAIRWISE_SUBJECT,
-                        Collections.singletonList(
-                                new ClientConsent(
-                                        CLIENT_ID,
-                                        claimsForListOfScopes,
-                                        LocalDateTime.now(ZoneId.of("UTC")).toString())),
-                        false,
                         oidcClaimsRequest,
                         false,
                         JWSAlgorithm.ES256,
@@ -294,8 +273,6 @@ class TokenServiceTest {
         createSignedAccessToken();
         Map<String, Object> additionalTokenClaims = new HashMap<>();
         additionalTokenClaims.put("nonce", nonce);
-        Set<String> claimsForListOfScopes =
-                ValidScopes.getClaimsForListOfScopes(SCOPES.toStringList());
         OIDCTokenResponse tokenResponse =
                 tokenService.generateTokenResponse(
                         CLIENT_ID,
@@ -304,12 +281,6 @@ class TokenServiceTest {
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
                         INTERNAL_PAIRWISE_SUBJECT,
-                        Collections.singletonList(
-                                new ClientConsent(
-                                        CLIENT_ID,
-                                        claimsForListOfScopes,
-                                        LocalDateTime.now(ZoneId.of("UTC")).toString())),
-                        false,
                         null,
                         false,
                         JWSAlgorithm.ES256,
@@ -329,8 +300,6 @@ class TokenServiceTest {
         createSignedAccessToken();
         Map<String, Object> additionalTokenClaims = new HashMap<>();
         additionalTokenClaims.put("nonce", nonce);
-        Set<String> claimsForListOfScopes =
-                ValidScopes.getClaimsForListOfScopes(SCOPES_OFFLINE_ACCESS.toStringList());
         OIDCTokenResponse tokenResponse =
                 tokenService.generateTokenResponse(
                         CLIENT_ID,
@@ -339,12 +308,6 @@ class TokenServiceTest {
                         additionalTokenClaims,
                         PUBLIC_SUBJECT,
                         INTERNAL_PAIRWISE_SUBJECT,
-                        Collections.singletonList(
-                                new ClientConsent(
-                                        CLIENT_ID,
-                                        claimsForListOfScopes,
-                                        LocalDateTime.now(ZoneId.of("UTC")).toString())),
-                        false,
                         null,
                         false,
                         JWSAlgorithm.ES256,


### PR DESCRIPTION
Some changes to orchestration-shared, but only to methods used in oidc-api; i.e., TokenService (in orchestration-shared) is only used in oidc-api

See all removal [here](https://github.com/govuk-one-login/authentication-api/pull/4080)
