### PR TITLE
Revert "AUT-2882: Add CHECK_BYPASSED audit event"

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -9,8 +9,7 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     ACCOUNT_MANAGEMENT_AUTHENTICATE,
     ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
     DELETE_ACCOUNT,
-    SEND_OTP,
-    EMAIL_FRAUD_CHECK_BYPASSED;
+    SEND_OTP;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -17,14 +17,12 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
 import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
@@ -117,36 +115,6 @@ public class UpdateEmailHandler
         try {
             UpdateEmailRequest updateInfoRequest =
                     objectMapper.readValue(input.getBody(), UpdateEmailRequest.class);
-
-            boolean isValidOtpCode =
-                    codeStorageService.isValidOtpCode(
-                            updateInfoRequest.getReplacementEmailAddress(),
-                            updateInfoRequest.getOtp(),
-                            NotificationType.VERIFY_EMAIL);
-            if (!isValidOtpCode) {
-                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1020);
-            }
-
-            Optional<ErrorResponse> emailValidationErrors =
-                    ValidationHelper.validateEmailAddressUpdate(
-                            updateInfoRequest.getExistingEmailAddress(),
-                            updateInfoRequest.getReplacementEmailAddress());
-            if (emailValidationErrors.isPresent()) {
-                return generateApiGatewayProxyErrorResponse(400, emailValidationErrors.get());
-            }
-
-            if (dynamoService.userExists(updateInfoRequest.getReplacementEmailAddress())) {
-                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1009);
-            }
-
-            var userProfile =
-                    dynamoService
-                            .getUserProfileByEmailMaybe(updateInfoRequest.getExistingEmailAddress())
-                            .orElseThrow(
-                                    () ->
-                                            new UserNotFoundException(
-                                                    "User not found with given email"));
-
             AtomicReference<EmailCheckResultStatus> resultStatus =
                     new AtomicReference<>(EmailCheckResultStatus.PENDING);
             dynamoEmailCheckResultService
@@ -155,27 +123,31 @@ public class UpdateEmailHandler
             LOG.info(
                     "UpdateEmailHandler: Experian email verification status: {}",
                     resultStatus.get());
-            if (resultStatus.get().equals(EmailCheckResultStatus.PENDING)) {
-                auditService.submitAuditEvent(
-                        AccountManagementAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED,
-                        input.getRequestContext()
-                                .getAuthorizer()
-                                .getOrDefault("clientId", AuditService.UNKNOWN)
-                                .toString(),
-                        ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
-                        sessionId,
-                        userProfile.getSubjectID(),
-                        updateInfoRequest.getReplacementEmailAddress(),
-                        IpAddressHelper.extractIpAddress(input),
-                        userProfile.getPhoneNumber(),
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                        AuditHelper.buildRestrictedSection(input.getHeaders()),
-                        AuditService.MetadataPair.pair(
-                                "journey_type", JourneyType.ACCOUNT_MANAGEMENT.getValue()),
-                        AuditService.MetadataPair.pair(
-                                "assessment_checked_at_timestamp", NowHelper.now()),
-                        AuditService.MetadataPair.pair("iss", AuditService.COMPONENT_ID));
+            boolean isValidOtpCode =
+                    codeStorageService.isValidOtpCode(
+                            updateInfoRequest.getReplacementEmailAddress(),
+                            updateInfoRequest.getOtp(),
+                            NotificationType.VERIFY_EMAIL);
+            if (!isValidOtpCode) {
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1020);
             }
