### PR TITLE
AUT-2165: log the status of experian email check during update email process

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -4,6 +4,7 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
 import uk.gov.di.accountmanagement.lambda.UpdateEmailHandler;
@@ -11,6 +12,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
 import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.Collections;
@@ -36,6 +38,10 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final Subject SUBJECT = new Subject();
     private static final String INTERNAl_SECTOR_HOST = "test.account.gov.uk";
     private static final String CLIENT_ID = "some-client-id";
+
+    @RegisterExtension
+    protected static final EmailCheckResultExtension emailCheckResultExtension =
+            new EmailCheckResultExtension();
 
     @BeforeEach
     void setup() {


### PR DESCRIPTION


## What

In UpdateEmail lambda in the Account Management API, added a step check the status of the users fraudulent email check for the new email address that the user is proposing to update their profile to use and log the result.

Interim stage of email phone check process where we will log the status of the asynchronous request sent to Experian to get an idea of how long it takes

## How to review

1. Code Review

## Checklist


- [x] Impact on orch and auth mutual dependencies has been checked.