### PR TITLE
AUT-2150: Ensure email request during registration only occurs for email notifications

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -203,6 +203,7 @@ public class SendOtpNotificationHandler
                                                 JourneyType.ACCOUNT_MANAGEMENT,
                                                 NowHelper.now().toInstant().getEpochSecond(),
                                                 isTestUserRequest)));
+                        LOG.info("PendingEmailCheckRequest enqueued");
                     }
 
                     return handleNotificationRequest(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -291,31 +291,31 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
         var testClientWithAllowedEmail =
                 isTestClientWithAllowedEmail(userContext, configurationService);
 
-        if (request.getJourneyType() == JourneyType.REGISTRATION) {
+        if (configurationService.isEmailCheckEnabled()
+                && notificationType == NotificationType.VERIFY_EMAIL
+                && request.getJourneyType() == JourneyType.REGISTRATION) {
             String sessionId = userContext.getSession().getSessionId();
             String clientSessionId = userContext.getClientSessionId();
             String persistentSessionId =
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
 
-            if (configurationService.isEmailCheckEnabled()) {
-                pendingEmailCheckSqsClient.send(
-                        objectMapper.writeValueAsString(
-                                new PendingEmailCheckRequest(
-                                        AuditService.UNKNOWN,
-                                        UUID.randomUUID(),
-                                        destination,
-                                        sessionId,
-                                        clientSessionId,
-                                        persistentSessionId,
-                                        IpAddressHelper.extractIpAddress(input),
-                                        JourneyType.REGISTRATION,
-                                        NowHelper.now().toInstant().getEpochSecond(),
-                                        testClientWithAllowedEmail)));
-            }
+            pendingEmailCheckSqsClient.send(
+                    objectMapper.writeValueAsString(
+                            new PendingEmailCheckRequest(
+                                    AuditService.UNKNOWN,
+                                    UUID.randomUUID(),
+                                    destination,
+                                    sessionId,
+                                    clientSessionId,
+                                    persistentSessionId,
+                                    IpAddressHelper.extractIpAddress(input),
+                                    JourneyType.REGISTRATION,
+                                    NowHelper.now().toInstant().getEpochSecond(),
+                                    testClientWithAllowedEmail)));
+            LOG.info("PendingEmailCheckRequest enqueued");
         }
 
         if (!testClientWithAllowedEmail) {
-
             if (notificationType == VERIFY_PHONE_NUMBER) {
                 METRICS.putEmbeddedValue(
                         "SendingSms",

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -232,7 +232,8 @@ class SendNotificationHandlerTest {
                                                 notificationType,
                                                 TEST_SIX_DIGIT_CODE,
                                                 SupportedLanguage.EN)));
-                if (journeyType == JourneyType.REGISTRATION) {
+                if (notificationType == NotificationType.VERIFY_EMAIL
+                        && journeyType == JourneyType.REGISTRATION) {
                     verify(pendingEmailCheckSqsClient)
                             .send(
                                     format(


### PR DESCRIPTION
## What

Previously it was possible for numbers to be sent to the email checker during registration. This stops that from happening by ensuring it's only emails that are checked during registration.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.


## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3912