### PR TITLE
AUT-2814: Switch on phone checks using SQS in all environments including production

### DIFF
--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -49,8 +49,7 @@ email_acct_creation_otp_code_ttl_duration = 60
 
 orch_client_id = "orchestrationAuth"
 
-contra_state_bucket      = "di-auth-development-tfstate"
-phone_checker_with_retry = false
+contra_state_bucket = "di-auth-development-tfstate"
 
 orch_frontend_api_gateway_integration_enabled = false
 

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -48,8 +48,7 @@ email_acct_creation_otp_code_ttl_duration = 60
 
 orch_client_id = "orchestrationAuth"
 
-contra_state_bucket      = "di-auth-development-tfstate"
-phone_checker_with_retry = false
+contra_state_bucket = "di-auth-development-tfstate"
 
 orch_redirect_uri                  = "https://oidc.authdev2.sandpit.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -40,8 +40,7 @@ orch_client_id                     = "orchestrationAuth"
 orch_redirect_uri                  = "https://oidc.build.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
 
-contra_state_bucket      = "digital-identity-dev-tfstate"
-phone_checker_with_retry = false
+contra_state_bucket = "digital-identity-dev-tfstate"
 
 orch_account_id = "767397776536"
 

--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -41,5 +41,4 @@ authorize_protected_subnet_enabled = true
 
 orch_account_id = "767397776536"
 
-contra_state_bucket      = "di-auth-development-tfstate"
-phone_checker_with_retry = false
+contra_state_bucket = "di-auth-development-tfstate"

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -35,8 +35,7 @@ orch_client_id                     = "orchestrationAuth"
 orch_redirect_uri                  = "https://oidc.integration.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
 
-contra_state_bucket      = "digital-identity-dev-tfstate"
-phone_checker_with_retry = true
+contra_state_bucket = "digital-identity-dev-tfstate"
 
 orch_account_id = "058264132019"
 

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -35,8 +35,7 @@ orch_client_id                     = "orchestrationAuth"
 orch_redirect_uri                  = "https://oidc.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
 
-contra_state_bucket      = "digital-identity-prod-tfstate"
-phone_checker_with_retry = false
+contra_state_bucket = "digital-identity-prod-tfstate"
 
 orch_account_id = "533266965190"
 

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -56,7 +56,6 @@ support_email_check_enabled = true
 
 txma_audit_encoded_enabled = true
 contra_state_bucket        = "digital-identity-dev-tfstate"
-phone_checker_with_retry   = false
 
 orch_openid_configuration_enabled    = true
 orch_doc_app_callback_enabled        = true

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -20,8 +20,7 @@ cmk_for_back_channel_logout_enabled             = true
 spot_request_queue_cross_account_access_enabled = true
 txma_audit_encoded_enabled                      = true
 
-contra_state_bucket      = "di-auth-staging-tfstate"
-phone_checker_with_retry = true
+contra_state_bucket = "di-auth-staging-tfstate"
 
 oidc_origin_domain_enabled  = true
 oidc_cloudfront_dns_enabled = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -328,7 +328,7 @@ variable "ipv_no_session_response_enabled" {
 
 variable "phone_checker_with_retry" {
   type    = bool
-  default = false
+  default = true
 }
 
 variable "internal_sector_uri" {


### PR DESCRIPTION
## What

Switch on phone checks using SQS in all environments including production.

In effect this PR switches to SQS in build then production.  The changes have been running in integration since May 31.

Triggers a phone check in authentication-contra-indicators by putting a message on an SQS queue.

## How to review

1. Code Review

## Related PRs

#4608 

https://github.com/govuk-one-login/authentication-contra-indicators/pull/171

https://github.com/govuk-one-login/authentication-contra-indicators/pull/170

