### PR TITLE
AUT-2267: async Experian phone check is triggered after change of phone number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -319,6 +319,7 @@ task oidcTerraform (type: Terraform) {
             environment "FRONTEND_API_KEY", json.frontend_api_key.value
             environment "EVENTS_SNS_TOPIC_ARN", json.events_sns_topic_arn.value
             environment "EMAIL_QUEUE_URL", json.email_queue.value
+            environment "EXPERIAN_PHONE_CHECK_QUEUE_URL", json.experian_phone_check_queue.value
         }
         allprojects.findAll {it.name == "account-management-integration-tests"}.first().tasks.getByName("test") {
             environment "EVENTS_SNS_TOPIC_ARN", json.events_sns_topic_arn.value

--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -49,6 +49,9 @@ email_acct_creation_otp_code_ttl_duration = 60
 
 orch_client_id = "orchestrationAuth"
 
+contra_state_bucket      = "di-auth-development-tfstate"
+phone_checker_with_retry = false
+
 orch_frontend_api_gateway_integration_enabled = false
 
 orch_redirect_uri = "https://oidc.authdev1.sandpit.account.gov.uk/orchestration-redirect"

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -48,6 +48,9 @@ email_acct_creation_otp_code_ttl_duration = 60
 
 orch_client_id = "orchestrationAuth"
 
+contra_state_bucket      = "di-auth-development-tfstate"
+phone_checker_with_retry = false
+
 orch_redirect_uri                  = "https://oidc.authdev2.sandpit.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
 

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -39,6 +39,9 @@ orch_client_id                     = "orchestrationAuth"
 orch_redirect_uri                  = "https://oidc.build.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
 
+contra_state_bucket      = "digital-identity-dev-tfstate"
+phone_checker_with_retry = false
+
 orch_openid_configuration_name = "build-OpenIdConfigurationFunction"
 
 orch_account_id = "767397776536"

--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -9,3 +9,5 @@ shared_state_bucket                  = "di-auth-development-tfstate"
 test_clients_enabled                 = true
 internal_sector_uri                  = "https://identity.dev.account.gov.uk"
 orch_client_id                       = "orchestrationAuth"
+contra_state_bucket                  = "di-auth-development-tfstate"
+phone_checker_with_retry             = false

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -35,4 +35,7 @@ orch_client_id                     = "orchestrationAuth"
 orch_redirect_uri                  = "https://oidc.integration.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
 
+contra_state_bucket      = "digital-identity-dev-tfstate"
+phone_checker_with_retry = false
+
 orch_account_id = "058264132019"

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -35,4 +35,7 @@ orch_client_id                     = "orchestrationAuth"
 orch_redirect_uri                  = "https://oidc.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
 
+contra_state_bucket      = "digital-identity-prod-tfstate"
+phone_checker_with_retry = false
+
 orch_account_id = "533266965190"

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -54,6 +54,8 @@ authorize_protected_subnet_enabled = true
 
 support_email_check_enabled = true
 
+contra_state_bucket      = "digital-identity-dev-tfstate"
+phone_checker_with_retry = false
 
 orch_openid_configuration_enabled = true
 orch_openid_configuration_name    = "dev-OpenIdConfigurationFunction"

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -30,6 +30,16 @@ data "terraform_remote_state" "auth-ext-api" {
   }
 }
 
