### PR TITLE
AUT-2165: log the status of Experian email check during update email process

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -4,6 +4,7 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
 import uk.gov.di.accountmanagement.lambda.UpdateEmailHandler;
@@ -11,6 +12,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
 import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.Collections;
@@ -36,6 +38,10 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final Subject SUBJECT = new Subject();
     private static final String INTERNAl_SECTOR_HOST = "test.account.gov.uk";
     private static final String CLIENT_ID = "some-client-id";
+
+    @RegisterExtension
+    protected static final EmailCheckResultExtension emailCheckResultExtension =
+            new EmailCheckResultExtension();
 
     @BeforeEach
     void setup() {

--- a/ci/terraform/account-management/dynamo-policies.tf
+++ b/ci/terraform/account-management/dynamo-policies.tf
@@ -18,6 +18,25 @@ data "aws_dynamodb_table" "account_modifiers_table" {
   name = "${var.environment}-account-modifiers"
 }
 
+data "aws_dynamodb_table" "email_check_results_table" {
+  name = "${var.environment}-email-check-result"
+}
+data "aws_iam_policy_document" "check_email_fraud_block_read_dynamo_read_access_policy" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+    ]
+    resources = [
+      data.aws_dynamodb_table.email_check_results_table.arn,
+      "${data.aws_dynamodb_table.email_check_results_table.arn}/index/*",
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -251,4 +270,12 @@ resource "aws_iam_policy" "dynamo_am_account_modifiers_delete_access_policy" {
   description = "IAM policy for managing delete permissions to the Dynamo Account Modifiers table"
 
   policy = data.aws_iam_policy_document.dynamo_am_account_modifiers_delete_access_policy_document.json
+}
+
+resource "aws_iam_policy" "check_email_fraud_block_read_dynamo_read_access_policy" {
+  name_prefix = "dynamo-email-check-results-read-policy"
+  path        = "/${var.environment}/am-shared/"
+  description = "IAM policy for managing read permissions to the Dynamo Email Check Results table"
+
+  policy = data.aws_iam_policy_document.check_email_fraud_block_read_dynamo_read_access_policy.json
 }

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -8,6 +8,7 @@ module "account_management_api_update_email_role" {
     aws_iam_policy.dynamo_am_user_read_access_policy.arn,
     aws_iam_policy.dynamo_am_user_write_access_policy.arn,
     aws_iam_policy.dynamo_am_user_delete_access_policy.arn,
+    aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.parameter_policy.arn,
     module.account_management_txma_audit.access_policy_arn,


### PR DESCRIPTION
## What

In UpdateEmail lambda in the Account Management API, added a step check the status of the users fraudulent email check for the new email address that the user is proposing to update their profile to use and log the result.

Interim stage of email phone check process where we will log the status of the asynchronous request sent to Experian to get an idea of how long it takes

## How to review

1. Code Review
2. Deploy and confirm role permissioning if necessary as in below screenshot

## Checklist


- [x] Impact on orch and auth mutual dependencies has been checked.

## Dynamo access evidence

<img width="1652" alt="Screenshot 2024-05-23 at 13 32 05" src="https://github.com/govuk-one-login/authentication-api/assets/144702012/d03f5935-e558-4b03-94f9-460073df018a">
