### PR TITLE
ATO-659: JWKS endpoint to publish MFA reset storage token public key

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -36,6 +36,12 @@ resource "aws_api_gateway_usage_plan_key" "di_auth_frontend_usage_plan_key" {
   usage_plan_id = aws_api_gateway_usage_plan.di_auth_frontend_usage_plan.id
 }
 
+resource "aws_api_gateway_resource" "auth_frontend_wellknown_resource" {
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  path_part   = ".well-known"
+}
+
 locals {
   frontend_api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_frontend_api.id}/${var.environment}/_user_request_" : "https://${local.frontend_api_fqdn}/"
 }
@@ -79,6 +85,8 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.orch_auth_code.method_trigger_value,
       module.identity_progress.integration_trigger_value,
       module.identity_progress.method_trigger_value,
+      module.mfa_reset_storage_token_jwk.integration_trigger_value,
+      module.mfa_reset_storage_token_jwk.method_trigger_value,
       local.deploy_account_interventions_count == 1 ? module.account_interventions[0].integration_trigger_value : null,
       local.deploy_account_interventions_count == 1 ? module.account_interventions[0].method_trigger_value : null,
       local.deploy_reauth_user_count == 1 ? module.check_reauth_user[0].integration_trigger_value : null,
@@ -110,6 +118,7 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
     module.doc-app-authorize,
     module.orch_auth_code,
     module.check_reauth_user,
+    module.mfa_reset_storage_token_jwk,
   ]
 }
 
@@ -210,6 +219,7 @@ resource "aws_api_gateway_stage" "endpoint_frontend_stage" {
     module.orch_auth_code,
     module.check_reauth_user,
     module.check_email_fraud_block,
+    module.mfa_reset_storage_token_jwk,
     aws_api_gateway_deployment.deployment,
   ]
 }

--- a/ci/terraform/oidc/kms-policies.tf
+++ b/ci/terraform/oidc/kms-policies.tf
@@ -160,7 +160,7 @@ resource "aws_iam_policy" "authentication_callback_userinfo_encryption_key_kms_p
   policy = data.aws_iam_policy_document.authentication_callback_userinfo_encryption_key_policy_document.json
 }
 
-### Storage Token signing key access
+### Encrypted VC storage token signing key access
 
 data "aws_iam_policy_document" "storage_token_kms_signing_policy_document" {
   statement {
@@ -183,4 +183,28 @@ resource "aws_iam_policy" "storage_token_kms_signing_policy" {
   description = "IAM policy for managing KMS connection for a lambda which allows signing of storage token payloads"
 
   policy = data.aws_iam_policy_document.storage_token_kms_signing_policy_document.json
+}
+
+### MFA reset storage token signing key access
+
+data "aws_iam_policy_document" "mfa_reset_storage_token_kms_signing_policy_document" {
+  statement {
+    sid    = "AllowAccessToMfaResetStorageTokenKmsSigningKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:GetPublicKey",
+    ]
+    resources = [
+      aws_kms_key.mfa_reset_signing_key_ecc.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "mfa_reset_storage_token_kms_signing_policy" {
+  name_prefix = "kms-mfa-reset-storage-token-signing-policy"
+  path        = "/${var.environment}/mfa-reset-storage-token/"
+  description = "IAM policy for managing KMS connection for a lambda which allows signing of MFA reset storage token payloads"
+
+  policy = data.aws_iam_policy_document.mfa_reset_storage_token_kms_signing_policy_document.json
 }

--- a/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
@@ -1,0 +1,57 @@
+module "mfa_reset_storage_token_jwk_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "mfa-reset-jwk-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.mfa_reset_storage_token_kms_signing_policy.arn
+  ]
+}
+
+module "mfa_reset_storage_token_jwk" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "mfa-reset-jwk.json"
+  path_part       = "mfa-reset-jwk.json"
+  endpoint_method = ["GET"]
+  environment     = var.environment
+
+  handler_environment_variables = {
+    ENVIRONMENT                     = var.environment
+    DOC_APP_TOKEN_SIGNING_KEY_ALIAS = local.doc_app_auth_key_alias_name
+    STORAGE_TOKEN_SIGNING_KEY_ALIAS = aws_kms_alias.mfa_reset_signing_key_alias.name
+  }
+  handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetStorageTokenJwkHandler::handleRequest"
+
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_resource.auth_frontend_wellknown_resource.id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  memory_size                 = lookup(var.performance_tuning, "mfa-reset-jwk", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "mfa-reset-jwk", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "mfa-reset-jwk", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "mfa-reset-jwk", local.default_performance_parameters).scaling_trigger
+
+  source_bucket           = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn                 = local.authentication_vpc_arn
+  security_group_ids                     = [local.authentication_security_group_id]
+  subnet_id                              = local.authentication_private_subnet_ids
+  lambda_role_arn                        = module.mfa_reset_storage_token_jwk_role.arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+
+  use_localstack = false
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_frontend_api,
+    aws_api_gateway_resource.auth_frontend_wellknown_resource,
+  ]
+}

