### PR TITLE
Bau: Convert last frontend lambdas audit calls

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
@@ -5,13 +5,13 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -28,6 +28,8 @@ import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -133,17 +135,21 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
                 RequestHeaderHelper.getHeaderValueOrElse(
                         input.getHeaders(), SESSION_ID_HEADER, AuditService.UNKNOWN);
 
+        var auditContext =
+                new AuditContext(
+                        clientId,
+                        ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
+                        sessionId,
+                        AuditService.UNKNOWN,
+                        request.getEmail(),
+                        IpAddressHelper.extractIpAddress(input),
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                        Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+
         auditService.submitAuditEvent(
                 FrontendAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED,
-                clientId,
-                ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
-                sessionId,
-                AuditService.UNKNOWN,
-                request.getEmail(),
-                IpAddressHelper.extractIpAddress(input),
-                AuditService.UNKNOWN,
-                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                AuditHelper.buildRestrictedSection(input.getHeaders()),
+                auditContext,
                 AuditService.MetadataPair.pair("journey_type", JourneyType.REGISTRATION.getValue()),
                 AuditService.MetadataPair.pair(
                         "assessment_checked_at_timestamp",

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
@@ -9,7 +9,6 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
@@ -126,18 +125,13 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
             UserContext userContext,
             CheckEmailFraudBlockRequest request) {
 
-        var clientId =
-                userContext
-                        .getClient()
-                        .map(ClientRegistry::getClientID)
-                        .orElse(AuditService.UNKNOWN);
         var sessionId =
                 RequestHeaderHelper.getHeaderValueOrElse(
                         input.getHeaders(), SESSION_ID_HEADER, AuditService.UNKNOWN);
 
         var auditContext =
                 new AuditContext(
-                        clientId,
+                        userContext.getClientId(),
                         ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
                         sessionId,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.entity.UpdateProfileRequest;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
@@ -75,38 +76,35 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
     @Override
     public void onRequestReceived(String clientSessionId, String txmaAuditEncoded) {
-        var restrictedSection =
-                new AuditService.RestrictedSection(Optional.ofNullable(txmaAuditEncoded));
+        var auditContext =
+                new AuditContext(
+                        AuditService.UNKNOWN,
+                        clientSessionId,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        Optional.ofNullable(txmaAuditEncoded));
 
-        auditService.submitAuditEvent(
-                UPDATE_PROFILE_REQUEST_RECEIVED,
-                AuditService.UNKNOWN,
-                clientSessionId,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                restrictedSection);
+        auditService.submitAuditEvent(UPDATE_PROFILE_REQUEST_RECEIVED, auditContext);
     }
 
     @Override
     public void onRequestValidationError(String clientSessionId, String txmaAuditEncoded) {
-        var restrictedSection =
-                new AuditService.RestrictedSection(Optional.ofNullable(txmaAuditEncoded));
-
         auditService.submitAuditEvent(
                 UPDATE_PROFILE_REQUEST_ERROR,
-                AuditService.UNKNOWN,
-                clientSessionId,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                restrictedSection);
+                new AuditContext(
+                        AuditService.UNKNOWN,
+                        clientSessionId,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        Optional.ofNullable(txmaAuditEncoded)));
     }
 
     @Override
@@ -178,21 +176,20 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                     session.getInternalCommonSubjectIdentifier(),
                     AuditService.UNKNOWN);
         }
-        var restrictedSection =
-                new AuditService.RestrictedSection(
+
+        var auditContext =
+                new AuditContext(
+                        auditableClientId,
+                        userContext.getClientSessionId(),
+                        session.getSessionId(),
+                        session.getInternalCommonSubjectIdentifier(),
+                        session.getEmailAddress(),
+                        ipAddress,
+                        auditablePhoneNumber,
+                        persistentSessionId,
                         Optional.ofNullable(userContext.getTxmaAuditEncoded()));
 
-        auditService.submitAuditEvent(
-                auditableEvent,
-                auditableClientId,
-                userContext.getClientSessionId(),
-                session.getSessionId(),
-                session.getInternalCommonSubjectIdentifier(),
-                session.getEmailAddress(),
-                ipAddress,
-                auditablePhoneNumber,
-                persistentSessionId,
-                restrictedSection);
+        auditService.submitAuditEvent(auditableEvent, auditContext);
         return generateEmptySuccessApiGatewayResponse();
     }
 
@@ -205,20 +202,19 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
             String persistentSessionId,
             String subjectId,
             String txmaAuditEncoded) {
-        var restrictedSection =
-                new AuditService.RestrictedSection(Optional.ofNullable(txmaAuditEncoded));
+        var auditContext =
+                new AuditContext(
+                        clientId,
+                        clientSessionId,
+                        sessionId,
+                        subjectId,
+                        email,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        persistentSessionId,
+                        Optional.ofNullable(txmaAuditEncoded));
 
-        auditService.submitAuditEvent(
-                UPDATE_PROFILE_REQUEST_ERROR,
-                clientId,
-                clientSessionId,
-                sessionId,
-                subjectId,
-                email,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                persistentSessionId,
-                restrictedSection);
+        auditService.submitAuditEvent(UPDATE_PROFILE_REQUEST_ERROR, auditContext);
         return generateApiGatewayProxyErrorResponse(400, errorResponse);
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -9,7 +9,6 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.entity.UpdateProfileRequest;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -126,11 +125,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                         .getUserProfile()
                         .map(UserProfile::getPhoneNumber)
                         .orElse(AuditService.UNKNOWN);
-        String auditableClientId =
-                userContext
-                        .getClient()
-                        .map(ClientRegistry::getClientID)
-                        .orElse(AuditService.UNKNOWN);
+        String auditableClientId = userContext.getClientId();
         var auditContext =
                 new AuditContext(
                         auditableClientId,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
@@ -176,15 +177,16 @@ class CheckEmailFraudBlockHandlerTest {
             verify(auditServiceMock)
                     .submitAuditEvent(
                             FrontendAuditableEvent.EMAIL_FRAUD_CHECK_BYPASSED,
-                            CLIENT_ID,
-                            CLIENT_SESSION_ID,
-                            session.getSessionId(),
-                            AuditService.UNKNOWN,
-                            EMAIL,
-                            IP_ADDRESS,
-                            AuditService.UNKNOWN,
-                            DI_PERSISTENT_SESSION_ID,
-                            new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)),
+                            new AuditContext(
+                                    CLIENT_ID,
+                                    CLIENT_SESSION_ID,
+                                    session.getSessionId(),
+                                    AuditService.UNKNOWN,
+                                    EMAIL,
+                                    IP_ADDRESS,
+                                    AuditService.UNKNOWN,
+                                    DI_PERSISTENT_SESSION_ID,
+                                    Optional.of(ENCODED_DEVICE_DETAILS)),
                             AuditService.MetadataPair.pair(
                                     "journey_type", JourneyType.REGISTRATION.getValue()),
                             AuditService.MetadataPair.pair(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
@@ -91,6 +91,7 @@ class CheckEmailFraudBlockHandlerTest {
         var userProfile = generateUserProfile();
         when(clientRegistry.getClientID()).thenReturn(CLIENT_ID);
         when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
+        when(userContext.getClientId()).thenReturn(CLIENT_ID);
         when(userContext.getSession()).thenReturn(session);
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(userContext.getTxmaAuditEncoded()).thenReturn(ENCODED_DEVICE_DETAILS);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
@@ -96,6 +97,30 @@ class UpdateProfileHandlerTest {
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(expectedCommonSubject);
 
+    private final AuditContext auditContextWithAllUserInfo =
+            new AuditContext(
+                    CLIENT_ID.getValue(),
+                    CLIENT_SESSION_ID,
+                    SESSION_ID,
+                    expectedCommonSubject,
+                    EMAIL,
+                    IP_ADDRESS,
+                    UK_MOBILE_NUMBER,
+                    DI_PERSISTENT_SESSION_ID,
+                    Optional.of(ENCODED_DEVICE_DETAILS));
+
+    private final AuditContext auditContextWithOnlyClientSession =
+            new AuditContext(
+                    "",
+                    CLIENT_SESSION_ID,
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    Optional.of(ENCODED_DEVICE_DETAILS));
+
     @RegisterExtension
     private final CaptureLoggingExtension logging =
             new CaptureLoggingExtension(UpdateProfileHandler.class);
@@ -149,28 +174,10 @@ class UpdateProfileHandlerTest {
         assertThat(result, hasStatus(204));
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_PROFILE_REQUEST_RECEIVED,
-                        "",
-                        CLIENT_SESSION_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                        UPDATE_PROFILE_REQUEST_RECEIVED, auditContextWithOnlyClientSession);
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE,
-                        CLIENT_ID.getValue(),
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        CommonTestVariables.UK_MOBILE_NUMBER,
-                        DI_PERSISTENT_SESSION_ID,
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                        UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE, auditContextWithAllUserInfo);
     }
 
     @Test
@@ -194,28 +201,12 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_REQUEST_RECEIVED,
-                        "",
-                        CLIENT_SESSION_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        AuditService.RestrictedSection.empty);
+                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(Optional.empty()));
 
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE,
-                        CLIENT_ID.getValue(),
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        UK_MOBILE_NUMBER,
-                        DI_PERSISTENT_SESSION_ID,
-                        AuditService.RestrictedSection.empty);
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(Optional.empty()));
     }
 
     @Test
