### PR TITLE
ATO-661: Add method to generate storage access token for Auth to send to IPV

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -514,4 +514,26 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     public String getAccountInterventionsErrorMetricName() {
         return System.getenv().getOrDefault("ACCOUNT_INTERVENTIONS_ERROR_METRIC_NAME", "");
     }
+
+    public String getIPVAudience() {
+        return System.getenv().getOrDefault("IPV_AUDIENCE", "");
+    }
+
+    public String getStorageTokenSigningKeyAlias() {
+        return System.getenv("STORAGE_TOKEN_SIGNING_KEY_ALIAS");
+    }
+
+    public URI getCredentialStoreURI() {
+        return getURIOrDefault("CREDENTIAL_STORE_URI", "https://credential-store.account.gov.uk");
+    }
+
+    private URI getURIOrDefault(String envVar, String defaultUri) {
+        return getOptionalURI(envVar).orElseGet(() -> URI.create(defaultUri));
+    }
+
+    private Optional<URI> getOptionalURI(String envVar) {
+        return System.getenv().containsKey(envVar)
+                ? Optional.of(URI.create(System.getenv(envVar)))
+                : Optional.empty();
+    }
 }


### PR DESCRIPTION
## What

Add method to generate a signed storage access token. 

Authentication will send this storage token to IPV as a claim (named https://vocab.account.gov.uk/v1/storageAccessToken) in the JAR when identity re-verification is required. More details [here](https://govukverify.atlassian.net/wiki/spaces/Architecture/pages/4188799112/Storage+access+token).

This is required as part of the MFA reset initiative.

## How to review

1. Code review only
2. Confirm that sonarcloud analysis can be dismissed because:
  - ConfigurationService tests are not required
  - Code duplication is between authentication shared and orchestration shared which is expected


## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

