### PR TITLE
Revert "BAU: use batch-get-secret-value in read_secrets.sh"

### DIFF
--- a/ci/terraform/account-management/read_secrets.sh
+++ b/ci/terraform/account-management/read_secrets.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
@@ -12,37 +12,18 @@ if [ "$ENVIRONMENT" = "dev" ]; then
   ENVIRONMENT="build"
 fi
 
-function get_page() {
-  local next_token="${1:-}"
+secrets="$(
+  aws secretsmanager list-secrets \
+    --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
+    jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
+)"
 
-  if [ -n "${next_token}" ]; then
-    next_token="--next-token=${next_token}"
-  fi
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
-  aws secretsmanager batch-get-secret-value --filters 'Key=name,Values=/deploy/'"${ENVIRONMENT}"'/' --max-results 20 "${next_token}"
-
-}
-
-function get_page_secrets() {
-  jq -r '[.SecretValues[]|{name: (.Name|split("/")|last), value: .SecretString}]'
-}
-
-function get_next_token() {
-  jq -r '.NextToken // empty'
-}
-
-first_page="$(get_page)"
-
-SECRETS="$(get_page_secrets <<<"${first_page}")"
-
-next_token="$(get_next_token <<<"${first_page}")"
-while [ -n "${next_token}" ]; do
-  page="$(get_page "${next_token}")"
-  page_secrets="$(get_page_secrets <<<"${page}")"
-  SECRETS="$(jq -n --argjson secrets "${SECRETS}" --argjson page_secrets "${page_secrets}" '$secrets + $page_secrets')"
-  next_token="$(get_next_token <<<"${page}")"
-done
-
-while IFS=$'\t' read -r name value; do
+while IFS=$'\t' read -r arn name; do
+  value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
-done < <(jq -r '.[]|[.name, .value]|@tsv' <<<"${SECRETS}")
+done <<<"${secrets}"

--- a/ci/terraform/auth-external-api/read_secrets.sh
+++ b/ci/terraform/auth-external-api/read_secrets.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
@@ -12,37 +12,18 @@ if [ "$ENVIRONMENT" = "dev" ]; then
   ENVIRONMENT="build"
 fi
 
-function get_page() {
-  local next_token="${1:-}"
+secrets="$(
+  aws secretsmanager list-secrets \
+    --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
+    jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
+)"
 
-  if [ -n "${next_token}" ]; then
-    next_token="--next-token=${next_token}"
-  fi
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
-  aws secretsmanager batch-get-secret-value --filters 'Key=name,Values=/deploy/'"${ENVIRONMENT}"'/' --max-results 20 "${next_token}"
-
-}
-
-function get_page_secrets() {
-  jq -r '[.SecretValues[]|{name: (.Name|split("/")|last), value: .SecretString}]'
-}
-
-function get_next_token() {
-  jq -r '.NextToken // empty'
-}
-
-first_page="$(get_page)"
-
-SECRETS="$(get_page_secrets <<<"${first_page}")"
-
-next_token="$(get_next_token <<<"${first_page}")"
-while [ -n "${next_token}" ]; do
-  page="$(get_page "${next_token}")"
-  page_secrets="$(get_page_secrets <<<"${page}")"
-  SECRETS="$(jq -n --argjson secrets "${SECRETS}" --argjson page_secrets "${page_secrets}" '$secrets + $page_secrets')"
-  next_token="$(get_next_token <<<"${page}")"
-done
-
-while IFS=$'\t' read -r name value; do
+while IFS=$'\t' read -r arn name; do
+  value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
-done < <(jq -r '.[]|[.name, .value]|@tsv' <<<"${SECRETS}")
+done <<<"${secrets}"

--- a/ci/terraform/oidc/read_secrets.sh
+++ b/ci/terraform/oidc/read_secrets.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
@@ -12,37 +12,18 @@ if [ "$ENVIRONMENT" = "dev" ]; then
   ENVIRONMENT="build"
 fi
 
-function get_page() {
-  local next_token="${1:-}"
+secrets="$(
+  aws secretsmanager list-secrets \
+    --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
+    jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
+)"
 
