### PR TITLE
ATO-688: Add DynamoDB table to cache RP public keys

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -277,6 +277,65 @@ Resources:
               ArnLike:
                 kms:EncryptionContext:aws:logs:arn: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
 
+  #region RP Public Key DynamoDB Table
+
+  RpPublicKeyTableEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS encryption key for RP public key DynamoDB table
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Sid: AllowDynamodbAccessToEncryptionKey
+            Effect: Allow
+            Principal:
+              Service: dynamodb.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+
+  RpPublicKeyCacheTable:
+    Type: AWS::DynamoDB::Table
+    # checkov:skip=CKV_AWS_28: It would be harmful to restore old keys from a backup of this data, and keys will be fetched if not present anyway.
+    Properties:
+      TableName: RpPublicKeyCache
+      AttributeDefinitions:
+        - AttributeName: clientId
+          AttributeType: S
+        - AttributeName: keyId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: clientId
+          KeyType: HASH
+        - AttributeName: keyId
+          KeyType: RANGE
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEEnabled: true
+        KMSMasterKeyId: !GetAtt RpPublicKeyTableEncryptionKey.Arn
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      Tags:
+        - Key: Name
+          Value: RpPublicKeyCache
+
+  #endregion
+
   #region Open ID Configuration Lambda
 
   OpenIdConfigurationFunction:


### PR DESCRIPTION
## What

When an RP starts to share their signing key using a JWKS endpoint, Orchestration will need to retrieve and cache the key. This PRs adds a new DynamoDB table to store cached RP public keys. A key will be stored as a string in JWK format.

The table has a primary key schema with `clientId` as the partition key (HASH) and `keyId` as the sort key (RANGE).

A new KMS key is defined and used to encrypt the table.

TTL is enabled as keys will be fetched once per day.

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.
