### PR TITLE
AUT-2663: account management api consumes encoded txma audit header

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.AuthenticateRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
@@ -82,7 +83,7 @@ public class AuthenticateHandler
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                        AuditService.RestrictedSection.empty);
+                        AuditHelper.buildRestrictedSection(input.getHeaders()));
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
             }
             boolean hasValidCredentials =
@@ -99,7 +100,7 @@ public class AuthenticateHandler
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                        AuditService.RestrictedSection.empty);
+                        AuditHelper.buildRestrictedSection(input.getHeaders()));
                 return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
             }
             LOG.info("User has successfully Logged in. Generating successful AuthenticateResponse");
@@ -114,7 +115,7 @@ public class AuthenticateHandler
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                    AuditService.RestrictedSection.empty);
+                    AuditHelper.buildRestrictedSection(input.getHeaders()));
 
             return generateEmptySuccessApiGatewayResponse();
         } catch (JsonException e) {
@@ -128,7 +129,7 @@ public class AuthenticateHandler
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                    AuditService.RestrictedSection.empty);
+                    AuditHelper.buildRestrictedSection(input.getHeaders()));
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
     }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
@@ -55,7 +55,8 @@ public class ManuallyDeleteAccountHandler implements RequestHandler<String, Stri
 
         try {
             var userIdentifiers =
-                    accountDeletionService.removeAccount(Optional.empty(), userProfile);
+                    accountDeletionService.removeAccount(
+                            Optional.empty(), userProfile, AuditService.RestrictedSection.empty);
             return userIdentifiers.toString();
         } catch (Json.JsonException e) {
             throw new RuntimeException(e);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.accountmanagement.services.DynamoDeleteService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
+import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
@@ -116,7 +117,10 @@ public class RemoveAccountHandler
 
             authoriseRequest(input, userProfile);
 
-            accountDeletionService.removeAccount(Optional.of(input), userProfile);
+            accountDeletionService.removeAccount(
+                    Optional.of(input),
+                    userProfile,
+                    AuditHelper.buildRestrictedSection(input.getHeaders()));
 
             return generateEmptySuccessApiGatewayResponse();
         } catch (UserNotFoundException e) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.entity.PendingEmailCheckRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
@@ -292,7 +293,7 @@ public class SendOtpNotificationHandler
                 IpAddressHelper.extractIpAddress(input),
                 sendNotificationRequest.getPhoneNumber(),
                 PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                AuditService.RestrictedSection.empty,
+                AuditHelper.buildRestrictedSection(input.getHeaders()),
                 pair("notification-type", sendNotificationRequest.getNotificationType()),
                 pair("test-user", isTestUserRequest));
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
+import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
@@ -177,7 +178,7 @@ public class UpdateEmailHandler
                     IpAddressHelper.extractIpAddress(input),
                     userProfile.getPhoneNumber(),
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                    AuditService.RestrictedSection.empty,
+                    AuditHelper.buildRestrictedSection(input.getHeaders()),
                     AuditService.MetadataPair.pair(
                             "replacedEmail", updateInfoRequest.getExistingEmailAddress(), true));
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
 import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
