### PR TITLE
BAU: use gradle build raher than SAM controlled to improve caching and speed

### DIFF
--- a/.github/workflows/deploy-orch.yml
+++ b/.github/workflows/deploy-orch.yml
@@ -42,14 +42,10 @@ jobs:
           distribution: 'corretto'
           cache: gradle
 
-      - name: Cache SAM
-        uses: actions/cache@v4
-        with:
-          path: .aws-sam/cache
-          key: orch-sam
-
       - name: SAM build
-        run: sam build --cached --parallel
+        run: |
+          ./gradlew --no-daemon --parallel :oidc:buildZip :ipv-api:buildZip :doc-checking-app-api:buildZip :client-registry-api:buildZip
+          sam build --parallel
 
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@v3.8

--- a/.github/workflows/deploy-orch.yml
+++ b/.github/workflows/deploy-orch.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'corretto'
+          java-version: "17"
+          distribution: "corretto"
           cache: gradle
 
       - name: SAM build

--- a/template.yaml
+++ b/template.yaml
@@ -399,7 +399,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-FetchJwksFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.FetchJwksHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref FetchJwksFunctionLogGroup
@@ -437,7 +437,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-OpenIdConfigurationFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.WellknownHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref OpenIdConfigurationFunctionLogGroup
@@ -594,7 +594,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-TrustmarkFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.TrustMarkHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref TrustmarkFunctionLogGroup
@@ -744,7 +744,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-BackChannelLogoutRequestFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.BackChannelLogoutRequestHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref BackChannelLogoutRequestFunctionLogGroup
@@ -883,7 +883,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-DocAppCallbackFunction
       AutoPublishAlias: latest
-      CodeUri: ./doc-checking-app-api
+      CodeUri: ./doc-checking-app-api/build/distributions/doc-checking-app-api.zip
       Handler: uk.gov.di.authentication.app.lambda.DocAppCallbackHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref DocAppCallbackFunctionLogGroup
@@ -1049,7 +1049,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-TokenFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.TokenHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref TokenFunctionLogGroup
@@ -1244,7 +1244,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-LogoutFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.LogoutHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref LogoutFunctionLogGroup
@@ -1448,7 +1448,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-AuthenticationCallbackFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref AuthenticationCallbackFunctionLogGroup
@@ -1729,7 +1729,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-JwksFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.JwksHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref JwksFunctionLogGroup
@@ -1892,7 +1892,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-AuthorisationFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref AuthorisationFunctionLogGroup
@@ -2181,7 +2181,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-UserInfoFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref UserInfoFunctionLogGroup
@@ -2379,7 +2379,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-AuthCodeFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.AuthCodeHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref AuthCodeFunctionLogGroup
@@ -2561,7 +2561,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-UpdateClientConfigFunction
       AutoPublishAlias: latest
-      CodeUri: ./client-registry-api
+      CodeUri: ./client-registry-api/build/distributions/client-registry-api.zip
       Handler: uk.gov.di.authentication.clientregistry.lambda.UpdateClientConfigHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref UpdateClientConfigFunctionLogGroup
@@ -2714,7 +2714,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-ClientRegistrationFunction
       AutoPublishAlias: latest
-      CodeUri: ./client-registry-api
+      CodeUri: ./client-registry-api/build/distributions/client-registry-api.zip
       Handler: uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref ClientRegistrationFunctionLogGroup
@@ -2868,7 +2868,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-IpvCallbackFunction
       AutoPublishAlias: latest
-      CodeUri: ./ipv-api
+      CodeUri: ./ipv-api/build/distributions/ipv-api.zip
       Handler: uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref IpvCallbackFunctionLogGroup
@@ -3149,7 +3149,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-SpotResponseFunction
       AutoPublishAlias: latest
-      CodeUri: ./ipv-api
+      CodeUri: ./ipv-api/build/distributions/ipv-api.zip
       Handler: uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref SpotResponseFunctionLogGroup
@@ -3353,7 +3353,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-StorageTokenJwkFunction
       AutoPublishAlias: latest
-      CodeUri: ./oidc-api
+      CodeUri: ./oidc-api/build/distributions/oidc-api.zip
       Handler: uk.gov.di.authentication.oidc.lambda.StorageTokenJwkHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref StorageTokenJwkFunctionLogGroup


### PR DESCRIPTION
## What
Before SAM was in charge of building the gradle project. This mean that no caching was done, and dependencies were downloaded and compiled multiple times. This change manually compiles all of then required modules which gives us more control over the process and takes several minutes off a deploy. This is significant in all envs, but most of all in dev where this should really shorten the feedback cycle