### PR TITLE
Bau: Use new audit service method in mfa handlers

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -531,13 +531,13 @@ class VerifyCodeHandlerTest {
                         FrontendAuditableEvent.CODE_VERIFIED,
                         AUDIT_CONTEXT,
                         pair("notification-type", MFA_SMS.name()),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
-                        pair("loginFailureCount", 0),
-                        pair("MFACodeEntered", "123456"),
                         pair(
                                 "journey-type",
-                                journeyType != null ? String.valueOf(journeyType) : "SIGN_IN"));
+                                journeyType != null ? String.valueOf(journeyType) : "SIGN_IN"),
+                        pair("mfa-type", MFAMethodType.SMS.getValue()),
+                        pair("loginFailureCount", 0),
+                        pair("MFACodeEntered", "123456"));
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_RECOVERY_BLOCK_REMOVED,
@@ -568,11 +568,11 @@ class VerifyCodeHandlerTest {
                         FrontendAuditableEvent.CODE_VERIFIED,
                         AUDIT_CONTEXT,
                         pair("notification-type", MFA_SMS.name()),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
+                        pair("journey-type", "SIGN_IN"),
+                        pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("loginFailureCount", 0),
-                        pair("MFACodeEntered", "123456"),
-                        pair("journey-type", "SIGN_IN"));
+                        pair("MFACodeEntered", "123456"));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
                         Session.AccountState.EXISTING, CLIENT_ID, CLIENT_NAME, "P0", false, true);
@@ -593,12 +593,12 @@ class VerifyCodeHandlerTest {
                         FrontendAuditableEvent.INVALID_CODE_SENT,
                         AUDIT_CONTEXT,
                         pair("notification-type", MFA_SMS.name()),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
+                        pair("journey-type", "SIGN_IN"),
+                        pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("loginFailureCount", 0),
                         pair("MFACodeEntered", "6543221"),
-                        pair("MaxSmsCount", configurationService.getCodeMaxRetries()),
-                        pair("journey-type", "SIGN_IN"));
+                        pair("MaxSmsCount", configurationService.getCodeMaxRetries()));
     }
 
     @ParameterizedTest
@@ -625,14 +625,14 @@ class VerifyCodeHandlerTest {
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
                         AUDIT_CONTEXT,
                         pair("notification-type", MFA_SMS.name()),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
-                        pair("loginFailureCount", 0),
-                        pair("MFACodeEntered", "6543221"),
-                        pair("MaxSmsCount", configurationService.getCodeMaxRetries()),
                         pair(
                                 "journey-type",
-                                journeyType != null ? String.valueOf(journeyType) : "SIGN_IN"));
+                                journeyType != null ? String.valueOf(journeyType) : "SIGN_IN"),
+                        pair("mfa-type", MFAMethodType.SMS.getValue()),
+                        pair("loginFailureCount", 0),
+                        pair("MFACodeEntered", "6543221"),
+                        pair("MaxSmsCount", configurationService.getCodeMaxRetries()));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
@@ -132,6 +133,30 @@ class VerifyCodeHandlerTest {
                                     "^(.+)@digital.cabinet-office.gov.uk$",
                                     "testclient.user2@internet.com"));
 
+    private final AuditContext AUDIT_CONTEXT =
+            new AuditContext(
+                    CLIENT_ID,
+                    CLIENT_SESSION_ID,
+                    SESSION_ID,
+                    expectedCommonSubject,
+                    EMAIL,
+                    IP_ADDRESS,
+                    AuditService.UNKNOWN,
+                    DI_PERSISTENT_SESSION_ID,
+                    Optional.of(ENCODED_DEVICE_DETAILS));
+
+    private final AuditContext AUDIT_CONTEXT_FOR_TEST_CLIENT =
+            new AuditContext(
+                    TEST_CLIENT_ID,
+                    CLIENT_SESSION_ID,
+                    testSession.getSessionId(),
+                    expectedCommonSubject,
+                    EMAIL,
+                    IP_ADDRESS,
+                    AuditService.UNKNOWN,
+                    DI_PERSISTENT_SESSION_ID,
+                    Optional.of(ENCODED_DEVICE_DETAILS));
+
     private VerifyCodeHandler handler;
 
     @RegisterExtension
@@ -232,15 +257,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("notification-type", emailNotificationType.name()),
                         pair(
                                 "account-recovery",
@@ -285,15 +302,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        AuditService.RestrictedSection.empty,
+                        AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()),
                         pair("notification-type", emailNotificationType.name()),
                         pair(
                                 "account-recovery",
@@ -329,15 +338,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CODE_SENT,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("notification-type", emailNotificationType.name()),
                         pair(
                                 "account-recovery",
@@ -373,15 +374,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        testSession.getSessionId(),
-                        expectedCommonSubject,
-                        email,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT_FOR_TEST_CLIENT.withEmail(email),
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
@@ -415,15 +408,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        testSession.getSessionId(),
-                        expectedCommonSubject,
-                        email,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT_FOR_TEST_CLIENT.withEmail(email),
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
@@ -447,15 +432,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
@@ -523,15 +500,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("notification-type", VERIFY_CHANGE_HOW_GET_SECURITY_CODES.name()),
                         pair("account-recovery", true),
                         pair("journey-type", "ACCOUNT_RECOVERY"));
@@ -560,15 +529,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("notification-type", MFA_SMS.name()),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
@@ -580,15 +541,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_RECOVERY_BLOCK_REMOVED,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
@@ -613,15 +566,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("notification-type", MFA_SMS.name()),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
@@ -646,15 +591,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CODE_SENT,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("notification-type", MFA_SMS.name()),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
@@ -686,15 +623,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("notification-type", MFA_SMS.name()),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("account-recovery", false),
@@ -729,15 +658,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("notification-type", RESET_PASSWORD_WITH_CODE.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "PASSWORD_RESET"));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -215,8 +215,8 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.CODE_VERIFIED,
                 pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                 pair("account-recovery", false),