+import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
@@ -180,7 +181,7 @@ public class UpdatePasswordHandler
                     IpAddressHelper.extractIpAddress(input),
                     userProfile.getPhoneNumber(),
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                    AuditService.RestrictedSection.empty);
+                    AuditHelper.buildRestrictedSection(input.getHeaders()));
 
             return generateEmptySuccessApiGatewayResponse();
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
+import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
@@ -158,7 +159,7 @@ public class UpdatePhoneNumberHandler
                     IpAddressHelper.extractIpAddress(input),
                     updatePhoneNumberRequest.getPhoneNumber(),
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                    AuditService.RestrictedSection.empty);
+                    AuditHelper.buildRestrictedSection(input.getHeaders()));
 
             LOG.info("Message successfully added to queue. Generating successful gateway response");
             return generateEmptySuccessApiGatewayResponse();

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -45,7 +45,9 @@ public class AccountDeletionService {
     }
 
     public DeletedAccountIdentifiers removeAccount(
-            Optional<APIGatewayProxyRequestEvent> input, UserProfile userProfile)
+            Optional<APIGatewayProxyRequestEvent> input,
+            UserProfile userProfile,
+            AuditService.RestrictedSection restrictedSection)
             throws Json.JsonException {
         var accountIdentifiers =
                 new DeletedAccountIdentifiers(
@@ -102,7 +104,7 @@ public class AccountDeletionService {
                     AuditService.UNKNOWN,
                     userProfile.getPhoneNumber(),
                     AuditService.UNKNOWN,
-                    AuditService.RestrictedSection.empty);
+                    restrictedSection);
         } catch (Exception e) {
             LOG.error("Failed to audit account deletion: ", e);
         }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandlerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 
 import java.util.Optional;
