### PR TITLE
ATO-387: Remove consent required (ipv-api)

### DIFF
--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -914,7 +914,6 @@ class IPVCallbackHandlerTest {
     private static ClientRegistry generateClientRegistryNoClaims() {
         return new ClientRegistry()
                 .withClientID(CLIENT_ID.getValue())
-                .withConsentRequired(false)
                 .withClientName("test-client")
                 .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
                 .withSectorIdentifierUri("https://test.com")
@@ -924,7 +923,6 @@ class IPVCallbackHandlerTest {
     private static ClientRegistry generateClientWithReturnCodes() {
         return new ClientRegistry()
                 .withClientID(CLIENT_ID.getValue())
-                .withConsentRequired(false)
                 .withClientName("test-client")
                 .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
                 .withSectorIdentifierUri("https://test.com")


### PR DESCRIPTION
## What

Remove consent required from ipv-api module
