### PR TITLE
BAU: add metadata that codepipeline understands

### DIFF
--- a/.github/workflows/deploy-api-modules-dev.yml
+++ b/.github/workflows/deploy-api-modules-dev.yml
@@ -88,14 +88,14 @@ jobs:
             }
 
             const result = await github.graphql(query, variables).then((response) => {
-                const sanitisedCommitMessage = response.repository.object.message.replace(/\n/g, "\\n")
+                const firstLineOfCommitMessage = response.repository.object.message.slice(0, response.repository.object.message.indexOf("\n"));
                 const res = {
                     pr_number: null,
                     pr_title: null,
                     pr_merged_at: null,
                     pr_merge_commit_sha: null,
 
-                    commit_message: sanitisedCommitMessage,
+                    commit_message: firstLineOfCommitMessage,
 
                     repo_full_name: response.repository.nameWithOwner,
                     repo_owner: response.repository.owner.login,
@@ -103,8 +103,9 @@ jobs:
 
                     repository: response.repository.nameWithOwner,
                     commitsha: context.sha,
-                    commitmessage: sanitisedCommitMessage,
+                    commitmessage: firstLineOfCommitMessage,
                 }
+                res["codepipeline-artifact-revision-summary"] = `${context.sha}: ${firstLineOfCommitMessage}`;
 
                 if (response.repository.object.associatedPullRequests.nodes.length > 0 && response.repository.object.associatedPullRequests.nodes[0].merged) {
                     const prData = response.repository.object.associatedPullRequests.nodes[0];
@@ -113,7 +114,14 @@ jobs:
                     res.pr_merged_at = prData.mergedAt;
                     res.pr_merge_commit_sha = prData.mergeCommit.oid;
                     res.commitmessage = prData.title;
+
+                    res["codepipeline-artifact-revision-summary"] = `${prData.mergeCommit.oid}: ${response.repository.nameWithOwner}#${prData.number} ${prData.title}`;
                 }
+
+                if (res["codepipeline-artifact-revision-summary"].length > 2048) {
+                    res["codepipeline-artifact-revision-summary"] = res["codepipeline-artifact-revision-summary"].slice(0, 2048);
+                }
+
                 return res;
             }).catch((error) => {
                 throw error;

--- a/.github/workflows/deploy-api-modules.yml
+++ b/.github/workflows/deploy-api-modules.yml
@@ -88,17 +88,18 @@ jobs:
                 owner: context.repo.owner,
                 name: context.repo.repo,
                 oid: context.sha,
+                shortSha: context.sha.slice(0, 7),
             }
 
             const result = await github.graphql(query, variables).then((response) => {
-                const sanitisedCommitMessage = response.repository.object.message.replace(/\n/g, "\\n")
+                const firstLineOfCommitMessage = response.repository.object.message.slice(0, response.repository.object.message.indexOf("\n"));
                 const res = {
                     pr_number: null,
                     pr_title: null,
                     pr_merged_at: null,
                     pr_merge_commit_sha: null,
 
-                    commit_message: sanitisedCommitMessage,
+                    commit_message: firstLineOfCommitMessage,
 
                     repo_full_name: response.repository.nameWithOwner,
                     repo_owner: response.repository.owner.login,
@@ -106,8 +107,9 @@ jobs:
 
                     repository: response.repository.nameWithOwner,
                     commitsha: context.sha,
-                    commitmessage: sanitisedCommitMessage,
+                    commitmessage: firstLineOfCommitMessage,
                 }
+                res["codepipeline-artifact-revision-summary"] = `${context.sha}: ${firstLineOfCommitMessage}`;
 
                 if (response.repository.object.associatedPullRequests.nodes.length > 0 && response.repository.object.associatedPullRequests.nodes[0].merged) {
                     const prData = response.repository.object.associatedPullRequests.nodes[0];
@@ -116,7 +118,14 @@ jobs:
                     res.pr_merged_at = prData.mergedAt;
                     res.pr_merge_commit_sha = prData.mergeCommit.oid;
                     res.commitmessage = prData.title;
+
+                    res["codepipeline-artifact-revision-summary"] = `${prData.mergeCommit.oid}: ${response.repository.nameWithOwner}#${prData.number} ${prData.title}`;
                 }
+
+                if (res["codepipeline-artifact-revision-summary"].length > 2048) {
+                    res["codepipeline-artifact-revision-summary"] = res["codepipeline-artifact-revision-summary"].slice(0, 2048);
+                }
+
                 return res;
             }).catch((error) => {
                 throw error;

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ logs/
 # Contract Tests
 pact/
 node_modules
+.infracost


### PR DESCRIPTION
## What

As-per https://ordinaryexperts.com/blog/2019/04/27/better-codepipeline-metadata

This extra metadata is shown in the codepipeline UI and will allow better identification of where the artifact has come from.

<img width="665" alt="image" src="https://github.com/govuk-one-login/authentication-api/assets/3595020/549f2ecb-5744-484b-a1e0-f4b9acf3f37b">


## How to review

- Code review
- Deploy to dev from this branch (`./scripts/trigger-gha-current-branch.sh`) and confirm that the resulting pipeline run has the sensible metadata

Unfortunately the pr merge one is untestable without merging a pr. I guess 'trust me'?
