### PR TITLE
AUT-2701: Improve management of redis connection resources in lambdas.

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -30,11 +30,28 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
+    // INIT PHASE
     private static final Logger LOG = LogManager.getLogger(CheckReAuthUserHandler.class);
+    private static RedisConnectionService redis;
 
-    private final AuditService auditService;
-    private final CodeStorageService codeStorageService;
+    static {
+        if (System.getProperty("TEST") == null) {
+            redis = new RedisConnectionService(ConfigurationService.getInstance());
+        }
+    }
 
+    // FUNCTION INIT
+    public CheckReAuthUserHandler() {
+        this(ConfigurationService.getInstance(), redis);
+    }
+
+    public CheckReAuthUserHandler(ConfigurationService configurationService, RedisConnectionService redis) {
+        super(CheckReauthUserRequest.class, configurationService);
+        this.auditService = new AuditService(configurationService);
+        this.codeStorageService = new CodeStorageService(configurationService, redis);
+    }
+
+    // TEST ONLY CONSTRUCTORS
     public CheckReAuthUserHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
@@ -60,16 +77,9 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
         this.codeStorageService = new CodeStorageService(configurationService);
     }
 
-    public CheckReAuthUserHandler(
-            ConfigurationService configurationService, RedisConnectionService redis) {
-        super(CheckReauthUserRequest.class, configurationService, redis);
-        this.auditService = new AuditService(configurationService);
-        this.codeStorageService = new CodeStorageService(configurationService, redis);
-    }
-
-    public CheckReAuthUserHandler() {
-        this(ConfigurationService.getInstance());
-    }
+    // INVOKE PHASE
+    private final AuditService auditService;
+    private final CodeStorageService codeStorageService;
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -45,7 +45,8 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
         this(ConfigurationService.getInstance(), redis);
     }
 
-    public CheckReAuthUserHandler(ConfigurationService configurationService, RedisConnectionService redis) {
+    public CheckReAuthUserHandler(
+            ConfigurationService configurationService, RedisConnectionService redis) {
         super(CheckReauthUserRequest.class, configurationService);
         this.auditService = new AuditService(configurationService);
         this.codeStorageService = new CodeStorageService(configurationService, redis);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -96,13 +96,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
         this.codeStorageService = new CodeStorageService(configurationService);
     }
 
-    public CheckUserExistsHandler(
-            ConfigurationService configurationService, RedisConnectionService redis) {
-        super(CheckUserExistsRequest.class, configurationService, redis);
-        this.auditService = new AuditService(configurationService);
-        this.codeStorageService = new CodeStorageService(configurationService, redis);
-    }
-
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -50,7 +50,27 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
     private final AuditService auditService;
     private final CodeStorageService codeStorageService;
+    private static RedisConnectionService redis;
 
+    static {
+        if (System.getProperty("TEST") == null) {
+            redis = new RedisConnectionService(ConfigurationService.getInstance());
+        }
+    }
+
+    // Function Init
+    public CheckUserExistsHandler() {
+        this(ConfigurationService.getInstance(), redis);
+    }
+
+    public CheckUserExistsHandler(
+            ConfigurationService configurationService, RedisConnectionService redis) {
+        super(CheckUserExistsRequest.class, configurationService);
+        this.auditService = new AuditService(configurationService);
+        this.codeStorageService = new CodeStorageService(configurationService, redis);
+    }
+
+    // Test Only Constructors
     public CheckUserExistsHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
@@ -68,10 +88,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                 authenticationService);
         this.auditService = auditService;
         this.codeStorageService = codeStorageService;
-    }
-
-    public CheckUserExistsHandler() {
-        this(ConfigurationService.getInstance());
     }
 
     public CheckUserExistsHandler(ConfigurationService configurationService) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -61,7 +61,31 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
     private final AuditService auditService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final CommonPasswordsService commonPasswordsService;
+    private static RedisConnectionService redis;
 
