### PR TITLE
ATO-730: Fix missing component ID on events emitted from auth code handler

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -32,6 +32,7 @@ module "auth-code" {
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
     INTERNAl_SECTOR_URI      = var.internal_sector_uri
+    OIDC_API_BASE_URL        = local.api_base_url
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthCodeHandler::handleRequest"
 

--- a/template.yaml
+++ b/template.yaml
@@ -1821,6 +1821,9 @@ Resources:
             - 'arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-'
             - AccountId: !FindInMap [ EnvironmentConfiguration, !Ref Environment, authAccountId ]
               AuthEnvironment: !FindInMap [ EnvironmentConfiguration, !Ref Environment, authEnvironment ]
+          OIDC_API_BASE_URL: !Sub
+            - https://oidc.${ServiceDomain}/
+            - ServiceDomain: !FindInMap [ EnvironmentConfiguration, !Ref Environment, serviceDomain ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy


### PR DESCRIPTION
## What
Set the OIDC BASE URL env var on the auth code handler. This is used to set the component ID on audit events, and it was raised that this was missing.

## How to review
Check the value is set correctly, especially the template mapping
