### PR TITLE
BAU: Remove `reserved_concurrent_executions` from `*-email-check-writer` lambda

### DIFF
--- a/ci/terraform/utils/email_check_results_writer_lambda.tf
+++ b/ci/terraform/utils/email_check_results_writer_lambda.tf
@@ -26,14 +26,13 @@ module "email_check_results_writer_role" {
 
 resource "aws_lambda_function" "email_check_results_writer_lambda" {
   #checkov:skip=CKV_AWS_116:No DLQ is required for this lambda, as it is SQS driven, and the SQS has a DLQ
-  function_name                  = "${var.environment}-email-check-writer"
-  role                           = module.email_check_results_writer_role.arn
-  handler                        = "uk.gov.di.authentication.utils.lambda.EmailCheckResultWriterHandler::handleRequest"
-  timeout                        = 30
-  memory_size                    = 512
-  runtime                        = "java17"
-  publish                        = true
-  reserved_concurrent_executions = 1000
+  function_name = "${var.environment}-email-check-writer"
+  role          = module.email_check_results_writer_role.arn
+  handler       = "uk.gov.di.authentication.utils.lambda.EmailCheckResultWriterHandler::handleRequest"
+  timeout       = 30
+  memory_size   = 512
+  runtime       = "java17"
+  publish       = true
 
   s3_bucket         = aws_s3_object.utils_release_zip.bucket
   s3_key            = aws_s3_object.utils_release_zip.key


### PR DESCRIPTION
## What

If we reserve concurrency for Lambda other function cannot use it.

We have total full account concurrency of 3000, if this pool is used completely Lambda throttling will start causing errors.

## How to review

See that `reserved_concurrent_executions` has been removed from the Terraform definition of the lambda.

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.


## Related PRs

Originally added in https://github.com/govuk-one-login/authentication-api/pull/4239
