### PR TITLE
ATO-689: Create lambda to fetch RP JWKS

### DIFF
--- a/ci/stack-orchestration/configuration/dev/dev-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/dev-orch-be-pipeline/parameters.json
@@ -24,6 +24,10 @@
     "ParameterValue": "EC2"
   },
   {
+    "ParameterKey": "AllowedServiceFive",
+    "ParameterValue": "Lambda"
+  },
+  {
     "ParameterKey": "AdditionalCodeSigningVersionArns",
     "ParameterValue": "arn:aws:signer:eu-west-2:216552277552:/signing-profiles/DynatraceSigner/5uwzCCGTPq"
   },

--- a/ci/stack-orchestration/configuration/dev/vpc/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/vpc/parameters.json
@@ -30,5 +30,9 @@
   {
     "ParameterKey": "DynamoDBApiEnabled",
     "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "LambdaApiEnabled",
+    "ParameterValue": "Yes"
   }
 ]

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/FetchJwksResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/FetchJwksResponse.java
@@ -3,31 +3,4 @@ package uk.gov.di.authentication.oidc.entity;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 
-public class FetchJwksResponse {
-
-    private JWK jwk = null;
-    private ErrorObject error = null;
-
-    public FetchJwksResponse() {}
-
-    public FetchJwksResponse(JWK jwk, ErrorObject error) {
-        this.jwk = jwk;
-        this.error = error;
-    }
-
-    public JWK getJwk() {
-        return jwk;
-    }
-
-    public void setJwk(JWK jwk) {
-        this.jwk = jwk;
-    }
-
-    public ErrorObject getError() {
-        return error;
-    }
-
-    public void setError(ErrorObject error) {
-        this.error = error;
-    }
-}
+public record FetchJwksResponse(JWK jwk, ErrorObject error) {}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/FetchJwksResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/FetchJwksResponse.java
@@ -1,0 +1,33 @@
+package uk.gov.di.authentication.oidc.entity;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+
+public class FetchJwksResponse {
+
+    private JWK jwk = null;
+    private ErrorObject error = null;
+
+    public FetchJwksResponse() {}
+
+    public FetchJwksResponse(JWK jwk, ErrorObject error) {
+        this.jwk = jwk;
+        this.error = error;
+    }
+
+    public JWK getJwk() {
+        return jwk;
+    }
+
+    public void setJwk(JWK jwk) {
+        this.jwk = jwk;
+    }
+
+    public ErrorObject getError() {
+        return error;
+    }
+
+    public void setError(ErrorObject error) {
+        this.error = error;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/JwksResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/JwksResponse.java
@@ -3,4 +3,4 @@ package uk.gov.di.authentication.oidc.entity;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 
-public record FetchJwksResponse(JWK jwk, ErrorObject error) {}
+public record JwksResponse(JWK jwk, ErrorObject error) {}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
@@ -1,0 +1,63 @@
+package uk.gov.di.authentication.oidc.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.oidc.entity.FetchJwksResponse;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.JwksService;
+import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+public class FetchJwksHandler implements RequestHandler<Map<String, String>, FetchJwksResponse> {
+
+    private final JwksService jwksService;
+
+    public FetchJwksHandler(JwksService jwksService) {
+        this.jwksService = jwksService;
+    }
+
+    public FetchJwksHandler(ConfigurationService configurationService) {
+        var kmsConnectionService = new KmsConnectionService(configurationService);
+        this.jwksService = new JwksService(configurationService, kmsConnectionService);
+    }
+
+    public FetchJwksHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    FetchJwksResponse response = new FetchJwksResponse();
+
+    private static final Logger LOG = LogManager.getLogger(FetchJwksHandler.class);
+
+    @Override
+    public FetchJwksResponse handleRequest(Map<String, String> event, Context context) {
+        String url = event.get("url");
+        String keyId = event.get("keyId");
+        try {
+            if (url == null || keyId == null) {
+                throw new IllegalArgumentException(
+                        "FetchJwksHandler invoked with invalid argument(s)");
+            }
+            JWK jwk = jwksService.retrieveJwkFromURLWithKeyId(new URL(url), keyId);
+            response.setJwk(jwk);
+        } catch (KeySourceException e) {
+            LOG.error("Failed to fetch JWKS: could not find key with provided key ID", e);
+            response.setError(OAuth2Error.SERVER_ERROR);
+        } catch (MalformedURLException e) {
+            LOG.error("Failed to fetch JWKS: URL is malformed", e);
+            response.setError(OAuth2Error.SERVER_ERROR);
+        } catch (IllegalArgumentException e) {
+            LOG.error("Failed to fetch JWKS: url and/or keyId parameters not present", e);
+            response.setError(OAuth2Error.SERVER_ERROR);
+        }
+        return response;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
@@ -4,7 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.nimbusds.jose.KeySourceException;
 import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ErrorObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.JwksResponse;
@@ -47,14 +47,18 @@ public class FetchJwksHandler implements RequestHandler<Map<String, String>, Jwk
             JWK jwk = jwksService.retrieveJwkFromURLWithKeyId(new URL(url), keyId);
             return new JwksResponse(jwk, null);
         } catch (KeySourceException e) {
-            LOG.error("Failed to fetch JWKS: could not find key with provided key ID", e);
-            return new JwksResponse(null, OAuth2Error.SERVER_ERROR);
+            String errorMsg =
+                    "Failed to fetch JWKS: could not find key in JWKS that matches provided keyId";
+            LOG.error(errorMsg, e);
+            return new JwksResponse(null, new ErrorObject(null, errorMsg, 404));
         } catch (MalformedURLException e) {
-            LOG.error("Failed to fetch JWKS: URL is malformed", e);
-            return new JwksResponse(null, OAuth2Error.SERVER_ERROR);
+            String errorMsg = "Failed to fetch JWKS: URL is malformed";
+            LOG.error(errorMsg, e);
+            return new JwksResponse(null, new ErrorObject(null, errorMsg, 400));
         } catch (IllegalArgumentException e) {
-            LOG.error("Failed to fetch JWKS: url and/or keyId parameters not present", e);
-            return new JwksResponse(null, OAuth2Error.SERVER_ERROR);
+            String errorMsg = "Failed to fetch JWKS: url and/or keyId parameter not present";
+            LOG.error(errorMsg, e);
+            return new JwksResponse(null, new ErrorObject(null, errorMsg, 400));
         }
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
@@ -33,8 +33,6 @@ public class FetchJwksHandler implements RequestHandler<Map<String, String>, Fet
         this(ConfigurationService.getInstance());
     }
 
-    FetchJwksResponse response = new FetchJwksResponse();
-
     private static final Logger LOG = LogManager.getLogger(FetchJwksHandler.class);
 
     @Override
@@ -47,17 +45,16 @@ public class FetchJwksHandler implements RequestHandler<Map<String, String>, Fet
                         "FetchJwksHandler invoked with invalid argument(s)");
             }
             JWK jwk = jwksService.retrieveJwkFromURLWithKeyId(new URL(url), keyId);
