### PR TITLE
ATO-571: Accept a list of audiences in the auth external token endpoint

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.id.Audience;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
@@ -30,6 +31,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
@@ -117,9 +119,17 @@ public class TokenHandler
             var authExternalApiTokenEndpoint =
                     buildURI(authenticationBackendURI.toString(), "token");
 
+            var orchestrationBackendURI = configurationService.getOrchestrationBackendURI();
+            var orchAuthExternalApiTokenEndpoint =
+                    buildURI(orchestrationBackendURI.toString(), "token");
+
+            var expectedAudience =
+                    Set.of(
+                            new Audience(authExternalApiTokenEndpoint),
+                            new Audience(orchAuthExternalApiTokenEndpoint));
             tokenRequestValidator.validatePrivateKeyJwtClientAuth(
                     input.getBody(),
-                    authExternalApiTokenEndpoint,
+                    expectedAudience,
                     configurationService.getOrchestrationToAuthenticationSigningPublicKey());
 
             String suppliedAuthCode = requestBody.get("code");

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/validators/TokenRequestValidator.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/validators/TokenRequestValidator.java
@@ -15,11 +15,10 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.authentication.shared.validation.PrivateKeyJwtAuthPublicKeySelector;
 
-import java.net.URI;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 public class TokenRequestValidator {
     private static final Logger LOG = LogManager.getLogger(TokenRequestValidator.class);
@@ -72,7 +71,7 @@ public class TokenRequestValidator {
     }
 
     public void validatePrivateKeyJwtClientAuth(
-            String requestBody, URI expectedAudience, String publicKey)
+            String requestBody, Set<Audience> expectedAudience, String publicKey)
             throws TokenAuthInvalidException {
         try {
             PrivateKeyJWT privateKeyJWT = PrivateKeyJWT.parse(requestBody);
@@ -80,7 +79,7 @@ public class TokenRequestValidator {
             ClientAuthenticationVerifier<?> signatureVerifier =
                     new ClientAuthenticationVerifier<>(
                             new PrivateKeyJwtAuthPublicKeySelector(publicKey, KeyType.EC),
-                            Collections.singleton(new Audience(expectedAudience)));
+                            expectedAudience);
             signatureVerifier.verify(privateKeyJWT, null, null);
         } catch (ParseException e) {
             LOG.warn("Unable to parse private_key_jwt", e);

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
@@ -109,6 +109,8 @@ class TokenHandlerTest {
                 .thenReturn(URI.create("https://test-callback.com"));
         when(configurationService.getAuthenticationBackendURI())
                 .thenReturn(URI.create("https://test-backend.com"));
+        when(configurationService.getOrchestrationBackendURI())
+                .thenReturn(URI.create("https://orch-test-backend.com"));
         when(configurationService.getInternalSectorUri()).thenReturn("https://test-backend.com");
 
         accessTokenService = mock(AccessTokenService.class);

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/validators/TokenRequestValidatorTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/validators/TokenRequestValidatorTest.java
@@ -11,6 +11,7 @@ import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.id.Audience;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,12 +21,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.authentication.sharedtest.helper.JwtHelper;
 
-import java.net.URI;
 import java.security.spec.X509EncodedKeySpec;
 import java.text.ParseException;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -165,7 +166,9 @@ class TokenRequestValidatorTest {
 
     @Nested
     class ValidatePrivateKeyJwtAuthTests {
-        private static final URI EXPECTED_AUDIENCE = URI.create("https://example.com/resource");
+        private static final Audience AUDIENCE = new Audience("https://example.com/resource");
+        private static final Set<Audience> EXPECTED_AUDIENCE =
+                Set.of(AUDIENCE, new Audience("https://test.com/resource"));
         private static ECKey VALID_KEY_PAIR;
         private static String VALID_PUBLIC_KEY_AS_X509_STRING;
         private static ECKey ALTERNATE_EC_KEY_PAIR;
@@ -180,7 +183,7 @@ class TokenRequestValidatorTest {
         static void init() throws JOSEException, ParseException {
             String validClientAssertionPayload =
                     getClientAssertionPayload(
-                            EXPECTED_AUDIENCE.toString(),
+                            AUDIENCE.getValue(),
                             "matching-random",
                             "matching-random",
                             9999999999L,

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -34,6 +34,7 @@ module "auth_token" {
     AUTHENTICATION_AUTHORIZATION_CALLBACK_URI = var.authentication_auth_callback_uri
     ORCH_CLIENT_ID                            = var.orch_client_id
     AUTHENTICATION_BACKEND_URI                = "https://${aws_api_gateway_rest_api.di_auth_ext_api.id}-${data.aws_vpc_endpoint.auth_api_vpc_endpoint.id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
+    ORCHESTRATION_BACKEND_URI                 = "https://${aws_api_gateway_rest_api.di_auth_ext_api.id}-${var.orch_api_vpc_endpoint_id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
     ORCH_TO_AUTH_TOKEN_SIGNING_PUBLIC_KEY     = var.orch_to_auth_public_signing_key
     INTERNAl_SECTOR_URI                       = var.internal_sector_uri
   }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -187,6 +187,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return URI.create(System.getenv().getOrDefault("AUTHENTICATION_BACKEND_URI", ""));
     }
 
+    public URI getOrchestrationBackendURI() {
+        return URI.create(System.getenv().getOrDefault("ORCHESTRATION_BACKEND_URI", ""));
+    }
+
     public String getContactUsLinkRoute() {
         return System.getenv().getOrDefault("CONTACT_US_LINK_ROUTE", "");
     }


### PR DESCRIPTION
The URL of the private api gateway for the auth external api included the VPCE ID it is accessed through. That means when orch moves to a new AWS account, the audience in their client assertion changes. This change accepts either audience.