@@ -30,7 +31,7 @@ class ManuallyDeleteAccountHandlerTest {
         var userProfile = mock(UserProfile.class);
         when(authenticationService.getUserProfileByEmailMaybe(any()))
                 .thenReturn(Optional.ofNullable(userProfile));
-        when(accountDeletionService.removeAccount(any(), any()))
+        when(accountDeletionService.removeAccount(any(), any(), any()))
                 .thenReturn(mock(AccountDeletionService.DeletedAccountIdentifiers.class));
 
         // when
@@ -38,7 +39,8 @@ class ManuallyDeleteAccountHandlerTest {
 
         // then
         verify(authenticationService).getUserProfileByEmailMaybe(expectedEmail);
-        verify(accountDeletionService).removeAccount(Optional.empty(), userProfile);
+        verify(accountDeletionService)
+                .removeAccount(Optional.empty(), userProfile, AuditService.RestrictedSection.empty);
     }
 
     @Test
@@ -57,7 +59,7 @@ class ManuallyDeleteAccountHandlerTest {
         var userProfile = mock(UserProfile.class);
         when(authenticationService.getUserProfileByEmailMaybe(any()))
                 .thenReturn(Optional.ofNullable(userProfile));
-        when(accountDeletionService.removeAccount(any(), any()))
+        when(accountDeletionService.removeAccount(any(), any(), any()))
                 .thenThrow(Json.JsonException.class);
 
         // then

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.domain.RequestHeaders;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
@@ -66,6 +67,7 @@ class SendOtpNotificationHandlerTest {
     private static final String TEST_SIX_DIGIT_CODE = "123456";
     private static final String TEST_CLIENT_AND_USER_SIX_DIGIT_CODE = "654321";
     private static final String TEST_PHONE_NUMBER = "07755551084";
+    private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
     private static final long CODE_EXPIRY_TIME = 900;
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final Subject INTERNAL_SUBJECT = new Subject();
@@ -132,7 +134,9 @@ class SendOtpNotificationHandlerTest {
                         RequestHeaders.SESSION_ID_HEADER,
                         "some-session-id",
                         RequestHeaders.CLIENT_SESSION_ID_HEADER,
-                        "some-client-session-id"));
+                        "some-client-session-id",
+                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TXMA_ENCODED_HEADER_VALUE));
         event.setRequestContext(eventContext);
         event.setBody(
                 format(
@@ -180,7 +184,8 @@ class SendOtpNotificationHandlerTest {
                                 "123.123.123.123",
                                 null,
                                 persistentIdValue,
-                                AuditService.RestrictedSection.empty,
+                                new AuditService.RestrictedSection(
+                                        Optional.of(TXMA_ENCODED_HEADER_VALUE)),
                                 pair("notification-type", VERIFY_EMAIL),
                                 pair("test-user", false));
             }
@@ -209,7 +214,9 @@ class SendOtpNotificationHandlerTest {
                         RequestHeaders.SESSION_ID_HEADER,
                         "some-session-id",
                         RequestHeaders.CLIENT_SESSION_ID_HEADER,
-                        "some-client-session-id"));
+                        "some-client-session-id",
+                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TXMA_ENCODED_HEADER_VALUE));
         event.setRequestContext(eventContext);
         event.setBody(
                 format(
@@ -234,7 +241,12 @@ class SendOtpNotificationHandlerTest {
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of(ClientSessionIdHelper.SESSION_ID_HEADER_NAME, SESSION_ID));
+        event.setHeaders(
+                Map.of(
+                        ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
+                        SESSION_ID,
+                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TXMA_ENCODED_HEADER_VALUE));
         event.setRequestContext(eventContext);
         event.setBody(
                 format(
@@ -263,7 +275,7 @@ class SendOtpNotificationHandlerTest {
                         "123.123.123.123",
                         TEST_PHONE_NUMBER,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        AuditService.RestrictedSection.empty,
+                        new AuditService.RestrictedSection(Optional.of(TXMA_ENCODED_HEADER_VALUE)),
                         pair("notification-type", VERIFY_PHONE_NUMBER),
                         pair("test-user", false));
     }
@@ -280,7 +292,9 @@ class SendOtpNotificationHandlerTest {
                         PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
                         persistentIdValue,
                         ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
-                        SESSION_ID));
+                        SESSION_ID,
+                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TXMA_ENCODED_HEADER_VALUE));
         event.setRequestContext(eventContext);
         event.setBody(
                 format(
@@ -310,7 +324,7 @@ class SendOtpNotificationHandlerTest {
                         "123.123.123.123",
                         null,
                         persistentIdValue,
-                        AuditService.RestrictedSection.empty,
+                        new AuditService.RestrictedSection(Optional.of(TXMA_ENCODED_HEADER_VALUE)),
                         pair("notification-type", VERIFY_EMAIL),
                         pair("test-user", true));
     }
@@ -321,7 +335,12 @@ class SendOtpNotificationHandlerTest {
         String persistentIdValue = "some-persistent-session-id";
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
+        event.setHeaders(
+                Map.of(
+                        PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
+                        persistentIdValue,
+                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TXMA_ENCODED_HEADER_VALUE));
         event.setRequestContext(eventContext);
         event.setBody(
                 format(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
@@ -62,6 +63,7 @@ class UpdateEmailHandlerTest {
     private static final String SESSION_ID = "some-session-id";
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final String OTP = "123456";
+    private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
     private static final Subject INTERNAL_SUBJECT = new Subject();
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
@@ -113,7 +115,7 @@ class UpdateEmailHandlerTest {
                         "123.123.123.123",
                         userProfile.getPhoneNumber(),
                         PERSISTENT_ID,
-                        AuditService.RestrictedSection.empty,
+                        new AuditService.RestrictedSection(Optional.of(TXMA_ENCODED_HEADER_VALUE)),
                         AuditService.MetadataPair.pair(
                                 "replacedEmail", EXISTING_EMAIL_ADDRESS, true));
     }
@@ -256,7 +258,9 @@ class UpdateEmailHandlerTest {
                         PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
                         PERSISTENT_ID,
                         ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
-                        SESSION_ID));
+                        SESSION_ID,
+                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TXMA_ENCODED_HEADER_VALUE));
 
         return event;
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
+import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
@@ -67,6 +68,7 @@ class UpdatePasswordHandlerTest {
     private static final String SESSION_ID = "some-session-id";
     private static final String CLIENT_ID = "some-client-id";
     private static final Subject INTERNAL_SUBJECT = new Subject();
+    private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT.getValue(), "test.account.gov.uk", SALT);
@@ -118,7 +120,7 @@ class UpdatePasswordHandlerTest {
                         "123.123.123.123",
                         userProfile.getPhoneNumber(),
                         PERSISTENT_ID,
-                        AuditService.RestrictedSection.empty);
+                        new AuditService.RestrictedSection(Optional.of(TXMA_ENCODED_HEADER_VALUE)));
     }
 
     @Test
