### PR TITLE
ATO-673: cloudfront integration prereqs

### DIFF
--- a/ci/cloudfront-orchestration/waf/integration/parameters.json
+++ b/ci/cloudfront-orchestration/waf/integration/parameters.json
@@ -1,0 +1,6 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "integration"
+  }
+]

--- a/ci/cloudfront-orchestration/waf/integration/tags.json
+++ b/ci/cloudfront-orchestration/waf/integration/tags.json
@@ -1,0 +1,22 @@
+[
+  {
+    "Key": "Product",
+    "Value": "GOV.UK Sign In"
+  },
+  {
+    "Key": "System",
+    "Value": "Orchestration"
+  },
+  {
+    "Key": "Environment",
+    "Value": "integration"
+  },
+  {
+    "Key": "Owner",
+    "Value": "di-orchestration@digital.cabinet-office.gov.uk"
+  },
+  {
+    "Key": "Repository",
+    "Value": "govuk-one-login/authentication-api"
+  }
+]

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -39,3 +39,5 @@ contra_state_bucket      = "digital-identity-dev-tfstate"
 phone_checker_with_retry = false
 
 orch_account_id = "058264132019"
+
+oidc_origin_domain_enabled = true


### PR DESCRIPTION
## What
Just like https://github.com/govuk-one-login/authentication-api/pull/4594 but for integration. Doesn't affect anything until DNS cutover, just setting up prereqs