### PR TITLE
BAU: Fix email check status assignment

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
@@ -90,7 +90,7 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
             var status =
                     emailCheckResult
                             .map(EmailCheckResultStore::getStatus)
-                            .orElse(EmailCheckResultStatus.PENDING);
+                            .orElseGet(() -> EmailCheckResultStatus.PENDING);
 
             var checkEmailFraudBlockResponse = createResponse(request.getEmail(), status);
 


### PR DESCRIPTION
## What

Previously, the assignment of var status relied on the emailCheckResult being present, which it may not always be. This commit ensures that status will always be assigned a default value of PENDING if there is no record present in the DynamoDB table.

## How to review

1. Code Review