+    static {
+        if (System.getProperty("TEST") == null) {
+            redis = new RedisConnectionService(ConfigurationService.getInstance());
+        }
+    }
+
+    // Function Init
+    public LoginHandler() {
+        this(ConfigurationService.getInstance(), redis);
+    }
+
+    public LoginHandler(ConfigurationService configurationService, RedisConnectionService redis) {
+        super(LoginRequest.class, configurationService, true);
+        this.codeStorageService = new CodeStorageService(configurationService, redis);
+        this.userMigrationService =
+                new UserMigrationService(
+                        new DynamoService(configurationService), configurationService);
+        this.auditService = new AuditService(configurationService);
+        this.cloudwatchMetricsService = new CloudwatchMetricsService();
+        this.commonPasswordsService = new CommonPasswordsService(configurationService);
+    }
+
+    // Test Only Constructor
     public LoginHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
@@ -97,21 +121,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
         this.commonPasswordsService = new CommonPasswordsService(configurationService);
-    }
-
-    public LoginHandler(ConfigurationService configurationService, RedisConnectionService redis) {
-        super(LoginRequest.class, configurationService, true, redis);
-        this.codeStorageService = new CodeStorageService(configurationService, redis);
-        this.userMigrationService =
-                new UserMigrationService(
-                        new DynamoService(configurationService), configurationService);
-        this.auditService = new AuditService(configurationService);
-        this.cloudwatchMetricsService = new CloudwatchMetricsService();
-        this.commonPasswordsService = new CommonPasswordsService(configurationService);
-    }
-
-    public LoginHandler() {
-        this(ConfigurationService.getInstance());
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -114,15 +114,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.accountModifiersService = new DynamoAccountModifiersService(configurationService);
     }
 
-    public VerifyCodeHandler(
-            ConfigurationService configurationService, RedisConnectionService redis) {
-        super(VerifyCodeRequest.class, configurationService, redis);
-        this.codeStorageService = new CodeStorageService(configurationService, redis);
-        this.auditService = new AuditService(configurationService);
-        this.cloudwatchMetricsService = new CloudwatchMetricsService();
-        this.accountModifiersService = new DynamoAccountModifiersService(configurationService);
-    }
-
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -60,7 +60,29 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     private final AuditService auditService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final DynamoAccountModifiersService accountModifiersService;
+    private static RedisConnectionService redis;
 
+    static {
+        if (System.getProperty("TEST") == null) {
+            redis = new RedisConnectionService(ConfigurationService.getInstance());
+        }
+    }
+
+    // Function Init
+    public VerifyCodeHandler() {
+        this(ConfigurationService.getInstance(), redis);
+    }
+
+    public VerifyCodeHandler(
+            ConfigurationService configurationService, RedisConnectionService redis) {
+        super(VerifyCodeRequest.class, configurationService);
+        this.codeStorageService = new CodeStorageService(configurationService, redis);
+        this.auditService = new AuditService(configurationService);
+        this.cloudwatchMetricsService = new CloudwatchMetricsService();
+        this.accountModifiersService = new DynamoAccountModifiersService(configurationService);
+    }
+
+    // Test only constructors
     protected VerifyCodeHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
