### PR TITLE
AUT-2475: allow TICF CRI stub to be deployed by the pipelines

### DIFF
--- a/ci/terraform/ticf-cri-stub/build.tfvars
+++ b/ci/terraform/ticf-cri-stub/build.tfvars
@@ -1,0 +1,5 @@
+ticf_cri_stub_release_zip_file = "./artifacts/ticf-cri-stub.zip"
+shared_state_bucket            = "digital-identity-dev-tfstate"
+logging_endpoint_arns = [
+  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+]

--- a/ci/terraform/ticf-cri-stub/dev.tfvars
+++ b/ci/terraform/ticf-cri-stub/dev.tfvars
@@ -1,0 +1,3 @@
+ticf_cri_stub_release_zip_file = "./artifacts/ticf-cri-stub.zip"
+logging_endpoint_arns          = []
+shared_state_bucket            = "di-auth-development-tfstate"

--- a/ci/terraform/ticf-cri-stub/ticf-cri-stub-gateway.tf
+++ b/ci/terraform/ticf-cri-stub/ticf-cri-stub-gateway.tf
@@ -26,12 +26,9 @@ resource "aws_api_gateway_rest_api" "ticf_cri_stub" {
       "/auth" = {
         post = {
           x-amazon-apigateway-integration = {
-            type       = "aws_proxy"
-            httpMethod = "POST"
-            uri        = module.ticf_cri_stub_lambda.integration_uri
-            requestParameters = {
-              "integration.request.path.internalPairwiseId" = "method.request.path.internalPairwiseId"
-            }
+            type            = "aws_proxy"
+            httpMethod      = "POST"
+            uri             = module.ticf_cri_stub_lambda.integration_uri
             timeoutInMillis = 29000
           }
         }


### PR DESCRIPTION
## What

We don't currently deploy the TICF CRI stub anywhere, but the intention is to update the pipeline so that we deploy it up to, but not beyond, build. This PR contains a couple of changes that were necessary to do this in the dev pipeline, and have been tested out there (and the stub lambda is successfully deployed there).

The changes were:

* Adding the relevant tfvars file
* Removing an incorrectly specified variable from the url defined in the terraform endpoint.

## How to review

1. Code Review
2. Deploy this PR on the dev pipeline (which has had the pipeline change below applied to it) and see the "deploy TICF stub" stage pass successfully

## Related PRs

This PR needs to be merged before the pipeline is updated - that pipeline update is [here](https://github.com/govuk-one-login/devplatform-deploy/pull/1867) (although merging that will have no effect, it's only once we manually apply the new pipeline that we'd see problems without the current PR)