### PR TITLE
AUT-2882: Add EMAIL_FRAUD_CHECK_BYPASSED audit event

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -9,7 +9,8 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     ACCOUNT_MANAGEMENT_AUTHENTICATE,
     ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
     DELETE_ACCOUNT,
-    SEND_OTP;
+    SEND_OTP,
+    EMAIL_FRAUD_CHECK_BYPASSED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -17,12 +17,14 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
 import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
@@ -115,14 +117,7 @@ public class UpdateEmailHandler
         try {
             UpdateEmailRequest updateInfoRequest =
                     objectMapper.readValue(input.getBody(), UpdateEmailRequest.class);
-            AtomicReference<EmailCheckResultStatus> resultStatus =
-                    new AtomicReference<>(EmailCheckResultStatus.PENDING);
-            dynamoEmailCheckResultService
-                    .getEmailCheckStore(updateInfoRequest.getReplacementEmailAddress())
-                    .ifPresent(result -> resultStatus.set(result.getStatus()));
-            LOG.info(
-                    "UpdateEmailHandler: Experian email verification status: {}",
-                    resultStatus.get());
+
             boolean isValidOtpCode =
                     codeStorageService.isValidOtpCode(
                             updateInfoRequest.getReplacementEmailAddress(),
@@ -131,6 +126,7 @@ public class UpdateEmailHandler
             if (!isValidOtpCode) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1020);
             }
+
             Optional<ErrorResponse> emailValidationErrors =
                     ValidationHelper.validateEmailAddressUpdate(
                             updateInfoRequest.getExistingEmailAddress(),
@@ -138,9 +134,11 @@ public class UpdateEmailHandler
             if (emailValidationErrors.isPresent()) {
                 return generateApiGatewayProxyErrorResponse(400, emailValidationErrors.get());
             }
+
             if (dynamoService.userExists(updateInfoRequest.getReplacementEmailAddress())) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1009);
             }
+
             var userProfile =
                     dynamoService
                             .getUserProfileByEmailMaybe(updateInfoRequest.getExistingEmailAddress())
@@ -148,6 +146,36 @@ public class UpdateEmailHandler
                                     () ->
                                             new UserNotFoundException(
                                                     "User not found with given email"));
