### PR TITLE
Bau: Convert more handlers to use the new audit service method

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -221,7 +221,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                     return handleNotificationRequest(
                             request.getEmail(),
                             request.getNotificationType(),
-                            userContext.getSession(),
                             userContext,
                             request.isRequestNewCode(),
                             request,
@@ -245,7 +244,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                             PhoneNumberHelper.removeWhitespaceFromPhoneNumber(
                                     request.getPhoneNumber()),
                             request.getNotificationType(),
-                            userContext.getSession(),
                             userContext,
                             request.isRequestNewCode(),
                             request,
@@ -266,13 +264,13 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
     private APIGatewayProxyResponseEvent handleNotificationRequest(
             String destination,
             NotificationType notificationType,
-            Session session,
             UserContext userContext,
             Boolean requestNewCode,
             SendNotificationRequest request,
             APIGatewayProxyRequestEvent input,
             AuditContext auditContext)
             throws JsonException, ClientNotFoundException {
+        var session = userContext.getSession();
 
         String code =
                 requestNewCode != null && requestNewCode

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/CommonTestVariables.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/CommonTestVariables.java
@@ -20,6 +20,8 @@ public class CommonTestVariables {
             "YTtKVSlub1YlOSBTeEI4J3pVLVd7Jjl8VkBfREs2N3clZmN+fnU7fXNbcTJjKyEzN2IuUXIgMGttV058fGhUZ0xhenZUdldEblB8SH18XypwXUhWPXhYXTNQeURW%";
     public static final String SESSION_ID = "session-id";
     public static final String CLIENT_SESSION_ID = "known-client-session-id";
+    public static final String CLIENT_NAME = "client-name";
+    public static final String CLIENT_ID = "client-id";
     public static final Map<String, String> VALID_HEADERS =
             Map.ofEntries(
                     Map.entry(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsInboundRe
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsRequest;
 import uk.gov.di.authentication.frontendapi.entity.Intervention;
 import uk.gov.di.authentication.frontendapi.entity.State;
+import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.frontendapi.services.AccountInterventionsService;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -63,19 +64,13 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.PASSWORD_RESET_INTERVENTION;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.PERMANENTLY_BLOCKED_INTERVENTION;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.TEMP_SUSPENDED_INTERVENTION;
-import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.DI_PERSISTENT_SESSION_ID;
+import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.CLIENT_NAME;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.EMAIL;
-import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.ENCODED_DEVICE_DETAILS;
-import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.IP_ADDRESS;
-import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.SESSION_ID;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.TEST_CLIENT_ID;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class AccountInterventionsHandlerTest {
-    private static final String TEST_CLIENT_ID = "test_client_id";
-    private static final String TEST_CLIENT_NAME = "test_client_name";
-    private static final String TEST_SESSION_ID = "test-session-id";
-    private static final String TEST_CLIENT_SESSION_ID = "test-client-session-id";
     private static final String TEST_INTERNAL_SUBJECT_ID = "test-internal-subject-id";
     private static final String TEST_SUBJECT_ID = "subject-id";
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
@@ -106,22 +101,22 @@ class AccountInterventionsHandlerTest {
             mock(CloudwatchMetricsService.class);
     private static final ClientSession clientSession = getClientSession();
     private final Session session =
-            new Session(SESSION_ID)
+            new Session(CommonTestVariables.SESSION_ID)
                     .setEmailAddress(EMAIL)
-                    .setSessionId(TEST_SESSION_ID)
+                    .setSessionId(CommonTestVariables.SESSION_ID)
                     .setInternalCommonSubjectIdentifier(TEST_INTERNAL_SUBJECT_ID);
 
     private static final AuditContext AUDIT_CONTEXT =
             new AuditContext(
-                    TEST_CLIENT_ID,
-                    TEST_CLIENT_SESSION_ID,
-                    TEST_SESSION_ID,
+                    CommonTestVariables.CLIENT_ID,
+                    CommonTestVariables.CLIENT_SESSION_ID,
+                    CommonTestVariables.SESSION_ID,
                     TEST_INTERNAL_SUBJECT_ID,
                     EMAIL,
-                    IP_ADDRESS,
+                    CommonTestVariables.IP_ADDRESS,
                     AuditService.UNKNOWN,
-                    DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    CommonTestVariables.DI_PERSISTENT_SESSION_ID,
+                    Optional.of(CommonTestVariables.ENCODED_DEVICE_DETAILS));
     private static final Json objectMapper = SerializationService.getInstance();
 
     @BeforeEach
@@ -140,9 +135,10 @@ class AccountInterventionsHandlerTest {
                 .thenReturn(new URI("https://account-interventions.gov.uk/v1"));
         when(userContext.getSession()).thenReturn(session);
         when(userContext.getClientSession()).thenReturn(clientSession);
-        when(userContext.getClientId()).thenReturn(TEST_CLIENT_ID);
-        when(userContext.getClientSessionId()).thenReturn(TEST_CLIENT_SESSION_ID);
-        when(userContext.getTxmaAuditEncoded()).thenReturn(ENCODED_DEVICE_DETAILS);
+        when(userContext.getClientId()).thenReturn(CommonTestVariables.CLIENT_ID);
+        when(userContext.getClientSessionId()).thenReturn(CommonTestVariables.CLIENT_SESSION_ID);
+        when(userContext.getTxmaAuditEncoded())
+                .thenReturn(CommonTestVariables.ENCODED_DEVICE_DETAILS);
         when(configurationService.getAccountInterventionsErrorMetricName())
                 .thenReturn("AISException");
         when(configurationService.getEnvironment()).thenReturn(TEST_ENVIRONMENT);
@@ -389,9 +385,9 @@ class AccountInterventionsHandlerTest {
 
     private Map<String, String> getHeaders() {
         Map<String, String> headers = new HashMap<>();
-        headers.put("Session-Id", SESSION_ID);
-        headers.put("di-persistent-session-id", DI_PERSISTENT_SESSION_ID);
-        headers.put("X-Forwarded-For", IP_ADDRESS);
+        headers.put("Session-Id", CommonTestVariables.SESSION_ID);
+        headers.put("di-persistent-session-id", CommonTestVariables.DI_PERSISTENT_SESSION_ID);
+        headers.put("X-Forwarded-For", CommonTestVariables.IP_ADDRESS);
         return headers;
     }
 
@@ -407,7 +403,7 @@ class AccountInterventionsHandlerTest {
                                 URI.create("http://localhost/redirect"))
                         .build();
         return new ClientSession(
-                authRequest.toParameters(), null, mock(VectorOfTrust.class), TEST_CLIENT_NAME);
+                authRequest.toParameters(), null, mock(VectorOfTrust.class), CLIENT_NAME);
     }
 
     private static Stream<Arguments> httpErrorCodesAndAssociatedResponses() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsInboundResponse;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsRequest;
@@ -109,6 +110,18 @@ class AccountInterventionsHandlerTest {
                     .setEmailAddress(EMAIL)
                     .setSessionId(TEST_SESSION_ID)
                     .setInternalCommonSubjectIdentifier(TEST_INTERNAL_SUBJECT_ID);
+
+    private static final AuditContext AUDIT_CONTEXT =
+            new AuditContext(
+                    TEST_CLIENT_ID,
+                    TEST_CLIENT_SESSION_ID,
+                    TEST_SESSION_ID,
+                    TEST_INTERNAL_SUBJECT_ID,
+                    EMAIL,
+                    IP_ADDRESS,
+                    AuditService.UNKNOWN,
+                    DI_PERSISTENT_SESSION_ID,
+                    Optional.of(ENCODED_DEVICE_DETAILS));
     private static final Json objectMapper = SerializationService.getInstance();
 
     @BeforeEach
@@ -313,18 +326,7 @@ class AccountInterventionsHandlerTest {
                         String.valueOf(resetPassword));
         verify(cloudwatchMetricsService)
                 .incrementCounter("AuthAisResult", expectedMetricDimensions);
-        verify(auditService)
-                .submitAuditEvent(
-                        expectedEvent,
-                        TEST_CLIENT_ID,
-                        TEST_CLIENT_SESSION_ID,
-                        TEST_SESSION_ID,
-                        TEST_INTERNAL_SUBJECT_ID,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+        verify(auditService).submitAuditEvent(expectedEvent, AUDIT_CONTEXT);
     }
 
     @Test
@@ -356,16 +358,7 @@ class AccountInterventionsHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        expectedEvent,
-                        TEST_CLIENT_ID,
-                        TEST_CLIENT_SESSION_ID,
-                        TEST_SESSION_ID,
-                        TEST_INTERNAL_SUBJECT_ID,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        AuditService.RestrictedSection.empty);
+                        expectedEvent, AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()));
     }
 
     private UserProfile generateUserProfile() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.PasswordResetType;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
@@ -149,6 +150,18 @@ class ResetPasswordRequestHandlerTest {
                     codeStorageService,
                     auditService);
 
+    private final AuditContext auditContext =
+            new AuditContext(
+                    TEST_CLIENT_ID,
+                    CLIENT_SESSION_ID,
+                    SESSION_ID,
+                    expectedCommonSubject,
+                    CommonTestVariables.EMAIL,
+                    IP_ADDRESS,
+                    CommonTestVariables.UK_MOBILE_NUMBER,
+                    DI_PERSISTENT_SESSION_ID,
+                    Optional.of(ENCODED_DEVICE_DETAILS));
+
     @RegisterExtension
     public final CaptureLoggingExtension logging =
             new CaptureLoggingExtension(ResetPasswordRequestHandler.class);
@@ -258,21 +271,14 @@ class ResetPasswordRequestHandlerTest {
         @Test
         void shouldSubmitCorrectAuditEventForAValidRequest() {
             usingValidSession();
+            usingValidClientSession();
 
             handler.handleRequest(validEvent, context);
 
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.PASSWORD_RESET_REQUESTED,
-                            TEST_CLIENT_ID,
-                            CLIENT_SESSION_ID,
-                            SESSION_ID,
-                            expectedCommonSubject,
-                            CommonTestVariables.EMAIL,
-                            IP_ADDRESS,
-                            CommonTestVariables.UK_MOBILE_NUMBER,
-                            DI_PERSISTENT_SESSION_ID,
-                            new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                            auditContext,
                             PASSWORD_RESET_COUNTER,
                             PASSWORD_RESET_TYPE_FORGOTTEN_PASSWORD);
         }
@@ -294,15 +300,7 @@ class ResetPasswordRequestHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.PASSWORD_RESET_REQUESTED,
-                            TEST_CLIENT_ID,
-                            CLIENT_SESSION_ID,
-                            SESSION_ID,
-                            expectedCommonSubject,
-                            CommonTestVariables.EMAIL,
-                            IP_ADDRESS,
-                            CommonTestVariables.UK_MOBILE_NUMBER,
-                            DI_PERSISTENT_SESSION_ID,
-                            AuditService.RestrictedSection.empty,
+                            auditContext.withTxmaAuditEncoded(Optional.empty()),
                             PASSWORD_RESET_COUNTER,
                             PASSWORD_RESET_TYPE_FORGOTTEN_PASSWORD);
         }
@@ -348,15 +346,7 @@ class ResetPasswordRequestHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.PASSWORD_RESET_REQUESTED_FOR_TEST_CLIENT,
-                            TEST_CLIENT_ID,
-                            CLIENT_SESSION_ID,
-                            SESSION_ID,
-                            expectedCommonSubject,
-                            CommonTestVariables.EMAIL,
-                            IP_ADDRESS,
-                            CommonTestVariables.UK_MOBILE_NUMBER,
-                            DI_PERSISTENT_SESSION_ID,
-                            new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                            auditContext,
                             PASSWORD_RESET_COUNTER,
                             PASSWORD_RESET_TYPE_FORGOTTEN_PASSWORD);
         }
