### PR TITLE
AUT-2155: add cloudwatch metrics

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -196,10 +196,7 @@ public class SendOtpNotificationHandler
                                                 persistentSessionId,
                                                 IpAddressHelper.extractIpAddress(input),
                                                 JourneyType.ACCOUNT_MANAGEMENT,
-                                                String.valueOf(
-                                                        NowHelper.now()
-                                                                .toInstant()
-                                                                .getEpochSecond()))));
+                                                NowHelper.now().toInstant().getEpochSecond())));
                     }
 
                     return handleNotificationRequest(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -157,7 +157,7 @@ class SendOtpNotificationHandlerTest {
                 verify(pendingEmailCheckSqsClient)
                         .send(
                                 format(
-                                        "{\"requestReference\":\"%s\",\"emailAddress\":\"%s\",\"userSessionId\":\"%s\",\"govukSigninJourneyId\":\"%s\",\"persistentSessionId\":\"%s\",\"ipAddress\":\"%s\",\"journeyType\":\"%s\",\"timeOfInitialRequest\":\"%s\"}",
+                                        "{\"requestReference\":\"%s\",\"emailAddress\":\"%s\",\"userSessionId\":\"%s\",\"govukSigninJourneyId\":\"%s\",\"persistentSessionId\":\"%s\",\"ipAddress\":\"%s\",\"journeyType\":\"%s\",\"timeOfInitialRequest\":%d}",
                                         mockedUUID,
                                         TEST_EMAIL_ADDRESS,
                                         "some-session-id",

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -297,10 +297,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                                             persistentSessionId,
                                             IpAddressHelper.extractIpAddress(input),
                                             JourneyType.REGISTRATION,
-                                            String.valueOf(
-                                                    NowHelper.now()
-                                                            .toInstant()
-                                                            .getEpochSecond()))));
+                                            NowHelper.now().toInstant().getEpochSecond())));
                 }
             }
             var notifyRequest =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -218,7 +218,7 @@ class SendNotificationHandlerTest {
                     verify(pendingEmailCheckSqsClient)
                             .send(
                                     format(
-                                            "{\"requestReference\":\"%s\",\"emailAddress\":\"%s\",\"userSessionId\":\"%s\",\"govukSigninJourneyId\":\"%s\",\"persistentSessionId\":\"%s\",\"ipAddress\":\"%s\",\"journeyType\":\"%s\",\"timeOfInitialRequest\":\"%s\"}",
+                                            "{\"requestReference\":\"%s\",\"emailAddress\":\"%s\",\"userSessionId\":\"%s\",\"govukSigninJourneyId\":\"%s\",\"persistentSessionId\":\"%s\",\"ipAddress\":\"%s\",\"journeyType\":\"%s\",\"timeOfInitialRequest\":%d}",
                                             mockedUUID,
                                             TEST_EMAIL_ADDRESS,
                                             session.getSessionId(),

--- a/shared/src/main/java/uk/gov/di/authentication/entity/PendingEmailCheckRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/PendingEmailCheckRequest.java
@@ -15,4 +15,4 @@ public record PendingEmailCheckRequest(
         @SerializedName("persistentSessionId") @Expose @Required String persistentSessionId,
         @SerializedName("ipAddress") @Expose @Required String ipAddress,
         @SerializedName("journeyType") @Expose @Required JourneyType journeyType,
-        @SerializedName("timeOfInitialRequest") @Expose @Required String timeOfInitialRequest) {}
+        @SerializedName("timeOfInitialRequest") @Expose @Required Long timeOfInitialRequest) {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -7,7 +7,8 @@ public enum CloudwatchMetrics {
             "AuthenticationSuccessExistingAccountByClient"),
     SIGN_IN_NEW_ACCOUNT_BY_CLIENT("SignInNewAccountByClient"),
     SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT("SignInExistingAccountByClient"),
-    LOGOUT_SUCCESS("LogoutSuccess");
+    LOGOUT_SUCCESS("LogoutSuccess"),
+    EMAIL_CHECK_DURATION("EmailCheckDuration");
     private String value;
 
     CloudwatchMetrics(String value) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultSqsMessage.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultSqsMessage.java
@@ -8,4 +8,5 @@ public record EmailCheckResultSqsMessage(
         @Expose @SerializedName("Email") @Required String email,
         @Expose @SerializedName("Status") @Required EmailCheckResultStatus emailCheckResultStatus,
         @Expose @SerializedName("TimeToExist") @Required long timeToExist,
-        @Expose @SerializedName("ReferenceNumber") @Required String referenceNumber) {}
+        @Expose @SerializedName("ReferenceNumber") @Required String referenceNumber,
+        @Expose @SerializedName("TimeOfInitialRequest") @Required long timeOfInitialRequest) {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -18,6 +18,7 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_EXISTING_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_NEW_ACCOUNT_BY_CLIENT;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.EMAIL_CHECK_DURATION;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.LOGOUT_SUCCESS;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SIGN_IN_NEW_ACCOUNT_BY_CLIENT;
@@ -142,5 +143,12 @@ public class CloudwatchMetricsService {
                         configurationService.getEnvironment(),
                         CLIENT.getValue(),
                         clientId.orElse("unknown")));
+    }
+
+    public void logEmailCheckDuration(long duration) {
+        this.putEmbeddedValue(
+                EMAIL_CHECK_DURATION.getValue(),
+                duration,
+                Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
     }
 }


### PR DESCRIPTION
## What
Add a Cloudwatch metric with a dimension of timeFromInitial request, which is the delta between TimeOfInitialRequest (as captured in the SQS message) and now().

## Why

The intent here is to be able to assess the length of time it has taken to get a result as a metric.

## How to review

1. Code Review