-  if [ -n "${next_token}" ]; then
-    next_token="--next-token=${next_token}"
-  fi
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
-  aws secretsmanager batch-get-secret-value --filters 'Key=name,Values=/deploy/'"${ENVIRONMENT}"'/' --max-results 20 "${next_token}"
-
-}
-
-function get_page_secrets() {
-  jq -r '[.SecretValues[]|{name: (.Name|split("/")|last), value: .SecretString}]'
-}
-
-function get_next_token() {
-  jq -r '.NextToken // empty'
-}
-
-first_page="$(get_page)"
-
-SECRETS="$(get_page_secrets <<<"${first_page}")"
-
-next_token="$(get_next_token <<<"${first_page}")"
-while [ -n "${next_token}" ]; do
-  page="$(get_page "${next_token}")"
-  page_secrets="$(get_page_secrets <<<"${page}")"
-  SECRETS="$(jq -n --argjson secrets "${SECRETS}" --argjson page_secrets "${page_secrets}" '$secrets + $page_secrets')"
-  next_token="$(get_next_token <<<"${page}")"
-done
-
-while IFS=$'\t' read -r name value; do
+while IFS=$'\t' read -r arn name; do
+  value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
-done < <(jq -r '.[]|[.name, .value]|@tsv' <<<"${SECRETS}")
+done <<<"${secrets}"

--- a/ci/terraform/shared/read_secrets.sh
+++ b/ci/terraform/shared/read_secrets.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
@@ -12,37 +12,18 @@ if [ "$ENVIRONMENT" = "dev" ]; then
   ENVIRONMENT="build"
 fi
 
-function get_page() {
-  local next_token="${1:-}"
+secrets="$(
+  aws secretsmanager list-secrets \
+    --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
+    jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
+)"
 
-  if [ -n "${next_token}" ]; then
-    next_token="--next-token=${next_token}"
-  fi
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
-  aws secretsmanager batch-get-secret-value --filters 'Key=name,Values=/deploy/'"${ENVIRONMENT}"'/' --max-results 20 "${next_token}"
-
-}
-
-function get_page_secrets() {
-  jq -r '[.SecretValues[]|{name: (.Name|split("/")|last), value: .SecretString}]'
-}
-
-function get_next_token() {
-  jq -r '.NextToken // empty'
-}
-
-first_page="$(get_page)"
-
-SECRETS="$(get_page_secrets <<<"${first_page}")"
-
-next_token="$(get_next_token <<<"${first_page}")"
-while [ -n "${next_token}" ]; do
-  page="$(get_page "${next_token}")"
-  page_secrets="$(get_page_secrets <<<"${page}")"
-  SECRETS="$(jq -n --argjson secrets "${SECRETS}" --argjson page_secrets "${page_secrets}" '$secrets + $page_secrets')"
-  next_token="$(get_next_token <<<"${page}")"
-done
-
-while IFS=$'\t' read -r name value; do
+while IFS=$'\t' read -r arn name; do
+  value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
-done < <(jq -r '.[]|[.name, .value]|@tsv' <<<"${SECRETS}")
+done <<<"${secrets}"

--- a/ci/terraform/test-services/read_secrets.sh
+++ b/ci/terraform/test-services/read_secrets.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
@@ -12,37 +12,18 @@ if [ "$ENVIRONMENT" = "dev" ]; then
   ENVIRONMENT="build"
 fi
 
-function get_page() {
-  local next_token="${1:-}"
+secrets="$(
+  aws secretsmanager list-secrets \
+    --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
+    jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
+)"
 
-  if [ -n "${next_token}" ]; then
-    next_token="--next-token=${next_token}"
-  fi
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
-  aws secretsmanager batch-get-secret-value --filters 'Key=name,Values=/deploy/'"${ENVIRONMENT}"'/' --max-results 20 "${next_token}"
-
-}
-
-function get_page_secrets() {
-  jq -r '[.SecretValues[]|{name: (.Name|split("/")|last), value: .SecretString}]'
-}
-
-function get_next_token() {
-  jq -r '.NextToken // empty'
-}
-
-first_page="$(get_page)"
-
-SECRETS="$(get_page_secrets <<<"${first_page}")"
-
-next_token="$(get_next_token <<<"${first_page}")"
-while [ -n "${next_token}" ]; do
-  page="$(get_page "${next_token}")"
-  page_secrets="$(get_page_secrets <<<"${page}")"
-  SECRETS="$(jq -n --argjson secrets "${SECRETS}" --argjson page_secrets "${page_secrets}" '$secrets + $page_secrets')"
-  next_token="$(get_next_token <<<"${page}")"
-done
-
-while IFS=$'\t' read -r name value; do
+while IFS=$'\t' read -r arn name; do
+  value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
-done < <(jq -r '.[]|[.name, .value]|@tsv' <<<"${SECRETS}")
+done <<<"${secrets}"

