### PR TITLE
ATO-632: Add AuthFrontend Class

### DIFF
--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -45,7 +45,6 @@ module "authentication_callback" {
     IPV_AUTHORISATION_URI                       = var.ipv_authorisation_uri
     IPV_TOKEN_SIGNING_KEY_ALIAS                 = local.ipv_token_auth_key_alias_name
     LOCALSTACK_ENDPOINT                         = var.use_localstack ? var.localstack_endpoint : null
-    LOGIN_URI                                   = "https://${local.frontend_fqdn}/"
     ORCH_CLIENT_ID                              = var.orch_client_id
     ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS        = local.orch_to_auth_signing_key_alias_name
     REDIS_KEY                                   = local.redis_key

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -37,7 +37,7 @@ module "authorize" {
     HEADERS_CASE_INSENSITIVE             = var.use_localstack ? "true" : "false"
     IDENTITY_ENABLED                     = var.ipv_api_enabled
     LOCALSTACK_ENDPOINT                  = var.use_localstack ? var.localstack_endpoint : null
-    LOGIN_URI                            = "https://${local.frontend_fqdn}/"
+    FRONTEND_BASE_URL                    = "https://${local.frontend_fqdn}/"
     OIDC_API_BASE_URL                    = local.api_base_url
     ORCH_CLIENT_ID                       = var.orch_client_id
     REDIS_KEY                            = local.redis_key

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -39,7 +39,7 @@ module "doc-app-callback" {
     ENVIRONMENT                        = var.environment
     INTERNAl_SECTOR_URI                = var.internal_sector_uri
     LOCALSTACK_ENDPOINT                = var.use_localstack ? var.localstack_endpoint : null
-    LOGIN_URI                          = "https://${local.frontend_fqdn}/"
+    FRONTEND_BASE_URL                  = "https://${local.frontend_fqdn}/"
     REDIS_KEY                          = local.redis_key
     TXMA_AUDIT_QUEUE_URL               = module.oidc_txma_audit.queue_url
     OIDC_API_BASE_URL                  = local.api_base_url

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -50,7 +50,6 @@ module "ipv-callback" {
     IPV_NO_SESSION_RESPONSE_ENABLED             = var.ipv_no_session_response_enabled
     IPV_TOKEN_SIGNING_KEY_ALIAS                 = local.ipv_token_auth_key_alias_name
     LOCALSTACK_ENDPOINT                         = var.use_localstack ? var.localstack_endpoint : null
-    LOGIN_URI                                   = "https://${local.frontend_fqdn}/"
     OIDC_API_BASE_URL                           = local.api_base_url
     REDIS_KEY                                   = local.redis_key
     SPOT_QUEUE_URL                              = aws_sqs_queue.spot_request_queue.id

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -27,7 +27,6 @@ module "logout" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DEFAULT_LOGOUT_URI                   = "https://${local.frontend_fqdn}/signed-out"
     TXMA_AUDIT_QUEUE_URL                 = module.oidc_txma_audit.queue_url
     LOCALSTACK_ENDPOINT                  = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                            = local.redis_key

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -78,6 +78,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.orchestration.shared.entity.VectorOfTrust.parseFromAuthRequestAttribute;
+import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -89,6 +90,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     public static final Scope SCOPE = new Scope(OIDCScopeValue.OPENID);
     public static final State RP_STATE = new State();
     public static final State ORCH_TO_AUTH_STATE = new State();
+    private static final String BLOCKED_ENDPOINT = "unavailable-permanent";
+    private static final String SUSPENDED_ENDPOINT = "unavailable-temporary";
 
     @RegisterExtension
     public static final AuthExternalApiStubExtension authExternalApiStub =
@@ -198,7 +201,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
         assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
 
         assertTxmaAuditEventsReceived(
@@ -223,7 +226,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
         assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
 
         assertTxmaAuditEventsReceived(
@@ -682,7 +685,9 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         assertThat(
                 redirectLocationHeader.toString(),
-                containsString(configurationService.getAccountStatusSuspendedURI().toString()));
+                containsString(
+                        buildURI(configurationService.getFrontendBaseURL(), SUSPENDED_ENDPOINT)
+                                .toString()));
 
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
@@ -706,7 +711,9 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         assertThat(
                 redirectLocationHeader.toString(),
-                containsString(configurationService.getAccountStatusBlockedURI().toString()));
+                containsString(
+                        buildURI(configurationService.getFrontendBaseURL(), BLOCKED_ENDPOINT)
+                                .toString()));
 
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -73,6 +73,7 @@ import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISAT
 import static uk.gov.di.orchestration.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.orchestration.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.orchestration.shared.entity.ValidClaims.CORE_IDENTITY_JWT;
+import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.orchestration.shared.helpers.CookieHelper.getHttpCookieFromMultiValueResponseHeaders;
 import static uk.gov.di.orchestration.shared.helpers.PersistentIdHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp;
 import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
@@ -182,7 +183,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(302));
         assertThat(
                 getLocationResponseHeader(response),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
                         .isPresent(),
@@ -208,7 +209,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(302));
 
         String redirectUri = getLocationResponseHeader(response);
-        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                redirectUri,
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
                         .isPresent(),
@@ -238,7 +241,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(302));
         String redirectUri = getLocationResponseHeader(response);
-        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                redirectUri,
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(
                 response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).size(), equalTo(2));
         assertThat(
@@ -278,7 +283,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(302));
         String redirectUri = getLocationResponseHeader(response);
-        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                redirectUri,
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(
                 response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).size(), equalTo(3));
         assertThat(
@@ -320,7 +327,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(302));
         String redirectUri = getLocationResponseHeader(response);
