### PR TITLE
AUT-2498: Deploy ticf handler to integration

### DIFF
--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -42,7 +42,7 @@ locals {
 
   request_tracing_allowed              = contains(["build", "sandpit"], var.environment)
   deploy_account_interventions_count   = 1
-  deploy_ticf_cri_count                = contains(["sandpit", "authdev1", "authdev2", "dev", "build", "staging"], var.environment) ? 1 : 0
+  deploy_ticf_cri_count                = contains(["sandpit", "authdev1", "authdev2", "dev", "build", "staging", "integration"], var.environment) ? 1 : 0
   deploy_reauth_user_count             = contains(["build", "sandpit", "authdev1", "authdev2", "staging", "integration"], var.environment) ? 1 : 0
   deploy_check_email_fraud_block_count = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
 


### PR DESCRIPTION
This does yet enable the calls to the ticf cri as part of normal journeys, but just deploys the handler so we can test it out in the aws console.

The relevant variables have been populated in secrets


## How to review

1. Code Review

