### PR TITLE
ATO-674: Enforce cloudfront in production

### DIFF
--- a/ci/cloudfront-orchestration/cloudfront/integration/parameters.json
+++ b/ci/cloudfront-orchestration/cloudfront/integration/parameters.json
@@ -9,7 +9,7 @@
   },
   {
     "ParameterKey": "FraudHeaderEnabled",
-    "ParameterValue": "false"
+    "ParameterValue": "true"
   },
   {
     "ParameterKey": "CloudFrontWafACL",

--- a/ci/cloudfront-orchestration/cloudfront/production/parameters.json
+++ b/ci/cloudfront-orchestration/cloudfront/production/parameters.json
@@ -9,7 +9,7 @@
   },
   {
     "ParameterKey": "FraudHeaderEnabled",
-    "ParameterValue": "false"
+    "ParameterValue": "true"
   },
   {
     "ParameterKey": "CloudFrontWafACL",

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -42,6 +42,7 @@ orch_account_id = "533266965190"
 oidc_origin_domain_enabled  = true
 oidc_cloudfront_dns_enabled = true
 txma_audit_encoded_enabled  = true
+enforce_cloudfront          = true
 
 kms_cross_account_access_enabled                = true
 spot_request_queue_cross_account_access_enabled = true


### PR DESCRIPTION
## What

Same as https://github.com/govuk-one-login/authentication-api/pull/4677 but for production. This changes the firewall on the API gateway to one which requires all traffic to have the secret header set by CloudFront.

I have:
 - Checked all traffic is routed via CF: 
![image](https://github.com/govuk-one-login/authentication-api/assets/40488007/4db5ee5e-3d7d-4914-b198-d0ddb5124534)


 - Checked the WAF expects the correct values for the secret header