-        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                redirectUri,
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
                         .isPresent(),
@@ -371,7 +380,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(302));
         String redirectUri = getLocationResponseHeader(response);
-        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                redirectUri,
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
                         .isPresent(),
@@ -403,7 +414,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(302));
         String redirectUri = getLocationResponseHeader(response);
-        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                redirectUri,
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
                         .isPresent(),
@@ -440,7 +453,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(302));
         String redirectUri = getLocationResponseHeader(response);
-        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                redirectUri,
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         var cookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
         assertThat(
@@ -534,7 +549,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(302));
 
         String redirectUri = getLocationResponseHeader(response);
-        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                redirectUri,
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
 
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
@@ -574,7 +591,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(
                 getLocationResponseHeader(response),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
 
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
@@ -613,7 +630,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
         String redirectUri = getLocationResponseHeader(response);
-        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                redirectUri,
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(URI.create(redirectUri).getQuery(), containsString("prompt=login"));
 
         assertTxmaAuditEventsReceived(
@@ -654,7 +673,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
         String redirectUri = getLocationResponseHeader(response);
-        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                redirectUri,
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
 
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
@@ -835,7 +856,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
-                equalTo(TEST_CONFIGURATION_SERVICE.getLoginURI().toString() + "/error"));
+                equalTo(
+                        buildURI(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL(), "error")
+                                .toString()));
 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -205,7 +205,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
 
         assertTxmaAuditEventsReceived(
@@ -232,7 +232,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
 
         assertTxmaAuditEventsReceived(
@@ -291,7 +291,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
 
         assertTxmaAuditEventsReceived(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -141,7 +141,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
 
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
@@ -320,7 +320,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
     }
 
     @ParameterizedTest
@@ -378,7 +378,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         if (validLoC) {
             assertThat(
                     response.getHeaders().get(ResponseHeaders.LOCATION),
-                    startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+                    startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
 
             assertTxmaAuditEventsReceived(
                     txmaAuditQueue,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -39,11 +39,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
 import static uk.gov.di.orchestration.shared.domain.LogoutAuditableEvent.LOG_OUT_SUCCESS;
+import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.isRedirect;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.isRedirectTo;
 import static uk.gov.di.orchestration.sharedtest.matchers.UriMatcher.baseUri;
-import static uk.gov.di.orchestration.sharedtest.matchers.UriMatcher.redirectQueryParameters;
+import static uk.gov.di.orchestration.sharedtest.matchers.UriMatcher.queryParameters;
 
 public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
@@ -52,6 +53,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     public static final String REDIRECT_URL = "https://rp-build.build.stubs.account.gov.uk/";
     public static final String SESSION_ID = "session-id";
     public static final String CLIENT_SESSION_ID = "client-session-id";
+    private static final String DEFAULT_LOGOUT_PATH = "signed-out";
 
     @BeforeEach
     void setup() {
@@ -82,7 +84,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 isRedirectTo(
                         allOf(
                                 baseUri(URI.create(REDIRECT_URL)),
-                                redirectQueryParameters(hasEntry("state", STATE)))));
+                                queryParameters(hasEntry("state", STATE)))));
 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
@@ -110,7 +112,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 isRedirectTo(
                         allOf(
                                 baseUri(URI.create(REDIRECT_URL)),
-                                redirectQueryParameters(hasEntry("state", STATE)))));
+                                queryParameters(hasEntry("state", STATE)))));
 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