--- a/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
@@ -18,9 +18,9 @@ module "mfa_reset_storage_token_jwk" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT                     = var.environment
-    DOC_APP_TOKEN_SIGNING_KEY_ALIAS = local.doc_app_auth_key_alias_name
-    STORAGE_TOKEN_SIGNING_KEY_ALIAS = aws_kms_alias.mfa_reset_signing_key_alias.name
+    ENVIRONMENT                               = var.environment
+    DOC_APP_TOKEN_SIGNING_KEY_ALIAS           = local.doc_app_auth_key_alias_name
+    MFA_RESET_STORAGE_TOKEN_SIGNING_KEY_ALIAS = aws_kms_alias.mfa_reset_signing_key_alias.name
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetStorageTokenJwkHandler::handleRequest"
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetStorageTokenJwkHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetStorageTokenJwkHandler.java
@@ -1,0 +1,73 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.JwksService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+
+public class MfaResetStorageTokenJwkHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final JwksService jwksService;
+    private static final Logger LOG = LogManager.getLogger(MfaResetStorageTokenJwkHandler.class);
+
+    public MfaResetStorageTokenJwkHandler(JwksService jwksService) {
+        this.jwksService = jwksService;
+    }
+
+    public MfaResetStorageTokenJwkHandler(ConfigurationService configurationService) {
+        this.jwksService =
+                new JwksService(
+                        configurationService, new KmsConnectionService(configurationService));
+    }
+
+    public MfaResetStorageTokenJwkHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent event, Context context) {
+        return segmentedFunctionCall(
+                "frontend-api::" + getClass().getSimpleName(),
+                this::mfaResetStorageTokenJwkHandler);
+    }
+
+    public APIGatewayProxyResponseEvent mfaResetStorageTokenJwkHandler() {
+        try {
+            LOG.info("MfaResetStorageTokenJwk request received");
+
+            List<JWK> signingKeys = new ArrayList<>();
+
+            signingKeys.add(jwksService.getPublicMfaResetStorageTokenJwkWithOpaqueId());
+
+            JWKSet jwkSet = new JWKSet(signingKeys);
+
+            LOG.info("Generating MfaResetStorageTokenJwk successful response");
+
+            return generateApiGatewayProxyResponse(
+                    200,
+                    segmentedFunctionCall("serialiseJWKSet", () -> jwkSet.toString(true)),
+                    Map.of("Cache-Control", "max-age=86400"),
+                    null);
+        } catch (Exception e) {
+            LOG.error("Error in MfaResetStorageTokenJwk lambda", e);
+            return generateApiGatewayProxyResponse(
+                    500, "Error providing MfaResetStorageTokenJwk data");
+        }
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetStorageTokenJwkHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetStorageTokenJwkHandlerTest.java
@@ -1,0 +1,68 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.JwksService;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasHeader;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class MfaResetStorageTokenJwkHandlerTest {
+
+    private final Context context = mock(Context.class);
+    private final JwksService jwksService = mock(JwksService.class);
+    private MfaResetStorageTokenJwkHandler handler;
+    private final ECKey storageTokenSigningKey =
+            new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
+
+    MfaResetStorageTokenJwkHandlerTest() throws JOSEException {}
+
+    @BeforeEach
+    public void setUp() {
+        handler = new MfaResetStorageTokenJwkHandler(jwksService);
+        when(jwksService.getPublicMfaResetStorageTokenJwkWithOpaqueId())
+                .thenReturn(storageTokenSigningKey);
+    }
+
+    @Test
+    void shouldReturnMfaResetStorageTokenJwk() {
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
+
+        var expectedJWKSet = new JWKSet(List.of(storageTokenSigningKey));
+
+        assertThat(result, hasStatus(200));
+        assertThat(result, hasBody(expectedJWKSet.toString(true)));
+    }
+
+    @Test
+    void shouldReturn500WhenSigningKeyIsNotPresent() {
+        when(jwksService.getPublicMfaResetStorageTokenJwkWithOpaqueId()).thenReturn(null);
+
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasBody("Error providing MfaResetStorageTokenJwk data"));
+    }
+
+    @Test
+    void shouldSetACacheHeaderOfOneDayOnSuccess() {
+        var response = handler.handleRequest(new APIGatewayProxyRequestEvent(), context);
+        assertThat(response, hasHeader("Cache-Control", "max-age=86400"));
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -519,8 +519,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("IPV_AUDIENCE", "");
     }
 
-    public String getStorageTokenSigningKeyAlias() {
-        return System.getenv("STORAGE_TOKEN_SIGNING_KEY_ALIAS");
+    public String getMfaResetStorageTokenSigningKeyAlias() {
+        return System.getenv("MFA_RESET_STORAGE_TOKEN_SIGNING_KEY_ALIAS");
     }
 
     public URI getCredentialStoreURI() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
@@ -63,9 +63,7 @@ public class JwksService {
 
     public JWK getPublicMfaResetStorageTokenJwkWithOpaqueId() {
         LOG.info("Retrieving storage token public key");
-        // this is available when ATO-661 is deployed
-        // getPublicJWKWithKeyId(configurationService.getStorageTokenSigningKeyAlias());
-        return getPublicJWKWithKeyId("some-alias");
+        return getPublicJWKWithKeyId(configurationService.getMfaResetStorageTokenSigningKeyAlias());
     }
 
     public JWK retrieveJwkFromURLWithKeyId(URL url, String keyId) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
@@ -61,6 +61,13 @@ public class JwksService {
         return getPublicJWKWithKeyId(configurationService.getDocAppTokenSigningKeyAlias());
     }
 
+    public JWK getPublicMfaResetStorageTokenJwkWithOpaqueId() {
+        LOG.info("Retrieving storage token public key");
+        // this is available when ATO-661 is deployed
+        // getPublicJWKWithKeyId(configurationService.getStorageTokenSigningKeyAlias());
+        return getPublicJWKWithKeyId("some-alias");
+    }
+
     public JWK retrieveJwkFromURLWithKeyId(URL url, String keyId) {
         JWKSelector selector = new JWKSelector(new JWKMatcher.Builder().keyID(keyId).build());
         JWKSource<SecurityContext> jwkSource =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -399,7 +399,7 @@ public class TokenService {
                 claimsSet,
                 type,
                 JWSAlgorithm.ES256,
-                configService.getStorageTokenSigningKeyAlias());
+                configService.getMfaResetStorageTokenSigningKeyAlias());
     }
 
     private SignedJWT generateSignedJWT(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/PackageSettings.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/PackageSettings.java
@@ -1,0 +1,14 @@
+package uk.gov.di.authentication.shared;
+
+import org.approvaltests.core.ApprovalFailureReporter;
+import org.approvaltests.reporters.AutoApproveWhenEmptyReporter;
+import org.approvaltests.reporters.JunitReporter;
+
+public class PackageSettings {
+    public static ApprovalFailureReporter UseReporter =
+            new AutoApproveWhenEmptyReporter(new JunitReporter());
+    public static ApprovalFailureReporter FrontloadedReporter =
+            new AutoApproveWhenEmptyReporter(new JunitReporter());
+    public static String UseApprovalSubdirectory = "approvals";
+    public static String ApprovalBaseDirectory = "../resources";
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -191,7 +191,7 @@ public class TokenServiceTest {
         AccessToken token = tokenService.generateStorageTokenForMfaReset(new Subject());
         String[] splitToken = token.toString().split("\\.");
 
-        verify(configurationService).getStorageTokenSigningKeyAlias();
+        verify(configurationService).getMfaResetStorageTokenSigningKeyAlias();
         assertEquals(3, splitToken.length);
         assertThat(token.toString(), startsWith(STORAGE_TOKEN_PREFIX));
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -27,6 +27,11 @@ import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.claims.AccessTokenHash;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import net.minidev.json.JSONArray;
+import org.approvaltests.JsonApprovals;
+import org.approvaltests.core.Options;
+import org.approvaltests.scrubbers.GuidScrubber;
+import org.approvaltests.scrubbers.RegExScrubber;
+import org.approvaltests.scrubbers.Scrubbers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,6 +94,8 @@ public class TokenServiceTest {
     private static final Subject PUBLIC_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Subject INTERNAL_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Subject INTERNAL_PAIRWISE_SUBJECT = SubjectHelper.govUkSignInSubject();
+    private static final Subject FIXED_INTERNAL_PAIRWISE_SUBJECT =
+            new Subject("urn:fdc:gov.uk:2022:TJLt3WaiGkLh8UqeisH2zVKGAP0");
     private static final Scope SCOPES =
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PHONE);
     private static final String VOT = CredentialTrustLevel.MEDIUM_LEVEL.getValue();
@@ -182,18 +189,24 @@ public class TokenServiceTest {
     }
 
     @Test
-    void shouldGenerateWellFormedStorageTokenForMfaReset() throws JOSEException {
+    void shouldGenerateWellFormedStorageTokenForMfaReset() throws JOSEException, ParseException {
         when(configurationService.getCredentialStoreURI())
                 .thenReturn(URI.create(CREDENTIAL_STORE_URI));
         when(configurationService.getIPVAudience()).thenReturn(IPV_AUDIENCE);
         createSignedToken();
 
-        AccessToken token = tokenService.generateStorageTokenForMfaReset(new Subject());
-        String[] splitToken = token.toString().split("\\.");
+        AccessToken token =
+                tokenService.generateStorageTokenForMfaReset(FIXED_INTERNAL_PAIRWISE_SUBJECT);
+        var parsedToken = SignedJWT.parse(token.getValue());
 
         verify(configurationService).getMfaResetStorageTokenSigningKeyAlias();
-        assertEquals(3, splitToken.length);
+        assertEquals(3, parsedToken.getParsedParts().length);
         assertThat(token.toString(), startsWith(STORAGE_TOKEN_PREFIX));
+        var unixTimestampScrubber = new RegExScrubber("\\d{10}", "1700000000");
+        var guidScrubber = new GuidScrubber();
+        JsonApprovals.verifyAsJson(
+                parsedToken.getJWTClaimsSet().toJSONObject(),
+                new Options(Scrubbers.scrubAll(unixTimestampScrubber, guidScrubber)));
     }
 
     @Test

--- a/shared/src/test/resources/uk/gov/di/authentication/shared/services/approvals/TokenServiceTest.shouldGenerateWellFormedStorageTokenForMfaReset.approved.json
+++ b/shared/src/test/resources/uk/gov/di/authentication/shared/services/approvals/TokenServiceTest.shouldGenerateWellFormedStorageTokenForMfaReset.approved.json
@@ -1,0 +1,11 @@
+{
+  "aud": [
+    "https://credential-store.account.gov.uk",
+    "https://identity.test.account.gov.uk"
+  ],
+  "sub": "urn:fdc:gov.uk:2022:TJLt3WaiGkLh8UqeisH2zVKGAP0",
+  "scope": "reverification",
+  "exp": 1700000000,
+  "iat": 1700000000,
+  "jti": "guid_1"
+}


### PR DESCRIPTION
## What

Create new well-known endpoint on auth frontend API for MFA reset storage token signing public key

## Testing

After deploying to sandpit, key is available at https://auth.sandpit.account.gov.uk/.well-known/mfa-reset-jwk.json

## How to review

Code review only

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.




[ATO-661]: https://govukverify.atlassian.net/browse/ATO-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