### PR TITLE
ATO-675: Enable origin cloaking WAF build

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -47,4 +47,5 @@ orch_account_id = "767397776536"
 
 oidc_origin_domain_enabled  = true
 oidc_cloudfront_dns_enabled = true
+enforce_cloudfront          = true
 txma_audit_encoded_enabled  = true


### PR DESCRIPTION
## What

Mandate the use of CloudFront for the OIDC API in the build environment