@@ -131,8 +133,11 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 response,
                 isRedirectTo(
                         allOf(
-                                baseUri(TEST_CONFIGURATION_SERVICE.getDefaultLogoutURI()),
-                                redirectQueryParameters(hasEntry("state", STATE)))));
+                                baseUri(
+                                        buildURI(
+                                                TEST_CONFIGURATION_SERVICE.getFrontendBaseURL(),
+                                                DEFAULT_LOGOUT_PATH)),
+                                queryParameters(hasEntry("state", STATE)))));
 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
@@ -163,9 +168,11 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 response,
                 isRedirectTo(
                         allOf(
-                                baseUri(TEST_CONFIGURATION_SERVICE.getDefaultLogoutURI()),
-                                redirectQueryParameters(
-                                        hasEntry("error_code", "invalid_request")))));
+                                baseUri(
+                                        buildURI(
+                                                TEST_CONFIGURATION_SERVICE.getFrontendBaseURL(),
+                                                DEFAULT_LOGOUT_PATH)),
+                                queryParameters(hasEntry("error_code", "invalid_request")))));
 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
@@ -186,8 +193,11 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 response,
                 isRedirectTo(
                         allOf(
-                                baseUri(TEST_CONFIGURATION_SERVICE.getDefaultLogoutURI()),
-                                redirectQueryParameters(hasEntry("state", STATE)))));
+                                baseUri(
+                                        buildURI(
+                                                TEST_CONFIGURATION_SERVICE.getFrontendBaseURL(),
+                                                DEFAULT_LOGOUT_PATH)),
+                                queryParameters(hasEntry("state", STATE)))));
 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
@@ -214,10 +224,12 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 response,
                 isRedirectTo(
                         allOf(
-                                baseUri(TEST_CONFIGURATION_SERVICE.getDefaultLogoutURI()),
-                                redirectQueryParameters(hasEntry("state", STATE)),
-                                redirectQueryParameters(
-                                        hasEntry("error_code", "invalid_request")))));
+                                baseUri(
+                                        buildURI(
+                                                TEST_CONFIGURATION_SERVICE.getFrontendBaseURL(),
+                                                DEFAULT_LOGOUT_PATH)),
+                                queryParameters(hasEntry("state", STATE)),
+                                queryParameters(hasEntry("error_code", "invalid_request")))));
 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -232,7 +232,9 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
             APIGatewayProxyResponseEvent response) throws ParseException {
         assertThat(response, hasStatus(302));
         var redirectUri = getLocationResponseHeader(response);
-        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                redirectUri,
+                startsWith(TEST_CONFIGURATION_SERVICE.getFrontendBaseURL().toString()));
         var authorizationRequest = AuthorizationRequest.parse(URI.create(redirectUri));
         assertThat(authorizationRequest.getClientID().getValue(), equalTo(AUTH_INTERNAL_CLIENT_ID));
         assertThat(authorizationRequest.getResponseType(), equalTo(ResponseType.CODE));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -16,6 +16,7 @@ import com.nimbusds.openid.connect.sdk.claims.ClaimType;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -37,12 +38,17 @@ public class WellknownHandler
 
     private final String providerMetadata;
 