+data "terraform_remote_state" "contra" {
+  backend = "s3"
+  config = {
+    bucket   = var.contra_state_bucket
+    key      = "${var.environment}-contra-indicators-terraform.tfstate"
+    role_arn = var.deployer_role_arn
+    region   = var.aws_region
+  }
+}
+
 
 locals {
   redis_key                                           = "session"
@@ -74,4 +84,6 @@ locals {
   pending_email_check_queue_id                        = data.terraform_remote_state.shared.outputs.pending_email_check_queue_id
   pending_email_check_queue_access_policy_arn         = data.terraform_remote_state.shared.outputs.pending_email_check_queue_access_policy_arn
   user_profile_kms_key_arn                            = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
+  experian_phone_check_sqs_queue_id                   = data.terraform_remote_state.contra.outputs.aws_experian_phone_check_sqs_id
+  experian_phone_check_sqs_queue_policy_arn           = data.terraform_remote_state.contra.outputs.aws_experian_phone_check_sqs_policy_arn
 }

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -24,5 +24,8 @@ kms_cross_account_access_enabled                 = true
 cmk_for_back_channel_logout_enabled              = true
 txma_audit_encoded_enabled                       = true
 
+contra_state_bucket      = "di-auth-staging-tfstate"
+phone_checker_with_retry = false
+
 oidc_origin_domain_enabled  = true
 oidc_cloudfront_dns_enabled = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -244,8 +244,7 @@ variable "shared_state_bucket" {
 }
 
 variable "contra_state_bucket" {
-  type    = string
-  default = "digital-identity-dev-tfstate"
+  type = string
 }
 
 variable "cloudwatch_log_retention" {
@@ -323,6 +322,11 @@ variable "ipv_backend_uri" {
 }
 
 variable "ipv_no_session_response_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "phone_checker_with_retry" {
   type    = bool
   default = false
 }

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -16,7 +16,8 @@ module "frontend_api_verify_mfa_code_role" {
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    local.experian_phone_check_sqs_queue_policy_arn
   ]
 }
 
