### PR TITLE
BAU: Provide minimal concurrency for authdev1

### DIFF
--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -38,7 +38,7 @@ enable_api_gateway_execution_request_tracing = true
 spot_enabled                                 = false
 
 lambda_max_concurrency = 0
-lambda_min_concurrency = 0
+lambda_min_concurrency = 1
 endpoint_memory_size   = 1536
 
 


### PR DESCRIPTION


## What

Provide minimal concurrency for authdev1

Cold starts in the authdev environments are impacting the effectiveness of testing, as people are not sure things are working correctly due to the pauses in the flow.

## How to review

1. Code Review


