### PR TITLE
ATO-694: Fetch and cache RP public key from JWKS URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ logs/
 .vscode/
 .venv/
 .aws-sam
+**/.DS_Store
 
 # Approval Tests
 *.received.txt

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -38,6 +38,7 @@ import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.extensions.DocAppJwksExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.RpPublicKeyCacheExtension;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 
 import java.net.HttpCookie;
@@ -98,6 +99,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @RegisterExtension
     public static final KmsKeyExtension tokenSigningKey = new KmsKeyExtension("token-signing-key");
+
+    @RegisterExtension
+    public static final RpPublicKeyCacheExtension rpPublicKeyCacheExtension =
+            new RpPublicKeyCacheExtension(180);
 
     public static final String publicKey =
             "-----BEGIN PUBLIC KEY-----\n"

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -39,6 +39,7 @@ import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -51,6 +52,7 @@ import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.orchestration.sharedtest.extensions.RpPublicKeyCacheExtension;
 import uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.orchestration.sharedtest.helper.JsonArrayHelper;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
@@ -90,6 +92,10 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String DIFFERENT_CLIENT_ID = "different-test-id";
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
     private static final String REDIRECT_URI = "http://localhost/redirect";
+
+    @RegisterExtension
+    public static final RpPublicKeyCacheExtension rpPublicKeyCacheExtension =
+            new RpPublicKeyCacheExtension(180);
 
     @BeforeEach
     void setup() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/RpPublicKeyCacheServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/RpPublicKeyCacheServiceIntegrationTest.java
@@ -1,0 +1,35 @@
+package uk.gov.di.authentication.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.orchestration.shared.entity.RpPublicKeyCache;
+import uk.gov.di.orchestration.sharedtest.extensions.RpPublicKeyCacheExtension;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class RpPublicKeyCacheServiceIntegrationTest {
+
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String KEY_ID = "test-key-id";
+    private static final String PUBLIC_KEY = "test-public-key";
+
+    @RegisterExtension
+    protected static final RpPublicKeyCacheExtension rpPublicKeyCacheExtension =
+            new RpPublicKeyCacheExtension(180);
+
+    @Test
+    void shouldAddAndRetrieveUserInfo() {
+        rpPublicKeyCacheExtension.addRpPublicKeyCacheData(CLIENT_ID, KEY_ID, PUBLIC_KEY);
+
+        Optional<RpPublicKeyCache> retrievedUserInfo =
+                rpPublicKeyCacheExtension.getRpPublicKeyCacheData(CLIENT_ID, KEY_ID);
+
+        assertThat(retrievedUserInfo.isPresent(), equalTo(true));
+        assertThat(retrievedUserInfo.get().getClientId(), equalTo(CLIENT_ID));
+        assertThat(retrievedUserInfo.get().getKeyId(), equalTo(KEY_ID));
+        assertThat(retrievedUserInfo.get().getPublicKey(), equalTo(PUBLIC_KEY));
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -47,6 +47,8 @@ import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
+import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.DocAppSubjectIdHelper;
@@ -81,6 +83,8 @@ import java.util.stream.Collectors;
 
 import static com.nimbusds.oauth2.sdk.OAuth2Error.ACCESS_DENIED_CODE;
 import static com.nimbusds.oauth2.sdk.OAuth2Error.INVALID_REQUEST;
+import static com.nimbusds.oauth2.sdk.OAuth2Error.SERVER_ERROR;
+import static com.nimbusds.oauth2.sdk.OAuth2Error.VALIDATION_FAILED;
 import static java.util.Objects.isNull;
 import static uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService.VTR_PARAM;
 import static uk.gov.di.orchestration.shared.conditions.IdentityHelper.identityRequired;
@@ -324,6 +328,12 @@ public class AuthorisationHandler
         } catch (ClientRedirectUriValidationException e) {
             return generateApiGatewayProxyResponse(
                     INVALID_REQUEST.getHTTPStatusCode(), INVALID_REQUEST.getDescription());
+        } catch (ClientSignatureValidationException e) {
+            return generateApiGatewayProxyResponse(
+                    VALIDATION_FAILED.getHTTPStatusCode(), VALIDATION_FAILED.getDescription());
+        } catch (JwksException e) {
+            return generateApiGatewayProxyResponse(
+                    SERVER_ERROR.getHTTPStatusCode(), SERVER_ERROR.getDescription());
         }
 
         if (authRequestError.isPresent()) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -119,7 +119,7 @@ public class TokenHandler
         this.tokenClientAuthValidatorFactory =
                 new TokenClientAuthValidatorFactory(
                         new DynamoClientService(configurationService),
-                        new ClientSignatureValidationService(oidcApi));
+                        new ClientSignatureValidationService(configurationService));
     }
 
     public TokenHandler(ConfigurationService configurationService, RedisConnectionService redis) {
@@ -142,7 +142,7 @@ public class TokenHandler
         this.tokenClientAuthValidatorFactory =
                 new TokenClientAuthValidatorFactory(
                         new DynamoClientService(configurationService),
-                        new ClientSignatureValidationService(oidcApi));
+                        new ClientSignatureValidationService(configurationService));
     }
 
     public TokenHandler() {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -6,6 +6,8 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
 import uk.gov.di.authentication.oidc.services.IPVCapacityService;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
@@ -29,7 +31,8 @@ public abstract class BaseAuthorizeValidator {
         this.ipvCapacityService = ipvCapacityService;
     }
 
-    public abstract Optional<AuthRequestError> validate(AuthenticationRequest authRequest);
+    public abstract Optional<AuthRequestError> validate(AuthenticationRequest authRequest)
+            throws ClientSignatureValidationException, JwksException;
 
     ClientRegistry getClientFromDynamo(String clientId) {
         var client = dynamoClientService.getClient(clientId).orElse(null);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -62,7 +62,8 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                 new DynamoClientService(configurationService),
                 new IPVCapacityService(configurationService));
         this.oidcApi = new OidcAPI(configurationService);
-        this.clientSignatureValidationService = new ClientSignatureValidationService(oidcApi);
+        this.clientSignatureValidationService =
+                new ClientSignatureValidationService(configurationService);
     }
 
     @Override

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -18,6 +18,7 @@ import uk.gov.di.orchestration.shared.entity.ValidScopes;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -67,16 +68,17 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
     }
 
     @Override