@@ -383,15 +373,7 @@ class ResetPasswordRequestHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.PASSWORD_RESET_REQUESTED_FOR_TEST_CLIENT,
-                            TEST_CLIENT_ID,
-                            CLIENT_SESSION_ID,
-                            SESSION_ID,
-                            expectedCommonSubject,
-                            CommonTestVariables.EMAIL,
-                            IP_ADDRESS,
-                            CommonTestVariables.UK_MOBILE_NUMBER,
-                            DI_PERSISTENT_SESSION_ID,
-                            AuditService.RestrictedSection.empty,
+                            auditContext.withTxmaAuditEncoded(Optional.empty()),
                             PASSWORD_RESET_COUNTER,
                             PASSWORD_RESET_TYPE_FORGOTTEN_PASSWORD);
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
@@ -85,6 +86,7 @@ import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.E
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.ENCODED_DEVICE_DETAILS;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.SESSION_ID;
+import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.UK_MOBILE_NUMBER;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.VALID_HEADERS_WITHOUT_AUDIT_ENCODED;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
@@ -134,6 +136,18 @@ class SendNotificationHandlerTest {
             new Session(SESSION_ID)
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+
+    private final AuditContext auditContext =
+            new AuditContext(
+                    CLIENT_ID,
+                    CLIENT_SESSION_ID,
+                    SESSION_ID,
+                    expectedCommonSubject,
+                    EMAIL,
+                    IP_ADDRESS,
+                    AuditService.UNKNOWN,
+                    DI_PERSISTENT_SESSION_ID,
+                    Optional.of(ENCODED_DEVICE_DETAILS));
 
     private final SendNotificationHandler handler =
             new SendNotificationHandler(
@@ -213,12 +227,11 @@ class SendNotificationHandlerTest {
                                 EMAIL, notificationType, journeyType);
                 var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
 
-                var restrictedSection =
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS));
+                var expectedAuditContext = auditContext;
 
                 if (!ticfHeaderPresent) {
                     event.setHeaders(VALID_HEADERS_WITHOUT_AUDIT_ENCODED);
-                    restrictedSection = AuditService.RestrictedSection.empty;
+                    expectedAuditContext = auditContext.withTxmaAuditEncoded(Optional.empty());
                 }
 
                 var result = handler.handleRequest(event, context);
