### PR TITLE
ATO-324: subscription filter for lambda logs to splunk

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -236,6 +236,14 @@ Resources:
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 14
 
+  OpenIdConfigurationSubscriptionFilter:
+    Condition: IsNotDevEnvironment
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Ref LoggingSubscriptionEndpointArn
+      FilterPattern: ""
+      LogGroupName: !Ref OpenIdConfigurationFunctionLogGroup
+
   OpenIdConfigurationFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -349,6 +357,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${Environment}-trustmark-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 14
+
+  TrustmarkSubscriptionFilter:
+    Condition: IsNotDevEnvironment
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Ref LoggingSubscriptionEndpointArn
+      FilterPattern: ""
+      LogGroupName: !Ref TrustmarkFunctionLogGroup
 
   TrustmarkFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -468,6 +484,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${Environment}-backchannel-logout-request-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 14
+
+  BackChannelLogoutRequestSubscriptionFilter:
+    Condition: IsNotDevEnvironment
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Ref LoggingSubscriptionEndpointArn
+      FilterPattern: ""
+      LogGroupName: !Ref BackChannelLogoutRequestFunctionLogGroup
 
   BackChannelLogoutRequestFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -652,6 +676,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${Environment}-doc-app-callback-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 14
+
+  DocAppSubscriptionFilter:
+    Condition: IsNotDevEnvironment
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Ref LoggingSubscriptionEndpointArn
+      FilterPattern: ""
+      LogGroupName: !Ref DocAppCallbackFunctionLogGroup
 
   DocAppCallbackFunctionCrossAccountPermission:
     Type: AWS::Lambda::Permission
@@ -942,6 +974,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${Environment}-jwks-lambda
       KmsKeyId: !GetAtt MainKmsKey.Arn
       RetentionInDays: 14
+
+  JwksSubscriptionFilter:
+    Condition: IsNotDevEnvironment
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Ref LoggingSubscriptionEndpointArn
+      FilterPattern: ""
+      LogGroupName: !Ref JwksFunctionLogGroup
 
   JwksFunctionErrorMetricFilter:
     Type: AWS::Logs::MetricFilter


### PR DESCRIPTION
Add subscription filter for lambdas:

OpenIdConfiguration
Trustmark
BackChannelLogoutRequest
DocAppSubscription
JwksSubscription

