### PR TITLE
AUT-2495: Deploy ticf handler in staging

### DIFF
--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -42,7 +42,7 @@ locals {
 
   request_tracing_allowed              = contains(["build", "sandpit"], var.environment)
   deploy_account_interventions_count   = 1
-  deploy_ticf_cri_count                = contains(["sandpit", "authdev1", "authdev2", "dev", "build"], var.environment) ? 1 : 0
+  deploy_ticf_cri_count                = contains(["sandpit", "authdev1", "authdev2", "dev", "build", "staging"], var.environment) ? 1 : 0
   deploy_reauth_user_count             = contains(["build", "sandpit", "authdev1", "authdev2", "staging", "integration"], var.environment) ? 1 : 0
   deploy_check_email_fraud_block_count = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
 


### PR DESCRIPTION
A preparatory step for integrating with the ticf cri service in staging. These calls won't be being made yet as part of any journeys, but this will allow us to test manually in staging

## What

<!-- Describe what you have changed and why -->

## How to review

1. Code review

## Related PRs

PR where we deployed to all the test environments: https://github.com/govuk-one-login/authentication-api/pull/4809
