### PR TITLE
ATO-693: Refactor Client JWT Signature Validation Into Service

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -32,6 +32,7 @@ import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
+import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
@@ -115,7 +116,8 @@ public class TokenHandler
                         new JwksService(configurationService, kms), configurationService);
         this.tokenClientAuthValidatorFactory =
                 new TokenClientAuthValidatorFactory(
-                        configurationService, new DynamoClientService(configurationService));
+                        new DynamoClientService(configurationService),
+                        new ClientSignatureValidationService(configurationService));
     }
 
     public TokenHandler(ConfigurationService configurationService, RedisConnectionService redis) {
@@ -136,7 +138,8 @@ public class TokenHandler
                         new JwksService(configurationService, kms), configurationService);
         this.tokenClientAuthValidatorFactory =
                 new TokenClientAuthValidatorFactory(
-                        configurationService, new DynamoClientService(configurationService));
+                        new DynamoClientService(configurationService),
+                        new ClientSignatureValidationService(configurationService));
     }
 
     public TokenHandler() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientSignatureValidationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientSignatureValidationServiceTest.java
@@ -1,0 +1,149 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+import static com.nimbusds.jose.JWSAlgorithm.RS256;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ClientSignatureValidationServiceTest {
+
+    private static final String REDIRECT_URI = "https://localhost:8080";
+    private static final ClientID CLIENT_ID = new ClientID("test-id");
+    private static final URI OIDC_BASE_URI = URI.create("https://localhost");
+    private static final URI TOKEN_URI = URI.create("https://localhost/token");
+    private static final URI AUTHORIZE_URI = URI.create("https://localhost/authorize");
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private ClientSignatureValidationService clientSignatureValidationService;
+
+    @BeforeEach
+    void setup() {
+        when(configurationService.getOidcApiBaseURL())
+                .thenReturn(Optional.of(OIDC_BASE_URI.toString()));
+        clientSignatureValidationService =
+                new ClientSignatureValidationService(configurationService);
+    }
+
+    @Test
+    void shouldSuccessfullyReturnWhenValidatingValidSignedJWT() {
+        var keyPair = generateKeyPair();
+        var signedJWT = generateSignedJWT(keyPair.getPrivate());
+        var client = generatClientRegistry(keyPair.getPublic());
+        assertDoesNotThrow(() -> clientSignatureValidationService.validate(signedJWT, client));
+    }
+
+    @Test
+    void shouldSuccessfullyReturnWhenValidatingValidPrivateKeyJWT() {
+        var keyPair = generateKeyPair();
+        var privateKeyJWT = generatePrivateKeyJWT(keyPair.getPrivate());
+        var client = generatClientRegistry(keyPair.getPublic());
+        assertDoesNotThrow(
+                () ->
+                        clientSignatureValidationService.validateTokenClientAssertion(
+                                privateKeyJWT, client));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenValidatingInvalidSignedJWT() {
+        var keyPair1 = generateKeyPair();
+        var keyPair2 = generateKeyPair();
+        var signedJWT = generateSignedJWT(keyPair1.getPrivate());
+        var client = generatClientRegistry(keyPair2.getPublic());
+        assertThrows(
+                ClientSignatureValidationException.class,
+                () -> clientSignatureValidationService.validate(signedJWT, client));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenValidatingInvalidPrivateKeyJWT() {
+        var keyPair1 = generateKeyPair();
+        var keyPair2 = generateKeyPair();
+        var privateKeyJWT = generatePrivateKeyJWT(keyPair1.getPrivate());
+        var client = generatClientRegistry(keyPair2.getPublic());
+        assertThrows(
+                ClientSignatureValidationException.class,
+                () ->
+                        clientSignatureValidationService.validateTokenClientAssertion(
+                                privateKeyJWT, client));
+    }
+
+    private static SignedJWT generateSignedJWT(PrivateKey privateKey) {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUTHORIZE_URI.toString())
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", "openid")
+                        .claim("nonce", new Nonce().getValue())
+                        .claim("state", new State().toString())
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .claim("vtr", List.of("P0.Cl"))
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var jwsHeader = new JWSHeader(RS256);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        var signer = new RSASSASigner(privateKey);
+        try {
+            signedJWT.sign(signer);
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+        return signedJWT;
+    }
+
+    private static PrivateKeyJWT generatePrivateKeyJWT(PrivateKey privateKey) {
+        try {
+            return new PrivateKeyJWT(
+                    new ClientID(CLIENT_ID), TOKEN_URI, JWSAlgorithm.RS256, privateKey, null, null);
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static KeyPair generateKeyPair() {
+        KeyPairGenerator keyPairGenerator;
+        try {
+            keyPairGenerator = KeyPairGenerator.getInstance(KeyType.RSA.getValue());
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static ClientRegistry generatClientRegistry(PublicKey publicKey) {
+        var encodedPublicKey = Base64.getMimeEncoder().encodeToString(publicKey.getEncoded());
+        return new ClientRegistry()
+                .withClientID(CLIENT_ID.getValue())
+                .withPublicKey(encodedPublicKey);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/ClientSignatureValidationException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/ClientSignatureValidationException.java
@@ -1,0 +1,12 @@
+package uk.gov.di.orchestration.shared.exceptions;
+
+public class ClientSignatureValidationException extends Exception {
+
+    public ClientSignatureValidationException(String message) {
+        super(message);
+    }
+
+    public ClientSignatureValidationException(Exception cause) {
+        super(cause);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
@@ -1,0 +1,94 @@
+package uk.gov.di.orchestration.shared.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.auth.verifier.ClientAuthenticationVerifier;
+import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.validation.PrivateKeyJwtAuthPublicKeySelector;
+
+import java.net.URI;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Collections;
+
+import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
+
+public class ClientSignatureValidationService {
+
+    private static final Logger LOG = LogManager.getLogger(ClientSignatureValidationService.class);
+
+    private static final String TOKEN_PATH = "token";
+
+    private final ConfigurationService configurationService;
+
+    public ClientSignatureValidationService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    public void validate(SignedJWT signedJWT, ClientRegistry client)
+            throws ClientSignatureValidationException {
+        try {
+            var publicKey = getPublicKey(client);
+            JWSVerifier verifier = new RSASSAVerifier((RSAPublicKey) publicKey);
+            if (!signedJWT.verify(verifier)) {
+                throw new ClientSignatureValidationException("Failed to verify Signed JWT.");
+            }
+        } catch (ClientSignatureValidationException
+                | NoSuchAlgorithmException
+                | InvalidKeySpecException
+                | JOSEException e) {
+            logError("Signed JWT", client);
+            throw e instanceof ClientSignatureValidationException clientSigValException
+                    ? clientSigValException
+                    : new ClientSignatureValidationException(e);
+        }
+    }
+
+    public void validateTokenClientAssertion(PrivateKeyJWT privateKeyJWT, ClientRegistry client)
+            throws ClientSignatureValidationException {
+        try {
+            var publicKey = getPublicKey(client);
+            ClientAuthenticationVerifier<?> authenticationVerifier =
+                    new ClientAuthenticationVerifier<>(
+                            new PrivateKeyJwtAuthPublicKeySelector(publicKey),
+                            Collections.singleton(new Audience(getTokenURI().toString())));
+            authenticationVerifier.verify(privateKeyJWT, null, null);
+        } catch (InvalidClientException
+                | NoSuchAlgorithmException
+                | InvalidKeySpecException
+                | JOSEException e) {
+            logError("Token Client Assertion JWT", client);
+            throw new ClientSignatureValidationException(e);
+        }
+    }
+
+    private PublicKey getPublicKey(ClientRegistry client)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        byte[] decodedKey = Base64.getMimeDecoder().decode(client.getPublicKey());
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(decodedKey);
+        KeyFactory kf = KeyFactory.getInstance(KeyType.RSA.getValue());
+        return kf.generatePublic(keySpec);
+    }
+
+    private void logError(String description, ClientRegistry client) {
+        LOG.error("Error validating {} for Client: {}.", description, client.getClientID());
+    }
+
+    private URI getTokenURI() {
+        return buildURI(configurationService.getOidcApiBaseURL().orElseThrow(), TOKEN_PATH);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtAuthPublicKeySelector.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtAuthPublicKeySelector.java
@@ -1,30 +1,21 @@
 package uk.gov.di.orchestration.shared.validation;
 
 import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.jwk.KeyType;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.auth.verifier.ClientCredentialsSelector;
 import com.nimbusds.oauth2.sdk.auth.verifier.Context;
-import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.X509EncodedKeySpec;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
 public class PrivateKeyJwtAuthPublicKeySelector implements ClientCredentialsSelector<String> {
-    private final String publicKey;
-    private final KeyType keyType;
+    private final PublicKey publicKey;
 
-    public PrivateKeyJwtAuthPublicKeySelector(String publicKey, KeyType keyType) {
+    public PrivateKeyJwtAuthPublicKeySelector(PublicKey publicKey) {
         this.publicKey = publicKey;
-        this.keyType = keyType;
     }
 
     @Override
@@ -41,15 +32,7 @@ public class PrivateKeyJwtAuthPublicKeySelector implements ClientCredentialsSele
             ClientAuthenticationMethod authMethod,
             JWSHeader jwsHeader,
             boolean forceRefresh,
-            Context<String> context)
-            throws InvalidClientException {
-        byte[] decodedKey = Base64.getMimeDecoder().decode(publicKey);
-        try {
-            X509EncodedKeySpec ecPublicKeySpec = new X509EncodedKeySpec(decodedKey);
-            KeyFactory kf = KeyFactory.getInstance(keyType.getValue());
-            return Collections.singletonList(kf.generatePublic(ecPublicKeySpec));
-        } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
-            throw new InvalidClientException(e.getMessage());
-        }
+            Context<String> context) {
+        return Collections.singletonList(publicKey);
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidator.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidator.java
@@ -1,7 +1,5 @@
 package uk.gov.di.orchestration.shared.validation;
 
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.jwk.KeyType;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.util.DateUtils;
@@ -10,35 +8,32 @@ import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
-import com.nimbusds.oauth2.sdk.auth.verifier.ClientAuthenticationVerifier;
 import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
-import com.nimbusds.oauth2.sdk.id.Audience;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
 import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
-import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 
-import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.addAnnotation;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 
 public class PrivateKeyJwtClientAuthValidator extends TokenClientAuthValidator {
 
-    private final ConfigurationService configurationService;
-    private static final String TOKEN_PATH = "token";
+    private final ClientSignatureValidationService clientSignatureValidationService;
     private static final String UNKNOWN_CLIENT_ID = "unknown";
 
     public PrivateKeyJwtClientAuthValidator(
-            DynamoClientService dynamoClientService, ConfigurationService configurationService) {
+            DynamoClientService dynamoClientService,
+            ClientSignatureValidationService clientSignatureValidationService) {
         super(dynamoClientService);
-        this.configurationService = configurationService;
+        this.clientSignatureValidationService = clientSignatureValidationService;
     }
 
     @Override
@@ -55,9 +50,6 @@ public class PrivateKeyJwtClientAuthValidator extends TokenClientAuthValidator {
             var clientRegistry = getClientRegistryFromTokenAuth(privateKeyJWT.getClientID());
             attachLogFieldToLogs(CLIENT_ID, clientRegistry.getClientID());
             addAnnotation("client_id", clientRegistry.getClientID());
-            var tokenUrl =
-                    buildURI(configurationService.getOidcApiBaseURL().orElseThrow(), TOKEN_PATH)
-                            .toString();
             if (Objects.nonNull(clientRegistry.getTokenAuthMethod())
                     && !clientRegistry
                             .getTokenAuthMethod()
@@ -78,12 +70,8 @@ public class PrivateKeyJwtClientAuthValidator extends TokenClientAuthValidator {
                         ClientAuthenticationMethod.PRIVATE_KEY_JWT,
                         clientRegistry.getClientID());
             }
-            ClientAuthenticationVerifier<?> authenticationVerifier =
-                    new ClientAuthenticationVerifier<>(
-                            new PrivateKeyJwtAuthPublicKeySelector(
-                                    clientRegistry.getPublicKey(), KeyType.RSA),
-                            Collections.singleton(new Audience(tokenUrl)));
-            authenticationVerifier.verify(privateKeyJWT, null, null);
+            clientSignatureValidationService.validateTokenClientAssertion(
+                    privateKeyJWT, clientRegistry);
             return clientRegistry;
         } catch (InvalidClientException e) {
             LOG.warn("Invalid client in private_kew_jwt", e);
@@ -91,7 +79,7 @@ public class PrivateKeyJwtClientAuthValidator extends TokenClientAuthValidator {
                     OAuth2Error.INVALID_CLIENT,
                     ClientAuthenticationMethod.PRIVATE_KEY_JWT,
                     UNKNOWN_CLIENT_ID);
-        } catch (JOSEException e) {
+        } catch (ClientSignatureValidationException e) {
             LOG.warn("Could not verify signature of private_key_jwt", e);
             throw new TokenAuthInvalidException(
                     new ErrorObject(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactory.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactory.java
@@ -2,7 +2,7 @@ package uk.gov.di.orchestration.shared.validation;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
 import java.util.Map;
@@ -10,13 +10,14 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class TokenClientAuthValidatorFactory {
-    private final ConfigurationService configurationService;
     private final DynamoClientService dynamoClientService;
+    private final ClientSignatureValidationService clientSignatureValidationService;
     private static final Logger LOG = LogManager.getLogger(TokenClientAuthValidatorFactory.class);
 
     public TokenClientAuthValidatorFactory(
-            ConfigurationService configurationService, DynamoClientService dynamoClientService) {
-        this.configurationService = configurationService;
+            DynamoClientService dynamoClientService,
+            ClientSignatureValidationService clientSignatureValidationService) {
+        this.clientSignatureValidationService = clientSignatureValidationService;
         this.dynamoClientService = dynamoClientService;
     }
 
@@ -30,7 +31,7 @@ public class TokenClientAuthValidatorFactory {
             checkAssertionType(requestBody);
             return Optional.of(
                     new PrivateKeyJwtClientAuthValidator(
-                            dynamoClientService, configurationService));
+                            dynamoClientService, clientSignatureValidationService));
         }
 
         if (requestBody.containsKey("client_secret") && requestBody.containsKey("client_id")) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactoryTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactoryTest.java
@@ -10,7 +10,7 @@ import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 
@@ -20,12 +20,14 @@ import static uk.gov.di.orchestration.shared.helpers.RequestBodyHelper.parseRequ
 
 class TokenClientAuthValidatorFactoryTest {
 
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
+    private final ClientSignatureValidationService clientSignatureValidationService =
+            mock(ClientSignatureValidationService.class);
     private static final ClientID CLIENT_ID = new ClientID();
     private static final Secret CLIENT_SECRET = new Secret();
     private final TokenClientAuthValidatorFactory tokenClientAuthValidatorFactory =
-            new TokenClientAuthValidatorFactory(configurationService, dynamoClientService);
+            new TokenClientAuthValidatorFactory(
+                    dynamoClientService, clientSignatureValidationService);
 
     @Test
     void shouldReturnPrivateKeyJwtClientAuthValidator() throws JOSEException {


### PR DESCRIPTION
## What

- Added ClientSignatureValidationService to validate RP signed JWTs
- Refactored RequestObjectAuthorizeValidator and PrivateKeyJwtClientAuthValidator to use ClientSignatureValidationService

## How to review

Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.