@@ -230,7 +232,9 @@ class UpdatePasswordHandlerTest {
                         PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
                         PERSISTENT_ID,
                         ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
-                        SESSION_ID));
+                        SESSION_ID,
+                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TXMA_ENCODED_HEADER_VALUE));
 
         return event;
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
@@ -57,6 +58,7 @@ class UpdatePhoneNumberHandlerTest {
     private static final String OTP = "123456";
     private static final String PERSISTENT_ID = "some-persistent-session-id";
     private static final String CLIENT_SESSION_ID = "test-client-session-id";
+    private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final Subject INTERNAL_SUBJECT = new Subject();
     private final String expectedCommonSubject =
@@ -114,7 +116,7 @@ class UpdatePhoneNumberHandlerTest {
                         "123.123.123.123",
                         NEW_PHONE_NUMBER,
                         PERSISTENT_ID,
-                        AuditService.RestrictedSection.empty);
+                        new AuditService.RestrictedSection(Optional.of(TXMA_ENCODED_HEADER_VALUE)));
     }
 
     @Test
@@ -209,7 +211,9 @@ class UpdatePhoneNumberHandlerTest {
                         PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
                         PERSISTENT_ID,
                         ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
-                        CLIENT_SESSION_ID));
+                        CLIENT_SESSION_ID,
+                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TXMA_ENCODED_HEADER_VALUE));
 
         return event;
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
@@ -89,7 +89,9 @@ class AccountDeletionServiceTest {
         when(userProfile.getSubjectID()).thenReturn(expectedSubjectId);
 
         // when
-        var deletedAccountIdentifiers = underTest.removeAccount(Optional.of(input), userProfile);
+        var deletedAccountIdentifiers =
+                underTest.removeAccount(
+                        Optional.of(input), userProfile, AuditService.RestrictedSection.empty);
 
         // then
         assertEquals(expectedPublicSubjectId, deletedAccountIdentifiers.publicSubjectId());
@@ -116,7 +118,8 @@ class AccountDeletionServiceTest {
         when(userProfile.getEmail()).thenReturn(expectedEmail);
         when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
         // when
-        underTest.removeAccount(Optional.of(input), userProfile);
+        underTest.removeAccount(
+                Optional.of(input), userProfile, AuditService.RestrictedSection.empty);
         // then
         verify(dynamoDeleteService).deleteAccount(eq(expectedEmail), any());
     }
@@ -132,7 +135,11 @@ class AccountDeletionServiceTest {
         // then
         assertThrows(
                 expectedException.getClass(),
-                () -> underTest.removeAccount(Optional.of(input), userProfile));
+                () ->
+                        underTest.removeAccount(
+                                Optional.of(input),
+                                userProfile,
+                                AuditService.RestrictedSection.empty));
     }
 
     @Test
