### PR TITLE
AUT-2775: Fixed check email bypassed timestamp format.

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -174,7 +174,8 @@ public class UpdateEmailHandler
                         AuditService.MetadataPair.pair(
                                 "journey_type", JourneyType.ACCOUNT_MANAGEMENT.getValue()),
                         AuditService.MetadataPair.pair(
-                                "assessment_checked_at_timestamp", NowHelper.now()),
+                                "assessment_checked_at_timestamp",
+                                NowHelper.toUnixTimestamp(NowHelper.now())),
                         AuditService.MetadataPair.pair("iss", AuditService.COMPONENT_ID));
             }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -35,7 +35,6 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -161,9 +160,11 @@ class UpdateEmailHandlerTest {
         when(dynamoEmailCheckResultService.getEmailCheckStore(NEW_EMAIL_ADDRESS))
                 .thenReturn(Optional.empty());
 
-        Date mockedDate = new Date();
+        long mockedTimestamp = 1719376320;
         try (MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class)) {
-            mockedNowHelperClass.when(NowHelper::now).thenReturn(mockedDate);
+            mockedNowHelperClass
+                    .when(() -> NowHelper.toUnixTimestamp(NowHelper.now()))
+                    .thenReturn(mockedTimestamp);
             var event = generateApiGatewayEvent(NEW_EMAIL_ADDRESS, expectedCommonSubject);
             handler.handleRequest(event, context);
 
@@ -189,7 +190,7 @@ class UpdateEmailHandlerTest {
                             AuditService.MetadataPair.pair(
                                     "journey_type", JourneyType.ACCOUNT_MANAGEMENT.getValue()),
                             AuditService.MetadataPair.pair(
-                                    "assessment_checked_at_timestamp", mockedDate),
+                                    "assessment_checked_at_timestamp", mockedTimestamp),
                             AuditService.MetadataPair.pair("iss", "AUTH"));
         }
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
@@ -145,7 +145,9 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
                 PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
                 AuditHelper.buildRestrictedSection(input.getHeaders()),
                 AuditService.MetadataPair.pair("journey_type", JourneyType.REGISTRATION.getValue()),
-                AuditService.MetadataPair.pair("assessment_checked_at_timestamp", NowHelper.now()),
+                AuditService.MetadataPair.pair(
+                        "assessment_checked_at_timestamp",
+                        NowHelper.toUnixTimestamp(NowHelper.now())),
                 AuditService.MetadataPair.pair("iss", AuditService.COMPONENT_ID));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
@@ -30,7 +30,6 @@ import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
-import java.util.Date;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -149,9 +148,11 @@ class CheckEmailFraudBlockHandlerTest {
 
         usingValidSession();
 
-        Date mockedDate = new Date();
+        long mockedTimestamp = 1719376320;
         try (MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class)) {
-            mockedNowHelperClass.when(NowHelper::now).thenReturn(mockedDate);
+            mockedNowHelperClass
+                    .when(() -> NowHelper.toUnixTimestamp(NowHelper.now()))
+                    .thenReturn(mockedTimestamp);
 
             var event =
                     new APIGatewayProxyRequestEvent()
@@ -187,7 +188,7 @@ class CheckEmailFraudBlockHandlerTest {
                             AuditService.MetadataPair.pair(
                                     "journey_type", JourneyType.REGISTRATION.getValue()),
                             AuditService.MetadataPair.pair(
-                                    "assessment_checked_at_timestamp", mockedDate),
+                                    "assessment_checked_at_timestamp", mockedTimestamp),
                             AuditService.MetadataPair.pair("iss", "AUTH"));
         }
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
@@ -25,6 +25,10 @@ public class NowHelper {
         return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS").format(date);
     }
 
+    public static long toUnixTimestamp(Date date) {
+        return date.toInstant().getEpochSecond();
+    }
+
     public static class NowClock {
         private final Clock clock;
 


### PR DESCRIPTION
## What

Previously, the timestamp was formatted 'yyyy-MM-dd'T'HH:mm:ss.SSSSSS'. This commit changes the format to unix timestamp, as is required by TxMA.

## How to review

1. Code Review