+
+            AtomicReference<EmailCheckResultStatus> resultStatus =
+                    new AtomicReference<>(EmailCheckResultStatus.PENDING);
+            dynamoEmailCheckResultService
+                    .getEmailCheckStore(updateInfoRequest.getReplacementEmailAddress())
+                    .ifPresent(result -> resultStatus.set(result.getStatus()));
+            LOG.info(
+                    "UpdateEmailHandler: Experian email verification status: {}",
+                    resultStatus.get());
+            if (resultStatus.get().equals(EmailCheckResultStatus.PENDING)) {
+                auditService.submitAuditEvent(
+                        AccountManagementAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED,
+                        input.getRequestContext()
+                                .getAuthorizer()
+                                .getOrDefault("clientId", AuditService.UNKNOWN)
+                                .toString(),
+                        ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
+                        sessionId,
+                        userProfile.getSubjectID(),
+                        updateInfoRequest.getReplacementEmailAddress(),
+                        IpAddressHelper.extractIpAddress(input),
+                        userProfile.getPhoneNumber(),
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                        AuditHelper.buildRestrictedSection(input.getHeaders()),
+                        AuditService.MetadataPair.pair(
+                                "journey_type", JourneyType.ACCOUNT_MANAGEMENT.getValue()),
+                        AuditService.MetadataPair.pair(
+                                "assessment_checked_at_timestamp", NowHelper.now()),
+                        AuditService.MetadataPair.pair("iss", AuditService.COMPONENT_ID));
+            }
 
             Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
             if (PrincipalValidationHelper.principleIsInvalid(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -7,6 +7,8 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
@@ -16,11 +18,13 @@ import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -31,6 +35,7 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -156,14 +161,37 @@ class UpdateEmailHandlerTest {
         when(dynamoEmailCheckResultService.getEmailCheckStore(NEW_EMAIL_ADDRESS))
                 .thenReturn(Optional.empty());
 
-        var event = generateApiGatewayEvent(NEW_EMAIL_ADDRESS, expectedCommonSubject);
-        handler.handleRequest(event, context);
+        Date mockedDate = new Date();
+        try (MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class)) {
+            mockedNowHelperClass.when(NowHelper::now).thenReturn(mockedDate);
+            var event = generateApiGatewayEvent(NEW_EMAIL_ADDRESS, expectedCommonSubject);
+            handler.handleRequest(event, context);
 
-        assertThat(
-                logging.events(),
-                hasItem(
-                        withMessageContaining(
-                                "UpdateEmailHandler: Experian email verification status: PENDING")));
+            assertThat(
+                    logging.events(),
+                    hasItem(
+                            withMessageContaining(
+                                    "UpdateEmailHandler: Experian email verification status: PENDING")));
+
+            verify(auditService)
+                    .submitAuditEvent(
+                            AccountManagementAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED,
+                            CLIENT_ID,
+                            SESSION_ID,
+                            AuditService.UNKNOWN,
+                            INTERNAL_SUBJECT.getValue(),
+                            NEW_EMAIL_ADDRESS,
+                            "123.123.123.123",
+                            userProfile.getPhoneNumber(),
+                            PERSISTENT_ID,
+                            new AuditService.RestrictedSection(
+                                    Optional.of(TXMA_ENCODED_HEADER_VALUE)),
+                            AuditService.MetadataPair.pair(
+                                    "journey_type", JourneyType.ACCOUNT_MANAGEMENT.getValue()),
+                            AuditService.MetadataPair.pair(
+                                    "assessment_checked_at_timestamp", mockedDate),
+                            AuditService.MetadataPair.pair("iss", "AUTH"));
+        }
     }
 
     @Test
@@ -187,7 +215,6 @@ class UpdateEmailHandlerTest {
 
         assertThat(expectedException.getMessage(), equalTo("Invalid Principal in request"));
         verifyNoInteractions(sqsClient);
-        verifyNoInteractions(auditService);
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.UPDATE_EMAIL;
 import static uk.gov.di.accountmanagement.entity.NotificationType.EMAIL_UPDATED;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
@@ -77,7 +78,8 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 EXISTING_EMAIL_ADDRESS, EMAIL_UPDATED, SupportedLanguage.EN),
                         new NotifyRequest(NEW_EMAIL_ADDRESS, EMAIL_UPDATED, SupportedLanguage.EN)));
 
-        assertTxmaAuditEventsSubmittedWithMatchingNames(txmaAuditQueue, List.of(UPDATE_EMAIL));
+        assertTxmaAuditEventsSubmittedWithMatchingNames(
+                txmaAuditQueue, List.of(UPDATE_EMAIL, EMAIL_FRAUD_CHECK_BYPASSED));
     }
 
     @Test

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -49,7 +49,8 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     PERMANENTLY_BLOCKED_INTERVENTION,
     PASSWORD_RESET_INTERVENTION_COMPLETE,
     REAUTHENTICATION_SUCCESSFUL,
-    REAUTHENTICATION_INVALID;
+    REAUTHENTICATION_INVALID,
+    EMAIL_FRAUD_CHECK_BYPASSED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
@@ -5,9 +5,17 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
+import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.helpers.AuditHelper;
+import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
+import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -76,20 +84,53 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
 
             var emailCheckResult =
                     dynamoEmailCheckResultService.getEmailCheckStore(request.getEmail());
+            var status =
+                    emailCheckResult
+                            .map(EmailCheckResultStore::getStatus)
+                            .orElse(EmailCheckResultStatus.PENDING);
 
