### PR TITLE
AUT-2903: Clear internal user id when switching users mid-journey

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -183,6 +183,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                                 isPhoneNumberVerified);
                 auditContext = auditContext.withSubjectId(internalPairwiseId);
             } else {
+                userContext.getSession().setInternalCommonSubjectIdentifier(null);
                 auditableEvent = FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL;
             }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -93,7 +93,7 @@ class CheckUserExistsHandlerTest {
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private CheckUserExistsHandler handler;
     private static final Json objectMapper = SerializationService.getInstance();
-    private final Session session = new Session(SESSION_ID);
+    private final Session session = mock(Session.class);
     private static final String CLIENT_ID = "test-client-id";
     private static final String CLIENT_NAME = "test-client-name";
     private static final Subject SUBJECT = new Subject();
@@ -129,6 +129,7 @@ class CheckUserExistsHandlerTest {
         when(configurationService.getMaxPasswordRetries()).thenReturn(5);
         when(codeStorageService.getIncorrectPasswordCount(EMAIL_ADDRESS)).thenReturn(0);
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
+        when(session.getSessionId()).thenReturn(SESSION_ID);
 
         handler =
                 new CheckUserExistsHandler(
@@ -153,7 +154,7 @@ class CheckUserExistsHandlerTest {
         }
 
         @Test
-        void shouldReturn200WithRelevantMfaMethod() throws Json.JsonException {
+        void shouldReturn200WithRelevantMfaMethod() {
             MFAMethod mfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, false);
             MFAMethod mfaMethod2 = verifiedMfaMethod(MFAMethodType.SMS, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
@@ -177,6 +178,7 @@ class CheckUserExistsHandlerTest {
             assertEquals(
                     JsonParser.parseString(result.getBody()),
                     JsonParser.parseString(expectedResponse));
+            verify(session).setInternalCommonSubjectIdentifier(getExpectedInternalPairwiseId());
         }
 
         @Test
@@ -186,17 +188,12 @@ class CheckUserExistsHandlerTest {
             var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
 
             assertThat(result, hasStatus(200));
-            var expectedRpPairwiseId =
-                    ClientSubjectHelper.calculatePairwiseIdentifier(
-                            SUBJECT.getValue(), "sector-identifier", SALT.array());
-            var expectedInternalPairwiseId =
-                    ClientSubjectHelper.calculatePairwiseIdentifier(
-                            SUBJECT.getValue(), "test.account.gov.uk", SALT.array());
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL,
-                            AUDIT_CONTEXT.withSubjectId(expectedInternalPairwiseId),
-                            AuditService.MetadataPair.pair("rpPairwiseId", expectedRpPairwiseId));
+                            AUDIT_CONTEXT.withSubjectId(getExpectedInternalPairwiseId()),
+                            AuditService.MetadataPair.pair(
+                                    "rpPairwiseId", getExpectedRpPairwiseId()));
         }
 
         @Test
@@ -209,19 +206,14 @@ class CheckUserExistsHandlerTest {
             var result = handler.handleRequest(req, context);
 
             assertThat(result, hasStatus(200));
-            var expectedRpPairwiseId =
-                    ClientSubjectHelper.calculatePairwiseIdentifier(
-                            SUBJECT.getValue(), "sector-identifier", SALT.array());
-            var expectedInternalPairwiseId =
-                    ClientSubjectHelper.calculatePairwiseIdentifier(
-                            SUBJECT.getValue(), "test.account.gov.uk", SALT.array());
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL,
                             AUDIT_CONTEXT
-                                    .withSubjectId(expectedInternalPairwiseId)
+                                    .withSubjectId(getExpectedInternalPairwiseId())
                                     .withTxmaAuditEncoded(Optional.empty()),
-                            AuditService.MetadataPair.pair("rpPairwiseId", expectedRpPairwiseId));
+                            AuditService.MetadataPair.pair(
+                                    "rpPairwiseId", getExpectedRpPairwiseId()));
         }
 
         @Test
@@ -304,6 +296,7 @@ class CheckUserExistsHandlerTest {
                 objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
         assertThat(checkUserExistsResponse.getEmail(), equalTo(EMAIL_ADDRESS));
         assertFalse(checkUserExistsResponse.doesUserExist());
+        verify(session).setInternalCommonSubjectIdentifier(null);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL,
@@ -390,6 +383,16 @@ class CheckUserExistsHandlerTest {
 
         return new ClientSession(
                 authRequest.toParameters(), null, mock(VectorOfTrust.class), CLIENT_NAME);
+    }
+
+    private static String getExpectedRpPairwiseId() {
+        return ClientSubjectHelper.calculatePairwiseIdentifier(
+                SUBJECT.getValue(), "sector-identifier", SALT.array());
+    }
+
+    private static String getExpectedInternalPairwiseId() {
+        return ClientSubjectHelper.calculatePairwiseIdentifier(
+                SUBJECT.getValue(), "test.account.gov.uk", SALT.array());
     }
 
     private void setupUserProfileAndClient(Optional<UserProfile> maybeUserProfile) {


### PR DESCRIPTION
## What

Clear internal user id when switching users mid-journey.

When starting a sign-in journey with one email, then abandoning and switching to another email in order to create an account, the user id for the first email rather than the second email is recorded in an audit event.

## How to review

1. Code Review

Steps to reproduce the issue in staging:

1. You need an existing account and an email that doesn't have an account so you can set one up.
2. Start a journey from the stub and enter the email for the existing user.
3. Stop on the enter password screen and do not enter a password.
4. Go back using the 'back' link.
5. Enter the new email to create an account and then continue.
6. Create a password then continue.
7. Add an mfa to complete creating the account.

Before the fix in this scenario the AUTH_CODE_VERIFIED event will have the user id for the existing user rather than the new user.

You can check the events in splunk in staging by retrieving the client session id/journey id and adding it to the query:

index="gds_di_development"  _client-session-id_ event_name="*" | sort -timestamp

