### PR TITLE
Aut 2490/make lambda invoker more generic

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -323,6 +323,7 @@ resource "aws_api_gateway_stage" "endpoint_stage" {
   ]
 }
 
+# TODO: Investigate if this can be done better in multi-env aws accounts
 resource "aws_api_gateway_account" "api_gateway_logging_role" {
   cloudwatch_role_arn = aws_iam_role.api_gateway_logging_iam_role.arn
 

--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -14,7 +14,7 @@ account_intervention_service_call_enabled   = true
 account_intervention_service_action_enabled = true
 account_intervention_service_abort_on_error = true
 send_storage_token_to_ipv_enabled           = true
-call_ticf_cri                               = false
+call_ticf_cri                               = true
 
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -14,6 +14,7 @@ account_intervention_service_call_enabled   = true
 account_intervention_service_action_enabled = true
 account_intervention_service_abort_on_error = true
 send_storage_token_to_ipv_enabled           = true
+call_ticf_cri                               = false
 
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -14,6 +14,7 @@ account_intervention_service_call_enabled   = true
 account_intervention_service_action_enabled = true
 account_intervention_service_abort_on_error = true
 send_storage_token_to_ipv_enabled           = true
+call_ticf_cri                               = true
 
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -8,6 +8,7 @@ logging_endpoint_arns                = []
 shared_state_bucket                  = "di-auth-development-tfstate"
 test_clients_enabled                 = true
 internal_sector_uri                  = "https://identity.dev.account.gov.uk"
+call_ticf_cri                        = true
 
 # lockout config
 lockout_duration                     = 60

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -14,6 +14,7 @@ account_intervention_service_call_enabled   = true
 account_intervention_service_action_enabled = true
 account_intervention_service_abort_on_error = true
 send_storage_token_to_ipv_enabled           = true
+call_ticf_cri                               = true
 auth_frontend_public_encryption_key         = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs41htFRe62BIfwQZ0OCT

--- a/ci/terraform/oidc/ticf-cri.tf
+++ b/ci/terraform/oidc/ticf-cri.tf
@@ -9,7 +9,7 @@ module "frontend_api_ticf_cri_role" {
 resource "aws_lambda_function" "ticf_cri_lambda" {
   count         = local.deploy_ticf_cri_count
   function_name = "${var.environment}-ticf-cri-lambda"
-  role          = module.frontend_api_ticf_cri_role[0].arn
+  role          = module.frontend_api_ticf_cri_role[count.index].arn
   handler       = "uk.gov.di.authentication.frontendapi.lambda.TicfCriHandler::handleRequest"
   runtime       = "java17"
   publish       = true
@@ -48,7 +48,7 @@ resource "aws_lambda_function" "ticf_cri_lambda" {
 resource "aws_cloudwatch_log_group" "ticf_cri_lambda_log_group" {
   count = local.deploy_ticf_cri_count # only create log group if lambda is deployed
 
-  name              = "/aws/lambda/${aws_lambda_function.ticf_cri_lambda[0].function_name}"
+  name              = "/aws/lambda/${aws_lambda_function.ticf_cri_lambda[count.index].function_name}"
   tags              = local.default_tags
   kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   retention_in_days = var.cloudwatch_log_retention
@@ -57,12 +57,36 @@ resource "aws_cloudwatch_log_group" "ticf_cri_lambda_log_group" {
 resource "aws_cloudwatch_log_subscription_filter" "ticf_cri_lambda_log_subscription" {
   count = local.deploy_ticf_cri_count == 1 ? length(var.logging_endpoint_arns) : 0 # only create log subscription(s) if lambda is deployed
 
-  name            = "${aws_lambda_function.ticf_cri_lambda[0].function_name}-log-subscription-${count.index}"
-  log_group_name  = aws_cloudwatch_log_group.ticf_cri_lambda_log_group[0].name
+  name            = "${aws_lambda_function.ticf_cri_lambda[count.index].function_name}-log-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.ticf_cri_lambda_log_group[count.index].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
 
   lifecycle {
     create_before_destroy = false
+  }
+}
+
+resource "aws_iam_policy" "ticf_cri_lambda_invocation_policy" {
+  count       = local.deploy_ticf_cri_count
+  name_prefix = "ticf-cri-lambda-invocation-policy"
+  description = "IAM policy managing lambda invocation access for the TICF CRI lambda."
+
+  policy = data.aws_iam_policy_document.ticf_cri_lambda_invocation_policy_document[count.index].json
+}
+
+data "aws_iam_policy_document" "ticf_cri_lambda_invocation_policy_document" {
+  count = local.deploy_ticf_cri_count
+  statement {
+    sid    = "AllowLambdaInvocation"
+    effect = "Allow"
+
+    actions = [
+      "lambda:InvokeFunction",
+    ]
+
+    resources = [
+      aws_lambda_function.ticf_cri_lambda[0].arn,
+    ]
   }
 }

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -699,6 +699,12 @@ variable "enforce_cloudfront" {
   description = "Feature flag to switch the WAF on the OIDC API Gateway to the Origin Cloaking WAF to mandate CloudFront"
 }
 
+variable "call_ticf_cri" {
+  type        = bool
+  default     = false
+  description = "Feature flag to switch on invoking TICF CRI lambda."
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -8,8 +8,8 @@ import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.authentication.entity.TICFCRIRequest;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.entity.TICFCRIRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsInboundResponse;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsRequest;
@@ -179,7 +179,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             submitAuditEvents(
                     accountInterventionsInboundResponse, input, userContext, persistentSessionID);
 
-            if (configurationService.getInvokeTicfCRILambda()) {
+            if (configurationService.isInvokeTicfCRILambdaEnabled() && request.authenticated()) {
                 sendTICF(userContext, internalPairwiseId);
             }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -179,7 +179,9 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             submitAuditEvents(
                     accountInterventionsInboundResponse, input, userContext, persistentSessionID);
 
-            sendTICF(userContext, internalPairwiseId);
+            if (configurationService.getInvokeTicfCRILambda()) {
+                sendTICF(userContext, internalPairwiseId);
+            }
 
             LOG.info("Generating Account Interventions outbound response for frontend");
             var accountInterventionsResponse =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -205,7 +205,10 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                             .getCredentialTrustLevel()
                             .getValue());
         } catch (Exception e) {
-            LOG.warn("Error retrieving effective vector of trust: {}", e.getMessage(), e);
+            LOG.warn(
+                    "Error retrieving effective vector of trust for TICF CRI Request: {}",
+                    e.getMessage(),
+                    e);
         }
 
         String journeyId = userContext.getClientSessionId();
@@ -217,10 +220,10 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         try {
             payload = gson.toJson(ticfRequest);
         } catch (JsonIOException | JsonSyntaxException | NullPointerException e) {
-            LOG.error("Error serializing ticfCriRequest {}", e.getMessage(), e);
+            LOG.error("Error serializing TICF CRI Request {}", e.getMessage(), e);
             return;
         } catch (Exception e) {
-            LOG.error("Unexpected error serializing ticfCriRequest {}", e.getMessage(), e);
+            LOG.error("Unexpected error serializing TICF CRI Request {}", e.getMessage(), e);
             return;
         }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -179,8 +179,9 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             submitAuditEvents(
                     accountInterventionsInboundResponse, input, userContext, persistentSessionID);
 
-            if (configurationService.isInvokeTicfCRILambdaEnabled() && request.authenticated()) {
-                sendTICF(userContext, internalPairwiseId);
+            if (configurationService.isInvokeTicfCRILambdaEnabled()
+                    && request.authenticated() != null) {
+                sendTICF(userContext, internalPairwiseId, request.authenticated());
             }
 
             LOG.info("Generating Account Interventions outbound response for frontend");
@@ -194,7 +195,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         }
     }
 
-    private void sendTICF(UserContext userContext, String internalPairwiseId) {
+    private void sendTICF(
+            UserContext userContext, String internalPairwiseId, boolean authenticated) {
         var vtr = new ArrayList<String>();
 
         try {
@@ -213,7 +215,9 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
 
         String journeyId = userContext.getClientSessionId();
 
-        var ticfRequest = TICFCRIRequest.basicTicfCriRequest(internalPairwiseId, vtr, journeyId);
+        var ticfRequest =
+                TICFCRIRequest.basicTicfCriRequest(
+                        internalPairwiseId, vtr, journeyId, authenticated);
 
         String payload;
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -129,15 +129,6 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
         assertThat(response, hasStatus(200));
     }
 
-    private Map<String, String> getHeaders() throws Json.JsonException {
-        Map<String, String> headers = new HashMap<>();
-        var sessionId = redis.createSession();
-        redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
-        headers.put("Session-Id", sessionId);
-        headers.put(TXMA_AUDIT_ENCODED_HEADER, ENCODED_DEVICE_DETAILS);
-        return headers;
-    }
-
     private Map<String, String> getHeadersForAuthenticatedSession() throws Json.JsonException {
         Map<String, String> headers = new HashMap<>();
         var sessionId = redis.createAuthenticatedSessionWithEmail(TEST_EMAIL_ADDRESS);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -9,17 +9,23 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.services.lambda.LambdaClient;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsResponse;
 import uk.gov.di.authentication.frontendapi.lambda.AccountInterventionsHandler;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.LambdaInvokerService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AccountInterventionsStubExtension;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +35,9 @@ import java.util.stream.Stream;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.PERMANENTLY_BLOCKED_INTERVENTION;
+import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.lambda.BaseFrontendHandler.TXMA_AUDIT_ENCODED_HEADER;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
@@ -57,12 +65,15 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
                     new AccountInterventionsTestConfigurationService(
                             accountInterventionsStubExtension);
 
+    protected static final LambdaClient mockLambdaClient = mock(LambdaClient.class);
+
     @BeforeEach
     void setup() throws JOSEException, Json.JsonException {
         handler =
                 new AccountInterventionsHandler(
                         ACCOUNT_INTERVENTIONS_HANDLER_CONFIGURATION_SERVICE,
-                        redisConnectionService);
+                        redisConnectionService,
+                        new LambdaInvokerService(mockLambdaClient));
         accountInterventionsStubExtension.initWithBlockedUserId(
                 setupUserAndRetrieveUserId(TEST_EMAIL_ADDRESS),
                 setupUserAndRetrieveUserId(TEST_EMAIL_ADDRESS_PERMANENTLY_BLOCKED_USER));
@@ -83,11 +94,13 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
     void shouldReturnSuccessful200Response(
             String emailAddress, boolean isUserBlocked, FrontendAuditableEvent expectedAuditEvent)
             throws Json.JsonException {
+
         var response =
                 makeRequest(
                         Optional.of(format("{\"email\":\"%s\"}", emailAddress)),
-                        getHeaders(),
+                        getHeadersForAuthenticatedSession(),
                         Map.of());
+
         assertThat(response, hasStatus(200));
         var accountInterventionsResponse =
                 new AccountInterventionsResponse(
@@ -111,7 +124,8 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
                 format(
                         "{\"email\":\"%s\",\"authenticated\":%b}",
                         TEST_EMAIL_ADDRESS, authenticated);
-        var response = makeRequest(Optional.of(body), getHeaders(), Map.of());
+        var response =
+                makeRequest(Optional.of(body), getHeadersForAuthenticatedSession(), Map.of());
         assertThat(response, hasStatus(200));
     }
 
@@ -120,6 +134,25 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
         var sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         headers.put("Session-Id", sessionId);
+        headers.put(TXMA_AUDIT_ENCODED_HEADER, ENCODED_DEVICE_DETAILS);
+        return headers;
+    }
+
+    private Map<String, String> getHeadersForAuthenticatedSession() throws Json.JsonException {
+        Map<String, String> headers = new HashMap<>();
+        var sessionId = redis.createAuthenticatedSessionWithEmail(TEST_EMAIL_ADDRESS);
+
+        var clientSession =
+                new ClientSession(
+                        null,
+                        LocalDateTime.now(),
+                        new VectorOfTrust(CredentialTrustLevel.LOW_LEVEL),
+                        "clientName");
+
+        redis.createClientSession("client-session-id", clientSession);
+
+        headers.put("Session-Id", sessionId);
+        headers.put(CLIENT_SESSION_ID_HEADER, "client-session-id");
         headers.put(TXMA_AUDIT_ENCODED_HEADER, ENCODED_DEVICE_DETAILS);
         return headers;
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
@@ -99,6 +99,7 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest
         handler = new BulkUserEmailAudienceLoaderScheduledEventHandler(configuration);
         var lambdaInvokerService =
                 new LambdaInvokerService((LambdaClient) null) {
+                    @Override
                     public void invokeAsyncWithPayload(String jsonPayload, String lambdaName) {
                         ScheduledEvent scheduledEvent = new ScheduledEvent();
 

--- a/shared/src/main/java/uk/gov/di/authentication/entity/TICFCRIRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/TICFCRIRequest.java
@@ -15,7 +15,8 @@ public record TICFCRIRequest(
         @Expose String passwordReset) {
 
     public static TICFCRIRequest basicTicfCriRequest(
-            String internalPairwiseId, List<String> vtr, String journeyId) {
-        return new TICFCRIRequest(internalPairwiseId, vtr, journeyId, "Y", null, null);
+            String internalPairwiseId, List<String> vtr, String journeyId, boolean authenticated) {
+        return new TICFCRIRequest(
+                internalPairwiseId, vtr, journeyId, authenticated ? "Y" : "N", null, null);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -183,6 +183,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("BULK_USER_EMAIL_AUDIENCE_LOADER_LAMBDA_NAME", "");
     }
 
+    public String getTicfCRILambdaName() {
+        return System.getenv().getOrDefault("TICF_CRI_LAMBDA_NAME", "");
+    }
+
     public URI getAuthenticationAuthCallbackURI() {
         return URI.create(
                 System.getenv().getOrDefault("AUTHENTICATION_AUTHORIZATION_CALLBACK_URI", ""));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -187,6 +187,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("TICF_CRI_LAMBDA_NAME", "");
     }
 
+    public boolean getInvokeTicfCRILambda() {
+        return System.getenv().getOrDefault("INVOKE_TICF_CRI_LAMBDA", "false").equals("true");
+    }
+
     public URI getAuthenticationAuthCallbackURI() {
         return URI.create(
                 System.getenv().getOrDefault("AUTHENTICATION_AUTHORIZATION_CALLBACK_URI", ""));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -187,7 +187,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("TICF_CRI_LAMBDA_NAME", "");
     }
 
-    public boolean getInvokeTicfCRILambda() {
+    public boolean isInvokeTicfCRILambdaEnabled() {
         return System.getenv().getOrDefault("INVOKE_TICF_CRI_LAMBDA", "false").equals("true");
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvoker.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvoker.java
@@ -1,7 +1,5 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
-
 public interface LambdaInvoker {
-    public void invokeWithPayload(ScheduledEvent scheduledEvent);
+    void invokeAsyncWithPayload(String jsonPayload, String functionName);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 public class LambdaInvokerService implements LambdaInvoker {
     private static final Logger LOG = LogManager.getLogger(LambdaInvokerService.class);
+    public static final String MISSING = "missing";
     private final LambdaClient lambdaClient;
 
     public LambdaInvokerService(LambdaClient lambdaClient) {
@@ -53,14 +54,14 @@ public class LambdaInvokerService implements LambdaInvoker {
             var errorMessage =
                     Optional.ofNullable(e.awsErrorDetails())
                             .map(AwsErrorDetails::errorMessage)
-                            .orElse("missing");
+                            .orElse(MISSING);
 
             var errorCode =
                     Optional.ofNullable(e.awsErrorDetails())
                             .map(AwsErrorDetails::errorCode)
-                            .orElse("missing");
+                            .orElse(MISSING);
 
-            var requestId = Optional.ofNullable(e.requestId()).orElse("missing");
+            var requestId = Optional.ofNullable(e.requestId()).orElse(MISSING);
 
             LOG.error(
                     "Lambda invocation error: {}\n Error code: {}\n Request ID: {}",

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
@@ -37,7 +37,8 @@ public class LambdaInvokerService implements LambdaInvoker {
         try {
             payload = SdkBytes.fromUtf8String(jsonPayload);
         } catch (Exception e) {
-            LOG.error("Could not convert payload for TICF CRI into SdkBytes: {}", jsonPayload);
+            LOG.error(
+                    "Could not convert payload for {} into SdkBytes: {}", lambdaName, jsonPayload);
             return;
         }
 
@@ -64,12 +65,13 @@ public class LambdaInvokerService implements LambdaInvoker {
             var requestId = Optional.ofNullable(e.requestId()).orElse(MISSING);
 
             LOG.error(
-                    "Lambda invocation error: {}\n Error code: {}\n Request ID: {}",
+                    "Lambda {} invocation error: {}\n Error code: {}\n Request ID: {}",
+                    lambdaName,
                     errorMessage,
                     errorCode,
                     requestId);
         } catch (Exception e) {
-            LOG.error("Lambda invocation failed in unexpected way: ", e);
+            LOG.error("Lambda {} invocation failed in unexpected way: ", lambdaName, e);
         }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
@@ -1,36 +1,27 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
-import net.minidev.json.JSONObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvocationType;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
-import uk.gov.di.authentication.shared.exceptions.LambdaInvokerServiceException;
-import uk.gov.di.authentication.shared.serialization.Json;
+import software.amazon.awssdk.services.lambda.model.LambdaException;
+
+import java.util.Optional;
 
 public class LambdaInvokerService implements LambdaInvoker {
-
     private static final Logger LOG = LogManager.getLogger(LambdaInvokerService.class);
-
-    protected final Json objectMapper = SerializationService.getInstance();
-
-    private final ConfigurationService configurationService;
-
     private final LambdaClient lambdaClient;
 
-    public LambdaInvokerService(
-            ConfigurationService configurationService, LambdaClient lambdaClient) {
-        this.configurationService = configurationService;
+    public LambdaInvokerService(LambdaClient lambdaClient) {
         this.lambdaClient = lambdaClient;
     }
 
     public LambdaInvokerService(ConfigurationService configurationService) {
-        this.configurationService = configurationService;
         this.lambdaClient =
                 LambdaClient.builder()
                         .credentialsProvider(DefaultCredentialsProvider.create())
@@ -39,21 +30,15 @@ public class LambdaInvokerService implements LambdaInvoker {
     }
 
     @Override
-    public void invokeWithPayload(ScheduledEvent scheduledEvent) {
-        String lambdaName = configurationService.getBulkEmailLoaderLambdaName();
+    public void invokeAsyncWithPayload(String jsonPayload, String lambdaName) {
+        SdkBytes payload;
 
-        if (lambdaName == null || lambdaName.isEmpty()) {
-            throw new LambdaInvokerServiceException(
-                    "BULK_USER_EMAIL_AUDIENCE_LOADER_LAMBDA_NAME environment variable not set");
+        try {
+            payload = SdkBytes.fromUtf8String(jsonPayload);
+        } catch (Exception e) {
+            LOG.error("Could not convert payload for TICF CRI into SdkBytes: {}", jsonPayload);
+            return;
         }
-
-        JSONObject detail = new JSONObject();
-        detail.appendField("lastEvaluatedKey", scheduledEvent.getDetail().get("lastEvaluatedKey"));
-        detail.appendField(
-                "globalUsersAddedCount", scheduledEvent.getDetail().get("globalUsersAddedCount"));
-
-        String jsonPayload = new JSONObject().appendField("detail", detail).toJSONString();
-        SdkBytes payload = SdkBytes.fromUtf8String(jsonPayload);
 
         InvokeRequest invokeRequest =
                 InvokeRequest.builder()
@@ -61,6 +46,29 @@ public class LambdaInvokerService implements LambdaInvoker {
                         .invocationType(InvocationType.EVENT)
                         .payload(payload)
                         .build();
-        lambdaClient.invoke(invokeRequest);
+
+        try {
+            lambdaClient.invoke(invokeRequest);
+        } catch (LambdaException e) {
+            var errorMessage =
+                    Optional.ofNullable(e.awsErrorDetails())
+                            .map(AwsErrorDetails::errorMessage)
+                            .orElse("missing");
+
+            var errorCode =
+                    Optional.ofNullable(e.awsErrorDetails())
+                            .map(AwsErrorDetails::errorCode)
+                            .orElse("missing");
+
+            var requestId = Optional.ofNullable(e.requestId()).orElse("missing");
+
+            LOG.error(
+                    "Lambda invocation error: {}\n Error code: {}\n Request ID: {}",
+                    errorMessage,
+                    errorCode,
+                    requestId);
+        } catch (Exception e) {
+            LOG.error("Lambda invocation failed in unexpected way: ", e);
+        }
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/LambdaInvokerServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/LambdaInvokerServiceTest.java
@@ -82,6 +82,10 @@ class LambdaInvokerServiceTest {
         assertDoesNotThrow(() -> lambdaInvokerService.invokeAsyncWithPayload(null, functionName));
         assertThat(
                 logging.events(),
-                hasItem(withMessage("Could not convert payload for TICF CRI into SdkBytes: null")));
+                hasItem(
+                        withMessage(
+                                "Could not convert payload for "
+                                        + functionName
+                                        + " into SdkBytes: null")));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/LambdaInvokerServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/LambdaInvokerServiceTest.java
@@ -1,73 +1,87 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
-import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvocationType;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
-import uk.gov.di.authentication.shared.serialization.Json;
+import software.amazon.awssdk.services.lambda.model.LambdaException;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessage;
 
 class LambdaInvokerServiceTest {
+    String functionName = "SOME_FUNCTION_NAME";
+    String payloadString = "{\"foo\": \"bar\"}";
+    SdkBytes payload = SdkBytes.fromUtf8String(payloadString);
+    InvokeRequest expectedInvokeRequest =
+            InvokeRequest.builder()
+                    .functionName(functionName)
+                    .invocationType(InvocationType.EVENT)
+                    .payload(payload)
+                    .build();
 
-    ConfigurationService configurationService = mock(ConfigurationService.class);
+    LambdaClient lambdaClient;
+    LambdaInvokerService lambdaInvokerService;
 
-    LambdaClient lambdaClient = mock(LambdaClient.class);
+    @RegisterExtension
+    private final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(LambdaInvokerService.class);
 
-    ScheduledEvent scheduledEvent = mock(ScheduledEvent.class);
-
-    @Test
-    void shouldInvokeTheLambdaWithTheGivenScheduledEvent() {
-        var functionName = "BULK_USER_EMAIL_AUDIENCE_LOADER";
-        when(configurationService.getBulkEmailLoaderLambdaName()).thenReturn(functionName);
-        var lastEvaluatedKey = "email@example.com";
-        var globalUsersAddedCount = "5";
-        Map<String, Object> details =
-                Map.of(
-                        "globalUsersAddedCount",
-                        globalUsersAddedCount,
-                        "lastEvaluatedKey",
-                        lastEvaluatedKey);
-        when(scheduledEvent.getDetail()).thenReturn(details);
-
-        JSONObject detail =
-                new JSONObject()
-                        .appendField("lastEvaluatedKey", lastEvaluatedKey)
-                        .appendField("globalUsersAddedCount", globalUsersAddedCount);
-        String payloadString = new JSONObject().appendField("detail", detail).toJSONString();
-
-        var payload = SdkBytes.fromUtf8String(payloadString);
-        InvokeRequest invokeRequest =
-                InvokeRequest.builder()
-                        .functionName(functionName)
-                        .invocationType(InvocationType.EVENT)
-                        .payload(payload)
-                        .build();
-        LambdaInvokerService lambdaInvokerService =
-                new LambdaInvokerService(configurationService, lambdaClient);
-
-        lambdaInvokerService.invokeWithPayload(scheduledEvent);
-
-        verify(lambdaClient).invoke(invokeRequest);
+    @BeforeEach
+    void beforeEach() {
+        lambdaClient = mock(LambdaClient.class);
+        lambdaInvokerService = new LambdaInvokerService(lambdaClient);
     }
 
     @Test
-    void shouldThrowErrorWhenLambdaNameNotSetInEnvironment() throws Json.JsonException {
-        when(configurationService.getBulkEmailLoaderLambdaName()).thenReturn("");
-        LambdaInvokerService lambdaInvokerService =
-                new LambdaInvokerService(configurationService, lambdaClient);
+    void shouldInvokeTheSpecifiedLambdaWithTheGivenPayload() {
+        assertDoesNotThrow(
+                () -> lambdaInvokerService.invokeAsyncWithPayload(payloadString, functionName));
 
-        assertThrows(
-                RuntimeException.class,
-                () -> lambdaInvokerService.invokeWithPayload(scheduledEvent),
-                "BULK_USER_EMAIL_AUDIENCE_LOADER_LAMBDA_NAME environment variable not set");
+        verify(lambdaClient).invoke(expectedInvokeRequest);
+    }
+
+    @Test
+    void shouldNotAllowExpectedExceptionsToEscape() {
+        when(lambdaClient.invoke((InvokeRequest) any())).thenThrow(mock(LambdaException.class));
+
+        assertDoesNotThrow(
+                () -> lambdaInvokerService.invokeAsyncWithPayload(payloadString, functionName));
+    }
+
+    @Test
+    void shouldNotAllowUnexpectedExceptionsToEscape() {
+        when(lambdaClient.invoke((InvokeRequest) any())).thenThrow(mock(RuntimeException.class));
+
+        assertDoesNotThrow(
+                () -> lambdaInvokerService.invokeAsyncWithPayload(payloadString, functionName));
+    }
+
+    @Test
+    void checkConstructor() {
+        var mockConfigurationService = mock(ConfigurationService.class);
+        when(mockConfigurationService.getAwsRegion()).thenReturn("eu-west-2");
+
+        assertDoesNotThrow(() -> new LambdaInvokerService(mockConfigurationService));
+
+        verify(mockConfigurationService).getAwsRegion();
+    }
+
+    @Test
+    void checkHandlesPayloadsThatDontConvertToSdkBytes() {
+        assertDoesNotThrow(() -> lambdaInvokerService.invokeAsyncWithPayload(null, functionName));
+        assertThat(
+                logging.events(),
+                hasItem(withMessage("Could not convert payload for TICF CRI into SdkBytes: null")));
     }
 }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->
The Account Interventions Handler has been modified to invoke the TICF Lambda dependent on the value of a feature switch.

## How to review

1. Code Review
2. Deploy to sandpit with `./deploy-sandpit.sh -a`
<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
