### PR TITLE
BAU: Refactor the audit service

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -63,6 +63,15 @@ class CheckReAuthUserHandlerTest {
 
     private final Session session =
             new Session(IdGenerator.generate()).setEmailAddress(EMAIL_ADDRESS);
+    private final AuditContext testAuditContext = new AuditContext(
+            CLIENT_ID,
+            CLIENT_SESSION_ID,
+            session.getSessionId(),
+            AuditService.UNKNOWN,
+            EMAIL_ADDRESS,
+            AuditService.UNKNOWN,
+            AuditService.UNKNOWN,
+            PERSISTENT_SESSION_ID);
     private final UserContext userContext = mock(UserContext.class);
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
     private static final byte[] SALT = SaltHelper.generateNewSalt();
@@ -126,17 +135,6 @@ class CheckReAuthUserHandlerTest {
                         userContext);
         assertEquals(200, result.getStatusCode());
 
-        AuditContext testAuditContext =
-                new AuditContext(
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        AuditService.UNKNOWN,
-                        EMAIL_ADDRESS,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
-
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
@@ -174,17 +172,6 @@ class CheckReAuthUserHandlerTest {
 
         assertEquals(200, result.getStatusCode());
 
-        AuditContext testAuditContext =
-                new AuditContext(
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        AuditService.UNKNOWN,
-                        EMAIL_ADDRESS,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
-
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
@@ -210,17 +197,6 @@ class CheckReAuthUserHandlerTest {
                         userContext);
         assertEquals(404, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1056));
-
-        AuditContext testAuditContext =
-                new AuditContext(
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        AuditService.UNKNOWN,
-                        EMAIL_ADDRESS,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
 
         verify(auditService)
                 .submitAuditEvent(
@@ -248,17 +224,6 @@ class CheckReAuthUserHandlerTest {
                         userContext);
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1057));
-
-        AuditContext testAuditContext =
-                new AuditContext(
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        AuditService.UNKNOWN,
-                        EMAIL_ADDRESS,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
 
         verify(auditService)
                 .submitAuditEvent(
@@ -309,17 +274,6 @@ class CheckReAuthUserHandlerTest {
                         userContext);
         assertEquals(404, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1056));
-
-        AuditContext testAuditContext =
-                new AuditContext(
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        session.getSessionId(),
-                        AuditService.UNKNOWN,
-                        EMAIL_ADDRESS,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
 
         verify(auditService)
                 .submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -126,9 +126,8 @@ class CheckReAuthUserHandlerTest {
                         userContext);
         assertEquals(200, result.getStatusCode());
 
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
+        AuditContext testAuditContext =
+                new AuditContext(
                         CLIENT_ID,
                         CLIENT_SESSION_ID,
                         session.getSessionId(),
@@ -136,7 +135,12 @@ class CheckReAuthUserHandlerTest {
                         EMAIL_ADDRESS,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID,
+                        PERSISTENT_SESSION_ID);
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
+                        testAuditContext,
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
     }
 
@@ -169,9 +173,9 @@ class CheckReAuthUserHandlerTest {
                         userContext);
 
         assertEquals(200, result.getStatusCode());
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
+
+        AuditContext testAuditContext =
+                new AuditContext(
                         CLIENT_ID,
                         CLIENT_SESSION_ID,
                         session.getSessionId(),
@@ -179,7 +183,12 @@ class CheckReAuthUserHandlerTest {
                         EMAIL_ADDRESS,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID,
+                        PERSISTENT_SESSION_ID);
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
+                        testAuditContext,
                         AuditService.RestrictedSection.empty);
     }
 
@@ -202,9 +211,8 @@ class CheckReAuthUserHandlerTest {
         assertEquals(404, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1056));
 
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.REAUTHENTICATION_INVALID,
+        AuditContext testAuditContext =
+                new AuditContext(
                         CLIENT_ID,
                         CLIENT_SESSION_ID,
                         session.getSessionId(),
@@ -212,7 +220,12 @@ class CheckReAuthUserHandlerTest {
                         EMAIL_ADDRESS,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID,
+                        PERSISTENT_SESSION_ID);
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.REAUTHENTICATION_INVALID,
+                        testAuditContext,
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
     }
 
@@ -297,9 +310,8 @@ class CheckReAuthUserHandlerTest {
         assertEquals(404, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1056));
 
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.REAUTHENTICATION_INVALID,
+        AuditContext testAuditContext =
+                new AuditContext(
                         CLIENT_ID,
                         CLIENT_SESSION_ID,
                         session.getSessionId(),
@@ -307,7 +319,12 @@ class CheckReAuthUserHandlerTest {
                         EMAIL_ADDRESS,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID,
+                        PERSISTENT_SESSION_ID);
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.REAUTHENTICATION_INVALID,
+                        testAuditContext,
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckReauthUserRequest;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
@@ -235,9 +236,8 @@ class CheckReAuthUserHandlerTest {
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1057));
 
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
+        AuditContext testAuditContext =
+                new AuditContext(
                         CLIENT_ID,
                         CLIENT_SESSION_ID,
                         session.getSessionId(),
@@ -245,7 +245,12 @@ class CheckReAuthUserHandlerTest {
                         EMAIL_ADDRESS,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID,
+                        PERSISTENT_SESSION_ID);
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
+                        testAuditContext,
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         AuditService.MetadataPair.pair(
                                 "number_of_attempts_user_allowed_to_login", 5));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -63,15 +63,16 @@ class CheckReAuthUserHandlerTest {
 
     private final Session session =
             new Session(IdGenerator.generate()).setEmailAddress(EMAIL_ADDRESS);
-    private final AuditContext testAuditContext = new AuditContext(
-            CLIENT_ID,
-            CLIENT_SESSION_ID,
-            session.getSessionId(),
-            AuditService.UNKNOWN,
-            EMAIL_ADDRESS,
-            AuditService.UNKNOWN,
-            AuditService.UNKNOWN,
-            PERSISTENT_SESSION_ID);
+    private final AuditContext testAuditContext =
+            new AuditContext(
+                    CLIENT_ID,
+                    CLIENT_SESSION_ID,
+                    session.getSessionId(),
+                    AuditService.UNKNOWN,
+                    EMAIL_ADDRESS,
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    PERSISTENT_SESSION_ID);
     private final UserContext userContext = mock(UserContext.class);
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
     private static final byte[] SALT = SaltHelper.generateNewSalt();

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -1,4 +1,12 @@
 package uk.gov.di.audit;
 
-public record AuditContext(String clientId, String clientSessionId, String sessionId) {}
+public record AuditContext(
+        String clientId,
+        String clientSessionId,
+        String sessionId,
+        String subjectId,
+        String email,
+        String ipAddress,
+        String phoneNumber,
+        String persistentSessionId) {}
 ;

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -8,5 +8,29 @@ public record AuditContext(
         String email,
         String ipAddress,
         String phoneNumber,
-        String persistentSessionId) {}
-;
+        String persistentSessionId) {
+
+    public AuditContext withPhoneNumber(String phoneNumber) {
+        return new AuditContext(
+                clientId,
+                clientSessionId,
+                sessionId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId);
+    }
+
+    public AuditContext withUserId(String subjectId) {
+        return new AuditContext(
+                clientId,
+                clientSessionId,
+                sessionId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -1,0 +1,4 @@
+package uk.gov.di.audit;
+
+public record AuditContext(String clientId, String clientSessionId, String sessionId) {}
+;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -128,7 +128,6 @@ public class AuditService {
                         .withGovukSigninJourneyId(auditContext.clientSessionId());
 
         submitAuditEvent(event, auditContext.clientId(), user, restrictedSection, metadataPairs);
-
     }
 
     public void submitAuditEvent(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.services;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.audit.TxmaAuditEvent;
 import uk.gov.di.audit.TxmaAuditUser;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
@@ -108,6 +109,31 @@ public class AuditService {
 
     public record RestrictedSection(Optional<String> encoded) {
         public static final RestrictedSection empty = new RestrictedSection(Optional.empty());
+    }
+
+    public void submitAuditEvent(
+            AuditableEvent event,
+            AuditContext auditContext,
+            String subjectId,
+            String email,
+            String ipAddress,
+            String phoneNumber,
+            String persistentSessionId,
+            RestrictedSection restrictedSection,
+            MetadataPair... metadataPairs) {
+
+        var user =
+                TxmaAuditUser.user()
+                        .withUserId(subjectId)
+                        .withPhone(phoneNumber)
+                        .withEmail(email)
+                        .withIpAddress(ipAddress)
+                        .withSessionId(auditContext.sessionId())
+                        .withPersistentSessionId(persistentSessionId)
+                        .withGovukSigninJourneyId(auditContext.clientSessionId());
+
+        submitAuditEvent(event, auditContext.clientId(), user, restrictedSection, metadataPairs);
+
     }
 
     public void submitAuditEvent(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -114,22 +114,17 @@ public class AuditService {
     public void submitAuditEvent(
             AuditableEvent event,
             AuditContext auditContext,
-            String subjectId,
-            String email,
-            String ipAddress,
-            String phoneNumber,
-            String persistentSessionId,
             RestrictedSection restrictedSection,
             MetadataPair... metadataPairs) {
 
         var user =
                 TxmaAuditUser.user()
-                        .withUserId(subjectId)
-                        .withPhone(phoneNumber)
-                        .withEmail(email)
-                        .withIpAddress(ipAddress)
+                        .withUserId(auditContext.subjectId())
+                        .withPhone(auditContext.phoneNumber())
+                        .withEmail(auditContext.email())
+                        .withIpAddress(auditContext.ipAddress())
                         .withSessionId(auditContext.sessionId())
-                        .withPersistentSessionId(persistentSessionId)
+                        .withPersistentSessionId(auditContext.persistentSessionId())
                         .withGovukSigninJourneyId(auditContext.clientSessionId());
 
         submitAuditEvent(event, auditContext.clientId(), user, restrictedSection, metadataPairs);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 import java.time.Clock;
@@ -60,6 +61,52 @@ class AuditServiceTest {
                 "client-id",
                 "request-id",
                 "session-id",
+                "subject-id",
+                "email",
+                "ip-address",
+                "phone-number",
+                "persistent-session-id",
+                AuditService.RestrictedSection.empty);
+
+        verify(awsSqsClient).send(txmaMessageCaptor.capture());
+
+        var txmaMessage = asJson(txmaMessageCaptor.getValue());
+
+        var expected =
+                """
+                {
+                "timestamp":1630534200,
+                "event_timestamp_ms":1630534200012,
+                "event_name":"AUTH_TEST_EVENT_ONE",
+                "client_id":"client-id",
+                "component_id":"AUTH",
+                "user": {
+                    "user_id":"subject-id",
+                    "transaction_id":null,
+                    "email":"email",
+                    "phone":"phone-number",
+                    "ip_address":"ip-address",
+                    "session_id":"session-id",
+                    "persistent_session_id":"persistent-session-id",
+                    "govuk_signin_journey_id":"request-id"
+                },
+                "platform":null,
+                "restricted":null,
+                "extensions":null}
+                """;
+
+        assertEquals(asJson(expected), txmaMessage);
+    }
+
+    @Test
+    void checkSimplifiedMethodCall() {
+        var myContext = new AuditContext("client-id",
+                "request-id",
+                "session-id");
+
+        auditService.submitAuditEvent(
+                TEST_EVENT_ONE,
+                myContext,
                 "subject-id",
                 "email",
                 "ip-address",

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -102,16 +102,16 @@ class AuditServiceTest {
     void checkSimplifiedMethodCall() {
         var myContext = new AuditContext("client-id",
                 "request-id",
-                "session-id");
-
-        auditService.submitAuditEvent(
-                TEST_EVENT_ONE,
-                myContext,
+                "session-id",
                 "subject-id",
                 "email",
                 "ip-address",
                 "phone-number",
-                "persistent-session-id",
+                "persistent-session-id");
+
+        auditService.submitAuditEvent(
+                TEST_EVENT_ONE,
+                myContext,
                 AuditService.RestrictedSection.empty);
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -100,19 +100,19 @@ class AuditServiceTest {
 
     @Test
     void checkSimplifiedMethodCall() {
-        var myContext = new AuditContext("client-id",
-                "request-id",
-                "session-id",
-                "subject-id",
-                "email",
-                "ip-address",
-                "phone-number",
-                "persistent-session-id");
+        var myContext =
+                new AuditContext(
+                        "client-id",
+                        "request-id",
+                        "session-id",
+                        "subject-id",
+                        "email",
+                        "ip-address",
+                        "phone-number",
+                        "persistent-session-id");
 
         auditService.submitAuditEvent(
-                TEST_EVENT_ONE,
-                myContext,
-                AuditService.RestrictedSection.empty);
+                TEST_EVENT_ONE, myContext, AuditService.RestrictedSection.empty);
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
 


### PR DESCRIPTION
## What

Introduces a new way of calling the audit service, intended to limit the number of parameters we pass in and repeat in each handler, making handlers easier to read and making it easier to see, for each audit event, what the important information is.

The idea is to introduce an AuditContext object (see prior art/closed PRs [here](https://github.com/govuk-one-login/authentication-api/commit/c2b3169e191f997be84b7f67c0504e970493a20d), [here](https://github.com/govuk-one-login/authentication-api/pull/4292) and [here](https://github.com/govuk-one-login/authentication-api/pull/4434), reflecting multiple independent people thinking along the same lines) to capture the common things that are submitted on all audit events within a handler, and generally either don't change between audit events, or are added to as we go in a handler as we learn more about a user.

This makes calls to the audit service much less noisy.

In this PR, we've converted two of our handlers to use this new pattern.

The idea is to incrementally introduce this across all of our handlers, so this is just a starter PR that gets the basics in and demonstrates how to migrate a handler.

## How to review

1. Code Review commit by commit

## Related PRs

The approach here is similar to a [previous refactoring](https://github.com/govuk-one-login/authentication-api/pull/4402) we did, although since we've changed our mind about this approach, hence reversing it in the login handler here.