-    public WellknownHandler(ConfigurationService configService) {
+    private final AuthFrontend authFrontend;
+
+    public WellknownHandler(AuthFrontend authFrontend, ConfigurationService configService) {
+        this.authFrontend = authFrontend;
         providerMetadata = constructProviderMetadata(configService);
     }
 
     public WellknownHandler() {
-        providerMetadata = constructProviderMetadata(ConfigurationService.getInstance());
+        this(
+                new AuthFrontend(ConfigurationService.getInstance()),
+                ConfigurationService.getInstance());
     }
 
     @Override
@@ -100,9 +106,8 @@ public class WellknownHandler
             oidcMetadata.setCustomParameter(
                     "trustmarks", buildURI(baseUrl, "/trustmark").toString());
 
-            var frontendUrl = configService.getFrontendBaseURL();
-            oidcMetadata.setPolicyURI(buildURI(frontendUrl, "privacy-notice"));
-            oidcMetadata.setTermsOfServiceURI(buildURI(frontendUrl, "terms-and-conditions"));
+            oidcMetadata.setPolicyURI(authFrontend.privacyNoticeURI());
+            oidcMetadata.setTermsOfServiceURI(authFrontend.termsOfServiceURI());
 
             oidcMetadata.setUILocales(parseLangTagList("en", "cy"));
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
@@ -90,7 +90,6 @@ class LogoutRequestTest {
 
     @BeforeEach
     void setUp() throws JOSEException {
-        when(configurationService.getDefaultLogoutURI()).thenReturn(DEFAULT_LOGOUT_URI);
         when(configurationService.getInternalSectorURI()).thenReturn(INTERNAL_SECTOR_URI);
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -102,8 +102,7 @@ class LogoutHandlerTest {
                         dynamoClientService,
                         tokenValidationService,
                         cloudwatchMetricsService,
-                        logoutService,
-                        configurationService);
+                        logoutService);
         ECKey ecSigningKey =
                 new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();
         signedIDToken =
@@ -115,9 +114,8 @@ class LogoutHandlerTest {
                         ecSigningKey);
         idTokenHint = signedIDToken.serialize();
 
-        when(configurationService.getDefaultLogoutURI()).thenReturn(DEFAULT_LOGOUT_URI);
         when(configurationService.getInternalSectorURI()).thenReturn(INTERNAL_SECTOR_URI);
-        when(logoutService.generateLogoutResponse(any(), any(), any(), any(), any(), any()))
+        when(logoutService.handleLogout(any(), any(), any(), any(), any(), any()))
                 .thenReturn(new APIGatewayProxyResponseEvent());
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(dynamoClientService.getClient("client-id"))
@@ -152,10 +150,10 @@ class LogoutHandlerTest {
         verify(logoutService, times(1)).destroySessions(session);
         verify(cloudwatchMetricsService).incrementLogout(Optional.of("client-id"));
         verify(logoutService, times(1))
-                .generateLogoutResponse(
-                        URI.create(CLIENT_LOGOUT_URI.toString()),
-                        Optional.of(STATE.toString()),
+                .handleLogout(
                         Optional.empty(),
+                        Optional.of(CLIENT_LOGOUT_URI),
+                        Optional.of(STATE.toString()),
                         auditUser,
                         Optional.of("client-id"),
                         Optional.of(SUBJECT.getValue()));
@@ -183,10 +181,10 @@ class LogoutHandlerTest {
         verify(logoutService, times(0)).destroySessions(any());
         verify(cloudwatchMetricsService, times(0)).incrementLogout(any());
         verify(logoutService, times(1))
-                .generateLogoutResponse(
-                        URI.create(CLIENT_LOGOUT_URI.toString()),
-                        Optional.of(STATE.toString()),
+                .handleLogout(
                         Optional.empty(),
+                        Optional.of(CLIENT_LOGOUT_URI),
+                        Optional.of(STATE.toString()),
                         auditUser,
                         Optional.of("client-id"),
                         Optional.of(SUBJECT.getValue()));
@@ -223,10 +221,10 @@ class LogoutHandlerTest {
         verify(logoutService, times(1)).destroySessions(session);
         verify(cloudwatchMetricsService).incrementLogout(Optional.of("client-id"));
         verify(logoutService, times(1))
-                .generateLogoutResponse(
-                        URI.create(CLIENT_LOGOUT_URI.toString()),
-                        Optional.of(STATE.toString()),
+                .handleLogout(
                         Optional.empty(),
+                        Optional.of(CLIENT_LOGOUT_URI),
+                        Optional.of(STATE.toString()),
                         auditUser,
                         Optional.of("client-id"),
                         Optional.of(SUBJECT.getValue()));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
@@ -9,9 +9,11 @@ import com.nimbusds.openid.connect.sdk.claims.ClaimType;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import org.approvaltests.Approvals;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,6 +29,7 @@ class WellknownHandlerTest {
 
     private final Context context = mock(Context.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
+    private final AuthFrontend authFrontend = mock(AuthFrontend.class);
 
     @Test
     void shouldReturn200WhenRequestIsSuccessful() {
@@ -67,7 +70,7 @@ class WellknownHandlerTest {
         var expectedException =
                 assertThrows(
                         RuntimeException.class,
-                        () -> new WellknownHandler(configService),
+                        () -> new WellknownHandler(authFrontend, configService),
                         "Expected to throw exception");
 
         assertThat(
@@ -77,9 +80,12 @@ class WellknownHandlerTest {
 
     private APIGatewayProxyResponseEvent getWellKnown() {
         when(configService.getOidcApiBaseURL()).thenReturn(Optional.of("http://localhost:8080"));
-        when(configService.getFrontendBaseURL()).thenReturn("http://localhost:8081");
+        when(authFrontend.privacyNoticeURI())
+                .thenReturn(URI.create("http://localhost:8081/privacy-notice"));
+        when(authFrontend.termsOfServiceURI())
+                .thenReturn(URI.create("http://localhost:8081/terms-and-conditions"));
 
-        WellknownHandler handler = new WellknownHandler(configService);
+        WellknownHandler handler = new WellknownHandler(authFrontend, configService);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         return handler.handleRequest(event, context);
     }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -313,8 +313,8 @@ public class IntegrationTest {
         }
 
         @Override
-        public String getFrontendBaseURL() {
-            return "http://localhost:3000/reset-password?code=";
+        public URI getFrontendBaseURL() {
+            return URI.create("http://localhost:3000/");
         }
 
         @Override

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/matchers/UriMatcher.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/matchers/UriMatcher.java
@@ -57,7 +57,7 @@ public class UriMatcher<T> extends TypeSafeDiagnosingMatcher<URI> {
                 equalTo(expected));
     }
 
-    public static UriMatcher<Map<? extends String, ? extends String>> redirectQueryParameters(
+    public static UriMatcher<Map<? extends String, ? extends String>> queryParameters(
             Matcher<Map<? extends String, ? extends String>> expected) {
         return new UriMatcher<>(
                 "uri query parameters", uri -> parseQueryString(uri.getRawQuery()), expected);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/api/AuthFrontend.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/api/AuthFrontend.java
@@ -1,0 +1,74 @@
+package uk.gov.di.orchestration.shared.api;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.openid.connect.sdk.Prompt;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
+
+public class AuthFrontend {
+
+    private final URI frontendBaseUri;
+
+    public AuthFrontend(ConfigurationService configurationService) {
+        frontendBaseUri = configurationService.getFrontendBaseURL();
+    }
+
+    public URI baseURI() {
+        return frontendBaseUri;
+    }
+
+    public URI privacyNoticeURI() {
+        return buildURI(frontendBaseUri, "privacy-notice");
+    }
+
+    public URI termsOfServiceURI() {
+        return buildURI(frontendBaseUri, "terms-and-conditions");
+    }
+
+    public URI ipvCallbackURI() {
+        return buildURI(frontendBaseUri, "ipv-callback");
+    }
+
+    public URI authorizeURI(Optional<Prompt.Type> prompt, Optional<String> googleAnalytics) {
+        var queryParameters = new HashMap<String, String>();
+        prompt.ifPresent(p -> queryParameters.put("prompt", p.toString()));
+        googleAnalytics.ifPresent(s -> queryParameters.put("result", s));
+
+        return buildURI(frontendBaseUri, "authorize", queryParameters);
+    }
+
+    public URI defaultLogoutURI() {
+        return buildURI(frontendBaseUri, "signed-out");
+    }
+
+    public URI errorLogoutURI(ErrorObject error) {
+        var queryParameters =
+                Map.of(
+                        "error_code", error.getCode(),
+                        "error_description", error.getDescription());
+
+        return buildURI(defaultLogoutURI(), queryParameters);
+    }
+
+    public URI accountBlockedURI() {
+        return buildURI(frontendBaseUri, "unavailable-permanent");
+    }
+
+    public URI accountSuspendedURI() {
+        return buildURI(frontendBaseUri, "unavailable-temporary");
+    }
+
+    public URI errorURI() {
+        return buildURI(frontendBaseUri, "error");
+    }
+
+    public URI errorIpvCallbackURI() {
+        return buildURI(frontendBaseUri, "ipv-callback-session-expiry-error");
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/ConstructUriHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/ConstructUriHelper.java
@@ -37,11 +37,11 @@ public class ConstructUriHelper {
     private static URI buildURI(
             String baseUri, Optional<String> path, Optional<Map<String, String>> queryParams) {
         try {
-            var uriBuilder = new URIBuilder(StringUtils.removeEnd(baseUri, "/"));
-            path.ifPresent(
-                    p ->
-                            uriBuilder.appendPath(
-                                    StringUtils.removeEnd(StringUtils.removeStart(p, "/"), "/")));
+            var uriBuilder =
+                    path.isEmpty()
+                            ? new URIBuilder(baseUri)
+                            : new URIBuilder(StringUtils.removeEnd(baseUri, "/"));
+            path.ifPresent(uriBuilder::appendPath);
             queryParams.ifPresent(
                     qp -> {
                         for (var entry : qp.entrySet()) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -106,16 +106,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("ACCOUNT_INTERVENTIONS_ERROR_METRIC_NAME", "");
     }
 
-    public URI getAccountStatusBlockedURI() {
-        return getURIOrDefault(
-                "ACCOUNT_STATUS_BLOCKED_URI", getFrontendBaseURL() + "unavailable-permanent");
-    }
-
-    public URI getAccountStatusSuspendedURI() {
-        return getURIOrDefault(
-                "ACCOUNT_STATUS_SUSPENDED_URI", getFrontendBaseURL() + "unavailable-temporary");
-    }
-
     public long getAuthCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("AUTH_CODE_EXPIRY", "300"));
     }
@@ -148,10 +138,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public boolean isCustomDocAppClaimEnabled() {
         return getFlagOrFalse("CUSTOM_DOC_APP_CLAIM_ENABLED");
-    }
-
-    public URI getDefaultLogoutURI() {
-        return getURIOrThrow("DEFAULT_LOGOUT_URI");
     }
 
     public URI getDocAppAuthorisationURI() {
@@ -214,8 +200,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("SPOT_QUEUE_URL");
     }
 
-    public String getFrontendBaseURL() {
-        return System.getenv().getOrDefault("FRONTEND_BASE_URL", "");
+    public URI getFrontendBaseURL() {
+        return getURIOrThrow("FRONTEND_BASE_URL");
     }
 
     public String getOrchestrationToAuthenticationTokenSigningKeyAlias() {
@@ -297,10 +283,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public String getInternalSectorURI() {
         return System.getenv("INTERNAl_SECTOR_URI");
-    }
-
-    public URI getLoginURI() {
-        return getURIOrThrow("LOGIN_URI");
     }
 
     public String getNotifyCallbackBearerToken() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/RedirectService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/RedirectService.java
@@ -4,8 +4,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
-import uk.gov.di.orchestration.shared.helpers.ConstructUriHelper;
 
+import java.net.URI;
 import java.util.Map;
 
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -13,15 +13,10 @@ import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.ge
 public class RedirectService {
     private static final Logger LOG = LogManager.getLogger(RedirectService.class);
 
-    public static APIGatewayProxyResponseEvent redirectToFrontendErrorPage(
-            String loginUri, String errorPagePath) {
-        LOG.info("Redirecting to frontend error page: {}", errorPagePath);
+    public static APIGatewayProxyResponseEvent redirectToFrontendErrorPage(URI errorPageUri) {
+        var errorPageUriStr = errorPageUri.toString();
+        LOG.info("Redirecting to frontend error page: {}", errorPageUriStr);
         return generateApiGatewayProxyResponse(
-                302,
-                "",
-                Map.of(
-                        ResponseHeaders.LOCATION,
-                        ConstructUriHelper.buildURI(loginUri, errorPagePath).toString()),
-                null);
+                302, "", Map.of(ResponseHeaders.LOCATION, errorPageUriStr), null);
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/api/AuthFrontendTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/api/AuthFrontendTest.java
@@ -1,0 +1,142 @@
+package uk.gov.di.orchestration.shared.api;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.openid.connect.sdk.Prompt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.sharedtest.matchers.UriMatcher.baseUri;
+import static uk.gov.di.orchestration.sharedtest.matchers.UriMatcher.queryParameters;
+
+class AuthFrontendTest {
+
+    private static final URI AUTH_FRONTEND_BASE_URI = URI.create("https://auth.frontend/");
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private AuthFrontend authFrontend;
+
+    @BeforeEach
+    void setup() {
+        when(configurationService.getFrontendBaseURL()).thenReturn(AUTH_FRONTEND_BASE_URI);
+        authFrontend = new AuthFrontend(configurationService);
+    }
+
+    @Test
+    void baseURIReturnsCorrectUri() {
+        var expectedUri = URI.create("https://auth.frontend/");
+        var actualUri = authFrontend.baseURI();
+        assertThat(actualUri, equalTo(expectedUri));
+    }
+
+    @Test
+    void privacyNoticeURIReturnsCorrectUri() {
+        var expectedUri = URI.create("https://auth.frontend/privacy-notice");
+        var actualUri = authFrontend.privacyNoticeURI();
+        assertThat(actualUri, equalTo(expectedUri));
+    }
+
+    @Test
+    void termsOfServiceURIReturnsCorrectUri() {
+        var expectedUri = URI.create("https://auth.frontend/terms-and-conditions");
+        var actualUri = authFrontend.termsOfServiceURI();
+        assertThat(actualUri, equalTo(expectedUri));
+    }
+
+    @Test
+    void ipvCallbackURIReturnsCorrectUri() {
+        var expectedUri = URI.create("https://auth.frontend/ipv-callback");
+        var actualUri = authFrontend.ipvCallbackURI();
+        assertThat(actualUri, equalTo(expectedUri));
+    }
+
+    @ParameterizedTest
+    @MethodSource("authorizeURICases")
+    void authorizeURIReturnsCorrectUri(
+            Optional<Prompt.Type> prompt,
+            Optional<String> googleAnalytics,
+            Map<String, String> expectedQueryParameters) {
+        var expectedBaseUri = URI.create("https://auth.frontend/authorize");
+        var actualUri = authFrontend.authorizeURI(prompt, googleAnalytics);
+        assertThat(actualUri, baseUri(expectedBaseUri));
+        assertThat(actualUri, queryParameters(aMapWithSize(expectedQueryParameters.size())));
+        for (var entry : expectedQueryParameters.entrySet()) {
+            assertThat(actualUri, queryParameters(hasEntry(entry.getKey(), entry.getValue())));
+        }
+    }
+
+    static Stream<Arguments> authorizeURICases() {
+        return Stream.of(
+                Arguments.of(Optional.empty(), Optional.empty(), Map.of()),
+                Arguments.of(
+                        Optional.of(Prompt.Type.LOGIN),
+                        Optional.empty(),
+                        Map.of("prompt", "login")),
+                Arguments.of(Optional.empty(), Optional.of("sign-in"), Map.of("result", "sign-in")),
+                Arguments.of(
+                        Optional.of(Prompt.Type.LOGIN),
+                        Optional.of("sign-in"),
+                        Map.of(
+                                "prompt", "login",
+                                "result", "sign-in")));
+    }
+
+    @Test
+    void defaultLogoutURIReturnsCorrectUri() {
+        var expectedUri = URI.create("https://auth.frontend/signed-out");
+        var actualUri = authFrontend.defaultLogoutURI();
+        assertThat(actualUri, equalTo(expectedUri));
+    }
+
+    @Test
+    void errorLogoutURIReturnsCorrectUri() {
+        var error = new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "invalid session");
+        var actualUri = authFrontend.errorLogoutURI(error);
+        var expectedBaseUri = URI.create("https://auth.frontend/signed-out");
+        var expectedQueryParameters =
+                Map.of(
+                        "error_description", "invalid session",
+                        "error_code", "invalid_request");
+        assertThat(actualUri, baseUri(expectedBaseUri));
+        assertThat(actualUri, queryParameters(aMapWithSize(expectedQueryParameters.size())));
+        for (var entry : expectedQueryParameters.entrySet()) {
+            assertThat(actualUri, queryParameters(hasEntry(entry.getKey(), entry.getValue())));
+        }
+    }
+
+    @Test
+    void accountSuspendedURIReturnsCorrectUri() {
+        var expectedUri = URI.create("https://auth.frontend/unavailable-temporary");
+        var actualUri = authFrontend.accountSuspendedURI();
+        assertThat(actualUri, equalTo(expectedUri));
+    }
+
+    @Test
+    void errorURIReturnsCorrectUri() {
+        var expectedUri = URI.create("https://auth.frontend/error");
+        var actualUri = authFrontend.errorURI();
+        assertThat(actualUri, equalTo(expectedUri));
+    }
+
+    @Test
+    void errorIpvCallbackURIReturnsCorrectUri() {
+        var expectedUri = URI.create("https://auth.frontend/ipv-callback-session-expiry-error");
+        var actualUri = authFrontend.errorIpvCallbackURI();
+        assertThat(actualUri, equalTo(expectedUri));
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -820,7 +820,7 @@ Resources:
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
             - ServiceDomain: !FindInMap [ EnvironmentConfiguration, !Ref Environment, serviceDomain ]
-          LOGIN_URI: !Sub
+          FRONTEND_BASE_URL: !Sub
             - https://signin.${ServiceDomain}/
             - ServiceDomain: !FindInMap [ EnvironmentConfiguration, !Ref Environment, serviceDomain ]
           REDIS_KEY: session
@@ -1074,9 +1074,6 @@ Resources:
             - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-
             - AccountId: !FindInMap [ EnvironmentConfiguration, !Ref Environment, authAccountId ]
               AuthEnvironment: !FindInMap [ EnvironmentConfiguration, !Ref Environment, authEnvironment ]
-          DEFAULT_LOGOUT_URI: !Sub
-            - https://signin.${ServiceDomain}/signed-out
-            - ServiceDomain: !FindInMap [ EnvironmentConfiguration, !Ref Environment, serviceDomain ]
           BACK_CHANNEL_LOGOUT_QUEUE_URI: !GetAtt BackChannelLogoutQueue.QueueUrl
           FRONTEND_BASE_URL: !Sub
             - https://signin.${ServiceDomain}/
@@ -1256,9 +1253,6 @@ Resources:
             - https://identity.${ServiceDomain}/oauth2/authorize
             - ServiceDomain: !FindInMap [ EnvironmentConfiguration, !Ref Environment, serviceDomain ]
           IPV_TOKEN_SIGNING_KEY_ALIAS: !FindInMap [ EnvironmentConfiguration, !Ref Environment, ipvTokenKeyArn ]
-          LOGIN_URI: !Sub
-            - https://signin.${ServiceDomain}/
-            - ServiceDomain: !FindInMap [ EnvironmentConfiguration, !Ref Environment, serviceDomain ]
           ORCH_CLIENT_ID: orchestrationAuth
           ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS: !FindInMap [ EnvironmentConfiguration, !Ref Environment, orchToAuthKeyArn ]
           REDIS_KEY: session
@@ -1581,7 +1575,7 @@ Resources:
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}
             - ServiceDomain: !FindInMap [ EnvironmentConfiguration, !Ref Environment, serviceDomain ]
-          LOGIN_URI: !Sub
+          FRONTEND_BASE_URL: !Sub
             - https://signin.${ServiceDomain}/
             - ServiceDomain: !FindInMap [ EnvironmentConfiguration, !Ref Environment, serviceDomain ]
           OIDC_API_BASE_URL: !Sub
@@ -2350,9 +2344,6 @@ Resources:
             - AccountId: !FindInMap [ EnvironmentConfiguration, !Ref Environment, authAccountId ]
               AuthEnvironment: !FindInMap [ EnvironmentConfiguration, !Ref Environment, authEnvironment ]
           FRONTEND_BASE_URL: !Sub
-            - https://signin.${ServiceDomain}/
-            - ServiceDomain: !FindInMap [ EnvironmentConfiguration, !Ref Environment, serviceDomain ]
-          LOGIN_URI: !Sub
             - https://signin.${ServiceDomain}/
             - ServiceDomain: !FindInMap [ EnvironmentConfiguration, !Ref Environment, serviceDomain ]
           ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED: true


### PR DESCRIPTION
## What

- Added AuthFrontend class for constructing relevant URIs
- Removed DEFAULT_LOGOUT_URI and LOGIN_URI environment variables (AuthFrontend class depends on FRONTEND_BASE_URL only)

## How to review

Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.