### PR TITLE
Aut 2851: Update ticf uri

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.util.Map;
 
 import static java.lang.String.format;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 
 public class TicfCriHandler implements RequestHandler<TICFCRIRequest, Void> {
 
@@ -93,7 +94,10 @@ public class TicfCriHandler implements RequestHandler<TICFCRIRequest, Void> {
         var timeoutInMilliseconds =
                 Duration.ofMillis(configurationService.getTicfCriServiceCallTimeout());
         var request =
-                HttpRequest.newBuilder(configurationService.getTicfCriServiceURI())
+                HttpRequest.newBuilder(
+                                buildURI(
+                                        configurationService.getTicfCriServiceURI().toString(),
+                                        "/auth"))
                         .POST(HttpRequest.BodyPublishers.ofString(body))
                         .timeout(timeoutInMilliseconds)
                         .build();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -95,9 +95,7 @@ public class TicfCriHandler implements RequestHandler<TICFCRIRequest, Void> {
                 Duration.ofMillis(configurationService.getTicfCriServiceCallTimeout());
         var request =
                 HttpRequest.newBuilder(
-                                buildURI(
-                                        configurationService.getTicfCriServiceURI().toString(),
-                                        "/auth"))
+                                buildURI(configurationService.getTicfCriServiceURI(), "/auth"))
                         .POST(HttpRequest.BodyPublishers.ofString(body))
                         .timeout(timeoutInMilliseconds)
                         .build();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
@@ -87,7 +87,8 @@ class TicfCriHandlerTest {
         var actualRequestBody =
                 bodyPublisherToString(httpRequestCaptor.getValue().bodyPublisher().get());
 
-        assertEquals(SERVICE_URI, httpRequestCaptor.getValue().uri());
+        var expectedUri = URI.create(SERVICE_URI.toString() + "/auth");
+        assertEquals(expectedUri, httpRequestCaptor.getValue().uri());
         assertEquals(expectedRequestBody, actualRequestBody);
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
@@ -46,7 +46,7 @@ class TicfCriHandlerTest {
 
     private TicfCriHandler handler;
 
-    private static final URI SERVICE_URI = URI.create("http://www.example.com");
+    private static final String SERVICE_URI = "http://www.example.com";
     private static final String COMMON_SUBJECTID = "a-subject-id";
     private static final String JOURNEY_ID = "journey-id";
     private static final List<String> VECTORS_OF_TRUST = List.of("Cl");
@@ -87,7 +87,7 @@ class TicfCriHandlerTest {
         var actualRequestBody =
                 bodyPublisherToString(httpRequestCaptor.getValue().bodyPublisher().get());
 
-        var expectedUri = URI.create(SERVICE_URI.toString() + "/auth");
+        var expectedUri = URI.create(SERVICE_URI + "/auth");
         assertEquals(expectedUri, httpRequestCaptor.getValue().uri());
         assertEquals(expectedRequestBody, actualRequestBody);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -499,8 +499,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return URI.create(System.getenv("ACCOUNT_INTERVENTION_SERVICE_URI"));
     }
 
-    public URI getTicfCriServiceURI() {
-        return URI.create(System.getenv("TICF_CRI_SERVICE_URI"));
+    public String getTicfCriServiceURI() {
+        return System.getenv("TICF_CRI_SERVICE_URI");
     }
 
     public boolean abortOnAccountInterventionsErrorResponse() {


### PR DESCRIPTION
## What

We were missing the "/auth" part from the URI, which was manifesting in 403 errors from the api gateway in sandpit.

This fixes this path, and also switches a config variable to being a string to stop unnecessary conversions.

## How to review


1. Code Review
