### PR TITLE
AUT-2779: Fix issues triggering EmailCheckResultWriterHandler

### DIFF
--- a/ci/terraform/account-management/authdev1.tfvars
+++ b/ci/terraform/account-management/authdev1.tfvars
@@ -15,5 +15,3 @@ lambda_min_concurrency = 0
 lockout_duration                          = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
-
-support_email_check_enabled = true

--- a/ci/terraform/account-management/authdev2.tfvars
+++ b/ci/terraform/account-management/authdev2.tfvars
@@ -15,5 +15,3 @@ lambda_min_concurrency = 0
 lockout_duration                          = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
-
-support_email_check_enabled = true

--- a/ci/terraform/account-management/dev.tfvars
+++ b/ci/terraform/account-management/dev.tfvars
@@ -13,5 +13,3 @@ scaling_trigger        = 0.6
 lockout_duration                          = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
-
-support_email_check_enabled = true

--- a/ci/terraform/account-management/staging-overrides.tfvars
+++ b/ci/terraform/account-management/staging-overrides.tfvars
@@ -20,3 +20,5 @@ logging_endpoint_arns = [
 ]
 
 common_state_bucket = "di-auth-staging-tfstate"
+
+support_email_check_enabled = true

--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -58,6 +58,4 @@ orch_redirect_uri = "https://oidc.authdev1.sandpit.account.gov.uk/orchestration-
 
 authorize_protected_subnet_enabled = true
 
-support_email_check_enabled = true
-
 oidc_origin_domain_enabled = true

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -54,7 +54,4 @@ phone_checker_with_retry = false
 orch_redirect_uri                  = "https://oidc.authdev2.sandpit.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
 
-support_email_check_enabled = true
-
-
 oidc_origin_domain_enabled = true

--- a/ci/terraform/oidc/dev-overrides.tfvars
+++ b/ci/terraform/oidc/dev-overrides.tfvars
@@ -50,5 +50,3 @@ lambda_max_concurrency = 0
 lambda_min_concurrency = 1
 endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
-
-support_email_check_enabled = true

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -91,3 +91,5 @@ logging_endpoint_arns = [
 ]
 
 shared_state_bucket = "di-auth-staging-tfstate"
+
+support_email_check_enabled = true

--- a/ci/terraform/utils/build-overrides.tfvars
+++ b/ci/terraform/utils/build-overrides.tfvars
@@ -16,3 +16,5 @@ bulk_user_email_email_sending_enabled = false
 bulk_user_email_batch_query_limit     = 25
 bulk_user_email_max_batch_count       = 100
 bulk_user_email_batch_pause_duration  = 0
+
+support_email_check_enabled = true

--- a/ci/terraform/utils/email_check_results_writer_lambda.tf
+++ b/ci/terraform/utils/email_check_results_writer_lambda.tf
@@ -1,4 +1,5 @@
 resource "aws_lambda_event_source_mapping" "lambda_sqs_mapping" {
+  count            = var.support_email_check_enabled ? 1 : 0
   event_source_arn = var.email_check_results_sqs_queue_arn
   function_name    = aws_lambda_function.email_check_results_writer_lambda.arn
 

--- a/ci/terraform/utils/sandpit.tfvars
+++ b/ci/terraform/utils/sandpit.tfvars
@@ -15,3 +15,4 @@ performance_tuning = {
     timeout = 300
   }
 }
+support_email_check_enabled = true

--- a/ci/terraform/utils/staging-overrides.tfvars
+++ b/ci/terraform/utils/staging-overrides.tfvars
@@ -9,3 +9,5 @@ allow_bulk_test_users = true
 shared_state_bucket = "di-auth-staging-tfstate"
 
 bulk_user_email_included_terms_and_conditions = "1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8"