--- a/ci/terraform/utils/read_secrets.sh
+++ b/ci/terraform/utils/read_secrets.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
@@ -12,37 +12,18 @@ if [ "$ENVIRONMENT" = "dev" ]; then
   ENVIRONMENT="build"
 fi
 
-function get_page() {
-  local next_token="${1:-}"
+secrets="$(
+  aws secretsmanager list-secrets \
+    --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
+    jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
+)"
 
-  if [ -n "${next_token}" ]; then
-    next_token="--next-token=${next_token}"
-  fi
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
-  aws secretsmanager batch-get-secret-value --filters 'Key=name,Values=/deploy/'"${ENVIRONMENT}"'/' --max-results 20 "${next_token}"
-
-}
-
-function get_page_secrets() {
-  jq -r '[.SecretValues[]|{name: (.Name|split("/")|last), value: .SecretString}]'
-}
-
-function get_next_token() {
-  jq -r '.NextToken // empty'
-}
-
-first_page="$(get_page)"
-
-SECRETS="$(get_page_secrets <<<"${first_page}")"
-
-next_token="$(get_next_token <<<"${first_page}")"
-while [ -n "${next_token}" ]; do
-  page="$(get_page "${next_token}")"
-  page_secrets="$(get_page_secrets <<<"${page}")"
-  SECRETS="$(jq -n --argjson secrets "${SECRETS}" --argjson page_secrets "${page_secrets}" '$secrets + $page_secrets')"
-  next_token="$(get_next_token <<<"${page}")"
-done
-
-while IFS=$'\t' read -r name value; do
+while IFS=$'\t' read -r arn name; do
+  value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
-done < <(jq -r '.[]|[.name, .value]|@tsv' <<<"${SECRETS}")
+done <<<"${secrets}"

--- a/scripts/read_secrets__main.sh
+++ b/scripts/read_secrets__main.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
@@ -12,37 +12,18 @@ if [ "$ENVIRONMENT" = "dev" ]; then
   ENVIRONMENT="build"
 fi
 
-function get_page() {
-  local next_token="${1:-}"
+secrets="$(
+  aws secretsmanager list-secrets \
+    --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
+    jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
+)"
 
-  if [ -n "${next_token}" ]; then
-    next_token="--next-token=${next_token}"
-  fi
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
-  aws secretsmanager batch-get-secret-value --filters 'Key=name,Values=/deploy/'"${ENVIRONMENT}"'/' --max-results 20 "${next_token}"
-
-}
-
-function get_page_secrets() {
-  jq -r '[.SecretValues[]|{name: (.Name|split("/")|last), value: .SecretString}]'
-}
-
-function get_next_token() {
-  jq -r '.NextToken // empty'
-}
-
-first_page="$(get_page)"
-
-SECRETS="$(get_page_secrets <<<"${first_page}")"
-
-next_token="$(get_next_token <<<"${first_page}")"
-while [ -n "${next_token}" ]; do
-  page="$(get_page "${next_token}")"
-  page_secrets="$(get_page_secrets <<<"${page}")"
-  SECRETS="$(jq -n --argjson secrets "${SECRETS}" --argjson page_secrets "${page_secrets}" '$secrets + $page_secrets')"
-  next_token="$(get_next_token <<<"${page}")"
-done
-
-while IFS=$'\t' read -r name value; do
+while IFS=$'\t' read -r arn name; do
+  value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
-done < <(jq -r '.[]|[.name, .value]|@tsv' <<<"${SECRETS}")
+done <<<"${secrets}"


### PR DESCRIPTION
This reverts commit 74bc0c90b78415912b48e414a2fe8c8e9f321a07.

We think this might have broken the acceptance tests in the pipeline, so this is an attempt to see if it fixes.