### PR TITLE
Bau/use audit context in check user exists handler

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
@@ -182,15 +183,16 @@ class CheckUserExistsHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL,
-                            CLIENT_ID,
-                            CLIENT_SESSION_ID,
-                            SESSION_ID,
-                            expectedInternalPairwiseId,
-                            EMAIL_ADDRESS,
-                            IP_ADDRESS,
-                            AuditService.UNKNOWN,
-                            DI_PERSISTENT_SESSION_ID,
-                            new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                            new AuditContext(
+                                    CLIENT_ID,
+                                    CLIENT_SESSION_ID,
+                                    SESSION_ID,
+                                    expectedInternalPairwiseId,
+                                    EMAIL_ADDRESS,
+                                    IP_ADDRESS,
+                                    AuditService.UNKNOWN,
+                                    DI_PERSISTENT_SESSION_ID,
+                                    Optional.of(ENCODED_DEVICE_DETAILS)),
                             AuditService.MetadataPair.pair("rpPairwiseId", expectedRpPairwiseId));
         }
 
@@ -213,15 +215,16 @@ class CheckUserExistsHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL,
-                            CLIENT_ID,
-                            CLIENT_SESSION_ID,
-                            SESSION_ID,
-                            expectedInternalPairwiseId,
-                            EMAIL_ADDRESS,
-                            IP_ADDRESS,
-                            AuditService.UNKNOWN,
-                            DI_PERSISTENT_SESSION_ID,
-                            AuditService.RestrictedSection.empty,
+                            new AuditContext(
+                                    CLIENT_ID,
+                                    CLIENT_SESSION_ID,
+                                    SESSION_ID,
+                                    expectedInternalPairwiseId,
+                                    EMAIL_ADDRESS,
+                                    IP_ADDRESS,
+                                    AuditService.UNKNOWN,
+                                    DI_PERSISTENT_SESSION_ID,
+                                    Optional.empty()),
                             AuditService.MetadataPair.pair("rpPairwiseId", expectedRpPairwiseId));
         }
 
@@ -286,15 +289,16 @@ class CheckUserExistsHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             ACCOUNT_TEMPORARILY_LOCKED,
-                            CLIENT_ID,
-                            CLIENT_SESSION_ID,
-                            SESSION_ID,
-                            AuditService.UNKNOWN,
-                            EMAIL_ADDRESS,
-                            IP_ADDRESS,
-                            AuditService.UNKNOWN,
-                            DI_PERSISTENT_SESSION_ID,
-                            new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                            new AuditContext(
+                                    CLIENT_ID,
+                                    CLIENT_SESSION_ID,
+                                    SESSION_ID,
+                                    AuditService.UNKNOWN,
+                                    EMAIL_ADDRESS,
+                                    IP_ADDRESS,
+                                    AuditService.UNKNOWN,
+                                    DI_PERSISTENT_SESSION_ID,
+                                    Optional.of(ENCODED_DEVICE_DETAILS)),
                             AuditService.MetadataPair.pair(
                                     "number_of_attempts_user_allowed_to_login", 5));
         }
@@ -316,15 +320,16 @@ class CheckUserExistsHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        EMAIL_ADDRESS,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        new AuditContext(
+                                CLIENT_ID,
+                                CLIENT_SESSION_ID,
+                                SESSION_ID,
+                                AuditService.UNKNOWN,
+                                EMAIL_ADDRESS,
+                                IP_ADDRESS,
+                                AuditService.UNKNOWN,
+                                DI_PERSISTENT_SESSION_ID,
+                                Optional.of(ENCODED_DEVICE_DETAILS)),
                         AuditService.MetadataPair.pair("rpPairwiseId", AuditService.UNKNOWN));
     }
 
@@ -362,15 +367,16 @@ class CheckUserExistsHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_INVALID_EMAIL,
-                        AuditService.UNKNOWN,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        "joe.bloggs",
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                        new AuditContext(
+                                AuditService.UNKNOWN,
+                                CLIENT_SESSION_ID,
+                                SESSION_ID,
+                                AuditService.UNKNOWN,
+                                "joe.bloggs",
+                                IP_ADDRESS,
+                                AuditService.UNKNOWN,
+                                DI_PERSISTENT_SESSION_ID,
+                                Optional.of(ENCODED_DEVICE_DETAILS)));
     }
 
     private void usingValidSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -102,6 +102,18 @@ class CheckUserExistsHandlerTest {
     private static final ByteBuffer SALT =
             ByteBuffer.wrap("a-test-salt".getBytes(StandardCharsets.UTF_8));
 
+    private static final AuditContext AUDIT_CONTEXT =
+            new AuditContext(
+                    CLIENT_ID,
+                    CLIENT_SESSION_ID,
+                    SESSION_ID,
+                    AuditService.UNKNOWN,
+                    EMAIL_ADDRESS,
+                    IP_ADDRESS,
+                    AuditService.UNKNOWN,
+                    DI_PERSISTENT_SESSION_ID,
+                    Optional.of(ENCODED_DEVICE_DETAILS));
+
     @RegisterExtension
     public final CaptureLoggingExtension logging =
             new CaptureLoggingExtension(CheckUserExistsHandler.class);
@@ -183,16 +195,7 @@ class CheckUserExistsHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL,
-                            new AuditContext(
-                                    CLIENT_ID,
-                                    CLIENT_SESSION_ID,
-                                    SESSION_ID,
-                                    expectedInternalPairwiseId,
-                                    EMAIL_ADDRESS,
-                                    IP_ADDRESS,
-                                    AuditService.UNKNOWN,
-                                    DI_PERSISTENT_SESSION_ID,
-                                    Optional.of(ENCODED_DEVICE_DETAILS)),
+                            AUDIT_CONTEXT.withSubjectId(expectedInternalPairwiseId),
                             AuditService.MetadataPair.pair("rpPairwiseId", expectedRpPairwiseId));
         }
 
