### PR TITLE
ATO-732: Pass Reauthentication Failures to RP

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AuthenticationCallbackValidationException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AuthenticationCallbackValidationException.java
@@ -1,0 +1,27 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+
+public class AuthenticationCallbackValidationException extends Exception {
+
+    private final ErrorObject error;
+    private final boolean logoutRequired;
+
+    public AuthenticationCallbackValidationException() {
+        this(OAuth2Error.SERVER_ERROR, false);
+    }
+
+    public AuthenticationCallbackValidationException(ErrorObject error, boolean logoutRequired) {
+        this.error = error;
+        this.logoutRequired = logoutRequired;
+    }
+
+    public ErrorObject getError() {
+        return error;
+    }
+
+    public boolean getLogoutRequired() {
+        return logoutRequired;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationService.java
@@ -1,13 +1,18 @@
 package uk.gov.di.authentication.oidc.services;
 
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.OIDCError;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.oidc.exceptions.AuthenticationCallbackValidationException;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -17,35 +22,45 @@ public class AuthenticationAuthorizationService {
     private final RedisConnectionService redisConnectionService;
     public static final String AUTHENTICATION_STATE_STORAGE_PREFIX = "auth-state:";
     private final Json objectMapper = SerializationService.getInstance();
+    public static final List<ErrorObject> reauthErrors =
+            List.of(OIDCError.LOGIN_REQUIRED, OAuth2Error.ACCESS_DENIED);
 
     public AuthenticationAuthorizationService(RedisConnectionService redisConnectionService) {
         this.redisConnectionService = redisConnectionService;
     }
 
-    public boolean validateRequest(Map<String, String> queryParams, String sessionId) {
+    public void validateRequest(Map<String, String> queryParams, String sessionId)
+            throws AuthenticationCallbackValidationException {
         LOG.info("Validating authentication callback request");
         if (queryParams == null || queryParams.isEmpty()) {
             LOG.warn("No query parameters in authentication callback request");
-            return false;
+            throw new AuthenticationCallbackValidationException();
         }
         if (queryParams.containsKey("error")) {
             LOG.warn("Error response found in authentication callback request");
-            return false;
+            var reauthError =
+                    reauthErrors.stream()
+                            .filter(error -> error.getCode().equals(queryParams.get("error")))
+                            .findFirst();
+            if (reauthError.isPresent()) {
+                throw new AuthenticationCallbackValidationException(reauthError.get(), true);
+            } else {
+                throw new AuthenticationCallbackValidationException();
+            }
         }
         if (!queryParams.containsKey("state") || queryParams.get("state").isEmpty()) {
             LOG.warn("No state param found in authentication callback request query parameters");
-            return false;
+            throw new AuthenticationCallbackValidationException();
         }
         if (!isStateValid(sessionId, queryParams.get("state"))) {
             LOG.warn("Authentication callback request state is invalid");
-            return false;
+            throw new AuthenticationCallbackValidationException();
         }
         if (!queryParams.containsKey("code") || queryParams.get("code").isEmpty()) {
             LOG.warn("No code param found in authentication callback request query parameters");
-            return false;
+            throw new AuthenticationCallbackValidationException();
         }
         LOG.info("Authentication callback request passed validation");
-        return true;
     }
 
     private boolean isStateValid(String sessionId, String responseState) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -19,7 +19,6 @@ import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
-import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
@@ -54,8 +53,6 @@ class LogoutHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
-    private final CloudwatchMetricsService cloudwatchMetricsService =
-            mock(CloudwatchMetricsService.class);
     private final TokenValidationService tokenValidationService =
             mock(TokenValidationService.class);
     private final LogoutService logoutService = mock(LogoutService.class);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -98,11 +98,7 @@ class LogoutHandlerTest {
     void setUp() throws JOSEException {
         handler =
                 new LogoutHandler(
-                        sessionService,
-                        dynamoClientService,
-                        tokenValidationService,
-                        cloudwatchMetricsService,
-                        logoutService);
+                        sessionService, dynamoClientService, tokenValidationService, logoutService);
         ECKey ecSigningKey =
                 new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();
         signedIDToken =
@@ -115,7 +111,7 @@ class LogoutHandlerTest {
         idTokenHint = signedIDToken.serialize();
 
         when(configurationService.getInternalSectorURI()).thenReturn(INTERNAL_SECTOR_URI);
-        when(logoutService.handleLogout(any(), any(), any(), any(), any(), any()))
+        when(logoutService.handleLogout(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(new APIGatewayProxyResponseEvent());
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(dynamoClientService.getClient("client-id"))
@@ -147,10 +143,9 @@ class LogoutHandlerTest {
 
         handler.handleRequest(event, context);
 
-        verify(logoutService, times(1)).destroySessions(session);
-        verify(cloudwatchMetricsService).incrementLogout(Optional.of("client-id"));
         verify(logoutService, times(1))
                 .handleLogout(
+                        Optional.of(session),
                         Optional.empty(),
                         Optional.of(CLIENT_LOGOUT_URI),
                         Optional.of(STATE.toString()),
@@ -178,10 +173,9 @@ class LogoutHandlerTest {
 
         handler.handleRequest(event, context);
 
-        verify(logoutService, times(0)).destroySessions(any());
-        verify(cloudwatchMetricsService, times(0)).incrementLogout(any());
         verify(logoutService, times(1))
                 .handleLogout(
+                        Optional.empty(),
                         Optional.empty(),
                         Optional.of(CLIENT_LOGOUT_URI),
                         Optional.of(STATE.toString()),
@@ -218,10 +212,9 @@ class LogoutHandlerTest {
 
         handler.handleRequest(event, context);
 
-        verify(logoutService, times(1)).destroySessions(session);
-        verify(cloudwatchMetricsService).incrementLogout(Optional.of("client-id"));
         verify(logoutService, times(1))
                 .handleLogout(
+                        Optional.of(session),
                         Optional.empty(),
                         Optional.of(CLIENT_LOGOUT_URI),
                         Optional.of(STATE.toString()),

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/LogoutReason.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/LogoutReason.java
@@ -1,0 +1,17 @@
+package uk.gov.di.orchestration.shared.entity;
+
+public enum LogoutReason {
+    FRONT_CHANNEL("front-channel"),
+    INTERVENTION("intervention"),
+    REAUTHENTICATION_FAILURE("reauthentication-failure");
+
+    private String value;
+
+    LogoutReason(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -52,13 +53,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.shared.domain.LogoutAuditableEvent.LOG_OUT_SUCCESS;
 import static uk.gov.di.orchestration.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
-public class LogoutServiceTest {
+class LogoutServiceTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final SessionService sessionService = mock(SessionService.class);
@@ -101,16 +101,18 @@ public class LogoutServiceTest {
     private static final String CLIENT_ID = "client-id";
     private static final Subject SUBJECT = new Subject();
     private static final String EMAIL = "joe.bloggs@test.com";
+    private static Session session;
 
     private static final String OIDC_API_BASE_URL = "https://oidc.test.account.gov.uk/";
     private static final String FRONTEND_BASE_URL = "https://signin.test.account.gov.uk/";
+    private static final URI REAUTH_FAILURE_URI =
+            URI.create("https://redirect.go.uk?error=access_denied");
 
     private static final String ENVIRONMENT = "test";
 
     private SignedJWT signedIDToken;
     private Optional<String> audience;
     private Optional<String> rpPairwiseId;
-    private Session session;
     private LogoutService logoutService;
     private final TxmaAuditUser auditUser =
             TxmaAuditUser.user()
@@ -164,9 +166,11 @@ public class LogoutServiceTest {
         rpPairwiseId = Optional.of(idToken.getJWTClaimsSet().getSubject());
 
         session =
-                generateSession()
+                new Session(SESSION_ID)
                         .setEmailAddress(EMAIL)
                         .setInternalCommonSubjectIdentifier(SUBJECT.getValue());
+        setUpClientSession(CLIENT_SESSION_ID, CLIENT_ID);
+        when(sessionService.getSessionFromSessionCookie(anyMap())).thenReturn(Optional.of(session));
     }
 
     @AfterEach
@@ -180,6 +184,7 @@ public class LogoutServiceTest {
     void successfullyReturnsClientLogoutResponse() {
         APIGatewayProxyResponseEvent response =
                 logoutService.handleLogout(
+                        Optional.of(session),
                         Optional.empty(),
                         Optional.of(CLIENT_LOGOUT_URI),
                         Optional.of(STATE.getValue()),
@@ -187,12 +192,18 @@ public class LogoutServiceTest {
                         Optional.of(audience.get()),
                         rpPairwiseId);
 
+        verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
+        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
+        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
         assertThat(
@@ -204,6 +215,7 @@ public class LogoutServiceTest {
     void successfullyReturnsLogoutResponseWithoutStateWhenStateIsAbsent() {
         APIGatewayProxyResponseEvent response =
                 logoutService.handleLogout(
+                        Optional.of(session),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
@@ -211,12 +223,18 @@ public class LogoutServiceTest {
                         audience,
                         rpPairwiseId);
 
+        verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
+        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
+        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
         assertThat(
@@ -228,6 +246,7 @@ public class LogoutServiceTest {
     void successfullyReturnsDefaultLogoutResponseWithStateWhenStateIsPresent() {
         APIGatewayProxyResponseEvent response =
                 logoutService.handleLogout(
+                        Optional.of(session),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.of(STATE.getValue()),
@@ -235,12 +254,18 @@ public class LogoutServiceTest {
                         audience,
                         rpPairwiseId);
 
+        verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
+        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
+        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
         assertThat(
@@ -253,20 +278,26 @@ public class LogoutServiceTest {
         var errorObject = new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "invalid session");
         APIGatewayProxyResponseEvent response =
                 logoutService.handleLogout(
+                        Optional.of(session),
                         Optional.of(errorObject),
                         Optional.empty(),
                         Optional.empty(),
                         auditUser,
-                        Optional.empty(),
+                        Optional.of(CLIENT_ID),
                         rpPairwiseId);
 
+        verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
+        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
-                        AuditService.UNKNOWN,
+                        CLIENT_ID,
                         auditUser,
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
-        verifyNoInteractions(cloudwatchMetricsService);
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
+        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
 
@@ -285,7 +316,15 @@ public class LogoutServiceTest {
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
         verify(sessionService).deleteSessionFromRedis(session.getSessionId());
-        verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, CLIENT_ID, auditUser);
+        verify(auditService)
+                .submitAuditEvent(
+                        LOG_OUT_SUCCESS,
+                        CLIENT_ID,
+                        auditUser,
+                        AuditService.MetadataPair.pair("logoutReason", "intervention"));
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
         verify(cloudwatchMetricsService)
                 .incrementLogout(Optional.of(CLIENT_ID), Optional.of(intervention));
 
@@ -306,7 +345,15 @@ public class LogoutServiceTest {
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
         verify(sessionService).deleteSessionFromRedis(session.getSessionId());
-        verify(auditService).submitAuditEvent(LOG_OUT_SUCCESS, CLIENT_ID, auditUser);
+        verify(auditService)
+                .submitAuditEvent(
+                        LOG_OUT_SUCCESS,
+                        CLIENT_ID,
+                        auditUser,
+                        AuditService.MetadataPair.pair("logoutReason", "intervention"));
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
         verify(cloudwatchMetricsService)
                 .incrementLogout(Optional.of(CLIENT_ID), Optional.of(intervention));
 
@@ -328,6 +375,7 @@ public class LogoutServiceTest {
         input.setRequestContext(contextWithSourceIp("123.123.123.123"));
 
         logoutService.handleLogout(
+                Optional.of(session),
                 Optional.empty(),
                 Optional.of(CLIENT_LOGOUT_URI),
                 Optional.of(STATE.getValue()),
@@ -335,37 +383,18 @@ public class LogoutServiceTest {
                 Optional.empty(),
                 rpPairwiseId);
 
-        verify(sessionService, times(0)).deleteSessionFromRedis(SESSION_ID);
-        verifyNoInteractions(cloudwatchMetricsService);
+        verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
+        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
+        verify(cloudwatchMetricsService).incrementLogout(Optional.empty());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
                         AuditService.UNKNOWN,
                         auditUserWhenNoCookie,
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
-    }
-
-    @Test
-    void sessionsAreDeletedWhenDestroySessionsIsCalled() {
-
-        setupAdditionalClientSessions();
-
-        logoutService.destroySessions(session);
-
-        verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id-1")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
-        verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id-2")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
-        verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id-3")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
-
-        verify(clientSessionService).deleteStoredClientSession("client-session-id-1");
-        verify(clientSessionService).deleteStoredClientSession("client-session-id-2");
-        verify(clientSessionService).deleteStoredClientSession("client-session-id-3");
-        verify(sessionService, times(1)).deleteSessionFromRedis(SESSION_ID);
     }
 
     @Test
@@ -388,6 +417,7 @@ public class LogoutServiceTest {
     void includesRpPairwiseIdInLogOutSuccessAuditEventWhenItIsAvailable() {
 
         logoutService.handleLogout(
+                Optional.of(session),
                 Optional.empty(),
                 Optional.of(CLIENT_LOGOUT_URI),
                 Optional.of(STATE.getValue()),
@@ -403,10 +433,48 @@ public class LogoutServiceTest {
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
     }
 
-    private Session generateSession() {
-        return new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID);
-    }
+    @Test
+    void sessionsAreAllDeletedOnLogout() {
+        setupAdditionalClientSessions();
 
+        APIGatewayProxyResponseEvent response =
+                logoutService.handleLogout(
+                        Optional.of(session),
+                        Optional.empty(),
+                        Optional.of(CLIENT_LOGOUT_URI),
+                        Optional.of(STATE.getValue()),
+                        auditUser,
+                        Optional.of(audience.get()),
+                        rpPairwiseId);
+
+        verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
+        verify(clientSessionService).deleteStoredClientSession("client-session-id-2");
+        verify(clientSessionService).deleteStoredClientSession("client-session-id-3");
+        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(auditService)
+                .submitAuditEvent(
+                        LOG_OUT_SUCCESS,
+                        CLIENT_ID,
+                        auditUser,
+                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
+                        AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id-2")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id-3")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
+        verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
+
+        assertThat(response, hasStatus(302));
+        assertThat(
+                response.getHeaders().get(ResponseHeaders.LOCATION),
+                equalTo(CLIENT_LOGOUT_URI + "?state=" + STATE));
+    }
+    
     public static ArgumentMatcher<ClientRegistry> withClientId(String clientId) {
         return new ArgumentMatcher<>() {
             @Override
@@ -422,25 +490,10 @@ public class LogoutServiceTest {
     }
 
     private void setupAdditionalClientSessions() {
-        setUpClientSession("client-session-id-1", "client-id-1");
         setUpClientSession("client-session-id-2", "client-id-2");
         setUpClientSession("client-session-id-3", "client-id-3");
         generateSessionFromCookie(session);
         setupClientSessionToken(signedIDToken);
-    }
-
-    private void setUpClientSession(String clientSessionId, String clientId) {
-        session.getClientSessions().add(clientSessionId);
-        when(clientSessionService.getClientSession(clientSessionId))
-                .thenReturn(
-                        Optional.of(
-                                new ClientSession(
-                                        Map.of("client_id", List.of(clientId)),
-                                        LocalDateTime.now(),
-                                        List.of(VectorOfTrust.getDefaults()),
-                                        "client_name")));
-        when(dynamoClientService.getClient(clientId))
-                .thenReturn(Optional.of(new ClientRegistry().withClientID(clientId)));
     }
 
     private void generateSessionFromCookie(Session session) {
@@ -467,5 +520,19 @@ public class LogoutServiceTest {
         clientSession.setIdTokenHint(idToken.serialize());
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(clientSession));
+    }
+
+    private void setUpClientSession(String clientSessionId, String clientId) {
+        session.getClientSessions().add(clientSessionId);
+        when(clientSessionService.getClientSession(clientSessionId))
+                .thenReturn(
+                        Optional.of(
+                                new ClientSession(
+                                        Map.of("client_id", List.of(clientId)),
+                                        LocalDateTime.now(),
+                                        List.of(VectorOfTrust.getDefaults()),
+                                        "client_name")));
+        when(dynamoClientService.getClient(clientId))
+                .thenReturn(Optional.of(new ClientRegistry().withClientID(clientId)));
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -199,6 +199,7 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
+                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
@@ -230,6 +231,7 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
+                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
@@ -261,6 +263,7 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
+                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
@@ -293,6 +296,7 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
+                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
@@ -408,6 +412,7 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         AuditService.UNKNOWN,
                         auditUserWhenNoCookie,
+                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
     }
 
@@ -444,6 +449,7 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
+                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
                         AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
     }
 


### PR DESCRIPTION
## What

- Refactored Logout Service / Logout Handler to destroy session in Logout Service rather than Logout Handler.
- Pass Reauthentication Failures To RP
- Add "logout reason" extension to LOG_OUT_SUCCESS audit event.

## How to review

Code Review

## Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.