### PR TITLE
BAU: Update set-up-sso with new role names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ disable = '''missing-module-docstring,
         missing-class-docstring,
         missing-function-docstring,
         invalid-name,
-        too-few-public-methods
+        too-few-public-methods,
+        too-many-branches
         '''
 ignore = ".venv"
 


### PR DESCRIPTION
## What

Our AWS accounts are commonly created with the roles
`AWSAdministratorAccess` and `ReadOnlyAccess`. The script will now
preferentially create profiles with these roles if they exist, and
ignore the 'old' role naming.

If these new roles do not exist, the script will fall back to the old
'does role end with xxx' logic.

## How to review

- Code review
- Run the script, ensure that the roles you expect are present afterwards
- Attempt to use one of the modified profiles, ensure that it works.