-            if (emailCheckResult.isPresent()) {
-                var checkEmailFraudBlockResponse =
-                        new CheckEmailFraudBlockResponse(
-                                request.getEmail(), emailCheckResult.get().getStatus().getValue());
-                return generateApiGatewayProxyResponse(200, checkEmailFraudBlockResponse);
+            var checkEmailFraudBlockResponse = createResponse(request.getEmail(), status);
+
+            if (status.equals(EmailCheckResultStatus.PENDING)) {
+                submitAuditEvent(input, userContext, request);
             }
-            return generateApiGatewayProxyResponse(
-                    200,
-                    new CheckEmailFraudBlockResponse(
-                            request.getEmail(), EmailCheckResultStatus.PENDING.getValue()));
+
+            return generateApiGatewayProxyResponse(200, checkEmailFraudBlockResponse);
         } catch (Json.JsonException e) {
             LOG.error("Unable to serialize check email fraud block response", e);
             throw new RuntimeException(e);
         }
+    }
+
+    private CheckEmailFraudBlockResponse createResponse(
+            String email, EmailCheckResultStatus status) {
+        return new CheckEmailFraudBlockResponse(email, status.getValue());
+    }
+
+    private void submitAuditEvent(
+            APIGatewayProxyRequestEvent input,
+            UserContext userContext,
+            CheckEmailFraudBlockRequest request) {
+
+        String clientId =
+                input.getRequestContext()
+                        .getAuthorizer()
+                        .getOrDefault("clientId", AuditService.UNKNOWN)
+                        .toString();
+
+        auditService.submitAuditEvent(
+                FrontendAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED,
+                clientId,
+                ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
+                userContext.getClientSessionId(),
+                AuditService.UNKNOWN,
+                request.getEmail(),
+                IpAddressHelper.extractIpAddress(input),
+                AuditService.UNKNOWN,
+                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                AuditHelper.buildRestrictedSection(input.getHeaders()),
+                AuditService.MetadataPair.pair("journeyType", JourneyType.REGISTRATION.getValue()),
+                AuditService.MetadataPair.pair("assessmentCheckedAtTimestamp", NowHelper.now()),
+                AuditService.MetadataPair.pair("iss", AuditService.COMPONENT_ID));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
@@ -5,14 +5,21 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -23,6 +30,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -31,9 +39,11 @@ import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
-import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
+import static uk.gov.di.authentication.shared.lambda.BaseFrontendHandler.TXMA_AUDIT_ENCODED_HEADER;
+import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.identityWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -45,6 +55,14 @@ class CheckEmailFraudBlockHandlerTest {
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final String CLIENT_SESSION_ID = "known-client-session-id";
     private static final Subject INTERNAL_SUBJECT_ID = new Subject();
+    private static final String CLIENT_ID = "some-client-id";
+    private static final String IP_ADDRESS = "123.123.123.123";
+    private static final Subject INTERNAL_SUBJECT = new Subject();
+    private final String expectedCommonSubject =
+            ClientSubjectHelper.calculatePairwiseIdentifier(
+                    INTERNAL_SUBJECT.getValue(), "test.account.gov.uk", SALT);
+    public static final String ENCODED_DEVICE_DETAILS =
+            "YTtKVSlub1YlOSBTeEI4J3pVLVd7Jjl8VkBfREs2N3clZmN+fnU7fXNbcTJjKyEzN2IuUXIgMGttV058fGhUZ0xhenZUdldEblB8SH18XypwXUhWPXhYXTNQeURW%";
 
     private static AuditService auditServiceMock;
     private static AuthenticationService authenticationServiceMock;
@@ -93,6 +111,9 @@ class CheckEmailFraudBlockHandlerTest {
     @ParameterizedTest
     @EnumSource(EmailCheckResultStatus.class)
     void shouldReturnCorrectStatusBasedOnDbResult(EmailCheckResultStatus status) {
+        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
+                getProxyRequestContext();
+
         var resultStore = new EmailCheckResultStore();
         resultStore.setStatus(status);
         when(dbMock.getEmailCheckStore(EMAIL)).thenReturn(Optional.of(resultStore));
@@ -104,7 +125,7 @@ class CheckEmailFraudBlockHandlerTest {
         headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
 
         var event = new APIGatewayProxyRequestEvent();
-        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+        event.setRequestContext(proxyRequestContext);
         event.setHeaders(headers);
         event.setBody(format("{ \"email\": \"%s\" }", EMAIL.toUpperCase()));
 
@@ -113,6 +134,59 @@ class CheckEmailFraudBlockHandlerTest {
 
         assertThat(result, hasStatus(200));
         assertThat(result, hasJsonBody(expectedResponse));
+    }
+
+    @Test
+    void shouldSubmitAuditWithPendingStatusWhenEmailCheckResultStoreNotPresent() {
+        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
+                getProxyRequestContext();
+
+        var resultStore = new EmailCheckResultStore();
+        resultStore.setStatus(EmailCheckResultStatus.PENDING);
+        when(dbMock.getEmailCheckStore(EMAIL)).thenReturn(Optional.of(resultStore));
+
+        usingValidSession();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
+        headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
+        headers.put(TXMA_AUDIT_ENCODED_HEADER, ENCODED_DEVICE_DETAILS);
+
+        Date mockedDate = new Date();
+        try (MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class)) {
+            mockedNowHelperClass.when(NowHelper::now).thenReturn(mockedDate);
+
+            var event = new APIGatewayProxyRequestEvent();
+            event.setHeaders(headers);
+            event.setRequestContext(proxyRequestContext);
+            event.setBody(format("{ \"email\": \"%s\" }", EMAIL.toUpperCase()));
+
+            var expectedResponse =
+                    new CheckEmailFraudBlockResponse(
+                            EMAIL, EmailCheckResultStatus.PENDING.getValue());
+            var result = handler.handleRequest(event, contextMock);
+
+            assertThat(result, hasStatus(200));
+            assertThat(result, hasJsonBody(expectedResponse));
+
+            verify(auditServiceMock)
+                    .submitAuditEvent(
+                            FrontendAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED,
+                            CLIENT_ID,
+                            CLIENT_SESSION_ID,
+                            CLIENT_SESSION_ID,
+                            AuditService.UNKNOWN,
+                            EMAIL,
+                            IP_ADDRESS,
+                            AuditService.UNKNOWN,
+                            PERSISTENT_ID,
+                            new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                            AuditService.MetadataPair.pair(
+                                    "journeyType", JourneyType.REGISTRATION.getValue()),
+                            AuditService.MetadataPair.pair(
+                                    "assessmentCheckedAtTimestamp", mockedDate),
+                            AuditService.MetadataPair.pair("iss", "AUTH"));
+        }
     }
 
     private void usingValidSession() {
@@ -125,5 +199,16 @@ class CheckEmailFraudBlockHandlerTest {
                 .withEmail(EMAIL)
                 .withEmailVerified(true)
                 .withSubjectID(INTERNAL_SUBJECT_ID.getValue());
+    }
+
+    private APIGatewayProxyRequestEvent.ProxyRequestContext getProxyRequestContext() {
+        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
+                new APIGatewayProxyRequestEvent.ProxyRequestContext();
+        Map<String, Object> authorizerParams = new HashMap<>();
+        authorizerParams.put("principalId", expectedCommonSubject);
+        authorizerParams.put("clientId", CLIENT_ID);
+        proxyRequestContext.setAuthorizer(authorizerParams);
+        proxyRequestContext.setIdentity(identityWithSourceIp(IP_ADDRESS));
+        return proxyRequestContext;
     }
 }


### PR DESCRIPTION
## What

AUT-2882: Add CHECK_BYPASSED audit event
- Apply BYPASSED block whenever the email checker status is still PENDING
- Event is triggered when updating email and registration for new account

## How to review

1. Code Review