### PR TITLE
AUT-2816: Align OTP TTL with Count TTL where OTP TTL > Count TTL

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -11,11 +11,14 @@ internal_sector_uri                  = "https://identity.build.account.gov.uk"
 ipv_api_enabled                      = true
 
 # lockout config
-lockout_duration                     = 60
-reduced_lockout_duration             = 30
-incorrect_password_lockout_count_ttl = 60
-lockout_count_ttl                    = 60
-otp_code_ttl_duration                = 60
+lockout_duration                          = 60
+reduced_lockout_duration                  = 30
+incorrect_password_lockout_count_ttl      = 60
+lockout_count_ttl                         = 60
+otp_code_ttl_duration                     = 60
+account_creation_lockout_count_ttl        = 60
+support_account_creation_count_ttl        = true
+email_acct_creation_otp_code_ttl_duration = 60
 
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -13,6 +13,7 @@ authorize_protected_subnet_enabled   = true
 lockout_duration                     = 7200
 reduced_lockout_duration             = 900
 incorrect_password_lockout_count_ttl = 7200
+support_account_creation_count_ttl   = true
 
 orch_account_id                                 = "590183975515"
 kms_cross_account_access_enabled                = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -208,6 +208,17 @@ variable "lockout_count_ttl" {
   default = 900
 }
 
+variable "account_creation_lockout_count_ttl" {
+  type    = number
+  default = 3600
+}
+
+variable "support_account_creation_count_ttl" {
+  default     = false
+  type        = bool
+  description = "Feature flag which enables using a designated variable for count TTL in the account creation journey"
+}
+
 variable "incorrect_password_lockout_count_ttl" {
   type    = number
   default = 7200

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -29,20 +29,22 @@ module "verify_code" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT                         = var.environment
-    LOCKOUT_DURATION                    = var.lockout_duration
-    TXMA_AUDIT_QUEUE_URL                = module.oidc_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT                 = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY                           = local.redis_key
-    DYNAMO_ENDPOINT                     = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TERMS_CONDITIONS_VERSION            = var.terms_and_conditions
-    TEST_CLIENT_VERIFY_EMAIL_OTP        = var.test_client_verify_email_otp
-    TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP = var.test_client_verify_phone_number_otp
-    TEST_CLIENTS_ENABLED                = var.test_clients_enabled
-    INTERNAl_SECTOR_URI                 = var.internal_sector_uri
-    CODE_MAX_RETRIES_INCREASED          = var.code_max_retries_increased
-    REDUCED_LOCKOUT_DURATION            = var.reduced_lockout_duration
-    LOCKOUT_COUNT_TTL                   = var.lockout_count_ttl
+    ENVIRONMENT                              = var.environment
+    LOCKOUT_DURATION                         = var.lockout_duration
+    TXMA_AUDIT_QUEUE_URL                     = module.oidc_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT                      = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                                = local.redis_key
+    DYNAMO_ENDPOINT                          = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TERMS_CONDITIONS_VERSION                 = var.terms_and_conditions
+    TEST_CLIENT_VERIFY_EMAIL_OTP             = var.test_client_verify_email_otp
+    TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP      = var.test_client_verify_phone_number_otp
+    TEST_CLIENTS_ENABLED                     = var.test_clients_enabled
+    INTERNAl_SECTOR_URI                      = var.internal_sector_uri
+    CODE_MAX_RETRIES_INCREASED               = var.code_max_retries_increased
+    REDUCED_LOCKOUT_DURATION                 = var.reduced_lockout_duration
+    LOCKOUT_COUNT_TTL                        = var.lockout_count_ttl
+    EMAIL_ACCOUNT_CREATION_LOCKOUT_COUNT_TTL = var.account_creation_lockout_count_ttl
+    SUPPORT_ACCOUNT_CREATION_COUNT_TTL       = var.support_account_creation_count_ttl
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest"
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -138,7 +138,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             codeRequest.code(),
                             codeStorageService,
                             session.getEmailAddress(),
-                            configurationService.getCodeMaxRetries());
+                            configurationService);
 
             if (errorResponse.stream().anyMatch(ErrorResponse.ERROR_1002::equals)) {
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -127,7 +127,7 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                         codeRequest.getCode(),
                         codeStorageService,
                         emailAddress,
-                        configurationService.getCodeMaxRetries());
+                        configurationService);
 
         if (errorResponse.isEmpty()) {
             codeStorageService.deleteOtpCode(emailAddress, notificationType);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -67,6 +67,13 @@ public class CodeStorageService {
                 configurationService.getLockoutCountTTL());
     }
 
