### PR TITLE
BAU: Add new stub client for the acceptance test micro rp in build

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -66,4 +66,27 @@ stub_rp_clients = [
     one_login_service = false
     service_type      = "MANDATORY"
   },
+  {
+    client_name           = "relying-party-micro-stub-build-acceptance-test"
+    sector_identifier_uri = "https://acceptance-test-rp-micro-stub-build.build.stubs.account.gov.uk"
+    callback_urls = [
+      "http://localhost:3031/callback",
+      "http://localhost:8080/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "http://localhost:3031/signed-out",
+      "http://localhost:8080/signed-out",
+    ]
+    test_client                     = "1"
+    identity_verification_supported = "1"
+    client_type                     = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+      "wallet-subject-id",
+    ]
+    one_login_service = false
+    service_type      = "MANDATORY"
+  },
 ]


### PR DESCRIPTION
## What

Add new stub client for the acceptance test micro rp in build.

The micro rp has additional config for its own client that needs to be in place for it to run, and this needs a new client first.

## How to review

1. Code Review

## Related PRs

https://github.com/govuk-one-login/authentication-acceptance-tests/pull/328
