### PR TITLE
Revert "ATO-561: Enforce client registry permitted levels of confidence"

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1042,10 +1042,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 "public",
                 clientType,
                 true,
-                jarValidationRequired,
-                List.of(
-                        LevelOfConfidence.MEDIUM_LEVEL.getValue(),
-                        LevelOfConfidence.HMRC200.getValue()));
+                jarValidationRequired);
     }
 
     private SignedJWT createSignedJWT(String uiLocales) throws JOSEException {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -105,19 +105,6 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
         List<String> authRequestVtr = authRequest.getCustomParameter(VTR_PARAM);
         try {
             var vtrList = VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
-            var levelOfConfidenceValues = VectorOfTrust.getRequestedLevelsOfConfidence(vtrList);
-            if (!client.getClientLoCs().containsAll(levelOfConfidenceValues)) {
-                LOG.error(
-                        "Level of confidence values have been requested which this client is not permitted to request. Level of confidence values in request: {}",
-                        levelOfConfidenceValues);
-                return Optional.of(
-                        new AuthRequestError(
-                                new ErrorObject(
-                                        OAuth2Error.INVALID_REQUEST_CODE,
-                                        "Request vtr is not permitted"),
-                                redirectURI,
-                                state));
-            }
             if (vtrList.get(0).containsLevelOfConfidence()
                     && !ipvCapacityService.isIPVCapacityAvailable()
                     && !client.isTestClient()) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -167,7 +167,7 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                                 "Request is missing nonce parameter"),
                         state);
             }
-            var vtrError = validateVtr(jwtClaimsSet, client);
+            var vtrError = validateVtr(jwtClaimsSet);
             if (vtrError.isPresent()) {
                 return errorResponse(redirectURI, vtrError.get(), state);
             }
@@ -221,20 +221,11 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
         }
     }
 
