### PR TITLE
Aut 2851/deploy ticf handler

### DIFF
--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -42,6 +42,7 @@ locals {
 
   request_tracing_allowed              = contains(["build", "sandpit"], var.environment)
   deploy_account_interventions_count   = 1
+  deploy_ticf_cri_count                = contains(["sandpit"], var.environment) ? 1 : 0
   deploy_reauth_user_count             = contains(["build", "sandpit", "authdev1", "authdev2", "staging", "integration"], var.environment) ? 1 : 0
   deploy_check_email_fraud_block_count = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
 

--- a/ci/terraform/oidc/ticf-cri.tf
+++ b/ci/terraform/oidc/ticf-cri.tf
@@ -1,0 +1,68 @@
+module "frontend_api_ticf_cri_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-ticf-cri-role"
+  vpc_arn     = local.authentication_vpc_arn
+  count       = local.deploy_ticf_cri_count
+}
+
+resource "aws_lambda_function" "ticf_cri_lambda" {
+  count         = local.deploy_ticf_cri_count
+  function_name = "${var.environment}-ticf-cri-lambda"
+  role          = module.frontend_api_ticf_cri_role[0].arn
+  handler       = "uk.gov.di.authentication.frontendapi.lambda.TicfCriHandler::handleRequest"
+  runtime       = "java17"
+  publish       = true
+
+  memory_size                    = lookup(var.performance_tuning, "ticf-cri", local.default_performance_parameters).memory
+  reserved_concurrent_executions = 1
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  s3_bucket         = aws_s3_bucket.source_bucket.bucket
+  s3_key            = aws_s3_object.frontend_api_release_zip.key
+  s3_object_version = aws_s3_object.frontend_api_release_zip.version_id
+
+  kms_key_arn             = local.lambda_env_vars_encryption_kms_key_arn
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  vpc_config {
+    security_group_ids = [local.authentication_egress_security_group_id]
+    subnet_ids         = local.authentication_private_subnet_ids
+  }
+
+  environment {
+    variables = merge(var.notify_template_map, {
+      ENVIRONMENT                   = var.environment
+      TICF_CRI_SERVICE_CALL_TIMEOUT = var.ticf_cri_service_call_timeout
+      TICF_CRI_SERVICE_URI          = var.ticf_cri_service_uri
+    })
+  }
+
+  tags = local.default_tags
+  # checkov:skip=CKV_AWS_116:Adding a DLQ would not be useful as we're not adding a retry policy.
+}
+
+resource "aws_cloudwatch_log_group" "ticf_cri_lambda_log_group" {
+  count = local.deploy_ticf_cri_count # only create log group if lambda is deployed
+
+  name              = "/aws/lambda/${aws_lambda_function.ticf_cri_lambda[0].function_name}"
+  tags              = local.default_tags
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "ticf_cri_lambda_log_subscription" {
+  count = local.deploy_ticf_cri_count == 1 ? length(var.logging_endpoint_arns) : 0 # only create log subscription(s) if lambda is deployed
+
+  name            = "${aws_lambda_function.ticf_cri_lambda[0].function_name}-log-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.ticf_cri_lambda_log_group[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -620,6 +620,17 @@ variable "account_intervention_service_call_timeout" {
   description = "The HTTP Client connection timeout for requests to Account Intervention Service (in milliseconds)."
 }
 
+variable "ticf_cri_service_uri" {
+  default = "undefined"
+  type    = string
+}
+
+variable "ticf_cri_service_call_timeout" {
+  default     = 2000
+  type        = number
+  description = "The HTTP Client connection timeout for requests to TICF CRI Service (in milliseconds)."
+}
+
 variable "orch_redirect_uri" {
   type        = string
   description = "The redirect URI set by Orchestration in the OAuth2 authorize request to Authentication"

--- a/ci/terraform/ticf-cri-stub/.terraform.lock.hcl
+++ b/ci/terraform/ticf-cri-stub/.terraform.lock.hcl
@@ -1,0 +1,77 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.44.0"
+  constraints = "5.44.0"
+  hashes = [
+    "h1:Cdt9DdAhuIqo/BqxybHPFRyC2Z4crxd7Xj39yHoyagk=",
+    "h1:K3sX+P4wofRNcVsnYW4PIhxHijd3w/ZD5AO7yWFPT6A=",
+    "h1:QqMTKuyylmJ633mwNheXdFupfd5sozqCUTTSj89pnm8=",
+    "h1:reyuKyPkBzHJXVMB/blUoZAY0RBSb7++Kw6Sjw4rKQo=",
+    "h1:vFYi1r4ge/VvhMtN2duljKR+0YlEiWOx+PN9pfynW9k=",
+    "zh:1224a42bb04574785549b89815d98bda11f6e9992352fc6c36c5622f3aea91c0",
+    "zh:2a8d1095a2f1ab097f516d9e7e0d289337849eebb3fcc34f075070c65063f4fa",
+    "zh:46cce11150eb4934196d9bff693b72d0494c85917ceb3c2914d5ff4a785af861",
+    "zh:4a7c15d585ee747d17f4b3904851cd95cfbb920fa197aed3df78e8d7ef9609b6",
+    "zh:508f1a85a0b0f93bf26341207d809bd55b60c8fdeede40097d91f30111fc6f5d",
+    "zh:52f968ffc21240213110378d0ffb298cbd23e9157a6d01dfac5a4360492d69c2",
+    "zh:5e9846b48ef03eb59541049e81b15cae8bc7696a3779ae4a5412fdce60bb24e0",
+    "zh:850398aecaf7dc0231fc320fdd6dffe41836e07a54c8c7b40eb28e7525d3c0a9",
+    "zh:8f87eeb05bdd1b873b6cfb3898dfad6402ac180dfa3c8f9754df8f85dcf92ca6",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c726b87cd6ed111536f875dccedecff21abc802a4087264515ffab113cac36dc",
+    "zh:d57ea706d2f98b93c7b05b0c6bc3420de8e8cf2d0b6703085dc15ed239b2cc49",
+    "zh:d5d1a21246e68c2a7a04c5619eb0ad5a81644f644c432cb690537b816a156de2",
+    "zh:e869904cac41114b7e4ee66bcd2ce4585ed15ca842040a60cb47119f69472c91",
+    "zh:f1a09f2f3ea72cbe795b865cf31ad9b1866a536a8050cf0bb93d3fa51069582e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.0"
+  constraints = "3.6.0"
+  hashes = [
+    "h1:5KeoKSVKVHJW308uiTgslxFbjQAdWzBGUFK68vgMRWY=",
+    "h1:I8MBeauYA8J8yheLJ8oSMWqB0kovn16dF/wKZ1QTdkk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
+    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:t0mRdJzegohRKhfdoQEJnv3JRISSezJRblN0HIe67vo=",
+    "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
+    "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
+    "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
+    "zh:30ffb297ffd1633175d6545d37c2217e2cef9545a6e03946e514c59c0859b77d",
+    "zh:454ce4b3dbc73e6775f2f6605d45cee6e16c3872a2e66a2c97993d6e5cbd7055",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:91df0a9fab329aff2ff4cf26797592eb7a3a90b4a0c04d64ce186654e0cc6e17",
+    "zh:aa57384b85622a9f7bfb5d4512ca88e61f22a9cea9f30febaa4c98c68ff0dc21",
+    "zh:c4a3e329ba786ffb6f2b694e1fd41d413a7010f3a53c20b432325a94fa71e839",
+    "zh:e2699bc9116447f96c53d55f2a00570f982e6f9935038c3810603572693712d0",
+    "zh:e747c0fd5d7684e5bfad8aa0ca441903f15ae7a98a737ff6aca24ba223207e2c",
+    "zh:f1ca75f417ce490368f047b63ec09fd003711ae48487fba90b4aba2ccf71920e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.10.0"
+  constraints = "0.10.0"
+  hashes = [
+    "h1:EeF/Lb4db1Kl1HEHzT1StTC7RRqHn/eB7aDR3C3yjVg=",
+    "h1:NAl8eupFAZXCAbE5uiHZTz+Yqler55B3fMG+jNPrjjM=",
+    "h1:QL1ivYrUSB3zvhgXcRBfQak4HDxvesT2zktM+N6StVo=",
+    "h1:rPbqd7mEyBetQPjyBDBAdwiARulKbh2LwzQp2GSl/AI=",
+    "h1:wraHzpOZSaxgC37HLOt0k5Mstl1iNrol7DvvqkSQ1kc=",
+    "zh:0ab31efe760cc86c9eef9e8eb070ae9e15c52c617243bbd9041632d44ea70781",
+    "zh:0ee4e906e28f23c598632eeac297ab098d6d6a90629d15516814ab90ad42aec8",
+    "zh:3bbb3e9da728b82428c6f18533b5b7c014e8ff1b8d9b2587107c966b985e5bcc",
+    "zh:6771c72db4e4486f2c2603c81dfddd9e28b6554d1ded2996b4cb37f887b467de",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:833c636d86c2c8f23296a7da5d492bdfd7260e22899fc8af8cc3937eb41a7391",
+    "zh:c545f1497ae0978ffc979645e594b57ff06c30b4144486f4f362d686366e2e42",
+    "zh:def83c6a85db611b8f1d996d32869f59397c23b8b78e39a978c8a2296b0588b2",
+    "zh:df9579b72cc8e5fac6efee20c7d0a8b72d3d859b50828b1c473d620ab939e2c7",
+    "zh:e281a8ecbb33c185e2d0976dc526c93b7359e3ffdc8130df7422863f4952c00e",
+    "zh:ecb1af3ae67ac7933b5630606672c94ec1f54b119bf77d3091f16d55ab634461",
+    "zh:f8109f13e07a741e1e8a52134f84583f97a819e33600be44623a21f6424d6593",
+  ]
+}

--- a/ci/terraform/ticf-cri-stub/sandpit.hcl
+++ b/ci/terraform/ticf-cri-stub/sandpit.hcl
@@ -1,0 +1,4 @@
+bucket  = "digital-identity-dev-tfstate"
+key     = "sandpit-ticf-cri-stub.tfstate"
+encrypt = true
+region  = "eu-west-2"

--- a/ci/terraform/ticf-cri-stub/versions.tf
+++ b/ci/terraform/ticf-cri-stub/versions.tf
@@ -1,0 +1,1 @@
+../versions.tf

--- a/scripts/dev_deploy_common.sh
+++ b/scripts/dev_deploy_common.sh
@@ -38,6 +38,7 @@ function usage() {
     -d, --delivery-receipts   run the delivery receipts terraform
     -u, --utils               run the utils terraform
     -t, --test-services       run the test services terraform
+    --ticf-stub               run the TICF stub terraform
     --destroy                 run all terraform with the -destroy flag (destroys all managed resources)
     -p, --prompt              will prompt for plan review before applying any terraform
     -x, --auth-external       run the auth external api terraform
@@ -57,6 +58,8 @@ RECEIPTS=0
 SHARED=0
 UTILS=0
 TEST_SERVICES=0
+TICF_STUB=0
+
 CLEAN=""
 RUN_SHELL=0
 TERRAFORM_OPTS="-auto-approve"
@@ -68,6 +71,7 @@ if [[ $# == 0 ]] || [[ $* == "-p" ]]; then
     OIDC=1
     INTERVENTIONS=1
     SHARED=1
+    TICF_STUB=1
 fi
 
 while [[ $# -gt 0 ]]; do
@@ -101,6 +105,9 @@ while [[ $# -gt 0 ]]; do
         ;;
     -t | --test-services)
         TEST_SERVICES=1
+        ;;
+    --ticf-stub)
+        TICF_STUB=1
         ;;
     --destroy)
         echo "PLEASE DON'T DESTROY, JUST REAPPLY"
@@ -152,6 +159,10 @@ fi
 
 if [[ $INTERVENTIONS == "1" ]]; then
     runTerraform "interventions-api-stub" "${TERRAFORM_OPTS}"
+fi
+
+if [[ $TICF_STUB == "1" ]]; then
+    runTerraform "ticf-cri-stub" "${TERRAFORM_OPTS}"
 fi
 
 if [[ $AM == "1" ]]; then


### PR DESCRIPTION
## What

Adds terraform to deploy the ticf handler in sandpit only.

A subsequent PR will deploy the handler in other environments.

Note that the permissions between the ticf handler and the ticf stub are not yet working, this will also be fixed subsequently, but getting this merged will allow for more parallel development.

## How to review

1. Code Review
