### PR TITLE
AUT-2908: Add optional authenticated parameter to account intervention request

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountInterventionsRequest.java
@@ -1,8 +1,7 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.validation.Required;
 
 public record AccountInterventionsRequest(
-        @SerializedName("email") @Expose @Required String email) {}
+        @Expose @Required String email, @Expose Boolean authenticated) {}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -291,7 +291,7 @@ class AccountInterventionsHandlerTest {
 
         var result =
                 handler.handleRequestWithUserContext(
-                        event, context, new AccountInterventionsRequest("test"), userContext);
+                        event, context, new AccountInterventionsRequest("test", null), userContext);
         assertThat(result, hasStatus(200));
 
         assertEquals(
@@ -350,7 +350,7 @@ class AccountInterventionsHandlerTest {
 
         var result =
                 handler.handleRequestWithUserContext(
-                        event, context, new AccountInterventionsRequest("test"), userContext);
+                        event, context, new AccountInterventionsRequest("test", null), userContext);
 
         assertThat(result, hasStatus(200));
 


### PR DESCRIPTION
This will support the call to the ticf cri (which for now we will do from the account interventions handler, only in the case where the user is authenticated).

This field is currently unused - later work will implement logic based on this, so this is just to ensure that the frontend is making a compatible call to the backend.

## How to review

1. Code Review
