### PR TITLE
ATO-659: JWKS endpoint to publish MFA reset public key

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetStorageTokenJwkHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetStorageTokenJwkHandler.java
@@ -1,0 +1,74 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.JwksService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+
+public class MfaResetStorageTokenJwkHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final JwksService jwksService;
+    private static final Logger LOG = LogManager.getLogger(MfaResetStorageTokenJwkHandler.class);
+
+    public MfaResetStorageTokenJwkHandler(JwksService jwksService) {
+        this.jwksService = jwksService;
+    }
+
+    public MfaResetStorageTokenJwkHandler(ConfigurationService configurationService) {
+        this.jwksService =
+                new JwksService(
+                        configurationService, new KmsConnectionService(configurationService));
+    }
+
+    public MfaResetStorageTokenJwkHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent event, Context context) {
+        return segmentedFunctionCall(
+                "frontend-api::" + getClass().getSimpleName(),
+                () -> mfaResetStorageTokenJwkHandler(event, context));
+    }
+
+    public APIGatewayProxyResponseEvent mfaResetStorageTokenJwkHandler(
+            APIGatewayProxyRequestEvent input, Context context) {
+        try {
+            LOG.info("MfaResetStorageTokenJwk request received");
+
+            List<JWK> signingKeys = new ArrayList<>();
+
+            signingKeys.add(jwksService.getPublicStorageTokenJwkWithOpaqueId());
+
+            JWKSet jwkSet = new JWKSet(signingKeys);
+
+            LOG.info("Generating MfaResetStorageTokenJwk successful response");
+
+            return generateApiGatewayProxyResponse(
+                    200,
+                    segmentedFunctionCall("serialiseJWKSet", () -> jwkSet.toString(true)),
+                    Map.of("Cache-Control", "max-age=86400"),
+                    null);
+        } catch (Exception e) {
+            LOG.error("Error in MfaResetStorageTokenJwk lambda", e);
+            return generateApiGatewayProxyResponse(
+                    500, "Error providing MfaResetStorageTokenJwk data");
+        }
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetStorageTokenJwkHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetStorageTokenJwkHandlerTest.java
@@ -1,0 +1,67 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.JwksService;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasHeader;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class MfaResetStorageTokenJwkHandlerTest {
+
+    private final Context context = mock(Context.class);
+    private final JwksService jwksService = mock(JwksService.class);
+    private MfaResetStorageTokenJwkHandler handler;
+    private final ECKey storageTokenSigningKey =
+            new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
+
+    MfaResetStorageTokenJwkHandlerTest() throws JOSEException {}
+
+    @BeforeEach
+    public void setUp() {
+        handler = new MfaResetStorageTokenJwkHandler(jwksService);
+        when(jwksService.getPublicStorageTokenJwkWithOpaqueId()).thenReturn(storageTokenSigningKey);
+    }
+
+    @Test
+    void shouldReturnMfaResetStorageTokenJwk() {
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
+
+        var expectedJWKSet = new JWKSet(List.of(storageTokenSigningKey));
+
+        assertThat(result, hasStatus(200));
+        assertThat(result, hasBody(expectedJWKSet.toString(true)));
+    }
+
+    @Test
+    void shouldReturn500WhenSigningKeyIsNotPresent() {
+        when(jwksService.getPublicStorageTokenJwkWithOpaqueId()).thenReturn(null);
+
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasBody("Error providing MfaResetStorageTokenJwk data"));
+    }
+
+    @Test
+    void shouldSetACacheHeaderOfOneDayOnSuccess() {
+        var response = handler.handleRequest(new APIGatewayProxyRequestEvent(), context);
+        assertThat(response, hasHeader("Cache-Control", "max-age=86400"));
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
@@ -61,6 +61,14 @@ public class JwksService {
         return getPublicJWKWithKeyId(configurationService.getDocAppTokenSigningKeyAlias());
     }
 
+    public JWK getPublicStorageTokenJwkWithOpaqueId() {
+        LOG.info("Retrieving storage token public key");
+        // TODO: this is not available until ATO-661 is deployed
+        //        return
+        // getPublicJWKWithKeyId(configurationService.getStorageTokenSigningKeyAlias());
+        return getPublicJWKWithKeyId("some-alias");
+    }
+
     public JWK retrieveJwkFromURLWithKeyId(URL url, String keyId) {
         JWKSelector selector = new JWKSelector(new JWKMatcher.Builder().keyID(keyId).build());
         JWKSource<SecurityContext> jwkSource =


### PR DESCRIPTION
Add logic for lambda (MfaResetStorageTokenJwkHandler) to publish MFA reset public key as JWKS endpoint

## What

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
