### PR TITLE
BAU: Remove unused configuration flags

### DIFF
--- a/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
+++ b/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
@@ -42,12 +42,8 @@ class NotifyCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
     private static final IntegrationTestConfigurationService CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
-                    auditTopic,
                     notificationsQueue,
-                    auditSigningKey,
                     tokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters,
                     new SystemService()) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -118,12 +118,8 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
         public AccountInterventionsTestConfigurationService(
                 AccountInterventionsStubExtension accountInterventionsStubExtension) {
             super(
-                    auditTopic,
                     notificationsQueue,
-                    auditSigningKey,
                     tokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters);
             this.accountInterventionsStubExtension = accountInterventionsStubExtension;

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
@@ -115,12 +115,8 @@ public class AccountRecoveryIntegrationTest extends ApiGatewayHandlerIntegration
 
         public AccountRecoveryTestConfigurationService() {
             super(
-                    auditTopic,
                     notificationsQueue,
-                    auditSigningKey,
                     tokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters);
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -51,12 +51,8 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
     void setup() {
         var configurationService =
                 new IntegrationTestConfigurationService(
-                        auditTopic,
                         notificationsQueue,
-                        auditSigningKey,
                         tokenSigner,
-                        ipvPrivateKeyJwtSigner,
-                        spotQueue,
                         docAppPrivateKeyJwtSigner,
                         configurationParameters) {
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
@@ -21,8 +21,6 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AccessTokenStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuthCodeExtension;
-import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
-import uk.gov.di.authentication.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
 import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 
@@ -68,13 +66,7 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
     void setup() throws JOSEException {
         var configurationService =
                 new AuthenticationTokenHandlerIntegrationTest.TestConfigurationService(
-                        auditTopic,
-                        notificationsQueue,
-                        auditSigningKey,
-                        tokenSigner,
-                        ipvPrivateKeyJwtSigner,
-                        spotQueue,
-                        docAppPrivateKeyJwtSigner);
+                        notificationsQueue, tokenSigner, docAppPrivateKeyJwtSigner);
 
         handler = new TokenHandler(configurationService);
 
@@ -207,20 +199,12 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
 
     private static class TestConfigurationService extends IntegrationTestConfigurationService {
         public TestConfigurationService(
-                SnsTopicExtension auditEventTopic,
                 SqsQueueExtension notificationQueue,
-                KmsKeyExtension auditSigningKey,
                 TokenSigningExtension tokenSigningKey,
-                TokenSigningExtension ipvPrivateKeyJwtSigner,
-                SqsQueueExtension spotQueue,
                 TokenSigningExtension docAppPrivateKeyJwtSigner) {
             super(
-                    auditEventTopic,
                     notificationQueue,
-                    auditSigningKey,
                     tokenSigningKey,
-                    ipvPrivateKeyJwtSigner,
-                    spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters);
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -37,7 +37,6 @@ import uk.gov.di.orchestration.shared.entity.ServiceType;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
-import uk.gov.di.orchestration.shared.helpers.LocaleHelper;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.extensions.DocAppJwksExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
@@ -129,12 +128,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 @Override
                 public String getTxmaAuditQueueUrl() {
                     return txmaAuditQueue.getQueueUrl();
-                }
-
-                @Override
-                public boolean isLanguageEnabled(LocaleHelper.SupportedLanguage supportedLanguage) {
-                    return supportedLanguage.equals(LocaleHelper.SupportedLanguage.EN)
-                            || supportedLanguage.equals(LocaleHelper.SupportedLanguage.CY);
                 }
 
                 @Override

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -33,8 +33,6 @@ import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.extensions.CriStubExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.DocumentAppCredentialStoreExtension;
-import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
-import uk.gov.di.orchestration.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 
@@ -91,9 +89,6 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     protected final ConfigurationService configurationService =
             new DocAppCallbackHandlerIntegrationTest.TestConfigurationService(
                     criStub,
-                    auditTopic,
-                    notificationsQueue,
-                    auditSigningKey,
                     externalTokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
@@ -374,9 +369,6 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
         public TestConfigurationService(
                 CriStubExtension criStubExtension,
-                SnsTopicExtension auditEventTopic,
-                SqsQueueExtension notificationQueue,
-                KmsKeyExtension auditSigningKey,
                 TokenSigningExtension tokenSigningKey,
                 TokenSigningExtension ipvPrivateKeyJwtSigner,
                 SqsQueueExtension spotQueue,
@@ -412,11 +404,6 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         @Override
         public URI getDocAppAuthorisationCallbackURI() {
             return URI.create("http://localhost/redirect");
-        }
-
-        @Override
-        public String getDocAppCriDataEndpoint() {
-            return "/userinfo/v2";
         }
 
         @Override

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.oidc.lambda.AuthorisationHandler;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.ServiceType;
-import uk.gov.di.orchestration.shared.helpers.LocaleHelper;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
@@ -352,12 +351,6 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
         @Override
         public String getTxmaAuditQueueUrl() {
             return txmaAuditQueue.getQueueUrl();
-        }
-
-        @Override
-        public boolean isLanguageEnabled(LocaleHelper.SupportedLanguage supportedLanguage) {
-            return supportedLanguage.equals(LocaleHelper.SupportedLanguage.EN)
-                    || supportedLanguage.equals(LocaleHelper.SupportedLanguage.CY);
         }
 
         @Override

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -245,12 +245,8 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         public ResetPasswordTestConfigurationService() {
             super(
-                    auditTopic,
                     notificationsQueue,
-                    auditSigningKey,
                     tokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters);
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -393,12 +393,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         public TestConfigurationService() {
             super(
-                    auditTopic,
                     notificationsQueue,
-                    auditSigningKey,
                     tokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters);
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
@@ -49,12 +49,8 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest
     void setup() {
         var configuration =
                 new IntegrationTestConfigurationService(
-                        auditTopic,
                         notificationsQueue,
-                        auditSigningKey,
                         tokenSigner,
-                        ipvPrivateKeyJwtSigner,
-                        spotQueue,
                         docAppPrivateKeyJwtSigner,
                         configurationParameters,
                         new SystemService()) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailSenderScheduledEventHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailSenderScheduledEventHandlerIntegrationTest.java
@@ -279,12 +279,8 @@ public class BulkUserEmailSenderScheduledEventHandlerIntegrationTest
     private static IntegrationTestConfigurationService configWithSendMode(String sendMode) {
         SecureRandom secureRandom = new SecureRandom();
         return new IntegrationTestConfigurationService(
-                auditTopic,
                 notificationsQueue,
-                auditSigningKey,
                 tokenSigner,
-                ipvPrivateKeyJwtSigner,
-                spotQueue,
                 docAppPrivateKeyJwtSigner,
                 configurationParameters) {
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -14,7 +14,6 @@ import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import uk.gov.di.orchestration.shared.configuration.AuditPublisherConfiguration;
 import uk.gov.di.orchestration.shared.configuration.BaseLambdaConfiguration;
 import uk.gov.di.orchestration.shared.exceptions.SSMParameterNotFoundException;
-import uk.gov.di.orchestration.shared.helpers.LocaleHelper.SupportedLanguage;
 
 import java.net.URI;
 import java.time.Clock;
@@ -125,10 +124,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Clock.systemDefaultZone();
     }
 
-    public String getBulkEmailLoaderLambdaName() {
-        return System.getenv().getOrDefault("BULK_USER_EMAIL_AUDIENCE_LOADER_LAMBDA_NAME", "");
-    }
-
     public URI getAuthenticationAuthCallbackURI() {
         return URI.create(
                 System.getenv().getOrDefault("AUTHENTICATION_AUTHORIZATION_CALLBACK_URI", ""));
@@ -179,10 +174,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public String getDocAppTokenSigningKeyAlias() {
         return System.getenv("DOC_APP_TOKEN_SIGNING_KEY_ALIAS");
-    }
-
-    public String getDocAppCriDataEndpoint() {
-        return System.getenv("DOC_APP_CRI_DATA_ENDPOINT");
     }
 
     public String getDocAppCriV2DataEndpoint() {
@@ -262,11 +253,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals("true");
     }
 
-    public boolean isLanguageEnabled(SupportedLanguage supportedLanguage) {
-        return supportedLanguage.equals(SupportedLanguage.EN)
-                || supportedLanguage.equals(SupportedLanguage.CY);
-    }
-
     public long getIDTokenExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
     }
@@ -328,14 +314,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         }
 
         return notifyCallbackBearerToken;
-    }
-
-    boolean commaSeparatedListContains(String searchTerm, String stringToSearch) {
-        return (searchTerm != null
-                && !searchTerm.isBlank()
-                && stringToSearch != null
-                && !stringToSearch.isBlank()
-                && Arrays.stream(stringToSearch.split(",")).anyMatch(id -> id.equals(searchTerm)));
     }
 
     public Optional<String> getOidcApiBaseURL() {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ConfigurationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ConfigurationServiceTest.java
@@ -1,9 +1,7 @@
 package uk.gov.di.orchestration.shared.services;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
 import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
@@ -57,15 +55,6 @@ class ConfigurationServiceTest {
                         "bda5cfb3-3d91-407e-90cc-b690c1fa8bf9",
                         "bda5cfb3-3d91-407e-90cc-b690c1fa8bf9,cc30aac4-4aae-4706-b147-9df40bd2feb8",
                         true));
-    }
-
-    @ParameterizedTest
-    @MethodSource("commaSeparatedStringContains")
-    void shouldCheckCommaSeparatedStringContains(
-            String searchTerm, String searchString, boolean result) {
-        ConfigurationService configurationService = new ConfigurationService();
-        assertEquals(
-                result, configurationService.commaSeparatedListContains(searchTerm, searchString));
     }
 
     @Test

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ConfigurationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ConfigurationServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.orchestration.shared.services;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.provider.Arguments;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
 import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
@@ -9,7 +8,6 @@ import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -31,30 +29,6 @@ class ConfigurationServiceTest {
     void getSessionCookieAttributesShouldEqualDefaultWhenEnvVarUnset() {
         ConfigurationService configurationService = new ConfigurationService();
         assertEquals("Secure; HttpOnly;", configurationService.getSessionCookieAttributes());
-    }
-
-    private static Stream<Arguments> commaSeparatedStringContains() {
-        return Stream.of(
-                Arguments.of("1234", null, false),
-                Arguments.of("1234", "", false),
-                Arguments.of("", "", false),
-                Arguments.of(null, "1234", false),
-                Arguments.of("1234", "1234", true),
-                Arguments.of("1234", "1234,4567", true),
-                Arguments.of("4567", "1234,4567", true),
-                Arguments.of("8901", "1234,4567,8901", true),
-                Arguments.of(
-                        "bda5cfb3-3d91-407e-90cc-b690c1fa8bf9",
-                        "bda5cfb3-3d91-407e-90cc-b690c1fa8bf9",
-                        true),
-                Arguments.of(
-                        "cc30aac4-4aae-4706-b147-9df40bd2feb8",
-                        "bda5cfb3-3d91-407e-90cc-b690c1fa8bf9,cc30aac4-4aae-4706-b147-9df40bd2feb8",
-                        true),
-                Arguments.of(
-                        "bda5cfb3-3d91-407e-90cc-b690c1fa8bf9",
-                        "bda5cfb3-3d91-407e-90cc-b690c1fa8bf9,cc30aac4-4aae-4706-b147-9df40bd2feb8",
-                        true));
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -27,7 +27,6 @@ import uk.gov.di.authentication.sharedtest.extensions.IdentityStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ParameterStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
-import uk.gov.di.authentication.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
 import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
@@ -41,7 +40,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.lang.String.valueOf;
 import static java.util.Collections.singletonList;
+import static java.util.Map.entry;
 import static org.mockito.Mockito.mock;
 import static uk.gov.di.authentication.shared.lambda.BaseFrontendHandler.TXMA_AUDIT_ENCODED_HEADER;
 
@@ -51,25 +52,9 @@ public abstract class HandlerIntegrationTest<Q, S> {
     private static final String REDIS_PASSWORD = null;
     private static final boolean DOES_REDIS_USE_TLS = false;
     private static final String BEARER_TOKEN = "notify-test-@bearer-token";
-    protected static final String LOCAL_ENDPOINT_FORMAT =
-            "http://localhost:45678/restapis/%s/local/_user_request_";
-    protected static final String LOCAL_API_GATEWAY_ID =
-            Optional.ofNullable(System.getenv().get("API_GATEWAY_ID")).orElse("");
-    protected static final String API_KEY =
-            Optional.ofNullable(System.getenv().get("API_KEY")).orElse("");
     protected static final String FRONTEND_API_KEY =
             Optional.ofNullable(System.getenv().get("FRONTEND_API_KEY")).orElse("");
-    public static final String ROOT_RESOURCE_URL =
-            Optional.ofNullable(System.getenv().get("ROOT_RESOURCE_URL"))
-                    .orElse(String.format(LOCAL_ENDPOINT_FORMAT, LOCAL_API_GATEWAY_ID));
-    public static final String FRONTEND_ROOT_RESOURCE_URL =
-            Optional.ofNullable(System.getenv().get("ROOT_RESOURCE_URL"))
-                    .orElse(
-                            String.format(
-                                    LOCAL_ENDPOINT_FORMAT,
-                                    Optional.ofNullable(
-                                                    System.getenv().get("FRONTEND_API_GATEWAY_ID"))
-                                            .orElse("")));
+
     public static final ECKey EC_KEY_PAIR;
     public static final String EC_PUBLIC_KEY;
     public static final String ENCODED_DEVICE_INFORMATION =
@@ -133,45 +118,33 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final ParameterStoreExtension configurationParameters =
             new ParameterStoreExtension(
                     Map.ofEntries(
-                            Map.entry("local-session-redis-master-host", REDIS_HOST),
-                            Map.entry(
-                                    "local-session-redis-password", String.valueOf(REDIS_PASSWORD)),
-                            Map.entry("local-session-redis-port", String.valueOf(REDIS_PORT)),
-                            Map.entry(
-                                    "local-session-redis-tls", String.valueOf(DOES_REDIS_USE_TLS)),
-                            Map.entry("local-account-management-redis-master-host", REDIS_HOST),
-                            Map.entry(
+                            entry("local-session-redis-master-host", REDIS_HOST),
+                            entry("local-session-redis-password", valueOf(REDIS_PASSWORD)),
+                            entry("local-session-redis-port", valueOf(REDIS_PORT)),
+                            entry("local-session-redis-tls", valueOf(DOES_REDIS_USE_TLS)),
+                            entry("local-account-management-redis-master-host", REDIS_HOST),
+                            entry(
                                     "local-account-management-redis-password",
-                                    String.valueOf(REDIS_PASSWORD)),
-                            Map.entry(
-                                    "local-account-management-redis-port",
-                                    String.valueOf(REDIS_PORT)),
-                            Map.entry(
+                                    valueOf(REDIS_PASSWORD)),
+                            entry("local-account-management-redis-port", valueOf(REDIS_PORT)),
+                            entry(
                                     "local-account-management-redis-tls",
-                                    String.valueOf(DOES_REDIS_USE_TLS)),
-                            Map.entry("local-password-pepper", "pepper"),
-                            Map.entry("local-auth-public-signing-key", EC_PUBLIC_KEY),
-                            Map.entry("local-notify-callback-bearer-token", BEARER_TOKEN)));
+                                    valueOf(DOES_REDIS_USE_TLS)),
+                            entry("local-password-pepper", "pepper"),
+                            entry("local-auth-public-signing-key", EC_PUBLIC_KEY),
+                            entry("local-notify-callback-bearer-token", BEARER_TOKEN)));
 
     protected static final ConfigurationService TEST_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
-                    auditTopic,
                     notificationsQueue,
-                    auditSigningKey,
                     tokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters);
 
     protected static final ConfigurationService TXMA_ENABLED_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
-                    auditTopic,
                     notificationsQueue,
-                    auditSigningKey,
                     tokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters) {
 
@@ -270,7 +243,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
                                 KeyPairHelper.GENERATE_RSA_KEY_PAIR().getPublic().getEncoded()),
                 singletonList("http://localhost/post-redirect-logout"),
                 "http://example.com",
-                String.valueOf(ServiceType.MANDATORY),
+                valueOf(ServiceType.MANDATORY),
                 "https://test.com",
                 "public",
                 true);
@@ -283,49 +256,29 @@ public abstract class HandlerIntegrationTest<Q, S> {
     public static class IntegrationTestConfigurationService extends ConfigurationService {
 
         private final SqsQueueExtension notificationQueue;
-        private final KmsKeyExtension auditSigningKey;
         private final TokenSigningExtension tokenSigningKey;
-        private final SnsTopicExtension auditEventTopic;
-        private final TokenSigningExtension ipvPrivateKeyJwtSigner;
-        private final SqsQueueExtension spotQueue;
         private final TokenSigningExtension docAppPrivateKeyJwtSigner;
 
         public IntegrationTestConfigurationService(
-                SnsTopicExtension auditEventTopic,
                 SqsQueueExtension notificationQueue,
-                KmsKeyExtension auditSigningKey,
                 TokenSigningExtension tokenSigningKey,
-                TokenSigningExtension ipvPrivateKeyJwtSigner,
-                SqsQueueExtension spotQueue,
                 TokenSigningExtension docAppPrivateKeyJwtSigner,
                 ParameterStoreExtension parameterStoreExtension) {
             super(parameterStoreExtension.getClient());
-            this.auditEventTopic = auditEventTopic;
             this.notificationQueue = notificationQueue;
             this.tokenSigningKey = tokenSigningKey;
-            this.auditSigningKey = auditSigningKey;
-            this.ipvPrivateKeyJwtSigner = ipvPrivateKeyJwtSigner;
-            this.spotQueue = spotQueue;
             this.docAppPrivateKeyJwtSigner = docAppPrivateKeyJwtSigner;
         }
 
         public IntegrationTestConfigurationService(
-                SnsTopicExtension auditEventTopic,
                 SqsQueueExtension notificationQueue,
-                KmsKeyExtension auditSigningKey,
                 TokenSigningExtension tokenSigningKey,
-                TokenSigningExtension ipvPrivateKeyJwtSigner,
-                SqsQueueExtension spotQueue,
                 TokenSigningExtension docAppPrivateKeyJwtSigner,
                 ParameterStoreExtension parameterStoreExtension,
                 SystemService systemService) {
             super(parameterStoreExtension.getClient());
-            this.auditEventTopic = auditEventTopic;
             this.notificationQueue = notificationQueue;
             this.tokenSigningKey = tokenSigningKey;
-            this.auditSigningKey = auditSigningKey;
-            this.ipvPrivateKeyJwtSigner = ipvPrivateKeyJwtSigner;
-            this.spotQueue = spotQueue;
             this.docAppPrivateKeyJwtSigner = docAppPrivateKeyJwtSigner;
             super.systemService = systemService;
         }
@@ -341,11 +294,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
         }
 
         @Override
-        public String getIPVTokenSigningKeyAlias() {
-            return ipvPrivateKeyJwtSigner.getKeyAlias();
-        }
-
-        @Override
         public String getDocAppTokenSigningKeyAlias() {
             return docAppPrivateKeyJwtSigner.getKeyAlias();
         }
@@ -353,16 +301,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
         @Override
         public String getFrontendBaseUrl() {
             return "http://localhost:3000/reset-password?code=";
-        }
-
-        @Override
-        public String getSpotQueueUri() {
-            return spotQueue.getQueueUrl();
-        }
-
-        @Override
-        public Optional<String> getIPVCapacity() {
-            return Optional.of("1");
         }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -13,8 +13,6 @@ import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
 import uk.gov.di.authentication.shared.configuration.BaseLambdaConfiguration;
 import uk.gov.di.authentication.shared.entity.DeliveryReceiptsNotificationType;
-import uk.gov.di.authentication.shared.exceptions.SSMParameterNotFoundException;
-import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 
 import java.net.URI;
 import java.time.Clock;
@@ -63,10 +61,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public String getAccountManagementURI() {
         return System.getenv("ACCOUNT_MANAGEMENT_URI");
-    }
-
-    public Long getAccountRecoveryBlockTTL() {
-        return Long.parseLong(System.getenv().getOrDefault("ACCOUNT_RECOVERY_BLOCK_TTL", "172800"));
     }
 
     public long getAuthCodeExpiry() {
@@ -207,16 +201,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("CUSTOM_DOC_APP_CLAIM_ENABLED", "false").equals("true");
     }
 
-    public URI getDefaultLogoutURI() {
-        return URI.create(System.getenv("DEFAULT_LOGOUT_URI"));
-    }
-
     public URI getDocAppAuthorisationURI() {
         return URI.create(System.getenv().getOrDefault("DOC_APP_AUTHORISATION_URI", ""));
-    }
-
-    public URI getDocAppBackendURI() {
-        return URI.create(System.getenv().getOrDefault("DOC_APP_BACKEND_URI", ""));
     }
 
     public URI getDocAppAuthorisationCallbackURI() {
@@ -239,20 +225,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("DOC_APP_TOKEN_SIGNING_KEY_ALIAS");
     }
 
-    public String getDocAppCriDataEndpoint() {
-        return System.getenv("DOC_APP_CRI_DATA_ENDPOINT");
-    }
-
-    public String getDocAppCriV2DataEndpoint() {
-        return System.getenv("DOC_APP_CRI_DATA_V2_ENDPOINT");
-    }
-
     public URI getDocAppDomain() {
         return URI.create(System.getenv("DOC_APP_DOMAIN"));
-    }
-
-    public String getDomainName() {
-        return System.getenv("DOMAIN_NAME");
     }
 
     public Optional<String> getDynamoEndpointUri() {
@@ -271,37 +245,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("EXPERIAN_PHONE_CHECKER_QUEUE_URL");
     }
 
-    public String getSpotQueueUri() {
-        return System.getenv("SPOT_QUEUE_URL");
-    }
-
     public String getFrontendBaseUrl() {
         return System.getenv().getOrDefault("FRONTEND_BASE_URL", "");
     }
 
-    public String getOrchestrationToAuthenticationTokenSigningKeyAlias() {
-        return System.getenv("ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS");
-    }
-
     public String getOrchestrationToAuthenticationSigningPublicKey() {
         return System.getenv("ORCH_TO_AUTH_TOKEN_SIGNING_PUBLIC_KEY");
-    }
-
-    public String getOrchestrationToAuthenticationEncryptionPublicKey() {
-        var paramName = format("{0}-auth-public-encryption-key", getEnvironment());
-        try {
-            var request =
-                    GetParameterRequest.builder().withDecryption(true).name(paramName).build();
-            return getSsmClient().getParameter(request).parameter().value();
-        } catch (ParameterNotFoundException e) {
-            String message = String.format("No parameter exists with name: %s", paramName);
-            LOG.error(message);
-            throw new SSMParameterNotFoundException(message, e);
-        }
-    }
-
-    public String getOrchestrationRedirectUri() {
-        return System.getenv().getOrDefault("ORCH_REDIRECT_URI", "orchestration-redirect");
     }
 
     public String getOrchestrationClientId() {
@@ -320,63 +269,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("IDENTITY_ENABLED", "false").equals("true");
     }
 
-    public boolean isIPVNoSessionResponseEnabled() {
-        return System.getenv()
-                .getOrDefault("IPV_NO_SESSION_RESPONSE_ENABLED", "false")
-                .equals("true");
-    }
-
-    public boolean isLanguageEnabled(SupportedLanguage supportedLanguage) {
-        return supportedLanguage.equals(SupportedLanguage.EN)
-                || supportedLanguage.equals(SupportedLanguage.CY);
-    }
-
     public long getIDTokenExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
     }
 
-    public URI getIPVAuthorisationURI() {
-        return URI.create(System.getenv().getOrDefault("IPV_AUTHORISATION_URI", ""));
-    }
-
-    public URI getIPVBackendURI() {
-        return URI.create(System.getenv().getOrDefault("IPV_BACKEND_URI", ""));
-    }
-
-    public String getIPVAudience() {
-        return System.getenv().getOrDefault("IPV_AUDIENCE", "");
-    }
-
-    public URI getIPVAuthorisationCallbackURI() {
-        return URI.create(System.getenv().getOrDefault("IPV_AUTHORISATION_CALLBACK_URI", ""));
-    }
-
-    public String getIPVAuthorisationClientId() {
-        return System.getenv().getOrDefault("IPV_AUTHORISATION_CLIENT_ID", "");
-    }
-
-    public String getIPVTokenSigningKeyAlias() {
-        return System.getenv("IPV_TOKEN_SIGNING_KEY_ALIAS");
-    }
-
-    public String getIPVAuthEncryptionPublicKey() {
-        var paramName = format("{0}-ipv-public-encryption-key", getEnvironment());
-        try {
-            var request =
-                    GetParameterRequest.builder().withDecryption(true).name(paramName).build();
-            return getSsmClient().getParameter(request).parameter().value();
-        } catch (ParameterNotFoundException e) {
-            LOG.error("No parameter exists with name: {}", paramName);
-            throw new RuntimeException(e);
-        }
-    }
-
     public String getInternalSectorUri() {
         return System.getenv("INTERNAl_SECTOR_URI");
-    }
-
-    public URI getLoginURI() {
-        return URI.create(System.getenv("LOGIN_URI"));
     }
 
     public String getNotifyApiKey() {
@@ -472,10 +370,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                         .get(format("{0}-{1}-redis-tls", getEnvironment(), getRedisKey())));
     }
 
-    public String getResetPasswordRoute() {
-        return System.getenv().getOrDefault("RESET_PASSWORD_ROUTE", "");
-    }
-
     public String getSessionCookieAttributes() {
         return Optional.ofNullable(System.getenv("SESSION_COOKIE_ATTRIBUTES"))
                 .orElse("Secure; HttpOnly;");
@@ -485,26 +379,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Integer.parseInt(System.getenv().getOrDefault("SESSION_COOKIE_MAX_AGE", "3600"));
     }
 
-    public int getPersistentCookieMaxAge() {
-        return Integer.parseInt(
-                System.getenv().getOrDefault("PERSISTENT_COOKIE_MAX_AGE", "47340000"));
-    }
-
-    public int getLanguageCookieMaxAge() {
-        return Integer.parseInt(
-                System.getenv().getOrDefault("LANGUAGE_COOKIE_MAX_AGE", "31536000"));
-    }
-
     public long getSessionExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("SESSION_EXPIRY", "3600"));
     }
 
     public String getSmoketestBucketName() {
         return System.getenv("SMOKETEST_SMS_BUCKET_NAME");
-    }
-
-    public URI getSkipLoginURI() {
-        return URI.create(System.getenv().getOrDefault("SKIP_LOGIN_URI", "http://skip-login"));
     }
 
     public Optional<String> getSqsEndpointUri() {
@@ -545,27 +425,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public boolean isRsaSigningAvailable() {
         return List.of("build", "staging", "integration", "production").contains(getEnvironment());
-    }
-
-    public String getAuditStorageS3Bucket() {
-        return System.getenv("AUDIT_STORAGE_S3_BUCKET");
-    }
-
-    public String getAuditHmacSecret() {
-        return System.getenv("AUDIT_HMAC_SECRET");
-    }
-
-    public Optional<String> getIPVCapacity() {
-        try {
-            var request =
-                    GetParameterRequest.builder()
-                            .withDecryption(true)
-                            .name(format("{0}-ipv-capacity", getEnvironment()))
-                            .build();
-            return Optional.of(getSsmClient().getParameter(request).parameter().value());
-        } catch (ParameterNotFoundException e) {
-            return Optional.empty();
-        }
     }
 
     private Map<String, String> getSsmRedisParameters() {
@@ -619,10 +478,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     private String getRedisKey() {
         return System.getenv("REDIS_KEY");
-    }
-
-    public String getBackChannelLogoutQueueUri() {
-        return System.getenv("BACK_CHANNEL_LOGOUT_QUEUE_URI");
     }
 
     public String getNotifyTemplateId(String templateName) {


### PR DESCRIPTION
This PR removes unused methods from the `ConfigurationService` classes in the auth and orch codebases.