+            Optional<ErrorResponse> emailValidationErrors =
+                    ValidationHelper.validateEmailAddressUpdate(
+                            updateInfoRequest.getExistingEmailAddress(),
+                            updateInfoRequest.getReplacementEmailAddress());
+            if (emailValidationErrors.isPresent()) {
+                return generateApiGatewayProxyErrorResponse(400, emailValidationErrors.get());
+            }
+            if (dynamoService.userExists(updateInfoRequest.getReplacementEmailAddress())) {
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1009);
+            }
+            var userProfile =
+                    dynamoService
+                            .getUserProfileByEmailMaybe(updateInfoRequest.getExistingEmailAddress())
+                            .orElseThrow(
+                                    () ->
+                                            new UserNotFoundException(
+                                                    "User not found with given email"));
 
             Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
             if (PrincipalValidationHelper.principleIsInvalid(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -7,8 +7,6 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
@@ -18,13 +16,11 @@ import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -35,7 +31,6 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -161,37 +156,14 @@ class UpdateEmailHandlerTest {
         when(dynamoEmailCheckResultService.getEmailCheckStore(NEW_EMAIL_ADDRESS))
                 .thenReturn(Optional.empty());
 
-        Date mockedDate = new Date();
-        try (MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class)) {
-            mockedNowHelperClass.when(NowHelper::now).thenReturn(mockedDate);
-            var event = generateApiGatewayEvent(NEW_EMAIL_ADDRESS, expectedCommonSubject);
-            handler.handleRequest(event, context);
+        var event = generateApiGatewayEvent(NEW_EMAIL_ADDRESS, expectedCommonSubject);
+        handler.handleRequest(event, context);
 
-            assertThat(
-                    logging.events(),
-                    hasItem(
-                            withMessageContaining(
-                                    "UpdateEmailHandler: Experian email verification status: PENDING")));
-
-            verify(auditService)
-                    .submitAuditEvent(
-                            AccountManagementAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED,
-                            CLIENT_ID,
-                            SESSION_ID,
-                            AuditService.UNKNOWN,
-                            INTERNAL_SUBJECT.getValue(),
-                            NEW_EMAIL_ADDRESS,
-                            "123.123.123.123",
-                            userProfile.getPhoneNumber(),
-                            PERSISTENT_ID,
-                            new AuditService.RestrictedSection(
-                                    Optional.of(TXMA_ENCODED_HEADER_VALUE)),
-                            AuditService.MetadataPair.pair(
-                                    "journey_type", JourneyType.ACCOUNT_MANAGEMENT.getValue()),
-                            AuditService.MetadataPair.pair(
-                                    "assessment_checked_at_timestamp", mockedDate),
-                            AuditService.MetadataPair.pair("iss", "AUTH"));
-        }
+        assertThat(
+                logging.events(),
+                hasItem(
+                        withMessageContaining(
+                                "UpdateEmailHandler: Experian email verification status: PENDING")));
     }
 
     @Test
@@ -215,6 +187,7 @@ class UpdateEmailHandlerTest {
 
         assertThat(expectedException.getMessage(), equalTo("Invalid Principal in request"));
         verifyNoInteractions(sqsClient);
+        verifyNoInteractions(auditService);
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.UPDATE_EMAIL;
 import static uk.gov.di.accountmanagement.entity.NotificationType.EMAIL_UPDATED;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
@@ -78,8 +77,7 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 EXISTING_EMAIL_ADDRESS, EMAIL_UPDATED, SupportedLanguage.EN),
                         new NotifyRequest(NEW_EMAIL_ADDRESS, EMAIL_UPDATED, SupportedLanguage.EN)));
 
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(UPDATE_EMAIL, EMAIL_FRAUD_CHECK_BYPASSED));
+        assertTxmaAuditEventsSubmittedWithMatchingNames(txmaAuditQueue, List.of(UPDATE_EMAIL));
     }
 
     @Test

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -49,8 +49,7 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     PERMANENTLY_BLOCKED_INTERVENTION,
     PASSWORD_RESET_INTERVENTION_COMPLETE,
     REAUTHENTICATION_SUCCESSFUL,
