### PR TITLE
AUT-2775: Correct method to get userId for PendingEmailCheckRequest

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -184,12 +184,12 @@ public class SendOtpNotificationHandler
                     if (dynamoService.userExists(email)) {
                         return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1009);
                     }
-                    var userId =
-                            dynamoService
-                                    .getUserProfileByEmailMaybe(email)
-                                    .map(UserProfile::getSubjectID)
-                                    .orElse(AuditService.UNKNOWN);
                     if (configurationService.isEmailCheckEnabled()) {
+                        var userId =
+                                input.getRequestContext()
+                                        .getAuthorizer()
+                                        .getOrDefault("principalId", AuditService.UNKNOWN)
+                                        .toString();
                         pendingEmailCheckSqsClient.send(
                                 objectMapper.writeValueAsString(
                                         new PendingEmailCheckRequest(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -158,7 +158,7 @@ class SendOtpNotificationHandlerTest {
                         .send(
                                 format(
                                         "{\"userId\":\"%s\",\"requestReference\":\"%s\",\"emailAddress\":\"%s\",\"userSessionId\":\"%s\",\"govukSigninJourneyId\":\"%s\",\"persistentSessionId\":\"%s\",\"ipAddress\":\"%s\",\"journeyType\":\"%s\",\"timeOfInitialRequest\":%d,\"isTestUserRequest\":%b}",
-                                        AuditService.UNKNOWN,
+                                        expectedCommonSubject,
                                         mockedUUID,
                                         TEST_EMAIL_ADDRESS,
                                         "some-session-id",


### PR DESCRIPTION
## What

When on the `ACCOUNT_MANAGEMENT` journey to update the user email, we have a user profile and should add the id to `PendingEmailCheckRequest`.

The current way of finding the userId in `SendOtpNotificationHandler` looks up the profile from the email address we are sending the OTP too.

This has an issue because the user does not have that email yet. Instead, this commit looks up the userId from the authorizer principleId.

This is used in the same file to tie the SEND_OTP audit event to the same user.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.


## Related PRs

- https://github.com/govuk-one-login/authentication-api/pull/4665
