### PR TITLE
Bau/add audit encoded to audit context

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -22,6 +22,8 @@ import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.REAUTHENTICATION_INVALID;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1056;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -151,8 +153,7 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                         .getValue();
 
         if (calculatedPairwiseId != null && calculatedPairwiseId.equals(rpPairwiseId)) {
-            auditService.submitAuditEvent(
-                    FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL, auditContext);
+            auditService.submitAuditEvent(REAUTHENTICATION_SUCCESSFUL, auditContext);
             LOG.info("Successfully verified re-authentication");
             removeEmailCountLock(userProfile.getEmail());
             return Optional.of(rpPairwiseId);
@@ -175,8 +176,7 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
             throw new AccountLockedException(
                     "Account is locked due to too many failed attempts.", ErrorResponse.ERROR_1057);
         }
-        auditService.submitAuditEvent(
-                FrontendAuditableEvent.REAUTHENTICATION_INVALID, auditContext);
+        auditService.submitAuditEvent(REAUTHENTICATION_INVALID, auditContext);
         LOG.info("User not found or no match");
         codeStorageService.increaseIncorrectEmailCount(email);
         return generateApiGatewayProxyErrorResponse(404, ERROR_1056);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -89,7 +89,8 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                         request.email(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                        Optional.ofNullable(userContext.getTxmaAuditEncoded()));
 
         try {
             return authenticationService

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -10,7 +10,6 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckReauthUserRequest;
 import uk.gov.di.authentication.frontendapi.exceptions.AccountLockedException;
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -81,10 +80,7 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
 
         AuditContext auditContext =
                 new AuditContext(
-                        userContext
-                                .getClient()
-                                .map(ClientRegistry::getClientID)
-                                .orElse(AuditService.UNKNOWN),
+                        userContext.getClientId(),
                         userContext.getClientSessionId(),
                         userContext.getSession().getSessionId(),
                         AuditService.UNKNOWN,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -123,7 +123,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         request.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                        Optional.ofNullable(userContext.getTxmaAuditEncoded()));
 
         var restrictedSection =
                 new AuditService.RestrictedSection(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -40,6 +40,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.LOG_IN_SUCCESS;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL;
 import static uk.gov.di.authentication.frontendapi.services.UserMigrationService.userHasBeenPartlyMigrated;
 import static uk.gov.di.authentication.shared.conditions.MfaHelper.getUserMFADetail;
 import static uk.gov.di.authentication.shared.entity.Session.AccountState.EXISTING;
@@ -136,8 +137,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     authenticationService.getUserProfileByEmailMaybe(request.getEmail());
 
             if (userProfileMaybe.isEmpty() || userContext.getUserCredentials().isEmpty()) {
-                auditService.submitAuditEvent(
-                        FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL, auditContext);
+                auditService.submitAuditEvent(NO_ACCOUNT_WITH_EMAIL, auditContext);
 
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
             }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -92,6 +92,7 @@ class CheckReAuthUserHandlerTest {
         when(authenticationService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
         when(clientRegistry.getClientID()).thenReturn(CLIENT_ID);
         when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
+        when(userContext.getClientId()).thenReturn(CLIENT_ID);
         when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.of(clientRegistry));
         when(userContext.getSession()).thenReturn(session);
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -63,7 +63,7 @@ class CheckReAuthUserHandlerTest {
 
     private final Session session =
             new Session(IdGenerator.generate()).setEmailAddress(EMAIL_ADDRESS);
-    private final AuditContext testAuditContext =
+    private final AuditContext testAuditContextWithoutAuditEncoded =
             new AuditContext(
                     CLIENT_ID,
                     CLIENT_SESSION_ID,
@@ -72,7 +72,20 @@ class CheckReAuthUserHandlerTest {
                     EMAIL_ADDRESS,
                     AuditService.UNKNOWN,
                     AuditService.UNKNOWN,
-                    PERSISTENT_SESSION_ID);
+                    PERSISTENT_SESSION_ID,
+                    Optional.empty());
+
+    private final AuditContext testAuditContextWithAuditEncoded =
+            new AuditContext(
+                    CLIENT_ID,
+                    CLIENT_SESSION_ID,
+                    session.getSessionId(),
+                    AuditService.UNKNOWN,
+                    EMAIL_ADDRESS,
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    PERSISTENT_SESSION_ID,
+                    Optional.of(ENCODED_DEVICE_DETAILS));
     private final UserContext userContext = mock(UserContext.class);
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
     private static final byte[] SALT = SaltHelper.generateNewSalt();
@@ -139,7 +152,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
-                        testAuditContext,
+                        testAuditContextWithAuditEncoded,
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
     }
 
@@ -176,7 +189,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
-                        testAuditContext,
+                        testAuditContextWithoutAuditEncoded,
                         AuditService.RestrictedSection.empty);
     }
 
@@ -202,7 +215,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_INVALID,
-                        testAuditContext,
+                        testAuditContextWithAuditEncoded,
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
     }
 