-                pair("MFACodeEntered", CODE),
-                pair("journey-type", JourneyType.REGISTRATION));
+                pair("journey-type", JourneyType.REGISTRATION),
+                pair("MFACodeEntered", CODE));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
                         Session.AccountState.NEW, CLIENT_ID, CLIENT_NAME, "P0", false, true);
@@ -255,8 +255,8 @@ class VerifyMfaCodeHandlerTest {
                         AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()),
                         pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                         pair("account-recovery", false),
-                        pair("MFACodeEntered", CODE),
-                        pair("journey-type", JourneyType.REGISTRATION));
+                        pair("journey-type", JourneyType.REGISTRATION),
+                        pair("MFACodeEntered", CODE));
     }
 
     @ParameterizedTest
@@ -292,8 +292,8 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.CODE_VERIFIED,
                 pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                 pair("account-recovery", false),
-                pair("MFACodeEntered", CODE),
-                pair("journey-type", JourneyType.PASSWORD_RESET_MFA));
+                pair("journey-type", JourneyType.PASSWORD_RESET_MFA),
+                pair("MFACodeEntered", CODE));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
                         Session.AccountState.EXISTING, CLIENT_ID, CLIENT_NAME, "P0", false, true);
@@ -329,8 +329,8 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.CODE_VERIFIED,
                 pair("mfa-type", MFAMethodType.SMS.getValue()),
                 pair("account-recovery", false),
-                pair("MFACodeEntered", CODE),
-                pair("journey-type", JourneyType.REGISTRATION));
+                pair("journey-type", JourneyType.REGISTRATION),
+                pair("MFACodeEntered", CODE));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
                         Session.AccountState.NEW, CLIENT_ID, CLIENT_NAME, "P0", false, true);
@@ -366,8 +366,8 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.CODE_VERIFIED,
                 pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                 pair("account-recovery", true),
-                pair("MFACodeEntered", CODE),
-                pair("journey-type", JourneyType.ACCOUNT_RECOVERY));
+                pair("journey-type", JourneyType.ACCOUNT_RECOVERY),
+                pair("MFACodeEntered", CODE));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
                         Session.AccountState.EXISTING, CLIENT_ID, CLIENT_NAME, "P0", false, true);
@@ -403,8 +403,8 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.CODE_VERIFIED,
                 pair("mfa-type", MFAMethodType.SMS.getValue()),
                 pair("account-recovery", true),
-                pair("MFACodeEntered", CODE),
-                pair("journey-type", JourneyType.ACCOUNT_RECOVERY));
+                pair("journey-type", JourneyType.ACCOUNT_RECOVERY),
+                pair("MFACodeEntered", CODE));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
                         Session.AccountState.EXISTING, CLIENT_ID, CLIENT_NAME, "P0", false, true);
@@ -435,8 +435,8 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.CODE_VERIFIED,
                 pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                 pair("account-recovery", false),
-                pair("MFACodeEntered", CODE),
-                pair("journey-type", journeyType));
+                pair("journey-type", journeyType),
+                pair("MFACodeEntered", CODE));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
                         Session.AccountState.EXISTING, CLIENT_ID, CLIENT_NAME, "P0", false, true);
@@ -530,8 +530,8 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
                 pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                 pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                pair("journey-type", journeyType));
+                pair("journey-type", journeyType),
+                pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()));
     }
 
     @ParameterizedTest
@@ -567,8 +567,8 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
                 pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                 pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                pair("journey-type", journeyType));
+                pair("journey-type", journeyType),
+                pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()));
     }
 
     @ParameterizedTest
@@ -606,9 +606,9 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.INVALID_CODE_SENT,
                 pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                 pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
+                pair("journey-type", journeyType),
                 pair("loginFailureCount", 0),
-                pair("MFACodeEntered", CODE),
-                pair("journey-type", journeyType));
+                pair("MFACodeEntered", CODE));
     }
 
     private static Stream<Arguments> blockedCodeForInvalidPhoneNumberTooManyTimes() {
@@ -648,8 +648,8 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
                 pair("mfa-type", MFAMethodType.SMS.getValue()),
                 pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                pair("journey-type", journeyType));
+                pair("journey-type", journeyType),
+                pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()));
     }
 
     @ParameterizedTest
@@ -677,8 +677,8 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
                 pair("mfa-type", MFAMethodType.SMS.getValue()),
                 pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                pair("journey-type", journeyType));
+                pair("journey-type", journeyType),
+                pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()));
     }
 
     @ParameterizedTest
@@ -712,9 +712,9 @@ class VerifyMfaCodeHandlerTest {
                 FrontendAuditableEvent.INVALID_CODE_SENT,
                 pair("mfa-type", MFAMethodType.SMS.getValue()),
                 pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
+                pair("journey-type", journeyType),
                 pair("loginFailureCount", 0),
-                pair("MFACodeEntered", CODE),
-                pair("journey-type", journeyType));
+                pair("MFACodeEntered", CODE));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What

Uses our updated audit service method, using an audit context to share some common variables, in two more handlers.

Also refactors some of the audit service code in these handlers (construction of metadata pairs) to further tidy calls to the audit service up.

## How to review

1. Code Review commit by commit

## Related PRs

An [example PR](https://github.com/govuk-one-login/authentication-api/pull/4766) where we previously converted another handler