### PR TITLE
BAU: Add starter client for the dev environment

### DIFF
--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -43,3 +43,27 @@ orch_account_id = "767397776536"
 
 contra_state_bucket      = "di-auth-development-tfstate"
 phone_checker_with_retry = false
+
+stub_rp_clients = [
+  {
+    client_name           = "di-auth-stub-relying-party-dev"
+    sector_identifier_uri = "https://rp-dev.dev.stubs.account.gov.uk"
+    callback_urls = [
+      "https://rp-dev.dev.stubs.account.gov.uk/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://rp-dev.dev.stubs.account.gov.uk/signed-out",
+    ]
+    test_client                     = "0"
+    client_type                     = "web"
+    identity_verification_supported = "0"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+      "wallet-subject-id",
+    ]
+    one_login_service = false
+    service_type      = "MANDATORY"
+  },
+]


### PR DESCRIPTION

## What

Add starter client for the dev environment.

So we can create a url to launch the app in absence of a stub

## How to review

1. Code Review
