### PR TITLE
AUT-2833: implementation of lockout for too many incorrect passwords instead of the dependency on ttl duration

### DIFF
--- a/ci/terraform/account-management/authdev1.tfvars
+++ b/ci/terraform/account-management/authdev1.tfvars
@@ -11,7 +11,3 @@ logging_endpoint_arns    = []
 endpoint_memory_size   = 1536
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0
-
-lockout_duration                          = 30
-otp_code_ttl_duration                     = 120
-email_acct_creation_otp_code_ttl_duration = 60

--- a/ci/terraform/account-management/authdev2.tfvars
+++ b/ci/terraform/account-management/authdev2.tfvars
@@ -12,6 +12,3 @@ endpoint_memory_size   = 1536
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 
-lockout_duration                          = 30
-otp_code_ttl_duration                     = 120
-email_acct_creation_otp_code_ttl_duration = 60

--- a/ci/terraform/account-management/build-overrides.tfvars
+++ b/ci/terraform/account-management/build-overrides.tfvars
@@ -9,8 +9,4 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
-lockout_duration                          = 30
-otp_code_ttl_duration                     = 120
-email_acct_creation_otp_code_ttl_duration = 60
-
 support_email_check_enabled = true

--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -42,9 +42,13 @@ lambda_min_concurrency = 1
 endpoint_memory_size   = 1536
 
 
-lockout_duration                          = 30
-otp_code_ttl_duration                     = 120
-email_acct_creation_otp_code_ttl_duration = 60
+# lockout config
+lockout_duration                          = 600
+reduced_lockout_duration                  = 300
+incorrect_password_lockout_count_ttl      = 600
+lockout_count_ttl                         = 600
+otp_code_ttl_duration                     = 600
+email_acct_creation_otp_code_ttl_duration = 600
 
 
 orch_client_id  = "orchestrationAuth"

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -41,9 +41,13 @@ lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 endpoint_memory_size   = 1536
 
-lockout_duration                          = 30
-otp_code_ttl_duration                     = 120
-email_acct_creation_otp_code_ttl_duration = 60
+# lockout config
+lockout_duration                          = 600
+reduced_lockout_duration                  = 300
+incorrect_password_lockout_count_ttl      = 600
+lockout_count_ttl                         = 600
+otp_code_ttl_duration                     = 600
+email_acct_creation_otp_code_ttl_duration = 600
 
 
 orch_client_id  = "orchestrationAuth"

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -41,8 +41,12 @@ lambda_min_concurrency = 0
 endpoint_memory_size   = 1536
 
 
-lockout_duration                          = 30
-otp_code_ttl_duration                     = 120
+# lockout config
+lockout_duration                          = 60
+reduced_lockout_duration                  = 30
+incorrect_password_lockout_count_ttl      = 60
+lockout_count_ttl                         = 60
+otp_code_ttl_duration                     = 60
 email_acct_creation_otp_code_ttl_duration = 60
 
 orch_client_id = "orchestrationAuth"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -134,9 +134,9 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             var userExists = userProfile.isPresent();
             userContext.getSession().setEmailAddress(emailAddress);
 
