### PR TITLE
ATO-887: Return bad request when redirect uri is invalid

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -12,7 +12,7 @@ import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
-import uk.gov.di.orchestration.shared.exceptions.ClientRegistryValidationException;
+import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
@@ -48,7 +48,7 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
 
         if (!client.getRedirectUrls().contains(authRequest.getRedirectionURI().toString())) {
             LOG.warn("Invalid Redirect URI in request {}", authRequest.getRedirectionURI());
-            throw new ClientRegistryValidationException(
+            throw new ClientRedirectUriValidationException(
                     format(
                             "Invalid Redirect in request %s",
                             authRequest.getRedirectionURI().toString()));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -15,6 +15,7 @@ import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
+import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
@@ -31,6 +32,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.nimbusds.oauth2.sdk.ResponseType.CODE;
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
@@ -75,7 +77,13 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
             if (jwtClaimsSet.getStringClaim("redirect_uri") == null
                     || !client.getRedirectUrls()
                             .contains(jwtClaimsSet.getStringClaim("redirect_uri"))) {
-                throw new RuntimeException("Invalid Redirect URI in request JWT");
+                LOG.warn(
+                        "Invalid Redirect URI in request {}",
+                        jwtClaimsSet.getStringClaim("redirect_uri"));
+                throw new ClientRedirectUriValidationException(
+                        format(
+                                "Invalid Redirect in request %s",
+                                jwtClaimsSet.getStringClaim("redirect_uri")));
             }
 
             var redirectURI = URI.create((String) jwtClaimsSet.getClaim("redirect_uri"));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
@@ -28,6 +28,7 @@ import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
+import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
@@ -508,7 +509,7 @@ class QueryParamsAuthorizeValidatorTest {
     @Test
     void shouldThrowExceptionWhenRedirectUriIsInvalidInAuthRequest() {
         ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
-        String redirectURi = "http://localhost/redirect";
+        String redirectUri = "http://localhost/redirect";
         Scope scope = new Scope();
         scope.add(OIDCScopeValue.OPENID);
         when(dynamoClientService.getClient(CLIENT_ID.toString()))
@@ -519,14 +520,14 @@ class QueryParamsAuthorizeValidatorTest {
 
         var exception =
                 assertThrows(
-                        RuntimeException.class,
+                        ClientRedirectUriValidationException.class,
                         () ->
                                 queryParamsAuthorizeValidator.validate(
-                                        generateAuthRequest(redirectURi, responseType, scope)),
+                                        generateAuthRequest(redirectUri, responseType, scope)),
                         "Expected to throw exception");
         assertThat(
                 exception.getMessage(),
-                equalTo(format("Invalid Redirect in request %s", redirectURi)));
+                equalTo(format("Invalid Redirect in request %s", redirectUri)));
     }
 
     @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -20,6 +20,7 @@ import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
+import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -151,7 +152,7 @@ class RequestObjectAuthorizeValidatorTest {
                         .build();
         var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         assertThrows(
-                RuntimeException.class,
+                ClientRedirectUriValidationException.class,
                 () -> service.validate(authRequest),
                 "Expected to throw exception");
     }
@@ -170,7 +171,7 @@ class RequestObjectAuthorizeValidatorTest {
                         .build();
         var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         assertThrows(
-                RuntimeException.class,
+                ClientRedirectUriValidationException.class,
                 () -> service.validate(authRequest),
                 "Expected to throw exception");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/ClientRedirectUriValidationException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/ClientRedirectUriValidationException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.orchestration.shared.exceptions;
+
+public class ClientRedirectUriValidationException extends RuntimeException {
+    public ClientRedirectUriValidationException(String message) {
+        super(message);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/ClientRegistryValidationException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/ClientRegistryValidationException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.orchestration.shared.exceptions;
-
-public class ClientRegistryValidationException extends RuntimeException {
-    public ClientRegistryValidationException(String message) {
-        super(message);
-    }
-}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientRedirectUriValidationException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientRedirectUriValidationException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class ClientRedirectUriValidationException extends RuntimeException {
+    public ClientRedirectUriValidationException(String message) {
+        super(message);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientRedirectUriValidationException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientRedirectUriValidationException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.authentication.shared.exceptions;
-
-public class ClientRedirectUriValidationException extends RuntimeException {
-    public ClientRedirectUriValidationException(String message) {
-        super(message);
-    }
-}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientRegistryValidationException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientRegistryValidationException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.authentication.shared.exceptions;
-
-public class ClientRegistryValidationException extends RuntimeException {
-    public ClientRegistryValidationException(String message) {
-        super(message);
-    }
-}


### PR DESCRIPTION
## What

We're getting a lot of alarms go off in integration due to invalid redirect uri's being provided - we should return 400 rather than 500. Also renamed exception to make it clearer what case we are returning 400 in.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
