### PR TITLE
AUT-2879: Password Reset Align OTP TTL with Count TTL

### DIFF
--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -25,18 +25,19 @@ module "reset-password-request" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    FRONTEND_BASE_URL    = "https://${local.frontend_fqdn}/"
-    RESET_PASSWORD_ROUTE = var.reset_password_route
-    LOCKOUT_DURATION     = var.lockout_duration
-    LOCKOUT_COUNT_TTL    = var.lockout_count_ttl
-    SQS_ENDPOINT         = var.use_localstack ? "http://localhost:45678/" : null
-    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
-    TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY            = local.redis_key
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    ENVIRONMENT             = var.environment
+    FRONTEND_BASE_URL       = "https://${local.frontend_fqdn}/"
+    RESET_PASSWORD_ROUTE    = var.reset_password_route
+    LOCKOUT_DURATION        = var.lockout_duration
+    LOCKOUT_COUNT_TTL       = var.lockout_count_ttl
+    DEFAULT_OTP_CODE_EXPIRY = var.otp_code_ttl_duration
+    SQS_ENDPOINT            = var.use_localstack ? "http://localhost:45678/" : null
+    EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
+    TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY               = local.redis_key
+    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    INTERNAl_SECTOR_URI     = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ResetPasswordRequestHandler::handleRequest"
 


### PR DESCRIPTION
## What
Align OTP TTL with Count TTL where OTP TTL > Count TTL for  the Password Reset Check Email screen.

The ResetPasswordRequestHandler is the one that is generating and sending the Email OTP to the user. The default_otp_code expiry variable points out how long the email otp is available for. Because this variable was not included in the lambda environment variables, the otp was saved with the standard ttl value of 900.



## How to review

1. Code Review