-            var incorrectPasswordCount = codeStorageService.getIncorrectPasswordCount(emailAddress);
-
-            if (incorrectPasswordCount >= configurationService.getMaxPasswordRetries()) {
+            if (codeStorageService.isBlockedForEmail(
+                    emailAddress,
+                    CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.PASSWORD_RESET)) {
                 LOG.info("User account is locked");
                 sessionService.save(userContext.getSession());
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -178,7 +178,10 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                             : codeStorageService.getIncorrectPasswordCount(request.getEmail());
             LOG.info("incorrectPasswordCount: {}", incorrectPasswordCount);
 
-            if (incorrectPasswordCount >= configurationService.getMaxPasswordRetries()) {
+            String codeBlockedKeyPrefix =
+                    CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.PASSWORD_RESET;
+            if (codeStorageService.isBlockedForEmail(
+                    userProfile.getEmail(), codeBlockedKeyPrefix)) {
                 LOG.info("User has exceeded max password retries");
 
                 auditService.submitAuditEvent(
@@ -193,12 +196,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
             if (!credentialsAreValid(request, userProfile)) {
                 LOG.info("credentials are invalid");
-                if (isReauthJourney) {
-                    codeStorageService.increaseIncorrectPasswordCountReauthJourney(
-                            request.getEmail());
-                } else {
-                    codeStorageService.increaseIncorrectPasswordCount(request.getEmail());
-                }
                 var updatedIncorrectPasswordCount = incorrectPasswordCount + 1;
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
@@ -207,8 +204,20 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         pair("incorrectPasswordCount", updatedIncorrectPasswordCount),
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
 
-                if (incorrectPasswordCount + 1 >= configurationService.getMaxPasswordRetries()) {
-                    LOG.info("User has now exceeded max password retries");
+                if (updatedIncorrectPasswordCount >= configurationService.getMaxPasswordRetries()) {
+                    LOG.info("User has now exceeded max password retries, setting block");
+
+                    codeStorageService.saveBlockedForEmail(
+                            request.getEmail(),
+                            codeBlockedKeyPrefix,
+                            configurationService.getLockoutDuration());
+
+                    if (isReauthJourney) {
+                        codeStorageService.deleteIncorrectPasswordCountReauthJourney(
+                                request.getEmail());
+                    } else {
+                        codeStorageService.deleteIncorrectPasswordCount(request.getEmail());
+                    }
 
                     auditService.submitAuditEvent(
                             FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
@@ -222,17 +231,14 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1028);
                 }
 
-                return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
-            }
-
-            if (incorrectPasswordCount != 0) {
-                LOG.info("deleting incorrectPasswordCount");
                 if (isReauthJourney) {
-                    codeStorageService.deleteIncorrectPasswordCountReauthJourney(
+                    codeStorageService.increaseIncorrectPasswordCountReauthJourney(
                             request.getEmail());
                 } else {
-                    codeStorageService.deleteIncorrectPasswordCount(request.getEmail());
+                    codeStorageService.increaseIncorrectPasswordCount(request.getEmail());
                 }
+
+                return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
             }
 
             LOG.info("Setting internal common subject identifier in user session");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -12,6 +12,7 @@ import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ResetPasswordCompletionRequest;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
@@ -194,6 +195,13 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             if (incorrectPasswordCount != 0) {
                 codeStorageService.deleteIncorrectPasswordCount(userCredentials.getEmail());
             }
+
+            String codeBlockedKeyPrefix =
+                    CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.PASSWORD_RESET;
+
+            codeStorageService.deleteBlockForEmail(
+                    userCredentials.getEmail(), codeBlockedKeyPrefix);
+
             AuditableEvent auditableEvent;
             if (TestClientHelper.isTestClientWithAllowedEmail(userContext, configurationService)) {
                 auditableEvent = FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT;

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -127,7 +127,7 @@ class CheckUserExistsHandlerTest {
     void setup() {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(configurationService.getMaxPasswordRetries()).thenReturn(5);
-        when(codeStorageService.getIncorrectPasswordCount(EMAIL_ADDRESS)).thenReturn(0);
+        when(codeStorageService.isBlockedForEmail(any(), any())).thenReturn(false);
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
 
         handler =
@@ -275,7 +275,7 @@ class CheckUserExistsHandlerTest {
 
         @Test
         void shouldReturn400AndSaveEmailInUserSessionIfUserAccountIsLocked() {
-            when(codeStorageService.getIncorrectPasswordCount(EMAIL_ADDRESS)).thenReturn(5);
+            when(codeStorageService.isBlockedForEmail(any(), any())).thenReturn(true);
 
             var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -505,6 +505,7 @@ class LoginHandlerTest {
                 .thenReturn(Optional.of(userProfile));
         when(clientSession.getAuthRequestParams()).thenReturn(generateAuthRequest().toParameters());
         when(codeStorageService.getIncorrectPasswordCount(EMAIL)).thenReturn(6);
+        when(codeStorageService.isBlockedForEmail(any(), any())).thenReturn(true);
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
         usingDefaultVectorOfTrust();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.net.URI;
@@ -176,12 +177,8 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             throws JsonException {
         String emailAddress = "joe.bloggs+2@digital.cabinet-office.gov.uk";
         String sessionId = redis.createUnauthenticatedSessionWithEmail(emailAddress);
-        redis.incrementPasswordCount(emailAddress);
-        redis.incrementPasswordCount(emailAddress);
-        redis.incrementPasswordCount(emailAddress);
-        redis.incrementPasswordCount(emailAddress);
-        redis.incrementPasswordCount(emailAddress);
-        redis.incrementPasswordCount(emailAddress);
+        redis.blockMfaCodesForEmail(
+                emailAddress, CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.SIGN_IN);
 
         BaseFrontendRequest request = new CheckUserExistsRequest(emailAddress);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -202,42 +202,16 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         headers.put("X-API-Key", FRONTEND_API_KEY);
         headers.put(TXMA_AUDIT_ENCODED_HEADER, ENCODED_DEVICE_INFORMATION);
 
-        var response1 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response1, hasStatus(401));
-        var response2 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response2, hasStatus(401));
-        var response3 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response3, hasStatus(401));
-        var response4 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response4, hasStatus(401));
-        var response5 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response5, hasStatus(401));
-        var response6 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response6, hasStatus(400));
+        var request = new LoginRequest(email, password, JourneyType.SIGN_IN);
+
+        for (int i = 0; i < 5; i++) {
+            var response = makeRequest(Optional.of(request), headers, Map.of());
+            assertThat(response, hasStatus(401));
+        }
+
+        var response = makeRequest(Optional.of(request), headers, Map.of());
+        assertThat(response, hasStatus(400));
+
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(
@@ -262,42 +236,16 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         headers.put("X-API-Key", FRONTEND_API_KEY);
         headers.put(TXMA_AUDIT_ENCODED_HEADER, ENCODED_DEVICE_INFORMATION);
 
-        var response1 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response1, hasStatus(401));
-        var response2 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response2, hasStatus(401));
-        var response3 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response3, hasStatus(401));
-        var response4 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response4, hasStatus(401));
-        var response5 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response5, hasStatus(401));
-        var response6 =
-                makeRequest(
-                        Optional.of(new LoginRequest(email, password, JourneyType.SIGN_IN)),
-                        headers,
-                        Map.of());
-        assertThat(response6, hasStatus(400));
+        var request = new LoginRequest(email, password, JourneyType.SIGN_IN);
+
+        for (int i = 0; i < 5; i++) {
+            var response = makeRequest(Optional.of(request), headers, Map.of());
+            assertThat(response, hasStatus(401));
+        }
+
+        var response = makeRequest(Optional.of(request), headers, Map.of());
+        assertThat(response, hasStatus(400));
+
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -16,6 +16,7 @@ public class CodeStorageService {
 
     public static final String CODE_REQUEST_BLOCKED_KEY_PREFIX = "code-request-blocked:";
     public static final String CODE_BLOCKED_KEY_PREFIX = "code-blocked:";
+    public static final String PASSWORD_BLOCKED_KEY_PREFIX = "password-blocked:";
 
     private static final Logger LOG = LogManager.getLogger(CodeStorageService.class);
 
@@ -186,9 +187,21 @@ public class CodeStorageService {
         }
     }
 
+    public void deleteBlockForEmail(String email, String prefix) {
+        String encodedHash = HashHelper.hashSha256String(email);
+        String keys = prefix + encodedHash;
+        try {
+            redisConnectionService.deleteValue(keys);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to remove the block for this value");
+        }
+    }
+
     public boolean isBlockedForEmail(String emailAddress, String prefix) {
-        return redisConnectionService.getValue(prefix + HashHelper.hashSha256String(emailAddress))
-                != null;
+        String value =
+                redisConnectionService.getValue(prefix + HashHelper.hashSha256String(emailAddress));
+        LOG.info("block value: {}", value);
+        return value != null;
     }
 
     public void saveOtpCode(


### PR DESCRIPTION
## What

Add a lockout type for incorrect password attempts in redis and use during sign in journey.

## Why

The lockout duration for invalid password attempts during the sign in journey is linked to the ttl duration. This is believed to be because this was one of the first components to introduce lockout and at the time there was no distinction between tt and lockout duration.

We need to remove this dependency and implement lockout using redis in line with the rest of our lockout processes.

## How to review

1. Code Review
2. Deploy to dev/authdev
3. QA to test acceptance criteria from the [JIRA ticket](https://govukverify.atlassian.net/browse/AUT-2833)

## Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.