@@ -229,7 +242,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
-                        testAuditContext,
+                        testAuditContextWithAuditEncoded,
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         AuditService.MetadataPair.pair(
                                 "number_of_attempts_user_allowed_to_login", 5));
@@ -279,7 +292,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_INVALID,
-                        testAuditContext,
+                        testAuditContextWithAuditEncoded,
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -76,15 +76,7 @@ class CheckReAuthUserHandlerTest {
                     Optional.empty());
 
     private final AuditContext testAuditContextWithAuditEncoded =
-            new AuditContext(
-                    CLIENT_ID,
-                    CLIENT_SESSION_ID,
-                    session.getSessionId(),
-                    AuditService.UNKNOWN,
-                    EMAIL_ADDRESS,
-                    AuditService.UNKNOWN,
-                    AuditService.UNKNOWN,
-                    PERSISTENT_SESSION_ID,
+            testAuditContextWithoutAuditEncoded.withTxmaAuditEncoded(
                     Optional.of(ENCODED_DEVICE_DETAILS));
     private final UserContext userContext = mock(UserContext.class);
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
@@ -152,8 +144,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
-                        testAuditContextWithAuditEncoded,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                        testAuditContextWithAuditEncoded);
     }
 
     @Test
@@ -189,8 +180,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
-                        testAuditContextWithoutAuditEncoded,
-                        AuditService.RestrictedSection.empty);
+                        testAuditContextWithoutAuditEncoded);
     }
 
     @Test
@@ -215,8 +205,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_INVALID,
-                        testAuditContextWithAuditEncoded,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                        testAuditContextWithAuditEncoded);
     }
 
     @Test
@@ -243,7 +232,6 @@ class CheckReAuthUserHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
                         testAuditContextWithAuditEncoded,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         AuditService.MetadataPair.pair(
                                 "number_of_attempts_user_allowed_to_login", 5));
     }
@@ -292,8 +280,7 @@ class CheckReAuthUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_INVALID,
-                        testAuditContextWithAuditEncoded,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                        testAuditContextWithAuditEncoded);
     }
 
     private UserProfile generateUserProfile() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -163,7 +163,8 @@ class LoginHandlerTest {
                     EMAIL,
                     TEST_IP_ADDRESS,
                     CommonTestVariables.UK_MOBILE_NUMBER,
-                    PERSISTENT_ID);
+                    PERSISTENT_ID,
+                    Optional.empty());
 
     private final AuditContext auditContextWithoutUserInfo =
             new AuditContext(
@@ -174,7 +175,8 @@ class LoginHandlerTest {
                     EMAIL,
                     TEST_IP_ADDRESS,
                     AuditService.UNKNOWN,
-                    PERSISTENT_ID);
+                    PERSISTENT_ID,
+                    Optional.empty());
 
     @RegisterExtension
     private final CaptureLoggingExtension logging = new CaptureLoggingExtension(LoginHandler.class);
@@ -236,7 +238,8 @@ class LoginHandlerTest {
                         EMAIL,
                         TEST_IP_ADDRESS,
                         CommonTestVariables.UK_MOBILE_NUMBER,
-                        PERSISTENT_ID);
+                        PERSISTENT_ID,
+                        Optional.of(ENCODED_DEVICE_DETAILS));
 
         var expectedRestrictedSection =
                 new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS));
