### PR TITLE
AUT-2882: Add EMAIL_FRAUD_CHECK_BYPASSED audit event

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -9,7 +9,8 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     ACCOUNT_MANAGEMENT_AUTHENTICATE,
     ACCOUNT_MANAGEMENT_AUTHENTICATE_FAILURE,
     DELETE_ACCOUNT,
-    SEND_OTP;
+    SEND_OTP,
+    EMAIL_FRAUD_CHECK_BYPASSED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -49,7 +49,8 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     PERMANENTLY_BLOCKED_INTERVENTION,
     PASSWORD_RESET_INTERVENTION_COMPLETE,
     REAUTHENTICATION_SUCCESSFUL,
-    REAUTHENTICATION_INVALID;
+    REAUTHENTICATION_INVALID,
+    EMAIL_FRAUD_CHECK_BYPASSED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckEmailFraudBlockRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckEmailFraudBlockRequest.java
@@ -2,4 +2,13 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
-public class CheckEmailFraudBlockRequest extends BaseFrontendRequest {}
+public class CheckEmailFraudBlockRequest extends BaseFrontendRequest {
+
+    public CheckEmailFraudBlockRequest(String email) {
+        this.email = email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
@@ -5,14 +5,22 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -22,7 +30,9 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -31,10 +41,11 @@ import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
-import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
+import static uk.gov.di.authentication.shared.lambda.BaseFrontendHandler.TXMA_AUDIT_ENCODED_HEADER;
+import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.identityWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -46,6 +57,10 @@ class CheckEmailFraudBlockHandlerTest {
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final String CLIENT_SESSION_ID = "known-client-session-id";
     private static final Subject INTERNAL_SUBJECT_ID = new Subject();
+    private static final String CLIENT_ID = "some-client-id";
+    private static final String IP_ADDRESS = "123.123.123.123";
+    public static final String ENCODED_DEVICE_DETAILS =
+            "YTtKVSlub1YlOSBTeEI4J3pVLVd7Jjl8VkBfREs2N3clZmN+fnU7fXNbcTJjKyEzN2IuUXIgMGttV058fGhUZ0xhenZUdldEblB8SH18XypwXUhWPXhYXTNQeURW%";
 
     private static AuditService auditServiceMock;
     private static AuthenticationService authenticationServiceMock;
@@ -55,6 +70,8 @@ class CheckEmailFraudBlockHandlerTest {
     private static ClientSessionService clientSessionServiceMock;
     private static DynamoEmailCheckResultService dbMock;
     private static SessionService sessionServiceMock;
+    private static ClientRegistry clientRegistry;
+    private static UserContext userContext;
 
     private final Session session = new Session(IdGenerator.generate()).setEmailAddress(EMAIL);
     private CheckEmailFraudBlockHandler handler;
@@ -69,13 +86,20 @@ class CheckEmailFraudBlockHandlerTest {
         authenticationServiceMock = mock(AuthenticationService.class);
         sessionServiceMock = mock(SessionService.class);
         clientSessionServiceMock = mock(ClientSessionService.class);
+        clientRegistry = mock(ClientRegistry.class);
+        userContext = mock(UserContext.class);
     }
 
     @BeforeEach
     void setup() {
         var userProfile = generateUserProfile();
-
+        when(clientRegistry.getClientID()).thenReturn(CLIENT_ID);
+        when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
+        when(userContext.getSession()).thenReturn(session);
+        when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
+        when(userContext.getTxmaAuditEncoded()).thenReturn(ENCODED_DEVICE_DETAILS);
         when(configurationServiceMock.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
+        when(configurationServiceMock.isEmailCheckEnabled()).thenReturn(true);
         when(authenticationServiceMock.getOrGenerateSalt(userProfile)).thenReturn(SALT);
         when(authenticationServiceMock.getUserProfileFromEmail(EMAIL))
                 .thenReturn(Optional.of(userProfile));
@@ -94,6 +118,9 @@ class CheckEmailFraudBlockHandlerTest {
     @ParameterizedTest
     @EnumSource(EmailCheckResultStatus.class)
     void shouldReturnCorrectStatusBasedOnDbResult(EmailCheckResultStatus status) {
+        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
+                getProxyRequestContext();
+
         var resultStore = new EmailCheckResultStore();
         resultStore.setStatus(status);
         when(dbMock.getEmailCheckStore(EMAIL)).thenReturn(Optional.of(resultStore));
@@ -105,15 +132,75 @@ class CheckEmailFraudBlockHandlerTest {
         headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
 
         var event = new APIGatewayProxyRequestEvent();
-        event.setRequestContext(contextWithSourceIp(IP_ADDRESS));
+        event.setRequestContext(proxyRequestContext);
         event.setHeaders(headers);
-        event.setBody(format("{ \"email\": \"%s\" }", EMAIL.toUpperCase()));
+        event.setBody(format("{ \"email\": \"%s\" }", EMAIL));
 
         var expectedResponse = new CheckEmailFraudBlockResponse(EMAIL, status.getValue());
-        var result = handler.handleRequest(event, contextMock);
+        var result =
+                handler.handleRequestWithUserContext(
+                        event, contextMock, new CheckEmailFraudBlockRequest(EMAIL), userContext);
 
         assertThat(result, hasStatus(200));
         assertThat(result, hasJsonBody(expectedResponse));
+    }
+
+    @Test
+    void shouldSubmitAuditWithPendingStatusWhenEmailCheckResultStoreNotPresent() {
+        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
+                getProxyRequestContext();
+
+        var resultStore = new EmailCheckResultStore();
+        resultStore.setStatus(EmailCheckResultStatus.PENDING);
+        when(dbMock.getEmailCheckStore(EMAIL)).thenReturn(Optional.of(resultStore));
+
+        usingValidSession();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
+        headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
+        headers.put(TXMA_AUDIT_ENCODED_HEADER, ENCODED_DEVICE_DETAILS);
+
+        Date mockedDate = new Date();
+        try (MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class)) {
+            mockedNowHelperClass.when(NowHelper::now).thenReturn(mockedDate);
+
+            var event = new APIGatewayProxyRequestEvent();
+            event.setHeaders(headers);
+            event.setRequestContext(proxyRequestContext);
+            event.setBody(format("{ \"email\": \"%s\" }", EMAIL));
+
+            var expectedResponse =
+                    new CheckEmailFraudBlockResponse(
+                            EMAIL, EmailCheckResultStatus.PENDING.getValue());
+            var result =
+                    handler.handleRequestWithUserContext(
+                            event,
+                            contextMock,
+                            new CheckEmailFraudBlockRequest(EMAIL),
+                            userContext);
+
+            assertThat(result, hasStatus(200));
+            assertThat(result, hasJsonBody(expectedResponse));
+
+            verify(auditServiceMock)
+                    .submitAuditEvent(
+                            FrontendAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED,
+                            CLIENT_ID,
+                            CLIENT_SESSION_ID,
+                            session.getSessionId(),
+                            AuditService.UNKNOWN,
+                            EMAIL,
+                            IP_ADDRESS,
+                            AuditService.UNKNOWN,
+                            PERSISTENT_ID,
+                            new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                            AuditService.MetadataPair.pair(
+                                    "journey_type", JourneyType.REGISTRATION.getValue()),
+                            AuditService.MetadataPair.pair(
+                                    "assessment_checked_at_timestamp", mockedDate),
+                            AuditService.MetadataPair.pair("iss", "AUTH"));
+        }
     }
 
     private void usingValidSession() {
@@ -126,5 +213,12 @@ class CheckEmailFraudBlockHandlerTest {
                 .withEmail(EMAIL)
                 .withEmailVerified(true)
                 .withSubjectID(INTERNAL_SUBJECT_ID.getValue());
+    }
+
+    private APIGatewayProxyRequestEvent.ProxyRequestContext getProxyRequestContext() {
+        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
+                new APIGatewayProxyRequestEvent.ProxyRequestContext();
+        proxyRequestContext.setIdentity(identityWithSourceIp(IP_ADDRESS));
+        return proxyRequestContext;
     }
 }


### PR DESCRIPTION
## What

AUT-2882: Add CHECK_BYPASSED audit event
- Apply BYPASSED block whenever the email checker status is still PENDING
- Event is triggered when updating email and registration for new account

## How to review

1. Code Review