+
+support_email_check_enabled = true

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -184,3 +184,9 @@ variable "email_check_results_sqs_queue_arn" {
 variable "email_check_results_sqs_queue_encryption_key_arn" {
   description = "ARN of the CMK used for server side encryption on the SQS email results check queue"
 }
+
+variable "support_email_check_enabled" {
+  default     = false
+  type        = bool
+  description = "Feature flag which toggles the Experian email check on and off"
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/EmailCheckResultWriterIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/EmailCheckResultWriterIntegrationTest.java
@@ -58,7 +58,7 @@ class EmailCheckResultWriterIntegrationTest extends HandlerIntegrationTest<SQSEv
         if (doesMessageContainRequiredFields) {
             sqsMessage.setBody(
                     String.format(
-                            "{ \"Email\": \"%s\", \"Status\": \"%s\", \"TimeToExist\": \"%d\", \"ReferenceNumber\": \"%s\" }",
+                            "{ \"EmailAddress\": \"%s\", \"Status\": \"%s\", \"TimeToExist\": \"%d\", \"RequestReference\": \"%s\", \"TimeOfInitialRequest\":1000 }",
                             TEST_MSG_EMAIL,
                             status.toString(),
                             TEST_MSG_TIME_TO_EXIST,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultSqsMessage.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/EmailCheckResultSqsMessage.java
@@ -5,8 +5,8 @@ import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.validation.Required;
 
 public record EmailCheckResultSqsMessage(
-        @Expose @SerializedName("Email") @Required String email,
-        @Expose @SerializedName("Status") @Required EmailCheckResultStatus emailCheckResultStatus,
+        @Expose @SerializedName("EmailAddress") @Required String emailAddress,
+        @Expose @SerializedName("Status") @Required EmailCheckResultStatus status,
         @Expose @SerializedName("TimeToExist") @Required long timeToExist,
-        @Expose @SerializedName("ReferenceNumber") @Required String referenceNumber,
+        @Expose @SerializedName("RequestReference") @Required String requestReference,
         @Expose @SerializedName("TimeOfInitialRequest") @Required long timeOfInitialRequest) {}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
@@ -58,14 +58,14 @@ public class EmailCheckResultWriterHandler implements RequestHandler<SQSEvent, V
                         objectMapper.readValue(msg.getBody(), EmailCheckResultSqsMessage.class);
 
                 db.saveEmailCheckResult(
-                        emailCheckResult.email(),
-                        emailCheckResult.emailCheckResultStatus(),
+                        emailCheckResult.emailAddress(),
+                        emailCheckResult.status(),
                         emailCheckResult.timeToExist(),
-                        emailCheckResult.referenceNumber());
+                        emailCheckResult.requestReference());
 
                 LOG.info(
                         "Message for email check reference {} written to database",
-                        emailCheckResult.referenceNumber());
+                        emailCheckResult.requestReference());
                 var duration = now().getTime() - emailCheckResult.timeOfInitialRequest();
 
                 cloudwatchMetricsService.logEmailCheckDuration(duration);

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandlerTest.java
@@ -92,7 +92,7 @@ class EmailCheckResultWriterHandlerTest {
         if (doesMessageContainRequiredFields) {
             sqsMessage.setBody(
                     String.format(
-                            "{ \"Email\": \"%s\", \"Status\": \"%s\", \"TimeToExist\": \"%d\", \"ReferenceNumber\": \"%s\" }",
+                            "{ \"EmailAddress\": \"%s\", \"Status\": \"%s\", \"TimeToExist\": \"%d\", \"RequestReference\": \"%s\", \"TimeOfInitialRequest\":1000 }",
                             TEST_MSG_EMAIL,
                             status.toString(),
                             TEST_MSG_TIME_TO_EXIST,


### PR DESCRIPTION
## What


### Disable email check in all but one dev env
As there is a one-to-one relationship between the authentication-check-experian dev environment and the authentication-api sandpit environment, no other API dev environment is supported as it confuses matters and breaks workflows when cross account communication occurs. This may be resolvable in the future, but for now we're disabling the integration for all but the sandpit development environment


### Only deploy SQS trigger in supported envs
Added `support_email_check_enabled` to the utils module so we only deploy the email writer result SQS event trigger in supported environments. Set those environments to sandpit, build and staging.

This is to avoid cross account confusion and user journey breakages when a user creates an account in sandpit, the risk assessment is received and the writer lambda in authdev* or dev writes to it's own DynamoDB table


### Reconcile email check result message properties
The authentication-check-experian repo was writing messages with a different structure as to what authentication-api was expecting to receive. Here we make it match what is received.

There could be further opportunity to change the names of the DynamoDB fields, but that goes beyond the scope of AUT-2779 and is functionally irrelevant at the moment.


### Enable email check in staging
Manual integration testing/verification will take place in the staging environment


## How to review

- Read commit-by-commit
- Ensure only sandpit, build and staging has the `support_email_check_enabled` TF var set to true.

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.

