### PR TITLE
ATO-611: Move doc app callback to protected subnet

### DIFF
--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -58,7 +58,8 @@ logging_endpoint_enabled = false
 enforce_code_signing     = false
 orchestration_account_id = "816047645251"
 
-orch_privatesub_cidr_blocks = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
+orch_privatesub_cidr_blocks   = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
+orch_protectedsub_cidr_blocks = ["10.1.4.0/23", "10.1.6.0/23", "10.1.8.0/23"]
 
 kms_cross_account_access_enabled                = true
 doc_app_cross_account_access_enabled            = true

--- a/ci/terraform/shared/security-groups.tf
+++ b/ci/terraform/shared/security-groups.tf
@@ -50,7 +50,7 @@ resource "aws_security_group_rule" "allow_connection_to_oidc_redis" {
   type                     = "egress"
 }
 
-resource "aws_security_group_rule" "allow_incoming_redis_from_orch_subnet" {
+resource "aws_security_group_rule" "allow_incoming_redis_from_orch_private_subnet" {
   count = length(var.orch_privatesub_cidr_blocks) == 0 ? 0 : 1
 
   description       = "Allow ingress to Redis from orch private subnet"
@@ -59,6 +59,19 @@ resource "aws_security_group_rule" "allow_incoming_redis_from_orch_subnet" {
   from_port   = local.redis_port_number
   protocol    = "tcp"
   cidr_blocks = var.orch_privatesub_cidr_blocks
+  to_port     = local.redis_port_number
+  type        = "ingress"
+}
+
+resource "aws_security_group_rule" "allow_incoming_redis_from_orch_protected_subnet" {
+  count = length(var.orch_protectedsub_cidr_blocks) == 0 ? 0 : 1
+
+  description       = "Allow ingress to Redis from orch protected subnet"
+  security_group_id = aws_security_group.redis_security_group.id
+
+  from_port   = local.redis_port_number
+  protocol    = "tcp"
+  cidr_blocks = var.orch_protectedsub_cidr_blocks
   to_port     = local.redis_port_number
   type        = "ingress"
 }

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -180,6 +180,12 @@ variable "orch_privatesub_cidr_blocks" {
   default     = []
 }
 
+variable "orch_protectedsub_cidr_blocks" {
+  type        = list(string)
+  description = "Orchestration protected subnet cidr blocks"
+  default     = []
+}
+
 variable "authentication_callback_userinfo_table_cross_account_access_enabled" {
   default     = false
   type        = bool

--- a/template.yaml
+++ b/template.yaml
@@ -510,8 +510,8 @@ Resources:
 
   DocAppCallbackFunction:
     Type: AWS::Serverless::Function
+    IgnoreGlobals: [ VpcConfig ]
     # checkov:skip=CKV_AWS_116: DLQ is not appropriate for a Lambda invoked by an API
-    # checkov:skip=CKV_AWS_117: VPC settings are global
     Properties:
       FunctionName: !Sub ${Environment}-DocAppCallbackFunction
       AutoPublishAlias: latest
@@ -520,6 +520,13 @@ Resources:
       ReservedConcurrentExecutions: 1
       LoggingConfig:
         LogGroup: !Ref DocAppCallbackFunctionLogGroup
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroup
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdC
       Environment:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.


### PR DESCRIPTION
## What

Doc app callback needs to call out to dcmaw, so needs access to the internet through the firewall
## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
