### PR TITLE
ATO-824: Update manual account deletion lambda to send message to SNS

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/DeletedAccountIdentifiers.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/DeletedAccountIdentifiers.java
@@ -1,0 +1,4 @@
+package uk.gov.di.accountmanagement.entity;
+
+public record DeletedAccountIdentifiers(
+        String publicSubjectId, String legacySubjectId, String subjectId) {}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/LegacyAccountDeletionMessage.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/LegacyAccountDeletionMessage.java
@@ -1,0 +1,9 @@
+package uk.gov.di.accountmanagement.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public record LegacyAccountDeletionMessage(
+        @Expose @SerializedName("public_subject_id") String publicSubjectId,
+        @Expose @SerializedName("legacy_subject_id") String legacySubjectId,
+        @Expose @SerializedName("user_id") String commonSubjectId) {}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
@@ -3,43 +3,51 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
+import uk.gov.di.accountmanagement.services.AwsSnsClient;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.DynamoDeleteService;
-import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.accountmanagement.services.ManualAccountDeletionService;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
-import java.util.Optional;
-
 public class ManuallyDeleteAccountHandler implements RequestHandler<String, String> {
     private final AuthenticationService authenticationService;
-    private final AccountDeletionService accountDeletionService;
+    private final ManualAccountDeletionService manualAccountDeletionService;
 
     public ManuallyDeleteAccountHandler(
             AuthenticationService authenticationService,
-            AccountDeletionService accountDeletionService) {
+            ManualAccountDeletionService manualAccountDeletionService) {
         this.authenticationService = authenticationService;
-        this.accountDeletionService = accountDeletionService;
+        this.manualAccountDeletionService = manualAccountDeletionService;
     }
 
     public ManuallyDeleteAccountHandler(ConfigurationService configurationService) {
         this.authenticationService = new DynamoService(configurationService);
-        var sqsClient =
+        var emailSqsClient =
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
+        var legacyAccountDeletionSnsClient =
+                new AwsSnsClient(
+                        configurationService.getAwsRegion(),
+                        configurationService.getLegacyAccountDeletionTopicArn());
         var auditService = new AuditService(configurationService);
         var dynamoDeleteService = new DynamoDeleteService(configurationService);
-        this.accountDeletionService =
+        var accountDeletionService =
                 new AccountDeletionService(
                         authenticationService,
-                        sqsClient,
+                        emailSqsClient,
                         auditService,
                         configurationService,
                         dynamoDeleteService);
+        this.manualAccountDeletionService =
+                new ManualAccountDeletionService(
+                        accountDeletionService,
+                        legacyAccountDeletionSnsClient,
+                        configurationService);
     }
 
     public ManuallyDeleteAccountHandler() {
@@ -52,14 +60,7 @@ public class ManuallyDeleteAccountHandler implements RequestHandler<String, Stri
                 authenticationService
                         .getUserProfileByEmailMaybe(userEmail)
                         .orElseThrow(() -> new RuntimeException("User not found with given email"));
-
-        try {
-            var userIdentifiers =
-                    accountDeletionService.removeAccount(
-                            Optional.empty(), userProfile, Optional.empty());
-            return userIdentifiers.toString();
-        } catch (Json.JsonException e) {
-            throw new RuntimeException(e);
-        }
+        var accountIdentifiers = manualAccountDeletionService.manuallyDeleteAccount(userProfile);
+        return accountIdentifiers.toString();
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -49,17 +49,11 @@ public class AccountDeletionService {
         this.dynamoDeleteService = dynamoDeleteService;
     }
 
-    public DeletedAccountIdentifiers removeAccount(
+    public void removeAccount(
             Optional<APIGatewayProxyRequestEvent> input,
             UserProfile userProfile,
             Optional<String> txmaAuditEncoded)
             throws Json.JsonException {
-        var accountIdentifiers =
-                new DeletedAccountIdentifiers(
-                        userProfile.getPublicSubjectID(),
-                        userProfile.getLegacySubjectID(),
-                        userProfile.getSubjectID());
-
         LOG.info("Calculating internal common subject identifier");
         var internalCommonSubjectIdentifier =
                 ClientSubjectHelper.getSubjectWithSectorIdentifier(
@@ -128,9 +122,5 @@ public class AccountDeletionService {
         } catch (Exception e) {
             LOG.error("Failed to audit account deletion: ", e);
         }
-        return accountIdentifiers;
     }
-
-    public record DeletedAccountIdentifiers(
-            String publicSubjectId, String legacySubjectId, String subjectId) {}
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AwsSnsClient.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AwsSnsClient.java
@@ -1,0 +1,21 @@
+package uk.gov.di.accountmanagement.services;
+
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+
+public class AwsSnsClient {
+    private final SnsClient snsClient;
+    private final String topicArn;
+
+    public AwsSnsClient(String region, String topicArn) {
+        this.snsClient = SnsClient.builder().region(Region.of(region)).build();
+        this.topicArn = topicArn;
+    }
+
+    public void publish(String message) throws SdkClientException {
+        var publishRequest = PublishRequest.builder().message(message).topicArn(topicArn).build();
+        snsClient.publish(publishRequest);
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
@@ -1,0 +1,65 @@
+package uk.gov.di.accountmanagement.services;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.core.SdkBytes;
+import uk.gov.di.accountmanagement.entity.DeletedAccountIdentifiers;
+import uk.gov.di.accountmanagement.entity.LegacyAccountDeletionMessage;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class ManualAccountDeletionService {
+    private final AccountDeletionService accountDeletionService;
+    private final AwsSnsClient legacyAccountDeletionSnsClient;
+    private final ConfigurationService configurationService;
+    private static final Logger LOG = LogManager.getLogger(ManualAccountDeletionService.class);
+
+    public ManualAccountDeletionService(
+            AccountDeletionService accountDeletionService,
+            AwsSnsClient legacyAccountDeletionSnsClient,
+            ConfigurationService configurationService) {
+        this.accountDeletionService = accountDeletionService;
+        this.legacyAccountDeletionSnsClient = legacyAccountDeletionSnsClient;
+        this.configurationService = configurationService;
+    }
+
+    public DeletedAccountIdentifiers manuallyDeleteAccount(UserProfile userProfile) {
+        var accountIdentifiers =
+                new DeletedAccountIdentifiers(
+                        userProfile.getPublicSubjectID(),
+                        userProfile.getLegacySubjectID(),
+                        userProfile.getSubjectID());
+        var legacyAccountDeletionMessage =
+                new LegacyAccountDeletionMessage(
+                        userProfile.getPublicSubjectID(),
+                        userProfile.getLegacySubjectID(),
+                        getCommonSubjectId(userProfile));
+        try {
+            accountDeletionService.removeAccount(Optional.empty(), userProfile, Optional.empty());
+            var deletedAccountPayload =
+                    SerializationService.getInstance()
+                            .writeValueAsString(legacyAccountDeletionMessage);
+            legacyAccountDeletionSnsClient.publish(deletedAccountPayload);
+            return accountIdentifiers;
+        } catch (Json.JsonException e) {
+            LOG.error(
+                    "Error while deleting account: {}. Identifiers: {}",
+                    e.getMessage(),
+                    accountIdentifiers);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getCommonSubjectId(UserProfile userProfile) {
+        var internalSectorUri = URI.create(configurationService.getInternalSectorUri());
+        var salt = SdkBytes.fromByteBuffer(userProfile.getSalt()).asByteArray();
+        return ClientSubjectHelper.calculatePairwiseIdentifier(
+                userProfile.getSubjectID(), internalSectorUri, salt);
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
@@ -5,9 +5,6 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -24,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
@@ -76,40 +72,6 @@ class AccountDeletionServiceTest {
     public void setup() {
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
         when(authenticationService.getOrGenerateSalt(any())).thenReturn(new byte[0xaa]);
-    }
-
-    @ParameterizedTest
-    @MethodSource("identifiersSource")
-    void removeAccountReturnsCorrectIdentifiers(
-            String expectedPublicSubjectId,
-            String expectedLegacySubjectId,
-            String expectedSubjectId)
-            throws Json.JsonException {
-        // given
-        when(userProfile.getPublicSubjectID()).thenReturn(expectedPublicSubjectId);
-        when(userProfile.getLegacySubjectID()).thenReturn(expectedLegacySubjectId);
-        when(userProfile.getSubjectID()).thenReturn(expectedSubjectId);
-
-        // when
-        var deletedAccountIdentifiers =
-                underTest.removeAccount(Optional.of(input), userProfile, Optional.empty());
-
-        // then
-        assertEquals(expectedPublicSubjectId, deletedAccountIdentifiers.publicSubjectId());
-        assertEquals(expectedLegacySubjectId, deletedAccountIdentifiers.legacySubjectId());
-        assertEquals(expectedSubjectId, deletedAccountIdentifiers.subjectId());
-    }
-
-    private static Stream<Arguments> identifiersSource() {
-        var publicSubjectId = new Subject().getValue();
-        var legacySubjectId = new Subject().getValue();
-        var subjectId = new Subject().getValue();
-
-        return Stream.of(
-                Arguments.of(publicSubjectId, legacySubjectId, subjectId),
-                Arguments.of(publicSubjectId, null, subjectId),
-                Arguments.of(null, legacySubjectId, subjectId),
-                Arguments.of(null, null, subjectId));
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
@@ -1,0 +1,124 @@
+package uk.gov.di.accountmanagement.services;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.accountmanagement.entity.DeletedAccountIdentifiers;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ManualAccountDeletionServiceTest {
+    private final AccountDeletionService accountDeletionService =
+            mock(AccountDeletionService.class);
+    private final AwsSnsClient legacyAccountDeletionSnsClient = mock(AwsSnsClient.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final ManualAccountDeletionService underTest =
+            new ManualAccountDeletionService(
+                    accountDeletionService, legacyAccountDeletionSnsClient, configurationService);
+    private static final UserProfile USER_PROFILE = mock(UserProfile.class);
+    private static final String PUBLIC_SUBJECT_ID = "publicSubject";
+    private static final String LEGACY_SUBJECT_ID = "legacySubject";
+    private static final String SUBJECT_ID = "subjectId";
+    private static final String COMMON_SUBJECT_ID =
+            "urn:fdc:gov.uk:2022:xH7hrtJCgdi2NEF7TXcOC6SMz8DohdoLo9hWqQMWPRk";
+    private static final ByteBuffer SALT =
+            ByteBuffer.wrap(
+                    "Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw="
+                            .getBytes(StandardCharsets.UTF_8));
+
+    @BeforeEach
+    void setUp() {
+        when(USER_PROFILE.getPublicSubjectID()).thenReturn(PUBLIC_SUBJECT_ID);
+        when(USER_PROFILE.getLegacySubjectID()).thenReturn(LEGACY_SUBJECT_ID);
+        when(USER_PROFILE.getSubjectID()).thenReturn(SUBJECT_ID);
+        when(USER_PROFILE.getSalt()).thenReturn(SALT);
+        when(configurationService.getInternalSectorUri())
+                .thenReturn("https://identity.test.account.gov.uk");
+    }
+
+    @Test
+    void shouldCallRemoveAccountWithCorrectParameters() throws Json.JsonException {
+        // when
+        underTest.manuallyDeleteAccount(USER_PROFILE);
+
+        // then
+        verify(accountDeletionService)
+                .removeAccount(Optional.empty(), USER_PROFILE, Optional.empty());
+    }
+
+    @Test
+    void shouldSubmitMessageToLegacyAccountDeletionQueue() {
+        // given
+        var expectedSqsPayload =
+                String.format(
+                        "{\"public_subject_id\":\"%s\",\"legacy_subject_id\":\"%s\",\"user_id\":\"%s\"}",
+                        PUBLIC_SUBJECT_ID, LEGACY_SUBJECT_ID, COMMON_SUBJECT_ID);
+
+        // when
+        underTest.manuallyDeleteAccount(USER_PROFILE);
+
+        // then
+        verify(legacyAccountDeletionSnsClient).publish(expectedSqsPayload);
+    }
+
+    @ParameterizedTest
+    @MethodSource("identifiersSource")
+    void shouldReturnCorrectAccountIdentifiers(
+            String expectedPublicSubjectId,
+            String expectedLegacySubjectId,
+            String expectedSubjectId) {
+        // given
+        when(USER_PROFILE.getPublicSubjectID()).thenReturn(expectedPublicSubjectId);
+        when(USER_PROFILE.getLegacySubjectID()).thenReturn(expectedLegacySubjectId);
+        when(USER_PROFILE.getSubjectID()).thenReturn(expectedSubjectId);
+        var expectedDeletedAccountIdentifiers =
+                new DeletedAccountIdentifiers(
+                        expectedPublicSubjectId, expectedLegacySubjectId, expectedSubjectId);
+
+        // when
+        var result = underTest.manuallyDeleteAccount(USER_PROFILE);
+
+        // then
+        assertEquals(expectedDeletedAccountIdentifiers, result);
+    }
+
+    private static Stream<Arguments> identifiersSource() {
+        var publicSubjectId = new Subject().getValue();
+        var legacySubjectId = new Subject().getValue();
+        var subjectId = new Subject().getValue();
+
+        return Stream.of(
+                Arguments.of(publicSubjectId, legacySubjectId, subjectId),
+                Arguments.of(publicSubjectId, null, subjectId),
+                Arguments.of(null, legacySubjectId, subjectId),
+                Arguments.of(null, null, subjectId));
+    }
+
+    @Test
+    void shouldThrowExceptionIfAccountDeletionFails() throws Json.JsonException {
+        // given
+        doThrow(new Json.JsonException("error"))
+                .when(accountDeletionService)
+                .removeAccount(any(), any(), any());
+
+        // then
+        assertThrows(RuntimeException.class, () -> underTest.manuallyDeleteAccount(USER_PROFILE));
+    }
+}

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -224,6 +224,12 @@ variable "support_email_check_enabled" {
   description = "Feature flag which toggles the Experian email check on and off"
 }
 
+variable "legacy_account_deletion_topic_arn" {
+  type        = string
+  description = "SNS ARN for the account deletion topic owned by Home for use with the manual account deletion lambda. A dev topic is created if this value is not provided."
+  default     = null
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -559,6 +559,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getURIOrDefault("CREDENTIAL_STORE_URI", "https://credential-store.account.gov.uk");
     }
 
+    public String getLegacyAccountDeletionTopicArn() {
+        return System.getenv("LEGACY_ACCOUNT_DELETION_TOPIC_ARN");
+    }
+
     private URI getURIOrDefault(String envVar, String defaultUri) {
         return getOptionalURI(envVar).orElseGet(() -> URI.create(defaultUri));
     }


### PR DESCRIPTION
We need to post a message to the SNS topic owned by the Home team when an account is manually deleted so other programme components can action it, e.g. EVCS and AIS.