-    REAUTHENTICATION_INVALID,
-    EMAIL_FRAUD_CHECK_BYPASSED;
+    REAUTHENTICATION_INVALID;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
@@ -5,21 +5,14 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -30,7 +23,6 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -39,11 +31,9 @@ import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
-import static uk.gov.di.authentication.shared.lambda.BaseFrontendHandler.TXMA_AUDIT_ENCODED_HEADER;
-import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.identityWithSourceIp;
+import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -55,14 +45,6 @@ class CheckEmailFraudBlockHandlerTest {
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final String CLIENT_SESSION_ID = "known-client-session-id";
     private static final Subject INTERNAL_SUBJECT_ID = new Subject();
-    private static final String CLIENT_ID = "some-client-id";
-    private static final String IP_ADDRESS = "123.123.123.123";
-    private static final Subject INTERNAL_SUBJECT = new Subject();
-    private final String expectedCommonSubject =
-            ClientSubjectHelper.calculatePairwiseIdentifier(
-                    INTERNAL_SUBJECT.getValue(), "test.account.gov.uk", SALT);
-    public static final String ENCODED_DEVICE_DETAILS =
-            "YTtKVSlub1YlOSBTeEI4J3pVLVd7Jjl8VkBfREs2N3clZmN+fnU7fXNbcTJjKyEzN2IuUXIgMGttV058fGhUZ0xhenZUdldEblB8SH18XypwXUhWPXhYXTNQeURW%";
 
     private static AuditService auditServiceMock;
     private static AuthenticationService authenticationServiceMock;
@@ -111,9 +93,6 @@ class CheckEmailFraudBlockHandlerTest {
     @ParameterizedTest
     @EnumSource(EmailCheckResultStatus.class)
     void shouldReturnCorrectStatusBasedOnDbResult(EmailCheckResultStatus status) {
-        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
-                getProxyRequestContext();
-
         var resultStore = new EmailCheckResultStore();
         resultStore.setStatus(status);
         when(dbMock.getEmailCheckStore(EMAIL)).thenReturn(Optional.of(resultStore));
@@ -125,7 +104,7 @@ class CheckEmailFraudBlockHandlerTest {
         headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
 
         var event = new APIGatewayProxyRequestEvent();
-        event.setRequestContext(proxyRequestContext);
+        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         event.setHeaders(headers);
         event.setBody(format("{ \"email\": \"%s\" }", EMAIL.toUpperCase()));
 
@@ -134,59 +113,6 @@ class CheckEmailFraudBlockHandlerTest {
 
         assertThat(result, hasStatus(200));
         assertThat(result, hasJsonBody(expectedResponse));
-    }
-
-    @Test
-    void shouldSubmitAuditWithPendingStatusWhenEmailCheckResultStoreNotPresent() {
-        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
-                getProxyRequestContext();
-
-        var resultStore = new EmailCheckResultStore();
-        resultStore.setStatus(EmailCheckResultStatus.PENDING);
-        when(dbMock.getEmailCheckStore(EMAIL)).thenReturn(Optional.of(resultStore));
-
-        usingValidSession();
-        Map<String, String> headers = new HashMap<>();
-        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
-        headers.put("Session-Id", session.getSessionId());
-        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
-        headers.put(TXMA_AUDIT_ENCODED_HEADER, ENCODED_DEVICE_DETAILS);
-
-        Date mockedDate = new Date();
-        try (MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class)) {
-            mockedNowHelperClass.when(NowHelper::now).thenReturn(mockedDate);
-
-            var event = new APIGatewayProxyRequestEvent();
-            event.setHeaders(headers);
-            event.setRequestContext(proxyRequestContext);
-            event.setBody(format("{ \"email\": \"%s\" }", EMAIL.toUpperCase()));
-
-            var expectedResponse =
-                    new CheckEmailFraudBlockResponse(
-                            EMAIL, EmailCheckResultStatus.PENDING.getValue());
-            var result = handler.handleRequest(event, contextMock);
-
-            assertThat(result, hasStatus(200));
-            assertThat(result, hasJsonBody(expectedResponse));
-
-            verify(auditServiceMock)
-                    .submitAuditEvent(
-                            FrontendAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED,
-                            CLIENT_ID,
-                            CLIENT_SESSION_ID,
-                            CLIENT_SESSION_ID,
-                            AuditService.UNKNOWN,
-                            EMAIL,
-                            IP_ADDRESS,
-                            AuditService.UNKNOWN,
-                            PERSISTENT_ID,
-                            new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
-                            AuditService.MetadataPair.pair(
-                                    "journeyType", JourneyType.REGISTRATION.getValue()),
-                            AuditService.MetadataPair.pair(
-                                    "assessmentCheckedAtTimestamp", mockedDate),
-                            AuditService.MetadataPair.pair("iss", "AUTH"));
-        }
     }
 
     private void usingValidSession() {
@@ -199,16 +125,5 @@ class CheckEmailFraudBlockHandlerTest {
                 .withEmail(EMAIL)
                 .withEmailVerified(true)
                 .withSubjectID(INTERNAL_SUBJECT_ID.getValue());
-    }
-
-    private APIGatewayProxyRequestEvent.ProxyRequestContext getProxyRequestContext() {
-        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
-                new APIGatewayProxyRequestEvent.ProxyRequestContext();
-        Map<String, Object> authorizerParams = new HashMap<>();
-        authorizerParams.put("principalId", expectedCommonSubject);
-        authorizerParams.put("clientId", CLIENT_ID);
-        proxyRequestContext.setAuthorizer(authorizerParams);
-        proxyRequestContext.setIdentity(identityWithSourceIp(IP_ADDRESS));
-        return proxyRequestContext;
     }
 }


### PR DESCRIPTION
This reverts commit a06985c4ed01c1c550a78b938cfd94818b064cc6.

This was failing acceptance tests in build due to the following error:
```java.lang.NullPointerException / Cannot invoke "java.util.Map.getOrDefault(Object, Object)" because the return value of "com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent$ProxyRequestContext.getAuthorizer()" is null```
, reverting while we investigate further.

