### PR TITLE
ATO-687: Add Optional Type Adapter

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/serialization/OptionalAdapter.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/serialization/OptionalAdapter.java
@@ -1,0 +1,57 @@
+package uk.gov.di.orchestration.shared.serialization;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.util.Optional;
+
+public class OptionalAdapter<E> extends TypeAdapter<Optional<E>> {
+
+    public static final TypeAdapterFactory FACTORY =
+            new TypeAdapterFactory() {
+                @Override
+                public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+                    Class<T> rawType = (Class<T>) type.getRawType();
+                    if (rawType == Optional.class
+                            && type.getType() instanceof ParameterizedType parameterizedType) {
+                        return new OptionalAdapter(
+                                gson.getAdapter(
+                                        TypeToken.get(
+                                                parameterizedType.getActualTypeArguments()[0])));
+                    }
+                    return null;
+                }
+            };
+
+    private final TypeAdapter<E> valueAdapter;
+
+    public OptionalAdapter(TypeAdapter<E> valueAdapter) {
+        this.valueAdapter = valueAdapter;
+    }
+
+    @Override
+    public Optional<E> read(JsonReader jsonReader) throws IOException {
+        if (jsonReader.peek() != JsonToken.NULL) {
+            return Optional.ofNullable(valueAdapter.read(jsonReader));
+        } else {
+            jsonReader.nextNull();
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void write(JsonWriter jsonWriter, Optional<E> value) throws IOException {
+        if (value.isPresent()) {
+            valueAdapter.write(jsonWriter, value.get());
+        } else {
+            jsonWriter.nullValue();
+        }
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SerializationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SerializationService.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.LocalDateTimeAdapter;
+import uk.gov.di.orchestration.shared.serialization.OptionalAdapter;
 import uk.gov.di.orchestration.shared.serialization.StateAdapter;
 import uk.gov.di.orchestration.shared.serialization.SubjectAdapter;
 import uk.gov.di.orchestration.shared.validation.RequiredFieldValidator;
@@ -37,6 +38,7 @@ public class SerializationService implements Json {
                         .registerTypeAdapter(State.class, new StateAdapter())
                         .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter())
                         .registerTypeAdapter(Subject.class, new SubjectAdapter())
+                        .registerTypeAdapterFactory(OptionalAdapter.FACTORY)
                         .create();
     }
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/serialization/OptionalAdapterTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/serialization/OptionalAdapterTest.java
@@ -1,0 +1,55 @@
+package uk.gov.di.orchestration.shared.serialization;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+class OptionalAdapterTest {
+
+    private static final Type OPTIONAL_OF_STRING_TYPE =
+            new TypeToken<Optional<String>>() {}.getType();
+
+    public Gson gson;
+
+    @BeforeEach
+    void setup() {
+        gson = new GsonBuilder().registerTypeAdapterFactory(OptionalAdapter.FACTORY).create();
+    }
+
+    @Test
+    void shouldSerializeEmptyOptionalAsNull() {
+        var optional = Optional.empty();
+        var actualJson = gson.toJson(optional, OPTIONAL_OF_STRING_TYPE);
+        assertThat(actualJson, is(equalTo("null")));
+    }
+
+    @Test
+    void shouldSerializeNonEmptyOptionalAsValue() {
+        var optional = Optional.of("some text");
+        var json = gson.toJson(optional, OPTIONAL_OF_STRING_TYPE);
+        assertThat(json, is(equalTo("\"some text\"")));
+    }
+
+    @Test
+    void shouldDeserializeNullAsEmptyOptional() {
+        var json = "null";
+        var optional = gson.fromJson(json, OPTIONAL_OF_STRING_TYPE);
+        assertThat(optional, is(equalTo(Optional.empty())));
+    }
+
+    @Test
+    void shouldDeserializeValuesAsNonEmptyOptional() {
+        var json = "\"some text\"";
+        var optional = gson.fromJson(json, OPTIONAL_OF_STRING_TYPE);
+        assertThat(optional, is(equalTo(Optional.of("some text"))));
+    }
+}


### PR DESCRIPTION
## What

Added json type adapter for optionals.
Optionals of some value will be serialised to the inner value and vice versa.
Empty optionals will be serialised to null and vice versa.

## Why

The existing pubic key and new JWKS endpoint fields in client registry need to be nullable via the client registry APIs update handler. The update handler currently interprets both null and undefined fields in the update request as to be ignored. With this type adapter and by making those fields optionals, we will have a means of differentiating between explicit nulls which will deserialise to Optional.Empty and undefined fields which will deserialise to null.

## How to review

Code Review