### PR TITLE
BAU: strip non-ascii characters from metadata

### DIFF
--- a/.github/workflows/deploy-api-modules-dev.yml
+++ b/.github/workflows/deploy-api-modules-dev.yml
@@ -123,6 +123,8 @@ jobs:
                 if (result[key] == null) {
                     result[key] = "";
                 }
+                // strip non-ascii characters from all values
+                result[key] = result[key].replace(/[^\x20-\x7E]/g, '');
             }
 
             console.log(result);

--- a/.github/workflows/deploy-api-modules.yml
+++ b/.github/workflows/deploy-api-modules.yml
@@ -126,6 +126,8 @@ jobs:
                 if (result[key] == null) {
                     result[key] = "";
                 }
+                // strip non-ascii characters from all values
+                result[key] = result[key].replace(/[^\x20-\x7E]/g, '');
             }
 
             console.log(result);


### PR DESCRIPTION
## What

AWS can't handle non-ascii characters in S3 metadata, so strip them out

## How to review

- Code review