-            response.setJwk(jwk);
+            return new FetchJwksResponse(jwk, null);
         } catch (KeySourceException e) {
             LOG.error("Failed to fetch JWKS: could not find key with provided key ID", e);
-            response.setError(OAuth2Error.SERVER_ERROR);
+            return new FetchJwksResponse(null, OAuth2Error.SERVER_ERROR);
         } catch (MalformedURLException e) {
             LOG.error("Failed to fetch JWKS: URL is malformed", e);
-            response.setError(OAuth2Error.SERVER_ERROR);
+            return new FetchJwksResponse(null, OAuth2Error.SERVER_ERROR);
         } catch (IllegalArgumentException e) {
             LOG.error("Failed to fetch JWKS: url and/or keyId parameters not present", e);
-            response.setError(OAuth2Error.SERVER_ERROR);
+            return new FetchJwksResponse(null, OAuth2Error.SERVER_ERROR);
         }
-        return response;
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
@@ -7,7 +7,7 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.authentication.oidc.entity.FetchJwksResponse;
+import uk.gov.di.authentication.oidc.entity.JwksResponse;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
@@ -16,7 +16,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
-public class FetchJwksHandler implements RequestHandler<Map<String, String>, FetchJwksResponse> {
+public class FetchJwksHandler implements RequestHandler<Map<String, String>, JwksResponse> {
 
     private final JwksService jwksService;
 
@@ -36,7 +36,7 @@ public class FetchJwksHandler implements RequestHandler<Map<String, String>, Fet
     private static final Logger LOG = LogManager.getLogger(FetchJwksHandler.class);
 
     @Override
-    public FetchJwksResponse handleRequest(Map<String, String> event, Context context) {
+    public JwksResponse handleRequest(Map<String, String> event, Context context) {
         String url = event.get("url");
         String keyId = event.get("keyId");
         try {
@@ -45,16 +45,16 @@ public class FetchJwksHandler implements RequestHandler<Map<String, String>, Fet
                         "FetchJwksHandler invoked with invalid argument(s)");
             }
             JWK jwk = jwksService.retrieveJwkFromURLWithKeyId(new URL(url), keyId);
-            return new FetchJwksResponse(jwk, null);
+            return new JwksResponse(jwk, null);
         } catch (KeySourceException e) {
             LOG.error("Failed to fetch JWKS: could not find key with provided key ID", e);
-            return new FetchJwksResponse(null, OAuth2Error.SERVER_ERROR);
+            return new JwksResponse(null, OAuth2Error.SERVER_ERROR);
         } catch (MalformedURLException e) {
             LOG.error("Failed to fetch JWKS: URL is malformed", e);
-            return new FetchJwksResponse(null, OAuth2Error.SERVER_ERROR);
+            return new JwksResponse(null, OAuth2Error.SERVER_ERROR);
         } catch (IllegalArgumentException e) {
             LOG.error("Failed to fetch JWKS: url and/or keyId parameters not present", e);
-            return new FetchJwksResponse(null, OAuth2Error.SERVER_ERROR);
+            return new JwksResponse(null, OAuth2Error.SERVER_ERROR);
         }
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
@@ -21,8 +21,7 @@ class FetchJwksHandlerTest {
     JwksService jwksService = mock(JwksService.class);
     private final FetchJwksHandler handler = new FetchJwksHandler(jwksService);
     private final String keyId = "some-key-id";
-    private final String url =
-            "https://oidc.test.account.gov.uk/.well-known/storage-token-jwk.json";
+    private final String url = "https://oidc.test.account.gov.uk/.well-known/jwk.json";
 
     @Test
     void returnsErrorWhenServiceThrowsKeySourceException()

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
@@ -1,0 +1,68 @@
+package uk.gov.di.authentication.oidc.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.nimbusds.jose.KeySourceException;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.oidc.entity.FetchJwksResponse;
+import uk.gov.di.orchestration.shared.services.JwksService;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FetchJwksHandlerTest {
+
+    private static final Context CONTEXT = mock(Context.class);
+    JwksService jwksService = mock(JwksService.class);
+    private final FetchJwksHandler handler = new FetchJwksHandler(jwksService);
+    private final String keyId = "some-key-id";
+    private final String url =
+            "https://oidc.test.account.gov.uk/.well-known/storage-token-jwk.json";
+
+    @Test
+    void returnsErrorWhenServiceThrowsKeySourceException()
+            throws MalformedURLException, KeySourceException {
+        // given
+        Map<String, String> event = Map.of("url", url, "keyId", keyId);
+        when(jwksService.retrieveJwkFromURLWithKeyId(new URL(url), keyId))
+                .thenThrow(new KeySourceException());
+
+        // when
+        FetchJwksResponse response = handler.handleRequest(event, CONTEXT);
+
+        // then
+        assertThat(response.getError().getCode(), equalTo("server_error"));
+        assertThat(response.getJwk(), equalTo(null));
+    }
+
+    @Test
+    void returnsErrorWhenUrlIsMissing() {
+        // given
+        Map<String, String> event = Map.of("keyId", keyId);
+
+        // when
+        FetchJwksResponse response = handler.handleRequest(event, CONTEXT);
+
+        // then
+        assertThat(response.getError().getCode(), equalTo("server_error"));
+        assertThat(response.getJwk(), equalTo(null));
+    }
+
+    @Test
+    void returnsErrorWhenKeyIdIsMissing() {
+        // given
+        Map<String, String> event = Map.of("url", url);
+
+        // when
+        FetchJwksResponse response = handler.handleRequest(event, CONTEXT);
+
+        // then
+        assertThat(response.getError().getCode(), equalTo("server_error"));
+        assertThat(response.getJwk(), equalTo(null));
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
@@ -3,7 +3,7 @@ package uk.gov.di.authentication.oidc.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.nimbusds.jose.KeySourceException;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.oidc.entity.FetchJwksResponse;
+import uk.gov.di.authentication.oidc.entity.JwksResponse;
 import uk.gov.di.orchestration.shared.services.JwksService;
 
 import java.net.MalformedURLException;
@@ -33,7 +33,7 @@ class FetchJwksHandlerTest {
                 .thenThrow(new KeySourceException());
 
         // when
-        FetchJwksResponse response = handler.handleRequest(event, CONTEXT);
+        JwksResponse response = handler.handleRequest(event, CONTEXT);
 
         // then
         assertThat(response.error().getCode(), equalTo("server_error"));
@@ -46,7 +46,7 @@ class FetchJwksHandlerTest {
         Map<String, String> event = Map.of("keyId", keyId);
 
         // when
-        FetchJwksResponse response = handler.handleRequest(event, CONTEXT);
+        JwksResponse response = handler.handleRequest(event, CONTEXT);
 
         // then
         assertThat(response.error().getCode(), equalTo("server_error"));
@@ -59,7 +59,7 @@ class FetchJwksHandlerTest {
         Map<String, String> event = Map.of("url", url);
 
         // when
-        FetchJwksResponse response = handler.handleRequest(event, CONTEXT);
+        JwksResponse response = handler.handleRequest(event, CONTEXT);
 
         // then
         assertThat(response.error().getCode(), equalTo("server_error"));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
@@ -55,7 +55,11 @@ class FetchJwksHandlerTest {
         JwksResponse response = handler.handleRequest(event, CONTEXT);
 
         // then
-        assertThat(response.error().getCode(), equalTo("server_error"));
+        assertThat(
+                response.error().getDescription(),
+                equalTo(
+                        "Failed to fetch JWKS: could not find key in JWKS that matches provided keyId"));
+        assertThat(response.error().getHTTPStatusCode(), equalTo(404));
         assertThat(response.jwk(), equalTo(null));
     }
 
@@ -68,7 +72,10 @@ class FetchJwksHandlerTest {
         JwksResponse response = handler.handleRequest(event, CONTEXT);
 
         // then
-        assertThat(response.error().getCode(), equalTo("server_error"));
+        assertThat(
+                response.error().getDescription(),
+                equalTo("Failed to fetch JWKS: url and/or keyId parameter not present"));
+        assertThat(response.error().getHTTPStatusCode(), equalTo(400));
         assertThat(response.jwk(), equalTo(null));
     }
 
@@ -81,7 +88,26 @@ class FetchJwksHandlerTest {
         JwksResponse response = handler.handleRequest(event, CONTEXT);
 
         // then
-        assertThat(response.error().getCode(), equalTo("server_error"));
+        assertThat(
+                response.error().getDescription(),
+                equalTo("Failed to fetch JWKS: url and/or keyId parameter not present"));
+        assertThat(response.error().getHTTPStatusCode(), equalTo(400));
+        assertThat(response.jwk(), equalTo(null));
+    }
+
+    @Test
+    void returnsErrorWhenUrlIsMalformed() {
+        // given
+        Map<String, String> event = Map.of("url", "not-a-valid-url", "keyId", keyId);
+
+        // when
+        JwksResponse response = handler.handleRequest(event, CONTEXT);
+
+        // then
+        assertThat(
+                response.error().getDescription(),
+                equalTo("Failed to fetch JWKS: URL is malformed"));
+        assertThat(response.error().getHTTPStatusCode(), equalTo(400));
         assertThat(response.jwk(), equalTo(null));
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
@@ -36,8 +36,8 @@ class FetchJwksHandlerTest {
         FetchJwksResponse response = handler.handleRequest(event, CONTEXT);
 
         // then
-        assertThat(response.getError().getCode(), equalTo("server_error"));
-        assertThat(response.getJwk(), equalTo(null));
+        assertThat(response.error().getCode(), equalTo("server_error"));
+        assertThat(response.jwk(), equalTo(null));
     }
 
     @Test
@@ -49,8 +49,8 @@ class FetchJwksHandlerTest {
         FetchJwksResponse response = handler.handleRequest(event, CONTEXT);
 
         // then
-        assertThat(response.getError().getCode(), equalTo("server_error"));
-        assertThat(response.getJwk(), equalTo(null));
+        assertThat(response.error().getCode(), equalTo("server_error"));
+        assertThat(response.jwk(), equalTo(null));
     }
 
     @Test
@@ -62,7 +62,7 @@ class FetchJwksHandlerTest {
         FetchJwksResponse response = handler.handleRequest(event, CONTEXT);
 
         // then
-        assertThat(response.getError().getCode(), equalTo("server_error"));
-        assertThat(response.getJwk(), equalTo(null));
+        assertThat(response.error().getCode(), equalTo("server_error"));
+        assertThat(response.jwk(), equalTo(null));
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
@@ -2,12 +2,14 @@ package uk.gov.di.authentication.oidc.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.jwk.JWK;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.entity.JwksResponse;
 import uk.gov.di.orchestration.shared.services.JwksService;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.text.ParseException;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,6 +24,24 @@ class FetchJwksHandlerTest {
     private final FetchJwksHandler handler = new FetchJwksHandler(jwksService);
     private final String keyId = "some-key-id";
     private final String url = "https://oidc.test.account.gov.uk/.well-known/jwk.json";
+
+    @Test
+    void returnsAJwkWhenUrlAndKeyIdAreValid()
+            throws MalformedURLException, KeySourceException, ParseException {
+        // given
+        Map<String, String> event = Map.of("url", url, "keyId", keyId);
+        String jwkJson =
+                "{\"kty\":\"EC\",\"use\":\"sig\",\"crv\":\"P-256\",\"kid\":\"f27ff20940cdc6c8b34f97f44c24c8601ded9465c0713dd190ed152272d07ddb\",\"x\":\"sSdmBkED2EfjTdX-K2_cT6CfBwXQFt-DJ6v8-6tr_n8\",\"y\":\"WTXmQdqLwrmHN5tiFsTFUtNAvDYhhTQB4zyfteCrWIE\",\"alg\":\"ES256\"}";
+        JWK jwk = JWK.parse(jwkJson);
+        when(jwksService.retrieveJwkFromURLWithKeyId(new URL(url), keyId)).thenReturn(jwk);
+
+        // when
+        JwksResponse response = handler.handleRequest(event, CONTEXT);
+
+        // then
+        assertThat(response.jwk().toJSONString(), equalTo(jwkJson));
+        assertThat(response.error(), equalTo(null));
+    }
 
     @Test
     void returnsErrorWhenServiceThrowsKeySourceException()

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
@@ -7,6 +7,7 @@ import com.nimbusds.jose.JWEHeader;
 import com.nimbusds.jose.JWEObject;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.KeySourceException;
 import com.nimbusds.jose.Payload;
 import com.nimbusds.jose.crypto.RSAEncrypter;
 import com.nimbusds.jose.crypto.impl.ECDSA;
@@ -244,6 +245,9 @@ public class DocAppAuthorisationService {
                             configurationService.getDocAppJwksURI().toURL(),
                             configurationService.getDocAppEncryptionKeyID());
             return new RSAKey.Builder((RSAKey) encryptionJWK).build().toRSAPublicKey();
+        } catch (KeySourceException e) {
+            LOG.error("Could not find key with provided key ID", e);
+            throw new RuntimeException(e);
         } catch (JOSEException e) {
             LOG.error("Error parsing the public key to RSAPublicKey", e);
             throw new DocAppAuthorisationServiceException(e);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
@@ -79,7 +79,8 @@ public class JwksService {
         LOG.info("Retrieving JWKSet with URL: {}", url);
         return jwkSource.get(selector, null).stream()
                 .findFirst()
-                .orElseThrow(() -> new KeySourceException("No key found with given keyID"));
+                .orElseThrow(
+                        () -> new KeySourceException("No key found with given keyId: " + keyId));
     }
 
     private JWK getPublicJWKWithKeyId(String keyId) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
@@ -66,7 +66,7 @@ public class JwksService {
         return getPublicJWKWithKeyId(configurationService.getStorageTokenSigningKeyAlias());
     }
 
-    public JWK retrieveJwkFromURLWithKeyId(URL url, String keyId) {
+    public JWK retrieveJwkFromURLWithKeyId(URL url, String keyId) throws KeySourceException {
         JWKSelector selector = new JWKSelector(new JWKMatcher.Builder().keyID(keyId).build());
         JWKSource<SecurityContext> jwkSource =
                 JWKSourceBuilder.create(url)
@@ -75,15 +75,11 @@ public class JwksService {
                         .cache(false)
                         .rateLimited(false)
                         .build();
-        try {
-            LOG.info("Retrieving JWKSet with URL: {}", url);
-            return jwkSource.get(selector, null).stream()
-                    .findFirst()
-                    .orElseThrow(() -> new KeySourceException("No key found with given keyID"));
-        } catch (KeySourceException e) {
-            LOG.error("Unable to load JWKSet", e);
-            throw new RuntimeException(e);
-        }
+
+        LOG.info("Retrieving JWKSet with URL: {}", url);
+        return jwkSource.get(selector, null).stream()
+                .findFirst()
+                .orElseThrow(() -> new KeySourceException("No key found with given keyID"));
     }
 
     private JWK getPublicJWKWithKeyId(String keyId) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.orchestration.shared.services;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.KeySourceException;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.RSADecrypter;
 import com.nimbusds.jose.crypto.impl.ECDSA;
@@ -92,7 +93,7 @@ class DocAppAuthorisationServiceTest {
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
 
     @BeforeEach
-    void setUp() throws Json.JsonException, MalformedURLException {
+    void setUp() throws Json.JsonException, MalformedURLException, KeySourceException {
         when(configurationService.getDocAppJwksURI()).thenReturn(JWKS_URL);
         when(configurationService.getSessionExpiry()).thenReturn(SESSION_EXPIRY);
         when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + SESSION_ID))

--- a/template.yaml
+++ b/template.yaml
@@ -335,6 +335,41 @@ Resources:
 
   #endregion
 
+  #region Fetch JWKS Lambda
+
+  FetchJwksFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_115: Reserved concurrency will be looked into in ATO-657
+    # checkov:skip=CKV_AWS_116: DLQ is not required
+    # checkov:skip=CKV_AWS_117: Lambda needs to exist outside our VPC so default AWS Lambda service VPC is OK
+    Properties:
+      FunctionName: !Sub ${Environment}-FetchJwksFunction
+      AutoPublishAlias: latest
+      CodeUri: ./oidc-api
+      Handler: uk.gov.di.authentication.oidc.lambda.FetchJwksHandler::handleRequest
+      LoggingConfig:
+        LogGroup: !Ref FetchJwksFunctionLogGroup
+      ProvisionedConcurrencyConfig:
+        !If
+        - EnableProvisionedConcurrency
+        - ProvisionedConcurrentExecutions: !FindInMap
+            - ProvisionedConcurrency
+            - !Ref Environment
+            - FetchJwksFunction
+            - DefaultValue: !FindInMap [ EnvironmentConfiguration, !Ref Environment, defaultProvisionedConcurrency ]
+        - !Ref AWS::NoValue
+      Tags:
+        CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_117
+
+  FetchJwksFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${Environment}-fetch-jwks-lambda
+      KmsKeyId: !GetAtt MainKmsKey.Arn
+      RetentionInDays: 30
+
+  #endregion
+
   #region Open ID Configuration Lambda
 
   OpenIdConfigurationFunction:


### PR DESCRIPTION
## What

### Overview
We want to be able to fetch RP public keys from a JWKS endpoint that RPs own and publish, but lambdas in our existing VPC cannot call a public URL. The solution is to create a new lambda, outside our VPC, which can call public URLs. 

### New lambda
The new lambda (FetchJwksFunction) accepts two parameters, `keyId` and `url`, and returns a response object which will contain either a `JWK` or `ErrorObject` object. It will be directly invoked by AuthorisationHandler (implementation in a subsequent PR).

### VPC endpoint
To allow communication between AuthorisationHandler (in our VPC) and FetchJwksHandler, a lambda VPC endpoint has been configured. As we use secure pipelines we don’t provision the VPC in our own template file - instead a parameter (LambdaApiEnabled) has been set in stack-orchestration VPC parameters. Note that this has only been enabled in dev so far, to allow for careful testing before deploying to higher environments.

### Permissions boundary
Dev platform publish information about the [programmatic permissions boundary](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3394142260/Programmatic+Permissions+Boundary) which contains an allowed list of services. This PR adds Lambda as an allowed service, again only to the dev environment for now.

### Next up
A subsequent PR will include:
- The code to actually invoke FetchJwksFunction, including IAM permissions
- Alerting configuration in case fetching the JWKS fails


## How to review

1. Code Review, commit by commit
2. Confirm that the changes to DocAppAuthorisationService don't affect any functionality


## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.