@@ -417,7 +420,8 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
-                        auditContextWithAllUserInfo,
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
+                                Optional.of(ENCODED_DEVICE_DETAILS)),
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("passwordResetType", PasswordResetType.FORCED_WEAK_PASSWORD));
@@ -482,7 +486,8 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
-                        auditContextWithAllUserInfo,
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
+                                Optional.of(ENCODED_DEVICE_DETAILS)),
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("attemptNoFailedAt", maxRetriesAllowed),
@@ -514,7 +519,8 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
-                        auditContextWithAllUserInfo,
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
+                                Optional.of(ENCODED_DEVICE_DETAILS)),
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("incorrectPasswordCount", maxRetriesAllowed),
@@ -523,7 +529,8 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
-                        auditContextWithAllUserInfo,
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
+                                Optional.of(ENCODED_DEVICE_DETAILS)),
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("attemptNoFailedAt", maxRetriesAllowed),
@@ -554,7 +561,8 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
-                        auditContextWithAllUserInfo,
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
+                                Optional.of(ENCODED_DEVICE_DETAILS)),
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()),
@@ -608,7 +616,8 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
-                        auditContextWithAllUserInfo,
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
+                                Optional.of(ENCODED_DEVICE_DETAILS)),
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("incorrectPasswordCount", 1),
@@ -712,7 +721,8 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL,
-                        auditContextWithoutUserInfo,
+                        auditContextWithoutUserInfo.withTxmaAuditEncoded(
+                                Optional.of(ENCODED_DEVICE_DETAILS)),
                         new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
 
         assertThat(result, hasStatus(400));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -241,9 +241,6 @@ class LoginHandlerTest {
                         PERSISTENT_ID,
                         Optional.of(ENCODED_DEVICE_DETAILS));
 
-        var expectedRestrictedSection =
-                new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS));
-
         // Act
         var result = handler.handleRequest(event, context);
 
@@ -263,7 +260,6 @@ class LoginHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
                         expectedAuditContext,
-                        expectedRestrictedSection,
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()));
 
         verify(cloudwatchMetricsService)
@@ -311,7 +307,6 @@ class LoginHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
                         auditContextWithAllUserInfo,
-                        AuditService.RestrictedSection.empty,
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()));
     }
 
@@ -422,7 +417,6 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
                         auditContextWithAllUserInfo.withTxmaAuditEncoded(
                                 Optional.of(ENCODED_DEVICE_DETAILS)),
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("passwordResetType", PasswordResetType.FORCED_WEAK_PASSWORD));
         verifyNoInteractions(cloudwatchMetricsService);
@@ -488,7 +482,6 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
                         auditContextWithAllUserInfo.withTxmaAuditEncoded(
                                 Optional.of(ENCODED_DEVICE_DETAILS)),
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("attemptNoFailedAt", maxRetriesAllowed),
                         pair("number_of_attempts_user_allowed_to_login", maxRetriesAllowed));
@@ -521,7 +514,6 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
                         auditContextWithAllUserInfo.withTxmaAuditEncoded(
                                 Optional.of(ENCODED_DEVICE_DETAILS)),
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("incorrectPasswordCount", maxRetriesAllowed),
                         pair("attemptNoFailedAt", maxRetriesAllowed));
@@ -531,7 +523,6 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
                         auditContextWithAllUserInfo.withTxmaAuditEncoded(
                                 Optional.of(ENCODED_DEVICE_DETAILS)),
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("attemptNoFailedAt", maxRetriesAllowed),
                         pair("number_of_attempts_user_allowed_to_login", maxRetriesAllowed));
@@ -563,7 +554,6 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
                         auditContextWithAllUserInfo.withTxmaAuditEncoded(
                                 Optional.of(ENCODED_DEVICE_DETAILS)),
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()),
                         pair(
@@ -618,7 +608,6 @@ class LoginHandlerTest {
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
                         auditContextWithAllUserInfo.withTxmaAuditEncoded(
                                 Optional.of(ENCODED_DEVICE_DETAILS)),
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("incorrectPasswordCount", 1),
                         pair("attemptNoFailedAt", 6));
@@ -722,8 +711,7 @@ class LoginHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL,
                         auditContextWithoutUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                                Optional.of(ENCODED_DEVICE_DETAILS)));
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -1,5 +1,7 @@
 package uk.gov.di.audit;
 
