### PR TITLE
BAU: disable storage token in staging for testing

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -35,7 +35,7 @@ Conditions:
   IpvExists:
     !Or [ !Equals [ staging, !Ref Environment ], !Equals [ integration, !Ref Environment ], !Equals [ production, !Ref Environment ] ]
   SendStorageToken:
-    !Not [ !Or [ !Equals [ integration, !Ref Environment ], !Equals [ production, !Ref Environment ] ] ]
+    !Not [ !Or [ !Equals [ integration, !Ref Environment ], !Equals [ production, !Ref Environment ], !Equals [ staging, !Ref Environment] ] ]
   EnableProvisionedConcurrency:
     !Or [ !Equals [!Ref Environment, staging], !Equals [!Ref Environment, build], !Equals [!Ref Environment, integration], !Equals [!Ref Environment, production]]
   IsNotProduction:


### PR DESCRIPTION
To allow IPV to test their code to read the token when it is not present