-    private Optional<ErrorObject> validateVtr(JWTClaimsSet jwtClaimsSet, ClientRegistry client) {
+    private Optional<ErrorObject> validateVtr(JWTClaimsSet jwtClaimsSet) {
         List<String> authRequestVtr = new ArrayList<>();
         try {
             authRequestVtr = getRequestObjectVtrAsList(jwtClaimsSet);
             var vtrList = VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
-            var levelOfConfidenceValues = VectorOfTrust.getRequestedLevelsOfConfidence(vtrList);
-            if (!client.getClientLoCs().containsAll(levelOfConfidenceValues)) {
-                LOG.error(
-                        "Level of confidence values have been requested which this client is not permitted to request. Level of confidence values in request: {}",
-                        levelOfConfidenceValues);
-                return Optional.of(
-                        new ErrorObject(
-                                OAuth2Error.INVALID_REQUEST_CODE, "Request vtr is not permitted"));
-            }
             if (vtrList.get(0).containsLevelOfConfidence()
                     && !ipvCapacityService.isIPVCapacityAvailable()) {
                 return Optional.of(OAuth2Error.TEMPORARILY_UNAVAILABLE);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.oidc.services;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -18,7 +17,6 @@ import uk.gov.di.authentication.oidc.validators.RequestObjectAuthorizeValidator;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
-import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
@@ -42,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.oidc.helper.RequestObjectTestHelper.generateSignedJWT;
-import static uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 
 class RequestObjectAuthorizeValidatorTest {
 
@@ -323,34 +320,6 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorIfVtrIsNotPermittedForGivenClient() throws JOSEException {
-        var jwtClaimsSet =
-                new JWTClaimsSet.Builder()
-                        .audience(AUDIENCE)
-                        .claim("redirect_uri", REDIRECT_URI)
-                        .claim("response_type", ResponseType.CODE.toString())
-                        .claim("scope", "openid")
-                        .claim("nonce", NONCE.getValue())
-                        .claim("state", STATE.toString())
-                        .claim("client_id", CLIENT_ID.getValue())
-                        .claim("vtr", jsonArrayOf("Cl.Cm.PCL250"))
-                        .issuer(CLIENT_ID.getValue())
-                        .build();
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
-        var requestObjectError = service.validate(authRequest);
-
-        assertTrue(requestObjectError.isPresent());
-        assertThat(
-                requestObjectError.get().errorObject().toJSONObject(),
-                equalTo(
-                        new ErrorObject(
-                                        OAuth2Error.INVALID_REQUEST_CODE,
-                                        "Request vtr is not permitted")
-                                .toJSONObject()));
-        assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
-    }
-
-    @Test
     void shouldReturnErrorWhenClientHasNotRegisteredDocAppScope() throws JOSEException {
         var clientRegistry =
                 generateClientRegistry(
@@ -626,7 +595,6 @@ class RequestObjectAuthorizeValidatorTest {
                 .withRedirectUrls(singletonList(REDIRECT_URI))
                 .withSectorIdentifierUri("https://test.com")
                 .withSubjectType("pairwise")
-                .withClientLoCs(singletonList(LevelOfConfidence.MEDIUM_LEVEL.getValue()))
                 .withClientType(clientType);
     }
 

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
@@ -204,8 +204,7 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
             String subjectType,
             ClientType clientType,
             boolean consentRequired,
-            boolean jarValidationRequired,
-            List<String> clientLoCs) {
+            boolean jarValidationRequired) {
         registerClient(
                 clientID,
                 clientName,
@@ -221,8 +220,7 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 consentRequired,
                 clientType,
                 emptyList(),
-                jarValidationRequired,
-                clientLoCs);
+                jarValidationRequired);
     }
 
     public void registerClient(
@@ -294,45 +292,6 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 null,
                 ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
                 emptyList());
-    }
-
-    public void registerClient(
-            String clientID,
-            String clientName,
-            List<String> redirectUris,
-            List<String> contacts,
-            List<String> scopes,
-            String publicKey,
-            List<String> postLogoutRedirectUris,
-            String backChannelLogoutUri,
-            String serviceType,
-            String sectorIdentifierUri,
-            String subjectType,
-            boolean consentRequired,
-            ClientType clientType,
-            List<String> claims,
-            boolean jarValidationRequired,
-            List<String> clientLoCs) {
-        dynamoClientService.addClient(
-                clientID,
-                clientName,
-                redirectUris,
-                contacts,
-                scopes,
-                publicKey,
-                postLogoutRedirectUris,
-                backChannelLogoutUri,
-                serviceType,
-                sectorIdentifierUri,
-                subjectType,
-                consentRequired,
-                jarValidationRequired,
-                claims,
-                clientType.getValue(),
-                false,
-                null,
-                ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
-                clientLoCs);
     }
 
     public void registerClient(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/VectorOfTrust.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/VectorOfTrust.java
@@ -165,7 +165,6 @@ public class VectorOfTrust {
     public static List<String> getRequestedLevelsOfConfidence(List<VectorOfTrust> vtrList) {
         return vtrList.stream()
                 .map(VectorOfTrust::getLevelOfConfidence)
-                .filter(Objects::nonNull)
                 .map(LevelOfConfidence::getValue)
                 .toList();
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/VectorOfTrustTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/VectorOfTrustTest.java
@@ -11,7 +11,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -98,13 +97,6 @@ class VectorOfTrustTest {
                         VectorOfTrust.of(LOW_LEVEL, LevelOfConfidence.LOW_LEVEL));
         var levelsOfConfidence = VectorOfTrust.getRequestedLevelsOfConfidence(vtrList);
         assertThat(levelsOfConfidence, equalTo(List.of("P2", "P1")));
-    }
-
-    @Test
-    void shouldReturnEmptyListWhenOnlyLevelsOfConfidenceRequestedButNonePresent() {
-        var vtrList = List.of(new VectorOfTrust(LOW_LEVEL), new VectorOfTrust(MEDIUM_LEVEL));
-        var levelsOfConfidence = VectorOfTrust.getRequestedLevelsOfConfidence(vtrList);
-        assertThat(levelsOfConfidence, equalTo(emptyList()));
     }
 
     @ParameterizedTest
@@ -283,7 +275,7 @@ class VectorOfTrustTest {
 
     @Test
     void shouldThrowExceptionForEmptyVtrList() {
-        List<VectorOfTrust> vtrList = emptyList();
+        List<VectorOfTrust> vtrList = Collections.emptyList();
 
         IllegalArgumentException exception =
                 assertThrows(


### PR DESCRIPTION
Reverts govuk-one-login/authentication-api#4350

Reverting this change as, due to broken acceptance tests, it cannot be tested in staging now. Will retry tomorrow