### PR TITLE
Aut 2495/bump lambda timeout for ticf

### DIFF
--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -15,6 +15,7 @@ reduced_lockout_duration             = 900
 incorrect_password_lockout_count_ttl = 7200
 support_account_creation_count_ttl   = true
 call_ticf_cri                        = true
+ticf_cri_service_call_timeout        = 20000
 
 orch_account_id                     = "590183975515"
 cmk_for_back_channel_logout_enabled = true

--- a/ci/terraform/oidc/ticf-cri.tf
+++ b/ci/terraform/oidc/ticf-cri.tf
@@ -13,6 +13,7 @@ resource "aws_lambda_function" "ticf_cri_lambda" {
   handler       = "uk.gov.di.authentication.frontendapi.lambda.TicfCriHandler::handleRequest"
   runtime       = "java17"
   publish       = true
+  timeout       = 60
 
   memory_size                    = lookup(var.performance_tuning, "ticf-cri", local.default_performance_parameters).memory
   reserved_concurrent_executions = 1


### PR DESCRIPTION
## What

Bumps the lambda timeout for ticf, and also the http timeout in staging.

These are temporary measures while we ensure that the integration with the ticf cri in staging is working. Once we're happy with this, we can tune these variables back down.

## How to review

1. Code Review