@@ -267,15 +280,7 @@ class SendNotificationHandlerTest {
                                 notificationType.equals(VERIFY_EMAIL)
                                         ? EMAIL_CODE_SENT
                                         : ACCOUNT_RECOVERY_EMAIL_CODE_SENT,
-                                CLIENT_ID,
-                                CLIENT_SESSION_ID,
-                                SESSION_ID,
-                                expectedCommonSubject,
-                                EMAIL,
-                                IP_ADDRESS,
-                                AuditService.UNKNOWN,
-                                DI_PERSISTENT_SESSION_ID,
-                                restrictedSection);
+                                expectedAuditContext);
             }
         }
     }
@@ -330,20 +335,11 @@ class SendNotificationHandlerTest {
                                         notificationType,
                                         TEST_SIX_DIGIT_CODE,
                                         SupportedLanguage.EN)));
-        verify(auditService)
-                .submitAuditEvent(
-                        notificationType.equals(VERIFY_EMAIL)
-                                ? EMAIL_CODE_SENT
-                                : ACCOUNT_RECOVERY_EMAIL_CODE_SENT,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+        var expectedEvent =
+                notificationType.equals(VERIFY_EMAIL)
+                        ? EMAIL_CODE_SENT
+                        : ACCOUNT_RECOVERY_EMAIL_CODE_SENT;
+        verify(auditService).submitAuditEvent(expectedEvent, auditContext);
     }
 
     @Test
