### PR TITLE
ATO-644: Fix RS256 vs RSA256 Issue

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.nimbusds.jose.JWSAlgorithm.ES256;
+import static com.nimbusds.jose.JWSAlgorithm.RS256;
 import static java.util.Collections.singletonList;
 import static uk.gov.di.orchestration.shared.entity.ServiceType.MANDATORY;
 import static uk.gov.di.orchestration.shared.entity.ServiceType.OPTIONAL;
@@ -51,7 +52,7 @@ public class ClientConfigValidationService {
             new ErrorObject("invalid_client_metadata", "Invalid ID Token Signing Algorithm");
 
     private static final Set<String> VALID_ID_TOKEN_SIGNING_ALGORITHMS =
-            Stream.of(ES256.getName(), "RSA256").collect(Collectors.toSet());
+            Stream.of(ES256.getName(), RS256.getName()).collect(Collectors.toSet());
 
     public Optional<ErrorObject> validateClientRegistrationConfig(
             ClientRegistrationRequest registrationRequest) {

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.nimbusds.jose.JWSAlgorithm.ES256;
+import static com.nimbusds.jose.JWSAlgorithm.RS256;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -62,7 +63,7 @@ class ClientConfigValidationServiceTest {
                                 ValidClaims.PASSPORT.getValue()),
                         String.valueOf(OPTIONAL),
                         ClientType.APP.getValue(),
-                        "RSA256")); // Unclear why but currently we expect RSA256 instead of RS256.
+                        RS256.getName()));
     }
 
     @ParameterizedTest
@@ -325,10 +326,7 @@ class ClientConfigValidationServiceTest {
     }
 
     static Stream<Arguments> validAlgorithmSource() {
-        return Stream.of(
-                Arguments.of(ES256.getName()),
-                Arguments.of(
-                        "RSA256")); // Unclear why but currently we expect RSA256 instead of RS256.
+        return Stream.of(Arguments.of(ES256.getName()), Arguments.of(RS256.getName()));
     }
 
     @Test
@@ -468,12 +466,7 @@ class ClientConfigValidationServiceTest {
 
     static Stream<Arguments> invalidAlgorithmSource() {
         return Stream.of(
-                Arguments.of("NOT_AN_ALGORITHM"),
-                Arguments.of(JWSAlgorithm.PS256.getName()),
-                Arguments.of(
-                        JWSAlgorithm.RS256
-                                .getName())); // Unclear why but currently we expect RSA256 instead
-        // of RS256.
+                Arguments.of("NOT_AN_ALGORITHM"), Arguments.of(JWSAlgorithm.PS256.getName()));
     }
 
     private ClientRegistrationRequest generateClientRegRequest(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -314,7 +314,9 @@ public class TokenHandler
 
     private JWSAlgorithm getSigningAlgorithm(ClientRegistry clientRegistry) {
         return configurationService.isRsaSigningAvailable()
-                        && "RSA256".equals(clientRegistry.getIdTokenSigningAlgorithm())
+                        && clientRegistry
+                                .getIdTokenSigningAlgorithm()
+                                .equals(JWSAlgorithm.RS256.getName())
                 ? JWSAlgorithm.RS256
                 : JWSAlgorithm.ES256;
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -264,7 +264,8 @@ public class TokenHandlerTest {
                 new OIDCTokenResponse(new OIDCTokens(signedJWT, accessToken, refreshToken));
         PrivateKeyJWT privateKeyJWT = generatePrivateKeyJWT(keyPair.getPrivate());
         ClientRegistry clientRegistry =
-                generateClientRegistry(keyPair, CLIENT_ID).withIdTokenSigningAlgorithm("RSA256");
+                generateClientRegistry(keyPair, CLIENT_ID)
+                        .withIdTokenSigningAlgorithm(JWSAlgorithm.RS256.getName());
 
         when(tokenService.validateTokenRequestParams(anyString())).thenReturn(Optional.empty());
         when(tokenClientAuthValidatorFactory.getTokenAuthenticationValidator(any()))

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
@@ -1,5 +1,6 @@
 package uk.gov.di.orchestration.shared.entity;
 
+import com.nimbusds.jose.JWSAlgorithm;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
@@ -7,6 +8,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecon
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @DynamoDbBean
 public class ClientRegistry {
@@ -38,6 +40,9 @@ public class ClientRegistry {
     private String idTokenSigningAlgorithm = "ES256";
     private boolean smokeTest = false;
     private List<String> clientLoCs = new ArrayList<>();
+
+    private static final Set<String> RS256_MAPPINGS =
+            Set.of(JWSAlgorithm.RS256.getName(), "RSA256");
 
     public ClientRegistry() {}
 
@@ -325,7 +330,9 @@ public class ClientRegistry {
 
     @DynamoDbAttribute("IdTokenSigningAlgorithm")
     public String getIdTokenSigningAlgorithm() {
-        return idTokenSigningAlgorithm;
+        return idTokenSigningAlgorithm != null && RS256_MAPPINGS.contains(idTokenSigningAlgorithm)
+                ? JWSAlgorithm.RS256.getName()
+                : idTokenSigningAlgorithm;
     }
 
     public void setIdTokenSigningAlgorithm(String algorithm) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/ClientRegistryTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/ClientRegistryTest.java
@@ -1,16 +1,14 @@
 package uk.gov.di.orchestration.shared.entity;
 
+import com.nimbusds.jose.JWSAlgorithm;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.mock;
 
 class ClientRegistryTest {
-
-    private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
 
     @Test
     void shouldReturnP2andP0WhenidentityVerificationSupportedAndRegistryEmpty() {
@@ -31,5 +29,36 @@ class ClientRegistryTest {
         assertThat(
                 clientRegistry.getClientLoCs(),
                 equalTo(List.of(LevelOfConfidence.NONE.getValue())));
+    }
+
+    @Test
+    void shouldReturnES256IdTokenSigningAlgorithmCorrectly() {
+        var clientRegistry = new ClientRegistry();
+        clientRegistry.setIdTokenSigningAlgorithm(JWSAlgorithm.ES256.getName());
+        assertThat(
+                clientRegistry.getIdTokenSigningAlgorithm(), equalTo(JWSAlgorithm.ES256.getName()));
+    }
+
+    @Test
+    void shouldReturnRS256IdTokenSigningAlgorithmCorrectly() {
+        var clientRegistry = new ClientRegistry();
+        clientRegistry.setIdTokenSigningAlgorithm(JWSAlgorithm.RS256.getName());
+        assertThat(
+                clientRegistry.getIdTokenSigningAlgorithm(), equalTo(JWSAlgorithm.RS256.getName()));
+    }
+
+    @Test
+    void shouldReturnRS256IdTokenSigningAlgorithmWhenRSA256IsUsed() {
+        var clientRegistry = new ClientRegistry();
+        clientRegistry.setIdTokenSigningAlgorithm("RSA256");
+        assertThat(
+                clientRegistry.getIdTokenSigningAlgorithm(), equalTo(JWSAlgorithm.RS256.getName()));
+    }
+
+    @Test
+    void shouldReturnNullIdTokenSigningAlgorithmCorrectly() {
+        var clientRegistry = new ClientRegistry();
+        clientRegistry.setIdTokenSigningAlgorithm(null);
+        assertThat(clientRegistry.getIdTokenSigningAlgorithm(), equalTo(null));
     }
 }


### PR DESCRIPTION
## What

- Map id token signing algorithm from RSA256 to RS256 in client registry table.
- Only allow RS256 value to be used in the client registry API.

## How to review

Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.