### PR TITLE
Aut 2851/deploy ticf to other envs

### DIFF
--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -42,7 +42,7 @@ locals {
 
   request_tracing_allowed              = contains(["build", "sandpit"], var.environment)
   deploy_account_interventions_count   = 1
-  deploy_ticf_cri_count                = contains(["sandpit", "authdev1"], var.environment) ? 1 : 0
+  deploy_ticf_cri_count                = contains(["sandpit", "authdev1", "authdev2"], var.environment) ? 1 : 0
   deploy_reauth_user_count             = contains(["build", "sandpit", "authdev1", "authdev2", "staging", "integration"], var.environment) ? 1 : 0
   deploy_check_email_fraud_block_count = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
 

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -42,7 +42,7 @@ locals {
 
   request_tracing_allowed              = contains(["build", "sandpit"], var.environment)
   deploy_account_interventions_count   = 1
-  deploy_ticf_cri_count                = contains(["sandpit", "authdev1", "authdev2", "dev"], var.environment) ? 1 : 0
+  deploy_ticf_cri_count                = contains(["sandpit", "authdev1", "authdev2", "dev", "build"], var.environment) ? 1 : 0
   deploy_reauth_user_count             = contains(["build", "sandpit", "authdev1", "authdev2", "staging", "integration"], var.environment) ? 1 : 0
   deploy_check_email_fraud_block_count = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
 

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -42,7 +42,7 @@ locals {
 
   request_tracing_allowed              = contains(["build", "sandpit"], var.environment)
   deploy_account_interventions_count   = 1
-  deploy_ticf_cri_count                = contains(["sandpit"], var.environment) ? 1 : 0
+  deploy_ticf_cri_count                = contains(["sandpit", "authdev1"], var.environment) ? 1 : 0
   deploy_reauth_user_count             = contains(["build", "sandpit", "authdev1", "authdev2", "staging", "integration"], var.environment) ? 1 : 0
   deploy_check_email_fraud_block_count = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
 

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -42,7 +42,7 @@ locals {
 
   request_tracing_allowed              = contains(["build", "sandpit"], var.environment)
   deploy_account_interventions_count   = 1
-  deploy_ticf_cri_count                = contains(["sandpit", "authdev1", "authdev2"], var.environment) ? 1 : 0
+  deploy_ticf_cri_count                = contains(["sandpit", "authdev1", "authdev2", "dev"], var.environment) ? 1 : 0
   deploy_reauth_user_count             = contains(["build", "sandpit", "authdev1", "authdev2", "staging", "integration"], var.environment) ? 1 : 0
   deploy_check_email_fraud_block_count = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
 

--- a/ci/terraform/ticf-cri-stub/authdev1.hcl
+++ b/ci/terraform/ticf-cri-stub/authdev1.hcl
@@ -1,0 +1,4 @@
+bucket  = "di-auth-development-tfstate"
+key     = "authdev1-ticf-cri-stub.tfstate"
+encrypt = true
+region  = "eu-west-2"

--- a/ci/terraform/ticf-cri-stub/authdev1.tfvars
+++ b/ci/terraform/ticf-cri-stub/authdev1.tfvars
@@ -1,0 +1,2 @@
+environment         = "authdev1"
+shared_state_bucket = "di-auth-development-tfstate"

--- a/ci/terraform/ticf-cri-stub/authdev2.hcl
+++ b/ci/terraform/ticf-cri-stub/authdev2.hcl
@@ -1,0 +1,4 @@
+bucket  = "di-auth-development-tfstate"
+key     = "authdev2-ticf-cri-stub.tfstate"
+encrypt = true
+region  = "eu-west-2"

--- a/ci/terraform/ticf-cri-stub/authdev2.tfvars
+++ b/ci/terraform/ticf-cri-stub/authdev2.tfvars
@@ -1,0 +1,2 @@
+environment         = "authdev2"
+shared_state_bucket = "di-auth-development-tfstate"

--- a/scripts/dev_deploy_common.sh
+++ b/scripts/dev_deploy_common.sh
@@ -71,6 +71,7 @@ if [[ $# == 0 ]] || [[ $* == "-p" ]]; then
     OIDC=1
     INTERVENTIONS=1
     SHARED=1
+    TICF_STUB=1
 fi
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## What

Deploys the ticf lambda to all environments, now the relevant variables have been set in aws.

Also ensures that the stub is deployed to the authdev environments, meaning we can test in these lower environments.
I have tested this in all test environments.

## How to review

1. Code Review
1. If you like, you can deploy to one of the test envs, and test the ticf cri handler manually in the console (ping me and I'll walk you through it). Not vital though since I've tested in these envs already.
