### PR TITLE
BAU: ConstructUriHelper Improvement

### DIFF
--- a/orchestration-shared/build.gradle
+++ b/orchestration-shared/build.gradle
@@ -25,7 +25,8 @@ dependencies {
             configurations.xray,
             configurations.cloudwatch,
             configurations.gson,
-            configurations.apache
+            configurations.apache,
+            "org.apache.httpcomponents.core5:httpcore5:5.2"
 
     testImplementation configurations.tests,
             configurations.lambda_tests,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/ConstructUriHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/ConstructUriHelper.java
@@ -1,40 +1,56 @@
 package uk.gov.di.orchestration.shared.helpers;
 
-import org.apache.http.client.utils.URIBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.core5.net.URIBuilder;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 
 public class ConstructUriHelper {
 
+    public static URI buildURI(URI baseUrl, String path, Map<String, String> queryParams) {
+        return buildURI(baseUrl.toString(), path, queryParams);
+    }
+
     public static URI buildURI(String baseUrl, String path, Map<String, String> queryParams) {
-        if (!baseUrl.endsWith("/")) {
-            baseUrl = baseUrl + "/";
-        }
-        var uri =
-                Objects.isNull(path)
-                        ? URI.create(baseUrl)
-                        : URI.create(baseUrl + path.replaceAll("^/+", ""));
+        return buildURI(baseUrl, Optional.ofNullable(path), Optional.ofNullable(queryParams));
+    }
+
+    public static URI buildURI(URI baseUri, Map<String, String> queryParams) {
+        return buildURI(baseUri.toString(), queryParams);
+    }
+
+    public static URI buildURI(String baseUri, Map<String, String> queryParams) {
+        return buildURI(baseUri, Optional.empty(), Optional.ofNullable(queryParams));
+    }
+
+    public static URI buildURI(URI baseUri, String path) {
+        return buildURI(baseUri.toString(), path);
+    }
+
+    public static URI buildURI(String baseUri, String path) {
+        return buildURI(baseUri, Optional.ofNullable(path), Optional.empty());
+    }
+
+    private static URI buildURI(
+            String baseUri, Optional<String> path, Optional<Map<String, String>> queryParams) {
         try {
-            var uriBuilder = new URIBuilder(uri);
-            if (Objects.nonNull(queryParams)) {
-                for (Map.Entry<String, String> entry : queryParams.entrySet()) {
-                    uriBuilder.addParameter(entry.getKey(), entry.getValue());
-                }
-            }
+            var uriBuilder = new URIBuilder(StringUtils.removeEnd(baseUri, "/"));
+            path.ifPresent(
+                    p ->
+                            uriBuilder.appendPath(
+                                    StringUtils.removeEnd(StringUtils.removeStart(p, "/"), "/")));
+            queryParams.ifPresent(
+                    qp -> {
+                        for (var entry : qp.entrySet()) {
+                            uriBuilder.addParameter(entry.getKey(), entry.getValue());
+                        }
+                    });
             return uriBuilder.build();
         } catch (URISyntaxException e) {
             throw new RuntimeException("Unable to build URI", e);
         }
-    }
-
-    public static URI buildURI(String baseUrl, String path) {
-        return buildURI(baseUrl, path, null);
-    }
-
-    public static URI buildURI(String baseUrl) {
-        return buildURI(baseUrl, null, null);
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/ConstructUriHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/ConstructUriHelperTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -13,15 +14,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 class ConstructUriHelperTest {
-
-    @Test
-    void shouldBuildUriWhenOnlyBaseUrlIsPresent() {
-        var baseUrl = "https://GOV.UK";
-
-        var uri = ConstructUriHelper.buildURI(baseUrl);
-
-        assertThat(uri.toString(), equalTo("https://GOV.UK/"));
-    }
 
     private static Stream<Arguments> validVectorValues() {
         return Stream.of(
@@ -74,6 +66,32 @@ class ConstructUriHelperTest {
 
         var uri = ConstructUriHelper.buildURI(baseUrl, null, queryParams);
 
-        assertThat(uri.toString(), equalTo("https://GOV.UK/?referer=emailConfirmationEmail"));
+        assertThat(uri.toString(), equalTo("https://GOV.UK?referer=emailConfirmationEmail"));
+    }
+
+    @Test
+    void shouldBeAbleToChainBuildURI() {
+        var baseUrl = URI.create("https://GOV.UK/");
+        var path1 = "information";
+        var path2 = "user";
+        var query1 = Map.of("name", "smith");
+        var query2 = Map.of("dob", "2000-01-01");
+
+        var uri = ConstructUriHelper.buildURI(baseUrl, path1, query1);
+        uri = ConstructUriHelper.buildURI(uri, path2, query2);
+
+        assertThat(
+                uri.toString(),
+                equalTo("https://GOV.UK/information/user?name=smith&dob=2000-01-01"));
+    }
+
+    @Test
+    void shouldRemoveRedundantBackSlashes() {
+        var baseUrl = URI.create("https://GOV.UK/");
+        var path = "/information/";
+
+        var uri = ConstructUriHelper.buildURI(baseUrl, path);
+
+        assertThat(uri.toString(), equalTo("https://GOV.UK/information"));
     }
 }


### PR DESCRIPTION
## What

Minor improvements to ConstructUriHelper:

- Able to contract a URI from an existing URI.
- Dedicated function to construct a URI with a query and no added path.
- Consistently returns URIs without trialing backslash.
- Able to chain calls to BuildURI (previously the first call would return a URI with a trailing slash and if the path being added in the subsequent call started with a slash then then returned URI would contain a double slash).

<!-- Describe what you have changed and why -->

## How to review

Code Review



## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

