### PR TITLE
ATO-737 jwks endpoint for jar signing

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -85,6 +85,8 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.mfa_reset_storage_token_jwk.method_trigger_value,
       module.reverification_result.integration_trigger_value,
       module.reverification_result.method_trigger_value,
+      module.mfa_reset_jar_signing_jwk.integration_trigger_value,
+      module.mfa_reset_jar_signing_jwk.method_trigger_value,
       module.mfa_reset_authorize.integration_trigger_value,
       module.mfa_reset_authorize.method_trigger_value,
       local.deploy_account_interventions_count == 1 ? module.account_interventions[0].integration_trigger_value : null,
@@ -119,6 +121,7 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
     module.mfa_reset_authorize,
     module.mfa_reset_storage_token_jwk,
     module.reverification_result,
+    module.mfa_reset_jar_signing_jwk
   ]
 }
 

--- a/ci/terraform/oidc/kms-policies.tf
+++ b/ci/terraform/oidc/kms-policies.tf
@@ -255,3 +255,28 @@ resource "aws_iam_policy" "mfa_reset_jar_kms_signing_policy" {
 
   policy = data.aws_iam_policy_document.mfa_reset_jar_signing_policy_document.json
 }
+
+
+### MFA reset JAR signing key access
+
+data "aws_iam_policy_document" "mfa_reset_jar_jwk_document" {
+  statement {
+    sid    = "AllowAccessToJarSigningKmsPublicKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:GetPublicKey",
+    ]
+    resources = [
+      aws_kms_key.mfa_reset_jar_signing_key_ecc.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "mfa_reset_jar_kms_signing_jwk_policy" {
+  name_prefix = "kms-mfa-reset-jar-signing-jwk-policy"
+  path        = "/${var.environment}/mfa-reset-jar-jwk-policy/"
+  description = "IAM policy for a lambda to publish the JWK for the MFA reset JAR signing key"
+
+  policy = data.aws_iam_policy_document.mfa_reset_jar_jwk_document.json
+}

--- a/ci/terraform/oidc/mfa-reset-jar-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-jar-jwk.tf
@@ -1,0 +1,56 @@
+module "mfa_reset_jar_signing_jwk_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "mfa-reset-jar-jwk-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.mfa_reset_jar_kms_signing_jwk_policy.arn
+  ]
+}
+
+module "mfa_reset_jar_signing_jwk" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "reverification-jwk.json"
+  path_part       = "reverification-jwk.json"
+  endpoint_method = ["GET"]
+  environment     = var.environment
+
+  handler_environment_variables = {
+    ENVIRONMENT                     = var.environment
+    MFA_RESET_JAR_SIGNING_KEY_ALIAS = aws_kms_alias.mfa_reset_jar_signing_key_alias.name
+  }
+  handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetJarTokenJwkHandler::handleRequest"
+
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_resource.auth_frontend_wellknown_resource.id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  memory_size                 = lookup(var.performance_tuning, "mfa-reset-jar-jwk", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "mfa-reset-jar-jwk", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "mfa-reset-jar-jwk", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "mfa-reset-jar-jwk", local.default_performance_parameters).scaling_trigger
+
+  source_bucket           = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn                 = local.authentication_vpc_arn
+  security_group_ids                     = [local.authentication_security_group_id]
+  subnet_id                              = local.authentication_private_subnet_ids
+  lambda_role_arn                        = module.mfa_reset_jar_signing_jwk_role.arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+
+  use_localstack = false
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_frontend_api,
+    aws_api_gateway_resource.auth_frontend_wellknown_resource,
+  ]
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetJarJwkHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetJarJwkHandler.java
@@ -1,0 +1,70 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.JwksService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+
+public class MfaResetJarJwkHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+    private final JwksService jwksService;
+    private static final Logger LOG = LogManager.getLogger(MfaResetJarJwkHandler.class);
+
+    public MfaResetJarJwkHandler(JwksService jwksService) {
+        this.jwksService = jwksService;
+    }
+
+    public MfaResetJarJwkHandler(ConfigurationService configurationService) {
+        this.jwksService =
+                new JwksService(
+                        configurationService, new KmsConnectionService(configurationService));
+    }
+
+    public MfaResetJarJwkHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent event, Context context) {
+        return segmentedFunctionCall(
+                "frontend-api::" + getClass().getSimpleName(), this::mfaResetJarTokenJwkHandler);
+    }
+
+    public APIGatewayProxyResponseEvent mfaResetJarTokenJwkHandler() {
+        LOG.info("MFA reset JAR Signing JWK request received");
+        try {
+
+            List<JWK> signingKeys = new ArrayList<>();
+
+            signingKeys.add(jwksService.getPublicMfaResetJarJwkWithOpaqueId());
+
+            JWKSet jwkSet = new JWKSet(signingKeys);
+
+            LOG.info("Generating MFA reset JAR signing JWK successful response");
+
+            return generateApiGatewayProxyResponse(
+                    200,
+                    segmentedFunctionCall("serialiseJWKSet", () -> jwkSet.toString(true)),
+                    Map.of("Cache-Control", "max-age=86400"),
+                    null);
+        } catch (Exception e) {
+            LOG.error("Error in MfaResetJarJwkHandler lambda", e);
+            return generateApiGatewayProxyResponse(500, "Error providing MFA Reset JAR JWK data");
+        }
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetJarJwkHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetJarJwkHandlerTest.java
@@ -1,0 +1,62 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.JwksService;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasHeader;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class MfaResetJarJwkHandlerTest {
+
+    private final Context context = mock(Context.class);
+    private final JwksService jwksService = mock(JwksService.class);
+    private MfaResetJarJwkHandler handler;
+    private final ECKey jarPublicSigningKey =
+            new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
+
+    MfaResetJarJwkHandlerTest() throws JOSEException {}
+
+    @BeforeEach
+    public void setUp() {
+        handler = new MfaResetJarJwkHandler(jwksService);
+        when(jwksService.getPublicMfaResetJarJwkWithOpaqueId()).thenReturn(jarPublicSigningKey);
+    }
+
+    @Test
+    void shouldReturnMfaResetStorageTokenJwk() {
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
+
+        var expectedJWKSet = new JWKSet(List.of(jarPublicSigningKey));
+
+        assertThat(result, hasStatus(200));
+        assertThat(result, hasBody(expectedJWKSet.toString(true)));
+        assertThat(result, hasHeader("Cache-Control", "max-age=86400"));
+    }
+
+    @Test
+    void shouldReturn500WhenSigningKeyIsNotPresent() {
+        when(jwksService.getPublicMfaResetJarJwkWithOpaqueId()).thenReturn(null);
+
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasBody("Error providing MFA Reset JAR JWK data"));
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -551,6 +551,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("MFA_RESET_STORAGE_TOKEN_SIGNING_KEY_ALIAS");
     }
 
+    public String getMfaResetJarSigningKeyAlias() {
+        return System.getenv("MFA_RESET_JAR_SIGNING_KEY_ALIAS");
+    }
+
     public URI getCredentialStoreURI() {
         return getURIOrDefault("CREDENTIAL_STORE_URI", "https://credential-store.account.gov.uk");
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
@@ -66,6 +66,11 @@ public class JwksService {
         return getPublicJWKWithKeyId(configurationService.getMfaResetStorageTokenSigningKeyAlias());
     }
 
+    public JWK getPublicMfaResetJarJwkWithOpaqueId() {
+        LOG.info("Retrieving MFA Reset JAR signing public key");
+        return getPublicJWKWithKeyId(configurationService.getMfaResetJarSigningKeyAlias());
+    }
+
     public JWK retrieveJwkFromURLWithKeyId(URL url, String keyId) {
         JWKSelector selector = new JWKSelector(new JWKMatcher.Builder().keyID(keyId).build());
         JWKSource<SecurityContext> jwkSource =

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/JwksServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/JwksServiceTest.java
@@ -111,4 +111,32 @@ class JwksServiceTest {
         assertThat(publicKeyJwk.getAlgorithm(), equalTo(JWSAlgorithm.ES256));
         assertThat(publicKeyJwk.getKeyUse(), equalTo(KeyUse.SIGNATURE));
     }
+
+    @Test
+    void shouldReturnMfaResetJarSigningKeyAndParseToJwk() {
+
+        String mockKeyId = "123456789";
+        when(configurationService.getMfaResetJarSigningKeyAlias()).thenReturn(mockKeyId);
+
+        byte[] publicKey =
+                Base64.getDecoder()
+                        .decode(
+                                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9cKBC5iJvCv5TD5E+nqI0yes8bXlpqWza/cgYXX6QfL7xTjkgI7gblEYGctJgGTD8HbvO9pQX8n0H6+ibF4ewg==");
+
+        var result =
+                GetPublicKeyResponse.builder()
+                        .keyUsage(KeyUsageType.SIGN_VERIFY)
+                        .keyId(mockKeyId)
+                        .signingAlgorithms(SigningAlgorithmSpec.ECDSA_SHA_256)
+                        .publicKey(SdkBytes.fromByteArray(publicKey))
+                        .build();
+
+        when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class))).thenReturn(result);
+
+        JWK publicKeyJwk = jwksService.getPublicMfaResetJarJwkWithOpaqueId();
+
+        assertThat(publicKeyJwk.getKeyID(), equalTo(hashSha256String(mockKeyId)));
+        assertThat(publicKeyJwk.getAlgorithm(), equalTo(JWSAlgorithm.ES256));
+        assertThat(publicKeyJwk.getKeyUse(), equalTo(KeyUse.SIGNATURE));
+    }
 }


### PR DESCRIPTION
## What:
Adds a new JWKs endpoint to the Auth frontend API for the re-authenticate JAR signing key for MFA reset. 

<!-- Describe what you have changed and why -->

## How to review
- Deployed to sandpit, endpoint at https://auth.sandpit.account.gov.uk/.well-known/reverification-jwk.json, all looks fine

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