@@ -41,8 +42,11 @@ module "verify_mfa_code" {
     TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP = var.test_client_verify_phone_number_otp
     TEST_CLIENTS_ENABLED                = var.test_clients_enabled
     INTERNAl_SECTOR_URI                 = var.internal_sector_uri
+    EXPERIAN_PHONE_CHECKER_QUEUE_URL    = local.experian_phone_check_sqs_queue_id
+    PHONE_CHECKER_WITH_RETRY            = var.phone_checker_with_retry
     CODE_MAX_RETRIES_INCREASED          = var.code_max_retries_increased
     REDUCED_LOCKOUT_DURATION            = var.reduced_lockout_duration
+    SQS_ENDPOINT                        = var.use_localstack ? "http://localhost:45678/" : null
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler::handleRequest"
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/PhoneNumberRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/PhoneNumberRequest.java
@@ -1,0 +1,13 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+
+public record PhoneNumberRequest(
+        @Expose @SerializedName("phoneNumberVerified") boolean phoneNumberVerified,
+        @Expose @SerializedName("phoneNumber") String phoneNumber,
+        @Expose @SerializedName("updatedPhoneNumber") boolean updatedPhoneNumber,
+        @Expose @SerializedName("journeyType") JourneyType journeyType,
+        @Expose @SerializedName("internalCommonSubjectIdentifier")
+                String internalCommonSubjectIdentifier) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -1,19 +1,28 @@
 package uk.gov.di.authentication.frontendapi.validation;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.entity.PhoneNumberRequest;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
+import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.List;
@@ -27,6 +36,9 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
     private final ConfigurationService configurationService;
     private final UserContext userContext;
     private final CodeRequest codeRequest;
+    private final AwsSqsClient sqsClient;
+    private final Json objectMapper = SerializationService.getInstance();
+    private static final Logger LOG = LogManager.getLogger(PhoneNumberCodeProcessor.class);
 
     PhoneNumberCodeProcessor(
             CodeStorageService codeStorageService,
@@ -46,6 +58,33 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
         this.userContext = userContext;
         this.configurationService = configurationService;
         this.codeRequest = codeRequest;
+        this.sqsClient =
+                new AwsSqsClient(
+                        configurationService.getAwsRegion(),
+                        configurationService.getExperianPhoneCheckerQueueUri(),
+                        configurationService.getSqsEndpointUri());
+    }
+
+    PhoneNumberCodeProcessor(
+            CodeStorageService codeStorageService,
+            UserContext userContext,
+            ConfigurationService configurationService,
+            CodeRequest codeRequest,
+            AuthenticationService dynamoService,
+            AuditService auditService,
+            DynamoAccountModifiersService dynamoAccountModifiersService,
+            AwsSqsClient sqsClient) {
+        super(
+                userContext,
+                codeStorageService,
+                configurationService.getCodeMaxRetries(),
+                dynamoService,
+                auditService,
+                dynamoAccountModifiersService);
+        this.userContext = userContext;
+        this.configurationService = configurationService;
+        this.codeRequest = codeRequest;
+        this.sqsClient = sqsClient;
     }
 
     @Override
@@ -99,29 +138,57 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
 
     @Override
     public void processSuccessfulCodeRequest(String ipAddress, String persistentSessionId) {
-        switch (codeRequest.getJourneyType()) {
-            case REGISTRATION:
-                dynamoService.updatePhoneNumberAndAccountVerifiedStatus(
-                        emailAddress, codeRequest.getProfileInformation(), true, true);
-                submitAuditEvent(
-                        FrontendAuditableEvent.UPDATE_PROFILE_PHONE_NUMBER,
-                        MFAMethodType.SMS,
-                        codeRequest.getProfileInformation(),
-                        ipAddress,
-                        persistentSessionId,
-                        false);
-                break;
-            case ACCOUNT_RECOVERY:
-                dynamoService.setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(
-                        emailAddress, codeRequest.getProfileInformation());
-                submitAuditEvent(
-                        FrontendAuditableEvent.UPDATE_PROFILE_PHONE_NUMBER,
-                        MFAMethodType.SMS,
-                        codeRequest.getProfileInformation(),
-                        ipAddress,
-                        persistentSessionId,
-                        true);
-                break;
+        JourneyType journeyType = codeRequest.getJourneyType();
+        if (journeyType == JourneyType.REGISTRATION
+                || journeyType == JourneyType.ACCOUNT_RECOVERY) {
+            String phoneNumber =
+                    PhoneNumberHelper.formatPhoneNumber(codeRequest.getProfileInformation());
+
+            submitRequestToExperianPhoneCheckSQSQueue(journeyType, phoneNumber);
+
+            switch (journeyType) {
+                case REGISTRATION -> dynamoService.updatePhoneNumberAndAccountVerifiedStatus(
+                        emailAddress, phoneNumber, true, true);
+                case ACCOUNT_RECOVERY -> dynamoService
+                        .setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(emailAddress, phoneNumber);
+            }
+
+            submitAuditEvent(
+                    FrontendAuditableEvent.UPDATE_PROFILE_PHONE_NUMBER,
+                    MFAMethodType.SMS,
+                    phoneNumber,
+                    ipAddress,
+                    persistentSessionId,
+                    journeyType == JourneyType.ACCOUNT_RECOVERY);
+        }
+    }
+
+    private void submitRequestToExperianPhoneCheckSQSQueue(
+            JourneyType journeyType, String phoneNumber) {
+        UserProfile userProfile = userContext.getUserProfile().get();
+        boolean phoneNumberVerified = userProfile.isPhoneNumberVerified();
+        boolean updatedPhoneNumber = !phoneNumber.equals(userProfile.getPhoneNumber());
+
+        if (configurationService.isPhoneCheckerWithReplyEnabled()
+                && (journeyType != JourneyType.ACCOUNT_RECOVERY || updatedPhoneNumber)) {
+            Session session = userContext.getSession();
+            String internalCommonSubjectIdentifier =
+                    session != null ? session.getInternalCommonSubjectIdentifier() : "";
+
+            var phoneNumberRequest =
+                    new PhoneNumberRequest(
+                            phoneNumberVerified,
+                            phoneNumber,
+                            updatedPhoneNumber,
+                            journeyType,
+                            internalCommonSubjectIdentifier);
+            try {
+                sqsClient.send(objectMapper.writeValueAsString(phoneNumberRequest));
+            } catch (Exception e) {
+                LOG.error(
+                        "Unexpected exception when writing phone number request to experian checker SQS queue: {}",
+                        e.getMessage());
+            }
         }
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
@@ -8,6 +8,7 @@ import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
@@ -24,6 +25,7 @@ class MfaCodeProcessorFactoryTest {
     private final AuditService auditService = mock(AuditService.class);
     private final UserContext userContext = mock(UserContext.class);
     private final Session session = mock(Session.class);
+    private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final DynamoAccountModifiersService accountModifiersService =
             mock(DynamoAccountModifiersService.class);
     private final MfaCodeProcessorFactory mfaCodeProcessorFactory =
@@ -61,6 +63,7 @@ class MfaCodeProcessorFactoryTest {
     void whenMfaMethodGeneratesPhoneNumberCodeProcessor() {
         when(session.getEmailAddress()).thenReturn("test@test.com");
         when(userContext.getSession()).thenReturn(session);
+        when(configurationService.getAwsRegion()).thenReturn("eu-west-2");
         var mfaCodeProcessor =
                 mfaCodeProcessorFactory.getMfaCodeProcessor(
                         MFAMethodType.SMS,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -8,18 +8,22 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.entity.PhoneNumberRequest;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
@@ -44,15 +48,18 @@ class PhoneNumberCodeProcessorTest {
     private final Session session = mock(Session.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final UserContext userContext = mock(UserContext.class);
+    private final UserProfile userProfile = mock(UserProfile.class);
     private final AuditService auditService = mock(AuditService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final DynamoAccountModifiersService accountModifiersService =
             mock(DynamoAccountModifiersService.class);
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@example.com";
     private static final String VALID_CODE = "123456";
     private static final String INVALID_CODE = "826272";
     private static final String PHONE_NUMBER = "+447700900000";
+    private static final String DIFFERENT_PHONE_NUMBER = "+447700900001";
     private static final String PERSISTENT_ID = "some-persistent-session-id";
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final String SESSION_ID = "a-session-id";
@@ -273,12 +280,87 @@ class PhoneNumberCodeProcessorTest {
         verifyNoInteractions(auditService);
     }
 
+    @Test
+    void shouldSendPhoneNumberRequestToSqsClientIfFeatureSwitchIsOnDuringRegistration() {
+        when(configurationService.isPhoneCheckerWithReplyEnabled()).thenReturn(true);
+        setupPhoneNumberCode(
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, VALID_CODE, JourneyType.REGISTRATION, PHONE_NUMBER),
+                CodeRequestType.SMS_REGISTRATION);
+
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+
+        verify(sqsClient)
+                .send(
+                        SerializationService.getInstance()
+                                .writeValueAsString(
+                                        new PhoneNumberRequest(
+                                                true,
+                                                PHONE_NUMBER,
+                                                true,
+                                                JourneyType.REGISTRATION,
+                                                INTERNAL_SUB_ID)));
+    }
+
+    @Test
+    void shouldSendPhoneNumberRequestToSqsClientIfFeatureSwitchIsOnDuringAccountRecovery() {
+        when(configurationService.isPhoneCheckerWithReplyEnabled()).thenReturn(true);
+        setupPhoneNumberCode(
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, VALID_CODE, JourneyType.ACCOUNT_RECOVERY, PHONE_NUMBER),
+                CodeRequestType.SMS_ACCOUNT_RECOVERY);
+
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+
+        verify(sqsClient)
+                .send(
+                        SerializationService.getInstance()
+                                .writeValueAsString(
+                                        new PhoneNumberRequest(
+                                                true,
+                                                PHONE_NUMBER,
+                                                true,
+                                                JourneyType.ACCOUNT_RECOVERY,
+                                                INTERNAL_SUB_ID)));
+    }
+
+    @Test
+    void
+            shouldNotSendPhoneNumberRequestToSqsClientIfFeatureSwitchIsOnDuringAccountRecoveryUsingSamePhoneNumber() {
+        when(configurationService.isPhoneCheckerWithReplyEnabled()).thenReturn(true);
+        setupPhoneNumberCode(
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, VALID_CODE, JourneyType.ACCOUNT_RECOVERY, PHONE_NUMBER),
+                CodeRequestType.SMS_ACCOUNT_RECOVERY);
+        when(userProfile.getPhoneNumber()).thenReturn(PHONE_NUMBER);
+
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+
+        verifyNoInteractions(sqsClient);
+    }
+
+    @Test
+    void shouldNotSendPhoneNumberRequestToSqsClientIfFeatureSwitchIsOff() {
+        when(configurationService.isPhoneCheckerWithReplyEnabled()).thenReturn(false);
+        setupPhoneNumberCode(
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, VALID_CODE, JourneyType.REGISTRATION, PHONE_NUMBER),
+                CodeRequestType.SMS_REGISTRATION);
+
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+
+        verifyNoInteractions(sqsClient);
+    }
+
     public void setupPhoneNumberCode(CodeRequest codeRequest, CodeRequestType codeRequestType) {
         when(session.getEmailAddress()).thenReturn(TEST_EMAIL_ADDRESS);
         when(session.getSessionId()).thenReturn(SESSION_ID);
         when(session.getInternalCommonSubjectIdentifier()).thenReturn(INTERNAL_SUB_ID);
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(userContext.getSession()).thenReturn(session);
+        when(userContext.getUserProfile()).thenReturn(Optional.of(userProfile));
+        when(userProfile.isPhoneNumberVerified()).thenReturn(true);
+        when(userProfile.getPhoneNumber()).thenReturn(DIFFERENT_PHONE_NUMBER);
         when(configurationService.isTestClientsEnabled()).thenReturn(false);
         when(codeStorageService.getOtpCode(
                         TEST_EMAIL_ADDRESS, NotificationType.VERIFY_PHONE_NUMBER))
@@ -296,7 +378,8 @@ class PhoneNumberCodeProcessorTest {
                         codeRequest,
                         authenticationService,
                         auditService,
-                        accountModifiersService);
+                        accountModifiersService,
+                        sqsClient);
     }
 
     public void setUpPhoneNumberCodeRetryLimitExceeded(CodeRequest codeRequest) {
@@ -317,7 +400,8 @@ class PhoneNumberCodeProcessorTest {
                         codeRequest,
                         authenticationService,
                         auditService,
-                        accountModifiersService);
+                        accountModifiersService,
+                        sqsClient);
     }
 
     public void setUpBlockedPhoneNumberCode(
@@ -339,7 +423,8 @@ class PhoneNumberCodeProcessorTest {
                         codeRequest,
                         authenticationService,
                         auditService,
-                        accountModifiersService);
+                        accountModifiersService,
+                        sqsClient);
     }
 
     private static Stream<Arguments> codeRequestTypes() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -263,6 +263,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("PENDING_EMAIL_CHECK_QUEUE_URL");
     }
 
+    public String getExperianPhoneCheckerQueueUri() {
+        return System.getenv("EXPERIAN_PHONE_CHECKER_QUEUE_URL");
+    }
+
     public String getSpotQueueUri() {
         return System.getenv("SPOT_QUEUE_URL");
     }
@@ -517,6 +521,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public boolean isTestClientsEnabled() {
         return System.getenv().getOrDefault("TEST_CLIENTS_ENABLED", "false").equals("true");
+    }
+
+    public boolean isPhoneCheckerWithReplyEnabled() {
+        return System.getenv().getOrDefault("PHONE_CHECKER_WITH_RETRY", "false").equals("true");
     }
 
     public String getSyntheticsUsers() {


### PR DESCRIPTION
## What?

Update API to send message to SQS queue after sign up phone validation.

## Why?

When the Experian Phone Checker service (owned by Experian) has an outage then checks against phone numbers fail and do not happen.  There is no failure or DLQ for the transactions, so we have no way of trying to run them again.  The service has failed a few times recently which generates alerts that we have to deal with, but we are unable to recover the transactions.

## Related PRs
[contra indicator PR](https://github.com/govuk-one-login/authentication-contra-indicators/pull/144)

[AUT-2103]: https://govukverify.atlassian.net/browse/AUT-2103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