### PR TITLE
Bau/update mfa handler audit calls

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -133,18 +133,6 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                             ? request.getJourneyType()
                             : JourneyType.SIGN_IN;
 
-            if (!CodeRequestType.isValidCodeRequestType(
-                    NotificationType.MFA_SMS.getMfaMethodType(), journeyType)) {
-                LOG.warn(
-                        "Invalid MFA Type '{}' for journey '{}'",
-                        NotificationType.MFA_SMS.getMfaMethodType().getValue(),
-                        journeyType.getValue());
-                return generateApiGatewayProxyErrorResponse(400, ERROR_1002);
-            }
-
-            Optional<ErrorResponse> codeRequestValid =
-                    validateCodeRequestAttempts(email, journeyType, userContext);
-
             var auditContext =
                     new AuditContext(
                             userContext.getClientId(),
@@ -156,6 +144,18 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                             AuditService.UNKNOWN,
                             persistentSessionId,
                             Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+
+            if (!CodeRequestType.isValidCodeRequestType(
+                    NotificationType.MFA_SMS.getMfaMethodType(), journeyType)) {
+                LOG.warn(
+                        "Invalid MFA Type '{}' for journey '{}'",
+                        NotificationType.MFA_SMS.getMfaMethodType().getValue(),
+                        journeyType.getValue());
+                return generateApiGatewayProxyErrorResponse(400, ERROR_1002);
+            }
+
+            Optional<ErrorResponse> codeRequestValid =
+                    validateCodeRequestAttempts(email, journeyType, userContext);
 
             if (codeRequestValid.isPresent()) {
                 auditService.submitAuditEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -173,7 +173,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                         FrontendAuditableEvent.MFA_MISMATCHED_EMAIL,
                         auditContext,
                         pair("journey-type", journeyType),
-                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
+                        pair("mfa-type", MFAMethodType.SMS.getValue()));
 
                 return generateApiGatewayProxyErrorResponse(400, ERROR_1000);
             }
@@ -184,7 +184,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                         FrontendAuditableEvent.MFA_MISSING_PHONE_NUMBER,
                         auditContext,
                         pair("journey-type", journeyType),
-                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType()));
+                        pair("mfa-type", MFAMethodType.SMS.getValue()));
 
                 return generateApiGatewayProxyErrorResponse(400, ERROR_1014);
             } else {
@@ -232,7 +232,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     auditableEvent,
                     auditContext,
                     pair("journey-type", journeyType),
-                    pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
+                    pair("mfa-type", MFAMethodType.SMS.getValue()));
             LOG.info("Successfully processed request");
 
             return generateEmptySuccessApiGatewayResponse();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -466,16 +466,7 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT_FOR_TEST_CLIENT,
-                        new AuditContext(
-                                TEST_CLIENT_ID,
-                                CLIENT_SESSION_ID,
-                                SESSION_ID,
-                                expectedCommonSubject,
-                                EMAIL,
-                                IP_ADDRESS,
-                                CommonTestVariables.UK_MOBILE_NUMBER,
-                                DI_PERSISTENT_SESSION_ID,
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("journey-type", JourneyType.SIGN_IN),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -394,15 +394,7 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT.withPhoneNumber(AuditService.UNKNOWN),
                         pair("journey-type", journeyType),
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
@@ -427,15 +419,7 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT.withPhoneNumber(AuditService.UNKNOWN),
                         pair("journey-type", journeyType),
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
@@ -459,15 +443,7 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT.withPhoneNumber(AuditService.UNKNOWN),
                         pair("journey-type", journeyType),
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -326,7 +326,7 @@ class MfaHandlerTest {
                         FrontendAuditableEvent.MFA_MISSING_PHONE_NUMBER,
                         AUDIT_CONTEXT.withPhoneNumber(AuditService.UNKNOWN),
                         pair("journey-type", JourneyType.SIGN_IN),
-                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType()));
+                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -295,15 +295,16 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISMATCHED_EMAIL,
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        "wrong.email@gov.uk",
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        new AuditContext(
+                                TEST_CLIENT_ID,
+                                CLIENT_SESSION_ID,
+                                SESSION_ID,
+                                expectedCommonSubject,
+                                "wrong.email@gov.uk",
+                                IP_ADDRESS,
+                                AuditService.UNKNOWN,
+                                DI_PERSISTENT_SESSION_ID,
+                                Optional.of(ENCODED_DEVICE_DETAILS)),
                         pair("journey-type", JourneyType.SIGN_IN),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }


### PR DESCRIPTION
## What

Converts the MFA Handler to use the new submitAuditEvent signature with an audit context.

This removes a lot of noise from the handler as well as its tests, and makes it easier to read the information that is most important in both.

Also a small refactor to introduce a variable for the metadata pairs which are the same in all cases in this handler.

## How to review

1. Code Review commit by commit