+import java.util.Optional;
+
 public record AuditContext(
         String clientId,
         String clientSessionId,
@@ -8,7 +10,8 @@ public record AuditContext(
         String email,
         String ipAddress,
         String phoneNumber,
-        String persistentSessionId) {
+        String persistentSessionId,
+        Optional<String> txmaAuditEncoded) {
 
     public AuditContext withPhoneNumber(String phoneNumber) {
         return new AuditContext(
@@ -19,7 +22,8 @@ public record AuditContext(
                 email,
                 ipAddress,
                 phoneNumber,
-                persistentSessionId);
+                persistentSessionId,
+                txmaAuditEncoded);
     }
 
     public AuditContext withUserId(String subjectId) {
@@ -31,6 +35,20 @@ public record AuditContext(
                 email,
                 ipAddress,
                 phoneNumber,
-                persistentSessionId);
+                persistentSessionId,
+                txmaAuditEncoded);
+    }
+
+    public AuditContext withTxmaAuditEncoded(Optional<String> txmaAuditEncoded) {
+        return new AuditContext(
+                clientId,
+                clientSessionId,
+                sessionId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                txmaAuditEncoded);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -94,10 +94,7 @@ public class AuditService {
     }
 
     public void submitAuditEvent(
-            AuditableEvent event,
-            AuditContext auditContext,
-            RestrictedSection restrictedSection,
-            MetadataPair... metadataPairs) {
+            AuditableEvent event, AuditContext auditContext, MetadataPair... metadataPairs) {
 
         var user =
                 TxmaAuditUser.user()
@@ -115,7 +112,10 @@ public class AuditService {
                         .withComponentId(COMPONENT_ID)
                         .withUser(user);
 
-        addRestrictedSectionToAuditEvent(restrictedSection, txmaAuditEvent, metadataPairs);
+        addRestrictedSectionToAuditEvent(
+                new RestrictedSection(auditContext.txmaAuditEncoded()),
+                txmaAuditEvent,
+                metadataPairs);
         addExtensionSectionToAuditEvent(user, txmaAuditEvent, metadataPairs);
 
         txmaQueueClient.send(txmaAuditEvent.serialize());
@@ -146,7 +146,7 @@ public class AuditService {
                         persistentSessionId,
                         restrictedSection.encoded);
 
-        submitAuditEvent(event, auditContext, restrictedSection, metadataPairs);
+        submitAuditEvent(event, auditContext, metadataPairs);
     }
 
     public static class MetadataPair {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -143,7 +143,8 @@ public class AuditService {
                         email,
                         ipAddress,
                         phoneNumber,
-                        persistentSessionId);
+                        persistentSessionId,
+                        restrictedSection.encoded);
 
         submitAuditEvent(event, auditContext, restrictedSection, metadataPairs);
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -112,8 +112,7 @@ class AuditServiceTest {
                         "persistent-session-id",
                         Optional.empty());
 
-        auditService.submitAuditEvent(
-                TEST_EVENT_ONE, myContext, AuditService.RestrictedSection.empty);
+        auditService.submitAuditEvent(TEST_EVENT_ONE, myContext);
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -109,7 +109,8 @@ class AuditServiceTest {
                         "email",
                         "ip-address",
                         "phone-number",
-                        "persistent-session-id");
+                        "persistent-session-id",
+                        Optional.empty());
 
         auditService.submitAuditEvent(
                 TEST_EVENT_ONE, myContext, AuditService.RestrictedSection.empty);


### PR DESCRIPTION
## What

We recently added an audit context record that cleans up our calls to the audit service by pulling out data that is common to all audit events submitted by a handler into a single place, making the calls to the audit service less noisy.

This PR moves an extra field, the txma audit encoded field, from being a separate parameter in the calls to the audit service, into the audit context object. Previously, it was passed in in a RestrictedSection object. Moving it out to the common object better reflects that this value will be the same in all requests within a handler, and decouples the call to the audit service from the exact implementation of where the fields passed into it end up.

Eventually, when we've switched all calls to the audit service over to the new way of calling it, we can remove the RestrictedSection object.

## How to review

1. Code Review commit by commit