### PR TITLE
BAU: Final conversion of all handlers to the new audit service method

### DIFF
--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.external.domain.AuthExternalApiAuditableEvent;
 import uk.gov.di.authentication.external.services.TokenService;
 import uk.gov.di.authentication.external.validators.TokenRequestValidator;
@@ -234,14 +235,15 @@ class TokenHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AuthExternalApiAuditableEvent.TOKEN_SENT_TO_ORCHESTRATION,
-                        CLIENT_ID,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        internalPairwiseId,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.RestrictedSection.empty);
+                        new AuditContext(
+                                CLIENT_ID,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                internalPairwiseId,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                AuditService.UNKNOWN,
+                                Optional.empty()));
     }
 }

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
@@ -10,6 +10,7 @@ import com.nimbusds.oauth2.sdk.token.BearerTokenError;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.external.domain.AuthExternalApiAuditableEvent;
 import uk.gov.di.authentication.external.services.UserInfoService;
 import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
@@ -27,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -85,16 +85,17 @@ class UserInfoHandlerTest {
         verify(accessTokenService, times(1)).setAccessTokenStoreUsed(validToken.getValue(), true);
         verify(auditService)
                 .submitAuditEvent(
-                        eq(AuthExternalApiAuditableEvent.USERINFO_SENT_TO_ORCHESTRATION),
-                        any(),
-                        any(),
-                        any(),
-                        eq(TEST_SUBJECT.getValue()),
-                        eq("test@test.com"),
-                        any(),
-                        eq("0123456789"),
-                        any(),
-                        any());
+                        AuthExternalApiAuditableEvent.USERINFO_SENT_TO_ORCHESTRATION,
+                        new AuditContext(
+                                "",
+                                "",
+                                "",
+                                TEST_SUBJECT.getValue(),
+                                "test@test.com",
+                                "",
+                                "0123456789",
+                                "",
+                                Optional.empty()));
     }
 
     @Test

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -28,6 +28,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import java.util.Optional;
 
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
+import static uk.gov.di.audit.AuditContext.emptyAuditContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.UPDATE_PROFILE_REQUEST_ERROR;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.UPDATE_PROFILE_REQUEST_RECEIVED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE;
@@ -161,15 +162,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
     private AuditContext auditContextWithOnlyClientSessionId(
             String clientSessionId, String txmaAuditEncoded) {
-        return new AuditContext(
-                AuditService.UNKNOWN,
-                clientSessionId,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                Optional.ofNullable(txmaAuditEncoded));
+        return emptyAuditContext()
+                .withClientSessionId(clientSessionId)
+                .withTxmaAuditEncoded(Optional.ofNullable(txmaAuditEncoded));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -410,17 +410,8 @@ class SendNotificationHandlerTest {
                                         isSessionWithEmailSent(
                                                 session, notificationType, journeyType)));
 
