### PR TITLE
ATO-674: Cloudfront production prereqs

### DIFF
--- a/ci/cloudfront-orchestration/waf/production/parameters.json
+++ b/ci/cloudfront-orchestration/waf/production/parameters.json
@@ -1,0 +1,6 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "production"
+  }
+]

--- a/ci/cloudfront-orchestration/waf/production/tags.json
+++ b/ci/cloudfront-orchestration/waf/production/tags.json
@@ -1,0 +1,22 @@
+[
+  {
+    "Key": "Product",
+    "Value": "GOV.UK Sign In"
+  },
+  {
+    "Key": "System",
+    "Value": "Orchestration"
+  },
+  {
+    "Key": "Environment",
+    "Value": "production"
+  },
+  {
+    "Key": "Owner",
+    "Value": "di-orchestration@digital.cabinet-office.gov.uk"
+  },
+  {
+    "Key": "Repository",
+    "Value": "govuk-one-login/authentication-api"
+  }
+]

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -39,3 +39,5 @@ contra_state_bucket      = "digital-identity-prod-tfstate"
 phone_checker_with_retry = false
 
 orch_account_id = "533266965190"
+
+oidc_origin_domain_enabled = true


### PR DESCRIPTION
## What

Similar to https://github.com/govuk-one-login/authentication-api/pull/4594 but for production. Won't impact any traffic until DNS cutover tomorrow, just some prereqs