### PR TITLE
BAU: Enable identity in the build environment

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -8,6 +8,7 @@ logging_endpoint_arns                = []
 shared_state_bucket                  = "digital-identity-dev-tfstate"
 test_clients_enabled                 = true
 internal_sector_uri                  = "https://identity.build.account.gov.uk"
+ipv_api_enabled                      = true
 
 # lockout config
 lockout_duration                     = 60


### PR DESCRIPTION

## What

Enable identity in the build environment.

To facilitate testing of identity journeys in auth, where there are still identity specific pathways. Makes the build environment match production.
As there is no ipv stub in build it will not be possible to complete an identity journey back through orchestration, but it will still be possible to test the entire auth journey.

## How to review

1. Code Review (identity is already switched on in the sandpits)