@@ -382,17 +378,7 @@ class SendNotificationHandlerTest {
                                         TEST_SIX_DIGIT_CODE,
                                         SupportedLanguage.EN)));
         verify(auditService)
-                .submitAuditEvent(
-                        PHONE_CODE_SENT,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        CommonTestVariables.UK_MOBILE_NUMBER,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                .submitAuditEvent(PHONE_CODE_SENT, auditContext.withPhoneNumber(UK_MOBILE_NUMBER));
     }
 
     @ParameterizedTest
@@ -422,11 +408,9 @@ class SendNotificationHandlerTest {
                                 session ->
                                         isSessionWithEmailSent(
                                                 session, notificationType, journeyType)));
-        verify(auditService)
-                .submitAuditEvent(
-                        notificationType.equals(VERIFY_EMAIL)
-                                ? EMAIL_CODE_SENT_FOR_TEST_CLIENT
-                                : ACCOUNT_RECOVERY_EMAIL_CODE_SENT_FOR_TEST_CLIENT,
+
+        var testClientAuditContext =
+                new AuditContext(
                         TEST_CLIENT_ID,
                         CLIENT_SESSION_ID,
                         SESSION_ID,
@@ -435,7 +419,13 @@ class SendNotificationHandlerTest {
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
                         DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                        Optional.of(ENCODED_DEVICE_DETAILS));
+        verify(auditService)
+                .submitAuditEvent(
+                        notificationType.equals(VERIFY_EMAIL)
+                                ? EMAIL_CODE_SENT_FOR_TEST_CLIENT
+                                : ACCOUNT_RECOVERY_EMAIL_CODE_SENT_FOR_TEST_CLIENT,
+                        testClientAuditContext);
     }
 
     @ParameterizedTest
@@ -603,17 +593,7 @@ class SendNotificationHandlerTest {
                                         TEST_SIX_DIGIT_CODE,
                                         SupportedLanguage.EN)));
         verify(auditService)