@@ -235,28 +226,9 @@ class UpdateProfileHandlerTest {
                 .updatePhoneNumber(eq(EMAIL), eq(CommonTestVariables.UK_MOBILE_NUMBER));
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_PROFILE_REQUEST_RECEIVED,
-                        "",
-                        CLIENT_SESSION_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                        UPDATE_PROFILE_REQUEST_RECEIVED, auditContextWithOnlyClientSession);
         verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_PROFILE_REQUEST_ERROR,
-                        "",
-                        CLIENT_SESSION_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        new AuditService.RestrictedSection(Optional.of(ENCODED_DEVICE_DETAILS)));
+                .submitAuditEvent(UPDATE_PROFILE_REQUEST_ERROR, auditContextWithOnlyClientSession);
     }
 
     @Test
@@ -274,27 +246,11 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_REQUEST_RECEIVED,
-                        "",
-                        CLIENT_SESSION_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        AuditService.RestrictedSection.empty);
+                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(Optional.empty()));
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_REQUEST_ERROR,
-                        "",
-                        CLIENT_SESSION_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        AuditService.RestrictedSection.empty);
+                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(Optional.empty()));
     }
 
     private void usingValidSession() {


### PR DESCRIPTION
## What

PR to convert the last of the frontend lambdas to use our new method of submitting an audit event, using shared audit context.

This is a step towards retiring the old way - we still need to convert the code in other modules.

## How to review

1. Code Review commit by commit



## Related PRs

A [PR](https://github.com/govuk-one-login/authentication-api/pull/4817) where we did this for lots of other handlers