@@ -143,7 +150,8 @@ class AccountDeletionServiceTest {
         when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
 
         // when
-        underTest.removeAccount(Optional.of(input), userProfile);
+        underTest.removeAccount(
+                Optional.of(input), userProfile, AuditService.RestrictedSection.empty);
 
         // then
         var captor = ArgumentCaptor.forClass(String.class);
@@ -163,7 +171,12 @@ class AccountDeletionServiceTest {
         doThrow(new RuntimeException()).when(sqsClient).send(any());
 
         // then
-        assertDoesNotThrow(() -> underTest.removeAccount(Optional.of(input), userProfile));
+        assertDoesNotThrow(
+                () ->
+                        underTest.removeAccount(
+                                Optional.of(input),
+                                userProfile,
+                                AuditService.RestrictedSection.empty));
         assertThat(
                 logging.events(),
                 hasItem(withMessageContaining("Failed to send account deletion email")));
@@ -186,7 +199,8 @@ class AccountDeletionServiceTest {
         when(testClientIdObject.toString()).thenReturn(TEST_CLIENT_ID);
 
         // when
-        underTest.removeAccount(Optional.of(input), userProfile);
+        underTest.removeAccount(
+                Optional.of(input), userProfile, AuditService.RestrictedSection.empty);
 
         // then
         verify(auditService)
@@ -223,7 +237,12 @@ class AccountDeletionServiceTest {
                         any());
 
         // then
-        assertDoesNotThrow(() -> underTest.removeAccount(Optional.of(input), userProfile));
+        assertDoesNotThrow(
+                () ->
+                        underTest.removeAccount(
+                                Optional.of(input),
+                                userProfile,
+                                AuditService.RestrictedSection.empty));
         assertThat(
                 logging.events(),
                 hasItem(withMessageContaining("Failed to audit account deletion")));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/AuditHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/AuditHelper.java
@@ -1,0 +1,27 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.services.AuditService;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class AuditHelper {
+
+    private static final Logger LOG = LogManager.getLogger(AuditHelper.class);
+    public static final String TXMA_ENCODED_HEADER_NAME = "txma-audit-encoded";
+
+    public static AuditService.RestrictedSection buildRestrictedSection(
+            Map<String, String> headers) {
+        String txmaEncodedValue =
+                RequestHeaderHelper.getHeaderValueFromHeaders(
+                        headers, TXMA_ENCODED_HEADER_NAME, false);
+        if (txmaEncodedValue != null && !txmaEncodedValue.isEmpty()) {
+            return new AuditService.RestrictedSection(Optional.of(txmaEncodedValue));
+        } else {
+            LOG.warn("Audit header field value cannot be empty");
+            return AuditService.RestrictedSection.empty;
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -79,7 +79,7 @@ public class AuditService {
     }
 
     public record RestrictedSection(Optional<String> encoded) {
-        public static RestrictedSection empty = new RestrictedSection(Optional.empty());
+        public static final RestrictedSection empty = new RestrictedSection(Optional.empty());
     }
 
     public void submitAuditEvent(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/AuditHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/AuditHelperTest.java
@@ -1,0 +1,48 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.shared.helpers.AuditHelper.TXMA_ENCODED_HEADER_NAME;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
+
+class AuditHelperTest {
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging = new CaptureLoggingExtension(AuditHelper.class);
+
+    @Test
+    void restrictedSectionPopulatedWithValidHeader() {
+        String auditValue = "validHeaderValue";
+        AuditService.RestrictedSection restrictedSection =
+                AuditHelper.buildRestrictedSection(Map.of(TXMA_ENCODED_HEADER_NAME, auditValue));
+        assertEquals(restrictedSection.encoded().get(), auditValue);
+    }
+
+    @Test
+    void warningLoggedWhenMissingHeader() {
+        AuditService.RestrictedSection restrictedSection =
+                AuditHelper.buildRestrictedSection(Map.of());
+        assertEquals(restrictedSection, AuditService.RestrictedSection.empty);
+        assertThat(
+                logging.events(),
+                hasItem(withMessageContaining("Audit header field value cannot be empty")));
+    }
+
+    @Test
+    void warningLoggedWheEmptyHeader() {
+        AuditService.RestrictedSection restrictedSection =
+                AuditHelper.buildRestrictedSection(Map.of(TXMA_ENCODED_HEADER_NAME, ""));
+        assertEquals(restrictedSection, AuditService.RestrictedSection.empty);
+        assertThat(
+                logging.events(),
+                hasItem(withMessageContaining("Audit header field value cannot be empty")));
+    }
+}


### PR DESCRIPTION
## What

Pick up the newly added CF encoded header in the account management api lambda handlers.  If present send to txma in each subsequent audit event submitted.
AuditHelper class was added. No information on validation however I expect there will be additional format rules that we should be adding in the future.

## How to review

1. Code Review

## Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.

