### PR TITLE
BAU: Added SUPPORT_EMAIL_CHECK_ENABLED env var to lambdas

### DIFF
--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -40,6 +40,7 @@ module "send_otp_notification" {
     TEST_CLIENT_VERIFY_EMAIL_OTP           = var.test_client_verify_email_otp
     TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP    = var.test_client_verify_phone_number_otp
     TEST_CLIENTS_ENABLED                   = var.test_clients_enabled
+    SUPPORT_EMAIL_CHECK_ENABLED            = var.support_email_check_enabled
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler::handleRequest"
 

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -24,13 +24,14 @@ module "update_email" {
   path_part       = "update-email"
   endpoint_method = ["POST"]
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY            = local.redis_key
-    TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    ENVIRONMENT                 = var.environment
+    DYNAMO_ENDPOINT             = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EMAIL_QUEUE_URL             = aws_sqs_queue.email_queue.id
+    LOCALSTACK_ENDPOINT         = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                   = local.redis_key
+    TXMA_AUDIT_QUEUE_URL        = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI         = var.internal_sector_uri
+    SUPPORT_EMAIL_CHECK_ENABLED = var.support_email_check_enabled
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdateEmailHandler::handleRequest"
 

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -23,14 +23,15 @@ module "check_email_fraud_block" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    ENVIRONMENT          = var.environment
-    TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
-    REDIS_KEY            = local.redis_key
-    LOCKOUT_DURATION     = var.lockout_duration
-    LOCKOUT_COUNT_TTL    = var.lockout_count_ttl
+    DYNAMO_ENDPOINT             = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT         = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT                 = var.environment
+    TXMA_AUDIT_QUEUE_URL        = module.oidc_txma_audit.queue_url
+    INTERNAl_SECTOR_URI         = var.internal_sector_uri
+    REDIS_KEY                   = local.redis_key
+    LOCKOUT_DURATION            = var.lockout_duration
+    LOCKOUT_COUNT_TTL           = var.lockout_count_ttl
+    SUPPORT_EMAIL_CHECK_ENABLED = var.support_email_check_enabled
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.CheckEmailFraudBlockHandler::handleRequest"

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -41,6 +41,7 @@ module "send_notification" {
     DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
     EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
     INTERNAl_SECTOR_URI                    = var.internal_sector_uri
+    SUPPORT_EMAIL_CHECK_ENABLED            = var.support_email_check_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler::handleRequest"
 


### PR DESCRIPTION
## What

Added SUPPORT_EMAIL_CHECK_ENABLED env var to lambdas. Lambdas were previously not having access to this environment variable, so email fraud check logic could never be executed.

## How to review

1. Code Review