+    public void increaseIncorrectMfaCodeAttemptsCountAccountCreation(String email) {
+        increaseCount(
+                email,
+                MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX,
+                configurationService.getAccountCreationLockoutCountTTL());
+    }
+
     public void increaseIncorrectMfaCodeAttemptsCount(String email, MFAMethodType mfaMethodType) {
         String prefix = MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX + mfaMethodType.getValue();
         increaseCount(email, prefix, configurationService.getLockoutCountTTL());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -76,6 +76,17 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("LOCKOUT_COUNT_TTL", "900"));
     }
 
+    public long getAccountCreationLockoutCountTTL() {
+        return Long.parseLong(
+                System.getenv().getOrDefault("ACCOUNT_CREATION_LOCKOUT_COUNT_TTL", "3600"));
+    }
+
+    public boolean supportAccountCreationTTL() {
+        return System.getenv()
+                .getOrDefault("SUPPORT_ACCOUNT_CREATION_COUNT_TTL", String.valueOf(false))
+                .equals("true");
+    }
+
     public long getLockoutDuration() {
         return Long.parseLong(System.getenv().getOrDefault("LOCKOUT_DURATION", "900"));
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
@@ -32,6 +32,7 @@ class CodeStorageServiceTest {
     private static final String SUBJECT = "some-subject";
     private static final long CODE_EXPIRY_TIME = 900;
     private static final long PW_CODE_EXPIRY_TIME = 900;
+    private static final long ACCOUNT_CREATION_CODE_EXPIRY_TIME = 3600;
     private static final long AUTH_CODE_EXPIRY_TIME = 300;
     private static final String CODE_BLOCKED_VALUE = "blocked";
     private final RedisConnectionService redisConnectionService =
@@ -77,6 +78,8 @@ class CodeStorageServiceTest {
         when(configurationService.getLockoutCountTTL()).thenReturn(CODE_EXPIRY_TIME);
         when(configurationService.getIncorrectPasswordLockoutCountTTL())
                 .thenReturn(PW_CODE_EXPIRY_TIME);
+        when(configurationService.getAccountCreationLockoutCountTTL())
+                .thenReturn(ACCOUNT_CREATION_CODE_EXPIRY_TIME);
     }
 
     @Test
@@ -370,6 +373,21 @@ class CodeStorageServiceTest {
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),
                         String.valueOf(4),
                         CODE_EXPIRY_TIME);
+    }
+
+    @Test
+    void shouldIncrementCountForIncorrectMfaCodeAttemptsCountAccountCreation() {
+        when(redisConnectionService.getValue(
+                        RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
+                .thenReturn(String.valueOf(0));
+
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(TEST_EMAIL);
+
+        verify(redisConnectionService)
+                .saveWithExpiry(
+                        RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),
+                        String.valueOf(1),
+                        ACCOUNT_CREATION_CODE_EXPIRY_TIME);
     }
 
     @ParameterizedTest

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -36,6 +36,18 @@ class ConfigurationServiceTest {
         assertEquals("Secure; HttpOnly;", configurationService.getSessionCookieAttributes());
     }
 
+    @Test
+    void getAccountCreationLockoutCountTTLShouldEqualDefaultWhenEnvVarUnset() {
+        ConfigurationService configurationService = new ConfigurationService();
+        assertEquals(3600, configurationService.getAccountCreationLockoutCountTTL());
+    }
+
+    @Test
+    void supportAccountCreationTTLShouldEqualDefaultWhenEnvVarUnset() {
+        ConfigurationService configurationService = new ConfigurationService();
+        assertEquals(false, configurationService.supportAccountCreationTTL());
+    }
+
     private static Stream<Arguments> commaSeparatedStringContains() {
         return Stream.of(
                 Arguments.of("1234", null, false),


### PR DESCRIPTION
## What

Align OTP TTL with Count TTL.
As proposed in the description of [AUT-2816](https://govukverify.atlassian.net/browse/AUT-2816), when the count TTL is smaller than the OTP TTL, a user is able to send more than 5 attempts for one code. This PR is looking to fix that by introducing a new variable for the count TTL which is only used in the account creation journeys. 

For scenario 2, in build, the Default_Otp_Code_Expiry was not set in the tf file, making the ResetPasswordRequestHandler.tf use the standard 900 second value for the Otp Code Expiry. This would make the OTP TTL > Count TTL.

## How to review

1. Code Review



[AUT-2816]: https://govukverify.atlassian.net/browse/AUT-2816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