-                .submitAuditEvent(
-                        PHONE_CODE_SENT,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        phoneNumber,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                .submitAuditEvent(PHONE_CODE_SENT, auditContext.withPhoneNumber(phoneNumber));
     }
 
     @Test
@@ -741,18 +721,7 @@ class SendNotificationHandlerTest {
         verify(codeStorageService, never())
                 .saveOtpCode(EMAIL, TEST_SIX_DIGIT_CODE, CODE_EXPIRY_TIME, VERIFY_EMAIL);
         verifyNoInteractions(emailSqsClient);
-        verify(auditService)
-                .submitAuditEvent(
-                        EMAIL_INVALID_CODE_REQUEST,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+        verify(auditService).submitAuditEvent(EMAIL_INVALID_CODE_REQUEST, auditContext);
     }
 
     @Test
@@ -773,15 +742,7 @@ class SendNotificationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         EMAIL_INVALID_CODE_REQUEST,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        AuditService.RestrictedSection.empty);
+                        auditContext.withTxmaAuditEncoded(Optional.empty()));
     }
 
     @Test
@@ -813,17 +774,7 @@ class SendNotificationHandlerTest {
                         VERIFY_CHANGE_HOW_GET_SECURITY_CODES);
         verifyNoInteractions(emailSqsClient);
         verify(auditService)
-                .submitAuditEvent(
-                        ACCOUNT_RECOVERY_EMAIL_INVALID_CODE_REQUEST,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                .submitAuditEvent(ACCOUNT_RECOVERY_EMAIL_INVALID_CODE_REQUEST, auditContext);
     }
 
     @Test
@@ -855,16 +806,7 @@ class SendNotificationHandlerTest {
         verifyNoInteractions(emailSqsClient);
         verify(auditService)
                 .submitAuditEvent(
-                        PHONE_INVALID_CODE_REQUEST,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        CommonTestVariables.UK_MOBILE_NUMBER,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                        PHONE_INVALID_CODE_REQUEST, auditContext.withPhoneNumber(UK_MOBILE_NUMBER));
     }
 
     @Test
@@ -887,18 +829,7 @@ class SendNotificationHandlerTest {
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1031));
         verifyNoInteractions(emailSqsClient);
-        verify(auditService)
-                .submitAuditEvent(
-                        EMAIL_INVALID_CODE_REQUEST,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+        verify(auditService).submitAuditEvent(EMAIL_INVALID_CODE_REQUEST, auditContext);
     }
 
     @Test