-    public Optional<AuthRequestError> validate(AuthenticationRequest authRequest) {
+    public Optional<AuthRequestError> validate(AuthenticationRequest authRequest)
+            throws ClientSignatureValidationException, JwksException {
 
         var clientId = authRequest.getClientID().toString();
         attachLogFieldToLogs(CLIENT_ID, clientId);
         ClientRegistry client = getClientFromDynamo(clientId);
 
         var signedJWT = (SignedJWT) authRequest.getRequestObject();
+        clientSignatureValidationService.validate(signedJWT, client);
 
         try {
-            clientSignatureValidationService.validate(signedJWT, client);
             var jwtClaimsSet = signedJWT.getJWTClaimsSet();
 
             if (jwtClaimsSet.getStringClaim("redirect_uri") == null
@@ -186,7 +188,7 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
             }
             LOG.info("RequestObject has passed initial validation");
             return Optional.empty();
-        } catch (ParseException | ClientSignatureValidationException e) {
+        } catch (ParseException e) {
             throw new RuntimeException(e);
         }
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -66,6 +66,8 @@ import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
+import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.helpers.DocAppSubjectIdHelper;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.services.AuditService;
@@ -803,7 +805,8 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldValidateRequestObjectWhenJARValidationIsRequired() throws JOSEException {
+        void shouldValidateRequestObjectWhenJARValidationIsRequired()
+                throws JOSEException, JwksException, ClientSignatureValidationException {
             when(orchestrationAuthorizationService.isJarValidationRequired(any())).thenReturn(true);
             var event = new APIGatewayProxyRequestEvent();
             var jwtClaimsSet = buildjwtClaimsSet("https://localhost/authorize", null, null);
@@ -826,7 +829,8 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldValidateRequestObjectWhenJARValidationIsNotRequired() throws JOSEException {
+        void shouldValidateRequestObjectWhenJARValidationIsNotRequired()
+                throws JOSEException, JwksException, ClientSignatureValidationException {
             when(orchestrationAuthorizationService.isJarValidationRequired(any()))
                     .thenReturn(false);
             var event = new APIGatewayProxyRequestEvent();
@@ -919,7 +923,8 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldRedirectToLoginWhenRequestObjectIsValid() throws JOSEException {
+        void shouldRedirectToLoginWhenRequestObjectIsValid()
+                throws JOSEException, JwksException, ClientSignatureValidationException {
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(Optional.empty());
             var event = new APIGatewayProxyRequestEvent();
@@ -967,7 +972,8 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldRedirectToLoginWhenPostRequestObjectIsValid() throws JOSEException {
+        void shouldRedirectToLoginWhenPostRequestObjectIsValid()
+                throws JOSEException, JwksException, ClientSignatureValidationException {
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(Optional.empty());
             var event = new APIGatewayProxyRequestEvent();
@@ -1011,7 +1017,8 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldRedirectToRPWhenRequestObjectIsNotValid() throws JOSEException {
+        void shouldRedirectToRPWhenRequestObjectIsNotValid()
+                throws JOSEException, JwksException, ClientSignatureValidationException {
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(
                             Optional.of(
@@ -1044,7 +1051,8 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldRedirectToRPWhenPostRequestObjectIsNotValid() throws JOSEException {
+        void shouldRedirectToRPWhenPostRequestObjectIsNotValid()
+                throws JOSEException, JwksException, ClientSignatureValidationException {
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(
                             Optional.of(
@@ -1578,7 +1586,8 @@ class AuthorisationHandlerTest {
 
     @ParameterizedTest
     @MethodSource("expectedErrorObjects")
-    void shouldReturnErrorWhenRequestObjectIsInvalid(ErrorObject errorObject) {
+    void shouldReturnErrorWhenRequestObjectIsInvalid(ErrorObject errorObject)
+            throws JwksException, ClientSignatureValidationException {
         when(orchestrationAuthorizationService.isJarValidationRequired(any())).thenReturn(true);
         when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                 .thenReturn(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.nimbusds.jose.KeySourceException;
 import com.nimbusds.jose.jwk.JWK;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.oidc.entity.JwksResponse;
 import uk.gov.di.orchestration.shared.services.JwksService;
 
 import java.net.MalformedURLException;
@@ -36,11 +35,10 @@ class FetchJwksHandlerTest {
         when(jwksService.retrieveJwkFromURLWithKeyId(new URL(url), keyId)).thenReturn(jwk);
 
         // when
-        JwksResponse response = handler.handleRequest(event, CONTEXT);
+        String response = handler.handleRequest(event, CONTEXT);
 
         // then
-        assertThat(response.jwk().toJSONString(), equalTo(jwkJson));
-        assertThat(response.error(), equalTo(null));
+        assertThat(response, equalTo(jwkJson));
     }
 
     @Test
@@ -52,15 +50,10 @@ class FetchJwksHandlerTest {
                 .thenThrow(new KeySourceException());
 
         // when
-        JwksResponse response = handler.handleRequest(event, CONTEXT);
+        String response = handler.handleRequest(event, CONTEXT);
 
         // then
-        assertThat(
-                response.error().getDescription(),
-                equalTo(
-                        "Failed to fetch JWKS: could not find key in JWKS that matches provided keyId"));
-        assertThat(response.error().getHTTPStatusCode(), equalTo(404));
-        assertThat(response.jwk(), equalTo(null));
+        assertThat(response, equalTo("error"));
     }
 
     @Test
@@ -69,14 +62,10 @@ class FetchJwksHandlerTest {
         Map<String, String> event = Map.of("keyId", keyId);
 
         // when
-        JwksResponse response = handler.handleRequest(event, CONTEXT);
+        String response = handler.handleRequest(event, CONTEXT);
 
         // then
-        assertThat(
-                response.error().getDescription(),
-                equalTo("Failed to fetch JWKS: url and/or keyId parameter not present"));
-        assertThat(response.error().getHTTPStatusCode(), equalTo(400));
-        assertThat(response.jwk(), equalTo(null));
+        assertThat(response, equalTo("error"));
     }
 
     @Test
@@ -85,14 +74,10 @@ class FetchJwksHandlerTest {
         Map<String, String> event = Map.of("url", url);
 
         // when
-        JwksResponse response = handler.handleRequest(event, CONTEXT);
+        String response = handler.handleRequest(event, CONTEXT);
 
         // then
-        assertThat(
-                response.error().getDescription(),
-                equalTo("Failed to fetch JWKS: url and/or keyId parameter not present"));
-        assertThat(response.error().getHTTPStatusCode(), equalTo(400));
-        assertThat(response.jwk(), equalTo(null));
+        assertThat(response, equalTo("error"));
     }
 
     @Test
@@ -101,13 +86,9 @@ class FetchJwksHandlerTest {
         Map<String, String> event = Map.of("url", "not-a-valid-url", "keyId", keyId);
 
         // when
-        JwksResponse response = handler.handleRequest(event, CONTEXT);
+        String response = handler.handleRequest(event, CONTEXT);
 
         // then
-        assertThat(
-                response.error().getDescription(),
-                equalTo("Failed to fetch JWKS: URL is malformed"));
-        assertThat(response.error().getHTTPStatusCode(), equalTo(400));
-        assertThat(response.jwk(), equalTo(null));
+        assertThat(response, equalTo("error"));
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientSignatureValidationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/ClientSignatureValidationServiceTest.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.services.lambda.model.InvokeResponse;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.RpPublicKeyCacheService;
@@ -148,7 +149,7 @@ class ClientSignatureValidationServiceTest {
             var signedJWT = generateSignedJWT(keyPair.getPrivate());
 
             assertThrows(
-                    ClientSignatureValidationException.class,
+                    JwksException.class,
                     () -> clientSignatureValidationService.validate(signedJWT, client));
         }
 
@@ -218,7 +219,12 @@ class ClientSignatureValidationServiceTest {
     private static PrivateKeyJWT generatePrivateKeyJWT(PrivateKey privateKey) {
         try {
             return new PrivateKeyJWT(
-                    new ClientID(CLIENT_ID), TOKEN_URI, JWSAlgorithm.RS256, privateKey, null, null);
+                    new ClientID(CLIENT_ID),
+                    TOKEN_URI,
+                    JWSAlgorithm.RS256,
+                    privateKey,
+                    "12345",
+                    null);
         } catch (JOSEException e) {
             throw new RuntimeException(e);
         }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -23,6 +23,7 @@ import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
 import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
@@ -90,7 +91,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldSuccessfullyProcessRequestUriPayload() throws JOSEException {
+    void shouldSuccessfullyProcessRequestUriPayload()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         List<String> scopes = new ArrayList<>();
         scopes.add("openid");
         scopes.add("doc-checking-app");
@@ -114,7 +116,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldSuccessfullyProcessRequestUriPayloadWhenVtrIsPresent() throws JOSEException {
+    void shouldSuccessfullyProcessRequestUriPayloadWhenVtrIsPresent()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
         List<String> scopes = new ArrayList<>();
         scopes.add("openid");
@@ -201,7 +204,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenClientTypeIsNotAppOrWeb() throws JOSEException {
+    void shouldReturnErrorWhenClientTypeIsNotAppOrWeb()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var clientRegistry =
                 generateClientRegistry(
                         "not-app-or-web",
@@ -233,7 +237,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorForInvalidResponseType() throws JOSEException {
+    void shouldReturnErrorForInvalidResponseType()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -257,7 +262,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorForInvalidResponseTypeInQueryParams() throws JOSEException {
+    void shouldReturnErrorForInvalidResponseTypeInQueryParams()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -291,7 +297,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenClientIDIsInvalid() throws JOSEException {
+    void shouldReturnErrorWhenClientIDIsInvalid()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -314,7 +321,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorForUnsupportedScope() throws JOSEException {
+    void shouldReturnErrorForUnsupportedScope()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -336,7 +344,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorIfVtrIsNotPermittedForGivenClient() throws JOSEException {
+    void shouldReturnErrorIfVtrIsNotPermittedForGivenClient()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -364,7 +373,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenClientHasNotRegisteredDocAppScope() throws JOSEException {
+    void shouldReturnErrorWhenClientHasNotRegisteredDocAppScope()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var clientRegistry =
                 generateClientRegistry(
                         ClientType.APP.getValue(), new Scope(OIDCScopeValue.OPENID.getValue()));
@@ -393,7 +403,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenAuthRequestContainsInvalidScope() throws JOSEException {
+    void shouldReturnErrorWhenAuthRequestContainsInvalidScope()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -419,7 +430,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorForUnregisteredScope() throws JOSEException {
+    void shouldReturnErrorForUnregisteredScope()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -441,7 +453,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorForInvalidAudience() throws JOSEException {
+    void shouldReturnErrorForInvalidAudience()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience("invalid-audience")
@@ -464,7 +477,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorForInvalidIssuer() throws JOSEException {
+    void shouldReturnErrorForInvalidIssuer()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -487,7 +501,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorIfRequestClaimIsPresentJwt() throws JOSEException {
+    void shouldReturnErrorIfRequestClaimIsPresentJwt()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -511,7 +526,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorIfRequestUriClaimIsPresentJwt() throws JOSEException {
+    void shouldReturnErrorIfRequestUriClaimIsPresentJwt()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -535,7 +551,10 @@ class RequestObjectAuthorizeValidatorTest {
 
     @Test
     void shouldThrowWhenUnableToValidateRequestJwtSignature()
-            throws JOSEException, NoSuchAlgorithmException, ClientSignatureValidationException {
+            throws JOSEException,
+                    NoSuchAlgorithmException,
+                    ClientSignatureValidationException,
+                    JwksException {
         var keyPair2 = KeyPairGenerator.getInstance("RSA").generateKeyPair();
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
@@ -559,7 +578,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorIfStateIsMissingFromRequestObject() throws JOSEException {
+    void shouldReturnErrorIfStateIsMissingFromRequestObject()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -584,7 +604,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorIfNonceIsMissingFromRequestObject() throws JOSEException {
+    void shouldReturnErrorIfNonceIsMissingFromRequestObject()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -609,7 +630,8 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorForInvalidUILocales() throws JOSEException {
+    void shouldReturnErrorForInvalidUILocales()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RpPublicKeyCacheExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RpPublicKeyCacheExtension.java
@@ -1,0 +1,92 @@
+package uk.gov.di.orchestration.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.orchestration.shared.entity.RpPublicKeyCache;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.RpPublicKeyCacheService;
+import uk.gov.di.orchestration.sharedtest.basetest.DynamoTestConfiguration;
+
+import java.util.Optional;
+
+public class RpPublicKeyCacheExtension extends DynamoExtension implements AfterEachCallback {
+
+    public static final String TABLE_NAME = "local-RpPublicKeyCache";
+    public static final String CLIENT_ID_FIELD = "clientId";
+    public static final String KEY_ID_FIELD = "keyId";
+
+    private RpPublicKeyCacheService rpPublicKeyCacheService;
+    private final ConfigurationService configuration;
+
+    public RpPublicKeyCacheExtension(long ttl) {
+        createInstance();
+        this.configuration =
+                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT) {
+                    @Override
+                    public long getAccessTokenExpiry() {
+                        return ttl;
+                    }
+                };
+        rpPublicKeyCacheService = new RpPublicKeyCacheService(configuration);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+
+        rpPublicKeyCacheService = new RpPublicKeyCacheService(configuration);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, TABLE_NAME, CLIENT_ID_FIELD, Optional.of(KEY_ID_FIELD));
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(TABLE_NAME)) {
+            createRpPublicKeyCacheTable(TABLE_NAME);
+        }
+    }
+
+    private void createRpPublicKeyCacheTable(String tableName) {
+        CreateTableRequest request =
+                CreateTableRequest.builder()
+                        .tableName(tableName)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.HASH)
+                                        .attributeName(CLIENT_ID_FIELD)
+                                        .build(),
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.RANGE)
+                                        .attributeName(KEY_ID_FIELD)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(CLIENT_ID_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build(),
+                                AttributeDefinition.builder()
+                                        .attributeName(KEY_ID_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .build();
+        dynamoDB.createTable(request);
+    }
+
+    public Optional<RpPublicKeyCache> getRpPublicKeyCacheData(String clientId, String keyId) {
+        return rpPublicKeyCacheService.getRpPublicKeyCacheData(clientId, keyId);
+    }
+
+    public void addRpPublicKeyCacheData(String clientId, String keyId, String publicKey) {
+        rpPublicKeyCacheService.addRpPublicKeyCacheData(clientId, keyId, publicKey);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/RpPublicKeyCache.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/RpPublicKeyCache.java
@@ -1,0 +1,71 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+@DynamoDbBean
+public class RpPublicKeyCache {
+
+    private String clientId;
+    private String keyId;
+    private String publicKey;
+    private long timeToLive;
+
+    @DynamoDbPartitionKey
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public RpPublicKeyCache withClientId(String clientId) {
+        this.clientId = clientId;
+        return this;
+    }
+
+    @DynamoDbSortKey
+    public String getKeyId() {
+        return keyId;
+    }
+
+    public void setKeyId(String keyId) {
+        this.keyId = keyId;
+    }
+
+    public RpPublicKeyCache withKeyId(String keyId) {
+        this.keyId = keyId;
+        return this;
+    }
+
+    @DynamoDbAttribute("publicKey")
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    public RpPublicKeyCache withPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+        return this;
+    }
+
+    @DynamoDbAttribute("ttl")
+    public long getTimeToLive() {
+        return timeToLive;
+    }
+
+    public void setTimeToLive(long timeToLive) {
+        this.timeToLive = timeToLive;
+    }
+
+    public RpPublicKeyCache withTimeToLive(long timeToLive) {
+        this.timeToLive = timeToLive;
+        return this;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/JwksException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/JwksException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.orchestration.shared.exceptions;
+
+public class JwksException extends Exception {
+
+    public JwksException(String message) {
+        super(message);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
@@ -21,8 +21,17 @@ public class BaseDynamoService<T> {
 
     public BaseDynamoService(
             Class<T> objectClass, String table, ConfigurationService configurationService) {
+        this(objectClass, table, configurationService, false);
+    }
+
+    public BaseDynamoService(
+            Class<T> objectClass,
+            String table,
+            ConfigurationService configurationService,
+            boolean isTableInOrchAccount) {
+
         var tableName = table;
-        if (configurationService.getDynamoArnPrefix().isPresent()) {
+        if (configurationService.getDynamoArnPrefix().isPresent() && !isTableInOrchAccount) {
             tableName = configurationService.getDynamoArnPrefix().get() + tableName;
         } else {
             tableName = configurationService.getEnvironment() + "-" + tableName;
@@ -46,6 +55,12 @@ public class BaseDynamoService<T> {
     public Optional<T> get(String partition) {
         return Optional.ofNullable(
                 dynamoTable.getItem(Key.builder().partitionValue(partition).build()));
+    }
+
+    public Optional<T> get(String partition, String sort) {
+        return Optional.ofNullable(
+                dynamoTable.getItem(
+                        Key.builder().partitionValue(partition).sortValue(sort).build()));
     }
 
     public void delete(String partition) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
@@ -191,7 +191,8 @@ public class ClientSignatureValidationService {
             InvokeRequest request =
                     InvokeRequest.builder()
                             .functionName(
-                                    configurationService.getEnvironment() + "-FetchJwksFunction")
+                                    configurationService.getEnvironment()
+                                            + "-FetchJwksFunction:latest")
                             .payload(payload)
                             .build();
             return awsLambda.invoke(request);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
@@ -128,10 +128,7 @@ public class ClientSignatureValidationService {
     }
 
     private PublicKey retrievePublicKey(ClientRegistry client, String kid)
-            throws NoSuchAlgorithmException,
-                    InvalidKeySpecException,
-                    ClientSignatureValidationException,
-                    JwksException {
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JwksException {
         try {
             if (client.getPublicKeySource().equals(PublicKeySource.STATIC.getValue())) {
                 return convertPemToPublicKey(client.getPublicKey());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
@@ -13,6 +13,7 @@ import com.nimbusds.oauth2.sdk.id.Audience;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.lambda.LambdaClient;
@@ -59,6 +60,7 @@ public class ClientSignatureValidationService {
         this.lambdaClient =
                 LambdaClient.builder()
                         .region(Region.of(configurationService.getAwsRegion()))
+                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
                         .build();
         this.oidcAPI = new OidcAPI(configurationService);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
@@ -3,6 +3,7 @@ package uk.gov.di.orchestration.shared.services;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyType;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
@@ -11,9 +12,19 @@ import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+import software.amazon.awssdk.services.lambda.model.LambdaException;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.PublicKeySource;
+import uk.gov.di.orchestration.shared.entity.RpPublicKeyCache;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.validation.PrivateKeyJwtAuthPublicKeySelector;
 
 import java.net.URI;
@@ -23,27 +34,54 @@ import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.text.ParseException;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Optional;
 
 import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
 
 public class ClientSignatureValidationService {
 
     private static final Logger LOG = LogManager.getLogger(ClientSignatureValidationService.class);
-
     private static final String TOKEN_PATH = "token";
 
     private final OidcAPI oidcAPI;
+    private final ConfigurationService configurationService;
+    private final RpPublicKeyCacheService rpPublicKeyCacheService;
+    private final LambdaClient lambdaClient;
+    private final Json objectMapper = SerializationService.getInstance();
 
-    public ClientSignatureValidationService(OidcAPI oidcApi) {
-        this.oidcAPI = oidcApi;
+    public ClientSignatureValidationService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.rpPublicKeyCacheService = new RpPublicKeyCacheService(configurationService);
+        this.lambdaClient =
+                LambdaClient.builder()
+                        .region(Region.of(configurationService.getAwsRegion()))
+                        .build();
+        this.oidcAPI = new OidcAPI(configurationService);
+    }
+
+    public ClientSignatureValidationService(
+            ConfigurationService configurationService,
+            RpPublicKeyCacheService rpPublicKeyCacheService,
+            LambdaClient lambdaClient) {
+        this.configurationService = configurationService;
+        this.rpPublicKeyCacheService = rpPublicKeyCacheService;
+        this.lambdaClient = lambdaClient;
+        this.oidcAPI = new OidcAPI(configurationService);
     }
 
     public void validate(SignedJWT signedJWT, ClientRegistry client)
             throws ClientSignatureValidationException {
         try {
-            var publicKey = getPublicKey(client);
+            PublicKey publicKey;
+            if (configurationService.fetchRpPublicKeyFromJwksEnabled()) {
+                publicKey = retrievePublicKey(client, signedJWT.getHeader().getKeyID());
+            } else {
+                publicKey = convertPemToPublicKey(client.getPublicKey());
+            }
+
             JWSVerifier verifier = new RSASSAVerifier((RSAPublicKey) publicKey);
             if (!signedJWT.verify(verifier)) {
                 throw new ClientSignatureValidationException("Failed to verify Signed JWT.");
@@ -62,7 +100,14 @@ public class ClientSignatureValidationService {
     public void validateTokenClientAssertion(PrivateKeyJWT privateKeyJWT, ClientRegistry client)
             throws ClientSignatureValidationException {
         try {
-            var publicKey = getPublicKey(client);
+            PublicKey publicKey;
+            if (configurationService.fetchRpPublicKeyFromJwksEnabled()) {
+                publicKey =
+                        retrievePublicKey(
+                                client, privateKeyJWT.getClientAssertion().getHeader().getKeyID());
+            } else {
+                publicKey = convertPemToPublicKey(client.getPublicKey());
+            }
             ClientAuthenticationVerifier<?> authenticationVerifier =
                     new ClientAuthenticationVerifier<>(
                             new PrivateKeyJwtAuthPublicKeySelector(publicKey),
@@ -79,12 +124,78 @@ public class ClientSignatureValidationService {
         }
     }
 
-    private PublicKey getPublicKey(ClientRegistry client)
+    private PublicKey retrievePublicKey(ClientRegistry client, String kid)
+            throws NoSuchAlgorithmException,
+                    InvalidKeySpecException,
+                    ClientSignatureValidationException {
+        try {
+            if (client.getPublicKeySource().equals(PublicKeySource.STATIC.getValue())) {
+                return convertPemToPublicKey(client.getPublicKey());
+            }
+            if (kid == null) {
+                String error = "Key ID is null but is required to fetch JWKS";
+                LOG.error(error);
+                throw new ClientSignatureValidationException(error);
+            }
+            String jwksUrl = client.getJwksUrl();
+            if (client.getJwksUrl() == null) {
+                String error = "Client JWKS URL is null but is required to fetch JWKS";
+                LOG.error(error);
+                throw new ClientSignatureValidationException(error);
+            }
+            Optional<RpPublicKeyCache> cache =
+                    rpPublicKeyCacheService.getRpPublicKeyCacheData(client.getClientID(), kid);
+            if (cache.isPresent()) {
+                return JWK.parse(cache.get().getPublicKey()).toRSAKey().toPublicKey();
+            }
+
+            InvokeResponse response = invokeFetchJwksFunction(lambdaClient, jwksUrl, kid);
+            String unescapedPayload =
+                    objectMapper.readValue(response.payload().asUtf8String(), String.class);
+            if (unescapedPayload.equals("error")) {
+                String error = "Returned error from FetchJwksHandler";
+                LOG.error(error);
+                throw new ClientSignatureValidationException(error);
+            }
+
+            JWK jwk = JWK.parse(unescapedPayload);
+            rpPublicKeyCacheService.addRpPublicKeyCacheData(
+                    client.getClientID(), jwk.getKeyID(), jwk.toJSONString());
+            return jwk.toRSAKey().toPublicKey();
+        } catch (ParseException | Json.JsonException e) {
+            throw new RuntimeException();
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static PublicKey convertPemToPublicKey(String publicKeyPem)
             throws NoSuchAlgorithmException, InvalidKeySpecException {
-        byte[] decodedKey = Base64.getMimeDecoder().decode(client.getPublicKey());
+        byte[] decodedKey = Base64.getMimeDecoder().decode(publicKeyPem);
         X509EncodedKeySpec keySpec = new X509EncodedKeySpec(decodedKey);
         KeyFactory kf = KeyFactory.getInstance(KeyType.RSA.getValue());
         return kf.generatePublic(keySpec);
+    }
+
+    private InvokeResponse invokeFetchJwksFunction(
+            LambdaClient awsLambda, String jwksUrl, String kid) {
+        try {
+            JSONObject jsonObj = new JSONObject();
+            jsonObj.put("url", jwksUrl);
+            jsonObj.put("keyId", kid);
+            String json = jsonObj.toString();
+            SdkBytes payload = SdkBytes.fromUtf8String(json);
+
+            InvokeRequest request =
+                    InvokeRequest.builder()
+                            .functionName(
+                                    configurationService.getEnvironment() + "-FetchJwksFunction")
+                            .payload(payload)
+                            .build();
+            return awsLambda.invoke(request);
+        } catch (LambdaException e) {
+            throw new RuntimeException();
+        }
     }
 
     private URI getTokenURI() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -196,6 +196,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Optional.ofNullable(System.getenv("DYNAMO_ENDPOINT"));
     }
 
+    public boolean fetchRpPublicKeyFromJwksEnabled() {
+        return getFlagOrFalse("FETCH_RP_PUBLIC_KEY_FROM_JWKS_ENABLED");
+    }
+
     public String getSpotQueueURI() {
         return System.getenv("SPOT_QUEUE_URL");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/RpPublicKeyCacheService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/RpPublicKeyCacheService.java
@@ -1,0 +1,36 @@
+package uk.gov.di.orchestration.shared.services;
+
+import uk.gov.di.orchestration.shared.entity.RpPublicKeyCache;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+public class RpPublicKeyCacheService extends BaseDynamoService<RpPublicKeyCache> {
+
+    private final long timeToLive;
+
+    public RpPublicKeyCacheService(ConfigurationService configurationService) {
+        super(RpPublicKeyCache.class, "RpPublicKeyCache", configurationService, true);
+        this.timeToLive = 86400L; // 24 hours
+    }
+
+    public void addRpPublicKeyCacheData(String clientId, String keyId, String publicKey) {
+        var dbObject =
+                new RpPublicKeyCache()
+                        .withClientId(clientId)
+                        .withKeyId(keyId)
+                        .withPublicKey(publicKey)
+                        .withTimeToLive(
+                                NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond());
+
+        put(dbObject);
+    }
+
+    public Optional<RpPublicKeyCache> getRpPublicKeyCacheData(String clientId, String keyId) {
+        return get(clientId, keyId)
+                .filter(t -> t.getTimeToLive() > NowHelper.now().toInstant().getEpochSecond());
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidator.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidator.java
@@ -11,6 +11,7 @@ import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
@@ -88,9 +89,17 @@ public class PrivateKeyJwtClientAuthValidator extends TokenClientAuthValidator {
                     ClientAuthenticationMethod.PRIVATE_KEY_JWT,
                     UNKNOWN_CLIENT_ID);
         } catch (ParseException e) {
-            LOG.warn("Unable to parse private_kew_jwt", e);
+            LOG.warn("Unable to parse private_key_jwt", e);
             throw new TokenAuthInvalidException(
                     new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Invalid private_key_jwt"),
+                    ClientAuthenticationMethod.PRIVATE_KEY_JWT,
+                    UNKNOWN_CLIENT_ID);
+        } catch (JwksException e) {
+            LOG.warn("Failed to fetch or parse JWKS to verify signature of private_key_jwt", e);
+            throw new TokenAuthInvalidException(
+                    new ErrorObject(
+                            OAuth2Error.SERVER_ERROR_CODE,
+                            "Failed to fetch or parse JWKS to verify signature of private_key_jwt"),
                     ClientAuthenticationMethod.PRIVATE_KEY_JWT,
                     UNKNOWN_CLIENT_ID);
         }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.authentication.oidc.services;
+package uk.gov.di.orchestration.shared.services;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -27,9 +27,6 @@ import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
-import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
-import uk.gov.di.orchestration.shared.services.ConfigurationService;
-import uk.gov.di.orchestration.shared.services.RpPublicKeyCacheService;
 
 import java.net.URI;
 import java.security.KeyPair;

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
@@ -174,7 +175,7 @@ class PrivateKeyJwtClientAuthValidatorTest {
 
     @Test
     void shouldThrowIfUnableToValidatePrivateKeyJWTSignature()
-            throws JOSEException, ClientSignatureValidationException {
+            throws JOSEException, ClientSignatureValidationException, JwksException {
         var invalidKeyPair = generateRsaKeyPair();
         var publicKey =
                 Base64.getMimeEncoder().encodeToString(invalidKeyPair.getPublic().getEncoded());

--- a/template.yaml
+++ b/template.yaml
@@ -4412,7 +4412,7 @@ Resources:
         Statement:
           - Effect: Allow
             Action: lambda:InvokeFunction
-            Resource: !Sub arn:aws:lambda:eu-west-2:${AWS::AccountId}:function:${Environment}-FetchJwksFunction
+            Resource: !Sub arn:aws:lambda:eu-west-2:${AWS::AccountId}:function:${Environment}-FetchJwksFunction:latest
 
   #endregion
 

--- a/template.yaml
+++ b/template.yaml
@@ -2043,6 +2043,7 @@ Resources:
         - !Ref OrchToAuthSigningKmsAccessPolicy
         - !Ref AuthPublicEncryptionKeyAccessPolicy
         - !Ref IpvCapacityAccessPolicy
+        - !Ref InvokeFetchJwksHandlerPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -4374,6 +4375,17 @@ Resources:
           - Effect: Allow
             Action: kms:Decrypt
             Resource: !GetAtt MainKmsKey.Arn
+
+  InvokeFetchJwksHandlerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: lambda:InvokeFunction
+            Resource: !Sub arn:aws:lambda:eu-west-2:${AWS::AccountId}:function:${Environment}-FetchJwksFunction
+
 
   #endregion
 

--- a/template.yaml
+++ b/template.yaml
@@ -396,19 +396,8 @@ Resources:
       Handler: uk.gov.di.authentication.oidc.lambda.FetchJwksHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref FetchJwksFunctionLogGroup
-      ProvisionedConcurrencyConfig: !If
-        - EnableProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap
-            - ProvisionedConcurrency
-            - !Ref Environment
-            - FetchJwksFunction
-            - DefaultValue:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  defaultProvisionedConcurrency,
-                ]
-        - !Ref AWS::NoValue
+      SnapStart:
+        ApplyOn: PublishedVersions
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_117
 

--- a/template.yaml
+++ b/template.yaml
@@ -1112,6 +1112,7 @@ Resources:
         - !Ref RedisParametersAccessPolicy
         - !Ref IdTokenKmsAccessPolicy
         - !Ref IdTokenKmsRsaAccessPolicy
+        - !Ref RpPublicKeyCacheTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -2039,6 +2040,8 @@ Resources:
         - !Ref AuthPublicEncryptionKeyAccessPolicy
         - !Ref IpvCapacityAccessPolicy
         - !Ref InvokeFetchJwksHandlerPolicy
+        - !Ref RpPublicKeyCacheTableWriteAccessPolicy
+        - !Ref RpPublicKeyCacheTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -4048,6 +4051,36 @@ Resources:
                 !Ref Environment,
                 authenticationCallbackUserinfoKeyArn,
               ]
+
+  RpPublicKeyCacheTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowRpPublicKeyCacheTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt RpPublicKeyCacheTable.Arn
+          - Sid: AllowRpPublicKeyCacheTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: !GetAtt RpPublicKeyTableEncryptionKey.Arn
+
+  RpPublicKeyCacheTableWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowRpPublicKeyCacheTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+            Resource: !GetAtt RpPublicKeyCacheTable.Arn
 
   TxmaQueueSendPermissionPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -1114,6 +1114,7 @@ Resources:
         - !Ref IdTokenKmsRsaAccessPolicy
         - !Ref InvokeFetchJwksHandlerPolicy
         - !Ref RpPublicKeyCacheTableReadAccessPolicy
+        - !Ref RpPublicKeyCacheTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 

--- a/template.yaml
+++ b/template.yaml
@@ -1104,6 +1104,11 @@ Resources:
                   !Ref Environment,
                   authEnvironment,
                 ]
+          FETCH_RP_PUBLIC_KEY_FROM_JWKS_ENABLED: !If
+            - IsNotDevEnvironment
+            - false
+            - true
+
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -1112,6 +1112,7 @@ Resources:
         - !Ref RedisParametersAccessPolicy
         - !Ref IdTokenKmsAccessPolicy
         - !Ref IdTokenKmsRsaAccessPolicy
+        - !Ref InvokeFetchJwksHandlerPolicy
         - !Ref RpPublicKeyCacheTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173

--- a/template.yaml
+++ b/template.yaml
@@ -357,7 +357,7 @@ Resources:
     Type: AWS::DynamoDB::Table
     # checkov:skip=CKV_AWS_28: It would be harmful to restore old keys from a backup of this data, and keys will be fetched if not present anyway.
     Properties:
-      TableName: RpPublicKeyCache
+      TableName: !Sub ${Environment}-RpPublicKeyCache
       AttributeDefinitions:
         - AttributeName: clientId
           AttributeType: S

--- a/template.yaml
+++ b/template.yaml
@@ -2033,6 +2033,12 @@ Resources:
           REDIS_KEY: session
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
+          TXMA_AUDIT_ENCODED_ENABLED: true
+          FETCH_RP_PUBLIC_KEY_FROM_JWKS_ENABLED: !If
+            - IsNotDevEnvironment
+            - false
+            - true
+
 
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -55,6 +55,8 @@ Conditions:
         !Equals [production, !Ref Environment],
       ],
     ]
+  EnableFetchJwks:
+    !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]]
 
 Mappings:
   EnvironmentConfiguration:
@@ -1105,9 +1107,9 @@ Resources:
                   authEnvironment,
                 ]
           FETCH_RP_PUBLIC_KEY_FROM_JWKS_ENABLED: !If
-            - IsNotDevEnvironment
-            - false
+            - EnableFetchJwks
             - true
+            - false
 
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
@@ -2032,9 +2034,9 @@ Resources:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           TXMA_AUDIT_ENCODED_ENABLED: true
           FETCH_RP_PUBLIC_KEY_FROM_JWKS_ENABLED: !If
-            - IsNotDevEnvironment
-            - false
+            - EnableFetchJwks
             - true
+            - false
 
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -2029,7 +2029,6 @@ Resources:
             - false
             - true
 
-
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
@@ -4413,7 +4412,6 @@ Resources:
           - Effect: Allow
             Action: lambda:InvokeFunction
             Resource: !Sub arn:aws:lambda:eu-west-2:${AWS::AccountId}:function:${Environment}-FetchJwksFunction
-
 
   #endregion
 


### PR DESCRIPTION
## What

Enable fetching, caching, and retrieval of an RP public key that is served on a JWKS endpoint.

The first several commits are for setup.
The actual code to fetch / cache / retrieve the key is introduced in 1ab172b.

## How to review

1. For now code review only, easiest commit-by-commit

## Testing
Has been tested in dev with a dummy JWKS URL and a hard-coded `kid` value. Validation obviously fails but keys can be fetched from the URL, and cached and retrieved from the DB successfully.

## Still to do
I wanted to raise this PR now, but still have a few things to do:

- [x] Fix failing integration tests (failing due to not being able to find the new DynamoDB table)
- [ ] Add integration test(s)
- [x] Update the RP stub to send `kid` in the authorize request so that this can be fully tested in dev
- [ ] Run through testing in dev
- [x] sonar issues
- [ ] Update tech docs to explain 
  - [ ] Failure response codes, either due to validation error or fetching JWKS error
  - [ ]  Requirement that RP JWKS endpoint must respond within 5(?) seconds
- [x] Raise a ticket to remove the feature flag

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.


## Related PRs
PR which introduced FetchJwksFunction: https://github.com/govuk-one-login/authentication-api/pull/4747
