### PR TITLE
BAU: Dependabot reconfiguration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,38 +7,20 @@ updates:
       time: "03:00"
     open-pull-requests-limit: 100
     target-branch: main
-    commit-message: 
-      prefix: BAU
-    labels:
-      - dependabot
-  - package-ecosystem: docker
-    directory: "/docker"
-    schedule:
-      interval: daily
-      time: "03:00"
-    open-pull-requests-limit: 100
-    target-branch: main
     commit-message:
       prefix: BAU
-    labels:
-      - dependabot
-    ignore:
-      - dependency-name: localstack/localstack
-        versions:
-          - ">= 0.13"
+
   - package-ecosystem: github-actions
-    directory: /
+    directory: "/"
     open-pull-requests-limit: 100
     target-branch: main
+    schedule:
+      interval: weekly
     commit-message:
       prefix: BAU
-    labels:
-      - dependabot
-    schedule:
-      interval: daily
 
   - package-ecosystem: pip
-    directory: /
+    directory: "/"
     open-pull-requests-limit: 5
     target-branch: main
     commit-message:


### PR DESCRIPTION
## What

- Remove explicit PR labels. Without these set, PRs will be created with
  the label 'dependencies' and the name of the dependency type (e.g.
  a gha PR will have the label 'dependencies' and 'github_actions').
  This improves the experience of filtering the PRs in the UI.
- Remove the docker configuration - `/docker` hasn't existed for a long
  time now.
- Check actions weekly instead of daily: it's unlikely that we actually
  need to update these more than once a week.

## How to review

Code review