@@ -922,17 +853,7 @@ class SendNotificationHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1047));
         verifyNoInteractions(emailSqsClient);
         verify(auditService)
-                .submitAuditEvent(
-                        ACCOUNT_RECOVERY_EMAIL_INVALID_CODE_REQUEST,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                .submitAuditEvent(ACCOUNT_RECOVERY_EMAIL_INVALID_CODE_REQUEST, auditContext);
     }
 
     @Test
@@ -960,16 +881,7 @@ class SendNotificationHandlerTest {
         verifyNoInteractions(emailSqsClient);
         verify(auditService)
                 .submitAuditEvent(
-                        PHONE_INVALID_CODE_REQUEST,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        CommonTestVariables.UK_MOBILE_NUMBER,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                        PHONE_INVALID_CODE_REQUEST, auditContext.withPhoneNumber(UK_MOBILE_NUMBER));
     }
 
     @Test
@@ -991,18 +903,7 @@ class SendNotificationHandlerTest {
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1033));
         verifyNoInteractions(emailSqsClient);
-        verify(auditService)
-                .submitAuditEvent(
-                        EMAIL_INVALID_CODE_REQUEST,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+        verify(auditService).submitAuditEvent(EMAIL_INVALID_CODE_REQUEST, auditContext);
     }
 
     @Test
@@ -1025,17 +926,7 @@ class SendNotificationHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1048));
         verifyNoInteractions(emailSqsClient);
         verify(auditService)
-                .submitAuditEvent(
-                        ACCOUNT_RECOVERY_EMAIL_INVALID_CODE_REQUEST,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                .submitAuditEvent(ACCOUNT_RECOVERY_EMAIL_INVALID_CODE_REQUEST, auditContext);
     }
 
     @Test
@@ -1057,18 +948,7 @@ class SendNotificationHandlerTest {
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1034));
         verifyNoInteractions(emailSqsClient);