@@ -215,16 +218,9 @@ class CheckUserExistsHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL,
-                            new AuditContext(
-                                    CLIENT_ID,
-                                    CLIENT_SESSION_ID,
-                                    SESSION_ID,
-                                    expectedInternalPairwiseId,
-                                    EMAIL_ADDRESS,
-                                    IP_ADDRESS,
-                                    AuditService.UNKNOWN,
-                                    DI_PERSISTENT_SESSION_ID,
-                                    Optional.empty()),
+                            AUDIT_CONTEXT
+                                    .withSubjectId(expectedInternalPairwiseId)
+                                    .withTxmaAuditEncoded(Optional.empty()),
                             AuditService.MetadataPair.pair("rpPairwiseId", expectedRpPairwiseId));
         }
 
@@ -289,16 +285,7 @@ class CheckUserExistsHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             ACCOUNT_TEMPORARILY_LOCKED,
-                            new AuditContext(
-                                    CLIENT_ID,
-                                    CLIENT_SESSION_ID,
-                                    SESSION_ID,
-                                    AuditService.UNKNOWN,
-                                    EMAIL_ADDRESS,
-                                    IP_ADDRESS,
-                                    AuditService.UNKNOWN,
-                                    DI_PERSISTENT_SESSION_ID,
-                                    Optional.of(ENCODED_DEVICE_DETAILS)),
+                            AUDIT_CONTEXT,
                             AuditService.MetadataPair.pair(
                                     "number_of_attempts_user_allowed_to_login", 5));
         }
@@ -320,16 +307,7 @@ class CheckUserExistsHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL,
-                        new AuditContext(
-                                CLIENT_ID,
-                                CLIENT_SESSION_ID,
-                                SESSION_ID,
-                                AuditService.UNKNOWN,
-                                EMAIL_ADDRESS,
-                                IP_ADDRESS,
-                                AuditService.UNKNOWN,
-                                DI_PERSISTENT_SESSION_ID,
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         AuditService.MetadataPair.pair("rpPairwiseId", AuditService.UNKNOWN));
     }
 
@@ -359,6 +337,7 @@ class CheckUserExistsHandlerTest {
     @Test
     void shouldReturn400IfEmailAddressIsInvalid() {
         usingValidSession();
+        setupClient();
 
         var result = handler.handleRequest(userExistsRequest("joe.bloggs"), context);
 
@@ -367,16 +346,7 @@ class CheckUserExistsHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_INVALID_EMAIL,
-                        new AuditContext(
-                                AuditService.UNKNOWN,
-                                CLIENT_SESSION_ID,
-                                SESSION_ID,
-                                AuditService.UNKNOWN,
-                                "joe.bloggs",
-                                IP_ADDRESS,
-                                AuditService.UNKNOWN,
-                                DI_PERSISTENT_SESSION_ID,
-                                Optional.of(ENCODED_DEVICE_DETAILS)));
+                        AUDIT_CONTEXT.withEmail("joe.bloggs"));
     }
 
     private void usingValidSession() {
@@ -429,6 +399,10 @@ class CheckUserExistsHandlerTest {
                                 .thenReturn(SALT.array()));
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL_ADDRESS))
                 .thenReturn(maybeUserProfile);
+        setupClient();
+    }
+
+    private void setupClient() {
         when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.of(generateClientRegistry()));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -295,16 +295,9 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISMATCHED_EMAIL,
-                        new AuditContext(
-                                TEST_CLIENT_ID,
-                                CLIENT_SESSION_ID,
-                                SESSION_ID,
-                                expectedCommonSubject,
-                                "wrong.email@gov.uk",
-                                IP_ADDRESS,
-                                AuditService.UNKNOWN,
-                                DI_PERSISTENT_SESSION_ID,
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT
+                                .withEmail("wrong.email@gov.uk")
+                                .withPhoneNumber(AuditService.UNKNOWN),
                         pair("journey-type", JourneyType.SIGN_IN),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -51,4 +51,17 @@ public record AuditContext(
                 persistentSessionId,
                 txmaAuditEncoded);
     }
+
+    public AuditContext withSubjectId(String subjectId) {
+        return new AuditContext(
+                clientId,
+                clientSessionId,
+                sessionId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                txmaAuditEncoded);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -64,4 +64,17 @@ public record AuditContext(
                 persistentSessionId,
                 txmaAuditEncoded);
     }
+
+    public AuditContext withEmail(String email) {
+        return new AuditContext(
+                clientId,
+                clientSessionId,
+                sessionId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                txmaAuditEncoded);
+    }
 }


### PR DESCRIPTION
## What

Converts the Check User Exists Handler to use the new submitAuditEvent signature, which uses an AuditContext object to clean up references to common variables.

## How to review

1. Code Review commit by commit
## Related PRs

A [previous PR](https://github.com/govuk-one-login/authentication-api/pull/4745) doing this for another handler
