### PR TITLE
ATO-686: Disable spot response event mapping in int and prod

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -34,6 +34,8 @@ Conditions:
     !Or [ !Equals [ staging, !Ref Environment ], !Equals [ integration, !Ref Environment ], !Equals [ production, !Ref Environment ] ]
   SendStorageToken:
     !Not [ !Or [ !Equals [ integration, !Ref Environment ], !Equals [ production, !Ref Environment ] ] ]
+  SpotResponseEventMappingDisabled:
+    !Or [ !Equals [ integration, !Ref Environment ], !Equals [ production, !Ref Environment ] ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -3213,6 +3215,7 @@ Resources:
     Type: AWS::Lambda::EventSourceMapping
     Condition: IpvExists
     Properties:
+      Enabled: !If [ SpotResponseEventMappingDisabled, false, true ]
       EventSourceArn: !Sub
         - '{{resolve:secretsmanager:${SecretArn}:SecretString}}'
         - SecretArn: !Ref SpotResponseQueueArnSecret


### PR DESCRIPTION
## What

If the event mapping is not disabled, the lambda will pick up messages from the queue as soon as it's deployed