-        var testClientAuditContext =
-                new AuditContext(
-                        TEST_CLIENT_ID,
-                        CLIENT_SESSION_ID,
-                        SESSION_ID,
-                        expectedCommonSubject,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        DI_PERSISTENT_SESSION_ID,
-                        Optional.of(ENCODED_DEVICE_DETAILS));
+        var testClientAuditContext = auditContext.withClientId(TEST_CLIENT_ID);
+
         verify(auditService)
                 .submitAuditEvent(
                         notificationType.equals(VERIFY_EMAIL)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -146,16 +146,7 @@ class VerifyCodeHandlerTest {
                     Optional.of(ENCODED_DEVICE_DETAILS));
 
     private final AuditContext AUDIT_CONTEXT_FOR_TEST_CLIENT =
-            new AuditContext(
-                    TEST_CLIENT_ID,
-                    CLIENT_SESSION_ID,
-                    testSession.getSessionId(),
-                    expectedCommonSubject,
-                    EMAIL,
-                    IP_ADDRESS,
-                    AuditService.UNKNOWN,
-                    DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+            AUDIT_CONTEXT.withSessionId(testSession.getSessionId()).withClientId(TEST_CLIENT_ID);
 
     private VerifyCodeHandler handler;
 

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -1,5 +1,6 @@
 package uk.gov.di.audit;
 
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
@@ -32,6 +33,19 @@ public record AuditContext(
                 phoneNumber,
                 persistentSessionId,
                 Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+    }
+
+    public static AuditContext emptyAuditContext() {
+        return new AuditContext(
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                Optional.empty());
     }
 
     public AuditContext withPhoneNumber(String phoneNumber) {

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -138,4 +138,30 @@ public record AuditContext(
                 persistentSessionId,
                 txmaAuditEncoded);
     }
+
+    public AuditContext withClientSessionId(String clientSessionId) {
+        return new AuditContext(
+                clientId,
+                clientSessionId,
+                sessionId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                txmaAuditEncoded);
+    }
+
+    public AuditContext withSessionId(String sessionId) {
+        return new AuditContext(
+                clientId,
+                clientSessionId,
+                sessionId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                txmaAuditEncoded);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -112,4 +112,17 @@ public record AuditContext(
                 persistentSessionId,
                 txmaAuditEncoded);
     }
+
+    public AuditContext withIpAddress(String ipAddress) {
+        return new AuditContext(
+                clientId,
+                clientSessionId,
+                sessionId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                txmaAuditEncoded);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -125,4 +125,17 @@ public record AuditContext(
                 persistentSessionId,
                 txmaAuditEncoded);
     }
+
+    public AuditContext withClientId(String clientId) {
+        return new AuditContext(
+                clientId,
+                clientSessionId,
+                sessionId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                txmaAuditEncoded);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -73,10 +73,6 @@ public class AuditService {
                                 txmaAuditEvent.addExtension("phone_number_country_code", country));
     }
 
-    public record RestrictedSection(Optional<String> encoded) {
-        public static final RestrictedSection empty = new RestrictedSection(Optional.empty());
-    }
-
     public void submitAuditEvent(
             AuditableEvent event, AuditContext auditContext, MetadataPair... metadataPairs) {
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -103,34 +103,6 @@ public class AuditService {
         txmaQueueClient.send(txmaAuditEvent.serialize());
     }
 
-    public void submitAuditEvent(
-            AuditableEvent event,
-            String clientId,
-            String clientSessionId,
-            String sessionId,
-            String subjectId,
-            String email,
-            String ipAddress,
-            String phoneNumber,
-            String persistentSessionId,
-            RestrictedSection restrictedSection,
-            MetadataPair... metadataPairs) {
-
-        var auditContext =
-                new AuditContext(
-                        clientId,
-                        clientSessionId,
-                        sessionId,
-                        subjectId,
-                        email,
-                        ipAddress,
-                        phoneNumber,
-                        persistentSessionId,
-                        restrictedSection.encoded);
-
-        submitAuditEvent(event, auditContext, metadataPairs);
-    }
-
     public record MetadataPair(String key, Object value, boolean isRestricted) {
         public static MetadataPair pair(String key, Object value) {
             return new MetadataPair(key, value, false);

--- a/test-services-api/src/test/java/uk/gov/di/authentication/testservices/DeleteSyntheticsUserHandlerTest.java
+++ b/test-services-api/src/test/java/uk/gov/di/authentication/testservices/DeleteSyntheticsUserHandlerTest.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
@@ -40,6 +41,18 @@ class DeleteSyntheticsUserHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AuditService auditService = mock(AuditService.class);
 
+    private final AuditContext auditContext =
+            new AuditContext(
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    EMAIL,
+                    "123.123.123.123",
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    Optional.empty());
+
     @BeforeEach
     public void setUp() {
         handler =
@@ -62,17 +75,7 @@ class DeleteSyntheticsUserHandlerTest {
         assertThat(result, hasStatus(204));
         verify(authenticationService).removeAccount(EMAIL);
         verify(auditService)
-                .submitAuditEvent(
-                        TestServicesAuditableEvent.SYNTHETICS_USER_DELETED,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        userProfile.getEmail(),
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.RestrictedSection.empty);
+                .submitAuditEvent(TestServicesAuditableEvent.SYNTHETICS_USER_DELETED, auditContext);
     }
 
     @Test
@@ -100,15 +103,7 @@ class DeleteSyntheticsUserHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         TestServicesAuditableEvent.SYNTHETICS_USER_NOT_FOUND_FOR_DELETION,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        EMAIL,
-                        "123.123.123.123",
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.RestrictedSection.empty);
+                        auditContext);
     }
 
     private APIGatewayProxyRequestEvent generateApiGatewayEvent() {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
@@ -26,6 +26,7 @@ import uk.gov.service.notify.NotificationClientException;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.di.audit.AuditContext.emptyAuditContext;
 import static uk.gov.di.authentication.shared.entity.NotificationType.TERMS_AND_CONDITIONS_BULK_EMAIL;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
@@ -260,15 +261,9 @@ public class BulkUserEmailSenderScheduledEventHandler
                         : AuditService.UNKNOWN;
         auditService.submitAuditEvent(
                 utilsAuditableEvent,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                internalCommonSubjectIdentifier,
-                userProfile.getEmail(),
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.RestrictedSection.empty,
+                emptyAuditContext()
+                        .withEmail(userProfile.getEmail())
+                        .withSubjectId(internalCommonSubjectIdentifier),
                 pair("internalSubjectId", userProfile.getSubjectID()),
                 pair("bulk-email-type", BulkEmailType.VC_EXPIRY_BULK_EMAIL.name()));
     }


### PR DESCRIPTION
## What

Conversion of all remaining authentication code to use the new method of calling the audit service, which gets an audit context passed through to it in order to clean up some of the calling code and tests.

Removes the old method, as our conversion is now complete!

## How to review

1. Code Review commit by commit

## Related PRs

An example PR where we've done this conversion most recently: https://github.com/govuk-one-login/authentication-api/pull/4848