### PR TITLE
ATO-675: cloudfront build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 build/
 .gradle
 build
+!ci/cloudfront-orchestration/*/build
 **/.terraform/
 │**/*.tfstate*
 **/out

--- a/ci/cloudfront-orchestration/waf/build/parameters.json
+++ b/ci/cloudfront-orchestration/waf/build/parameters.json
@@ -1,0 +1,6 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  }
+]

--- a/ci/cloudfront-orchestration/waf/build/tags.json
+++ b/ci/cloudfront-orchestration/waf/build/tags.json
@@ -1,0 +1,22 @@
+[
+  {
+    "Key": "Product",
+    "Value": "GOV.UK Sign In"
+  },
+  {
+    "Key": "System",
+    "Value": "Orchestration"
+  },
+  {
+    "Key": "Environment",
+    "Value": "build"
+  },
+  {
+    "Key": "Owner",
+    "Value": "di-orchestration@digital.cabinet-office.gov.uk"
+  },
+  {
+    "Key": "Repository",
+    "Value": "govuk-one-login/authentication-api"
+  }
+]

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -46,3 +46,5 @@ phone_checker_with_retry = true
 orch_openid_configuration_name = "build-OpenIdConfigurationFunction"
 
 orch_account_id = "767397776536"
+
+oidc_origin_domain_enabled = true


### PR DESCRIPTION
## What
- Build settings for cloudfront WAF
- Enable origin.oidc.build.account.gov.uk