@@ -82,10 +104,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.accountModifiersService = accountModifiersService;
-    }
-
-    public VerifyCodeHandler() {
-        this(ConfigurationService.getInstance());
     }
 
     public VerifyCodeHandler(ConfigurationService configurationService) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckReauthUserRequest;

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckReauthUserRequest;
@@ -45,6 +46,10 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 
 class CheckReAuthUserHandlerTest {
 
+    static {
+        System.setProperty("TEST", "TRUE");
+    }
+
     private static final String EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String TEST_SUBJECT_ID = "subject-id";
     private static final String INTERNAL_SECTOR_URI = "http://www.example.com";
@@ -81,6 +86,8 @@ class CheckReAuthUserHandlerTest {
     private static final byte[] SALT = SaltHelper.generateNewSalt();
 
     private CheckReAuthUserHandler handler;
+
+    // LOCALSTACK_ENDPOINT
 
     @BeforeEach
     public void setUp() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -83,6 +83,10 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 
 class CheckUserExistsHandlerTest {
 
+    static {
+        System.setProperty("TEST", "TRUE");
+    }
+
     private final Context context = mock(Context.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -92,6 +92,10 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 
 class LoginHandlerTest {
 
+    static {
+        System.setProperty("TEST", "TRUE");
+    }
+
     private static final String EMAIL = CommonTestVariables.EMAIL;
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private final UserCredentials userCredentials =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -79,6 +79,10 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 
 class VerifyCodeHandlerTest {
 
+    static {
+        System.setProperty("TEST", "TRUE");
+    }
+
     private static final String CODE = "123456";
     private static final String INVALID_CODE = "6543221";
     private static final String CLIENT_ID = "client-id";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -6,6 +6,8 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,6 +21,7 @@ import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.net.URI;
@@ -58,11 +61,22 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     public static final String CLIENT_NAME = "test-client-name";
     public static final String ENCODED_DEVICE_INFORMATION =
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
+    private static RedisConnectionService redisConnectionService;
+
+    @BeforeAll
+    static void beforeAll() {
+        redisConnectionService = new RedisConnectionService(TXMA_ENABLED_CONFIGURATION_SERVICE);
+    }
 
     @BeforeEach
     void setup() {
         handler = new LoginHandler(TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
         txmaAuditQueue.clear();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        redisConnectionService.close();
     }
 
     @ParameterizedTest

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -113,18 +113,6 @@ public abstract class BaseFrontendHandler<T>
     protected BaseFrontendHandler(
             Class<T> clazz,
             ConfigurationService configurationService,
-            RedisConnectionService redis) {
-        this.clazz = clazz;
-        this.configurationService = configurationService;
-        this.sessionService = new SessionService(configurationService, redis);
-        this.clientSessionService = new ClientSessionService(configurationService, redis);
-        this.clientService = new DynamoClientService(configurationService);
-        this.authenticationService = new DynamoService(configurationService);
-    }
-
-    protected BaseFrontendHandler(
-            Class<T> clazz,
-            ConfigurationService configurationService,
             boolean loadUserCredentials) {
         this(clazz, configurationService);
         this.loadUserCredentials = loadUserCredentials;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -98,7 +98,10 @@ public abstract class BaseFrontendHandler<T>
         this.authenticationService = new DynamoService(configurationService);
     }
 
-    protected BaseFrontendHandler(Class<T> clazz, ConfigurationService configurationService, RedisConnectionService redis) {
+    protected BaseFrontendHandler(
+            Class<T> clazz,
+            ConfigurationService configurationService,
+            RedisConnectionService redis) {
         this.clazz = clazz;
         this.configurationService = configurationService;
         this.sessionService = new SessionService(configurationService, redis);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -98,6 +98,15 @@ public abstract class BaseFrontendHandler<T>
         this.authenticationService = new DynamoService(configurationService);
     }
 
+    protected BaseFrontendHandler(Class<T> clazz, ConfigurationService configurationService, RedisConnectionService redis) {
+        this.clazz = clazz;
+        this.configurationService = configurationService;
+        this.sessionService = new SessionService(configurationService, redis);
+        this.clientSessionService = new ClientSessionService(configurationService, redis);
+        this.clientService = new DynamoClientService(configurationService);
+        this.authenticationService = new DynamoService(configurationService);
+    }
+
     protected BaseFrontendHandler(
             Class<T> clazz,
             ConfigurationService configurationService,


### PR DESCRIPTION
The lambdas create a lot of new redis connections each time they are invoked.  These conections are not closed explicitly.  We can improve the management of these connections by moving their creation to the lambda runtime init phase.

## What

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
