### PR TITLE
Revert "Bump govuk-one-login/devplatform-upload-action from 3.8 to 3.9"

### DIFF
--- a/.github/workflows/deploy-orch.yml
+++ b/.github/workflows/deploy-orch.yml
@@ -52,7 +52,7 @@ jobs:
         run: sam build --cached --parallel
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@3.9
+        uses: govuk-one-login/devplatform-upload-action@v3.8
         with:
           artifact-bucket-name: ${{ secrets.ORCH_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.ORCH_SIGNING_PROFILE_NAME }}


### PR DESCRIPTION
Reverts govuk-one-login/authentication-api#4497

From devplatform:
I can see that you merged in a dependabot PR yesterday to bump the devplatform-upload-action-3.9 . This was actually a pre-release for testing only. Looks like due to the lack of -beta tag dependabot picked it up. Its not breaking anything but when you get time could you please downgrade to the v3.8.1 version please? https://github.com/govuk-one-login/devplatform-upload-action/releases/tag/v3.8.1
We will be removing the 3.9 tag once you have moved onto v3.8.1