### PR TITLE
BAU: Introduce constructor method for audit context

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -16,11 +16,19 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
-import uk.gov.di.authentication.shared.services.*;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
+import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.REAUTHENTICATION_INVALID;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1056;
@@ -85,17 +93,14 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
             UserContext userContext) {
         LOG.info("Processing CheckReAuthUser request");
 
-        AuditContext auditContext =
-                new AuditContext(
-                        userContext.getClientId(),
-                        userContext.getClientSessionId(),
-                        userContext.getSession().getSessionId(),
+        var auditContext =
+                auditContextFromUserContext(
+                        userContext,
                         AuditService.UNKNOWN,
                         request.email(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                        Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
         try {
             return authenticationService

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -6,7 +6,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.entity.UserMfaDetail;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsRequest;
@@ -35,6 +34,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.helpers.FrontendApiPhoneNumberHelper.getLastDigitsOfPhoneNumber;
 import static uk.gov.di.authentication.shared.conditions.MfaHelper.getUserMFADetail;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -112,16 +112,13 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
 
             var auditContext =
-                    new AuditContext(
-                            userContext.getClientId(),
-                            userContext.getClientSessionId(),
-                            userContext.getSession().getSessionId(),
+                    auditContextFromUserContext(
+                            userContext,
                             AuditService.UNKNOWN,
                             emailAddress,
                             IpAddressHelper.extractIpAddress(input),
                             AuditService.UNKNOWN,
-                            persistentSessionId,
-                            Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+                            persistentSessionId);
 
             if (errorResponse.isPresent()) {
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -40,6 +40,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import java.util.Objects;
 import java.util.Optional;
 
+import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.LOG_IN_SUCCESS;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL;
 import static uk.gov.di.authentication.frontendapi.services.UserMigrationService.userHasBeenPartlyMigrated;
@@ -128,16 +129,13 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             UserContext userContext) {
 
         AuditContext auditContext =
-                new AuditContext(
-                        userContext.getClientId(),
-                        userContext.getClientSessionId(),
-                        userContext.getSession().getSessionId(),
+                auditContextFromUserContext(
+                        userContext,
                         AuditService.UNKNOWN,
                         request.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                        Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
         attachSessionIdToLogs(userContext.getSession().getSessionId());
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -6,7 +6,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaRequest;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
@@ -38,6 +37,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import java.util.Locale;
 import java.util.Optional;
 
+import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.MFA_MISMATCHED_EMAIL;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.MFA_MISSING_PHONE_NUMBER;
@@ -141,16 +141,13 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                             : JourneyType.SIGN_IN;
 
             var auditContext =
-                    new AuditContext(
-                            userContext.getClientId(),
-                            userContext.getClientSessionId(),
-                            userContext.getSession().getSessionId(),
+                    auditContextFromUserContext(
+                            userContext,
                             userContext.getSession().getInternalCommonSubjectIdentifier(),
                             email,
                             IpAddressHelper.extractIpAddress(input),
                             AuditService.UNKNOWN,
-                            persistentSessionId,
-                            Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+                            persistentSessionId);
 
             var metadataPairs =
                     new AuditService.MetadataPair[] {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 
+import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.ACCOUNT_RECOVERY_BLOCK_ADDED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.PASSWORD_RESET_INTERVENTION_COMPLETE;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -172,10 +173,8 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                             authenticationService);
 
             var auditContext =
-                    new AuditContext(
-                            userContext.getClientId(),
-                            userContext.getClientSessionId(),
-                            userContext.getSession().getSessionId(),
+                    auditContextFromUserContext(
+                            userContext,
                             internalCommonSubjectId.getValue(),
                             userCredentials.getEmail(),
                             IpAddressHelper.extractIpAddress(input),
@@ -183,8 +182,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                                     .getUserProfile()
                                     .map(UserProfile::getPhoneNumber)
                                     .orElse(AuditService.UNKNOWN),
-                            PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+                            PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
             updateAccountRecoveryBlockTable(
                     userProfile, userCredentials, internalCommonSubjectId, auditContext);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.ACCOUNT_RECOVERY_EMAIL_CODE_SENT;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.ACCOUNT_RECOVERY_EMAIL_CODE_SENT_FOR_TEST_CLIENT;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.ACCOUNT_RECOVERY_EMAIL_INVALID_CODE_REQUEST;
@@ -174,16 +175,13 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
 
         attachSessionIdToLogs(userContext.getSession());
         var auditContext =
-                new AuditContext(
-                        userContext.getClientId(),
-                        userContext.getClientSessionId(),
-                        userContext.getSession().getSessionId(),
+                auditContextFromUserContext(
+                        userContext,
                         userContext.getSession().getInternalCommonSubjectIdentifier(),
                         request.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
                         Optional.ofNullable(request.getPhoneNumber()).orElse(AuditService.UNKNOWN),
-                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                        Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
         try {
             if (!userContext.getSession().validateSession(request.getEmail())) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -27,6 +27,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
+import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.UPDATE_PROFILE_REQUEST_ERROR;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.UPDATE_PROFILE_REQUEST_RECEIVED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE;
@@ -125,18 +126,14 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                         .getUserProfile()
                         .map(UserProfile::getPhoneNumber)
                         .orElse(AuditService.UNKNOWN);
-        String auditableClientId = userContext.getClientId();
         var auditContext =
-                new AuditContext(
-                        auditableClientId,
-                        userContext.getClientSessionId(),
-                        session.getSessionId(),
+                auditContextFromUserContext(
+                        userContext,
                         session.getInternalCommonSubjectIdentifier(),
                         session.getEmailAddress(),
                         ipAddress,
                         auditablePhoneNumber,
-                        persistentSessionId,
-                        Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+                        persistentSessionId);
 
         if (request.getUpdateProfileType().equals(UPDATE_TERMS_CONDS)) {
             authenticationService.updateTermsAndConditions(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Map.entry;
+import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.NONE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
@@ -129,16 +130,13 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
             var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
             var auditContext =
-                    new AuditContext(
-                            userContext.getClientId(),
-                            userContext.getClientSessionId(),
-                            session.getSessionId(),
+                    auditContextFromUserContext(
+                            userContext,
                             session.getInternalCommonSubjectIdentifier(),
                             session.getEmailAddress(),
                             IpAddressHelper.extractIpAddress(input),
                             AuditService.UNKNOWN,
-                            extractPersistentIdFromHeaders(input.getHeaders()),
-                            Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+                            extractPersistentIdFromHeaders(input.getHeaders()));
 
             if (isCodeBlockedForSession(session, codeBlockedKeyPrefix)) {
                 ErrorResponse errorResponse = blockedCodeBehaviour(codeRequest);

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -1,5 +1,7 @@
 package uk.gov.di.audit;
 
+import uk.gov.di.authentication.shared.state.UserContext;
+
 import java.util.Optional;
 
 public record AuditContext(
@@ -12,6 +14,25 @@ public record AuditContext(
         String phoneNumber,
         String persistentSessionId,
         Optional<String> txmaAuditEncoded) {
+
+    public static AuditContext auditContextFromUserContext(
+            UserContext userContext,
+            String subjectId,
+            String email,
+            String ipAddress,
+            String phoneNumber,
+            String persistentSessionId) {
+        return new AuditContext(
+                userContext.getClientId(),
+                userContext.getClientSessionId(),
+                userContext.getSession().getSessionId(),
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+    }
 
     public AuditContext withPhoneNumber(String phoneNumber) {
         return new AuditContext(


### PR DESCRIPTION
In most handlers, half of the fields in the audit context come from the user context. Therefore, creating a constructor which handles the retrieval of values from the user context makes the handler code less verbose.

I used my editor to optimise the imports in some handlers, which also reversed some wildcard imports, which we should be avoiding.

## How to review

1. Code Review