-        verify(auditService)
-                .submitAuditEvent(
-                        PHONE_INVALID_CODE_REQUEST,
-                        CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+        verify(auditService).submitAuditEvent(PHONE_INVALID_CODE_REQUEST, auditContext);
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -115,6 +115,10 @@ class SignUpHandlerTest {
         when(configurationService.getTermsAndConditionsVersion()).thenReturn("1.0");
         when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
         when(user.getUserProfile()).thenReturn(userProfile);
+        when(clientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(generateClientRegistry()));
+        when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(clientSession));
         when(authenticationService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
         doReturn(Optional.of(ErrorResponse.ERROR_1006)).when(passwordValidator).validate("pwd");
         handler =
@@ -132,10 +136,6 @@ class SignUpHandlerTest {
     @Test
     void shouldReturn200IfSignUpIsSuccessful() {
         when(authenticationService.userExists(EMAIL)).thenReturn(false);
-        when(clientService.getClient(CLIENT_ID.getValue()))
-                .thenReturn(Optional.of(generateClientRegistry()));
-        when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(clientSession));
         when(authenticationService.signUp(
                         eq(EMAIL), eq(PASSWORD), any(Subject.class), any(TermsAndConditions.class)))
                 .thenReturn(user);
@@ -188,10 +188,6 @@ class SignUpHandlerTest {
     @Test
     void checkCreateAccountAuditEventStillEmittedWhenTICFHeaderNotProvided() {
         when(authenticationService.userExists(EMAIL)).thenReturn(false);
-        when(clientService.getClient(CLIENT_ID.getValue()))
-                .thenReturn(Optional.of(generateClientRegistry()));
-        when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(clientSession));
         when(authenticationService.signUp(
                         eq(EMAIL), eq(PASSWORD), any(Subject.class), any(TermsAndConditions.class)))
                 .thenReturn(user);
@@ -271,6 +267,8 @@ class SignUpHandlerTest {
         when(authenticationService.userExists(eq(EMAIL))).thenReturn(true);
 
         usingValidSession();
+        usingValidClientSession();
+
         var body =
                 format(
                         "{ \"password\": \"%s\", \"email\": \"%s\" }",
@@ -284,7 +282,7 @@ class SignUpHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CREATE_ACCOUNT_EMAIL_ALREADY_EXISTS,
-                        AuditService.UNKNOWN,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         SESSION_ID,
                         AuditService.UNKNOWN,
@@ -312,7 +310,7 @@ class SignUpHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CREATE_ACCOUNT_EMAIL_ALREADY_EXISTS,
-                        AuditService.UNKNOWN,
+                        CLIENT_ID.getValue(),
                         CLIENT_SESSION_ID,
                         SESSION_ID,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -268,7 +268,7 @@ class SignUpHandlerTest {
 
     @Test
     void shouldReturn400IfUserAlreadyExists() {
-        when(authenticationService.userExists(eq("joe.bloggs@test.com"))).thenReturn(true);
+        when(authenticationService.userExists(eq(EMAIL))).thenReturn(true);
 
         usingValidSession();
         var body =
@@ -288,7 +288,7 @@ class SignUpHandlerTest {
                         CLIENT_SESSION_ID,
                         SESSION_ID,
                         AuditService.UNKNOWN,
-                        "joe.bloggs@test.com",
+                        EMAIL,
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
                         DI_PERSISTENT_SESSION_ID,
@@ -297,7 +297,7 @@ class SignUpHandlerTest {
 
     @Test
     void checkCreateAccountEmailAlreadyExistsAuditEventStillEmittedWhenTICFHeaderNotProvided() {
-        when(authenticationService.userExists(eq("joe.bloggs@test.com"))).thenReturn(true);
+        when(authenticationService.userExists(eq(EMAIL))).thenReturn(true);
         usingValidSession();
         var body =
                 format(
@@ -316,7 +316,7 @@ class SignUpHandlerTest {
                         CLIENT_SESSION_ID,
                         SESSION_ID,
                         AuditService.UNKNOWN,
-                        "joe.bloggs@test.com",
+                        EMAIL,
                         IP_ADDRESS,
                         AuditService.UNKNOWN,
                         DI_PERSISTENT_SESSION_ID,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ClientStartInfo;
 import uk.gov.di.authentication.frontendapi.entity.StartResponse;
@@ -99,6 +100,17 @@ class StartHandlerTest {
     private final Session session = new Session(SESSION_ID);
     private final ClientSession clientSession = getClientSession();
     private final ClientSession docAppClientSession = getDocAppClientSession();
+    private static final AuditContext AUDIT_CONTEXT =
+            new AuditContext(
+                    TEST_CLIENT_ID,
+                    CLIENT_SESSION_ID,
+                    SESSION_ID,
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    IP_ADDRESS,
+                    AuditService.UNKNOWN,
+                    DI_PERSISTENT_SESSION_ID,
+                    Optional.of(ENCODED_DEVICE_DETAILS));
 
     @BeforeEach
     void beforeEach() {
@@ -165,15 +177,7 @@ class StartHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.START_INFO_FOUND,
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("internalSubjectId", AuditService.UNKNOWN));
     }
 
@@ -225,15 +229,7 @@ class StartHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.START_INFO_FOUND,
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("internalSubjectId", AuditService.UNKNOWN));
     }
 
@@ -266,15 +262,7 @@ class StartHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.START_INFO_FOUND,
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        AUDIT_CONTEXT,
                         pair("internalSubjectId", AuditService.UNKNOWN));
     }
 
@@ -302,15 +290,7 @@ class StartHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.START_INFO_FOUND,
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        AuditService.RestrictedSection.empty,
+                        AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()),
                         pair("internalSubjectId", AuditService.UNKNOWN));
     }
 


### PR DESCRIPTION
## What

Another PR to convert handlers to use the new way of calling the audit service. I had ambitions for this to be the final PR for frontend handlers but not quite there and didn't want to make this PR too big.

This simplifies call sites and tests by introducing a shared audit context object with common variables used across all events in a handler.

## How to review

1. Code Review commit by commit

## Related PRs

A previous PR where we've done this for some other handlers: https://github.com/govuk-one-login/authentication-api/pull/4794