### PR TITLE
BAU: Deploy reauth endpoint in integration

### DIFF
--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -42,7 +42,7 @@ locals {
 
   request_tracing_allowed              = contains(["build", "sandpit"], var.environment)
   deploy_account_interventions_count   = 1
-  deploy_reauth_user_count             = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
+  deploy_reauth_user_count             = contains(["build", "sandpit", "authdev1", "authdev2", "staging", "integration"], var.environment) ? 1 : 0
   deploy_check_email_fraud_block_count = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
 
   access_logging_template = jsonencode({


### PR DESCRIPTION

## What

Deploy reauth endpoint in integration.

The endpoint is not currently deployed.

## How to review

1. Code Review

## Related 

https://github.com/govuk-one-login/authentication-frontend/pull/1644
