### PR TITLE
BAU: Better GHA gradle caching

### DIFF
--- a/.github/workflows/call_build-single-api-module.yml
+++ b/.github/workflows/call_build-single-api-module.yml
@@ -39,7 +39,7 @@ on:
       java_distribution:
         description: "The Java distribution to use"
         type: string
-        default: "temurin"
+        default: "corretto"
 
 jobs:
   build:

--- a/.github/workflows/call_build-single-api-module.yml
+++ b/.github/workflows/call_build-single-api-module.yml
@@ -71,21 +71,12 @@ jobs:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
 
-      - name: Set up Gradle cache for ${{ inputs.module_name }}
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ inputs.module_name }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-${{ inputs.module_name }}
-            ${{ runner.os }}-gradle-
-
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
         with:
-          cache-disabled: true
+          gradle-version: wrapper
+          cache-read-only: true
+          add-job-summary: "on-failure"
 
       - name: Build ${{ inputs.module_name }}
         id: build

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
         with:
           java-version: "17"
-          distribution: "temurin"
+          distribution: "corretto"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -33,7 +33,12 @@ jobs:
         with:
           java-version: "17"
           distribution: "temurin"
-          cache: "gradle"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: false
 
       - name: Run consumer contract tests
         run: ./gradlew pactConsumerTests

--- a/.github/workflows/dependency-review-on-pr.yml
+++ b/.github/workflows/dependency-review-on-pr.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
         with:
-          distribution: temurin
+          distribution: corretto
           java-version: 17
 
       - name: Generate and submit dependency graph

--- a/.github/workflows/dependency-review-on-pr.yml
+++ b/.github/workflows/dependency-review-on-pr.yml
@@ -1,0 +1,23 @@
+name: Dependency review for pull requests
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+
+      - name: Perform dependency review
+        uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,21 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
         with:
-          distribution: temurin
+          distribution: corretto
           java-version: 17
 
       - name: Generate and submit dependency graph

--- a/.github/workflows/deploy-api-modules-dev.yml
+++ b/.github/workflows/deploy-api-modules-dev.yml
@@ -9,6 +9,9 @@ env:
   ARTIFACT_BUCKET: dev-auth-deploy-pipeline-githubartifactsourcebuck-ssdefc91xjh6
   ARTIFACT_LOOKUP_TABLE: arn:aws:dynamodb:eu-west-2:706615647326:table/di-auth-non-production-artifact-lookup
 
+  JAVA_VERSION: 17
+  JAVA_DISTRIBUTION: temurin
+
 on: workflow_dispatch
 
 concurrency:
@@ -138,9 +141,33 @@ jobs:
             console.log(result);
             return result;
 
+  build-cache:
+    name: Set up build cache
+    runs-on: ubuntu-latest
+    outputs:
+      java_version: ${{ env.JAVA_VERSION }}
+      java_distribution: ${{ env.JAVA_DISTRIBUTION }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Set up JDK 17
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
+        with:
+          java-version: ${{ env.JAVA_VERSION}}
+          distribution: ${{ env.JAVA_DISTRIBUTION}}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: false
+      - name: Download dependencies for caching
+        run: ./gradlew --no-daemon --console=plain assemble
+
   build:
     name: Build modules
-    needs: set-up
+    needs:
+      - set-up
+      - build-cache
     strategy:
       matrix:
         module:
@@ -168,6 +195,8 @@ jobs:
       destination_bucket: ${{ needs.set-up.outputs.destination_bucket }}
       signing_profile: ${{ needs.set-up.outputs.signing_profile }}
       lookup_table: ${{ needs.set-up.outputs.artifact_lookup_table }}
+      java_version: ${{ needs.build-cache.outputs.java_version }}
+      java_distribution: ${{ needs.build-cache.outputs.java_distribution }}
 
   create-promotion-artifact-shared:
     name: Create Shared Promotion Artifact

--- a/.github/workflows/deploy-api-modules-dev.yml
+++ b/.github/workflows/deploy-api-modules-dev.yml
@@ -10,7 +10,7 @@ env:
   ARTIFACT_LOOKUP_TABLE: arn:aws:dynamodb:eu-west-2:706615647326:table/di-auth-non-production-artifact-lookup
 
   JAVA_VERSION: 17
-  JAVA_DISTRIBUTION: temurin
+  JAVA_DISTRIBUTION: corretto
 
 on: workflow_dispatch
 

--- a/.github/workflows/deploy-api-modules.yml
+++ b/.github/workflows/deploy-api-modules.yml
@@ -9,6 +9,9 @@ env:
   ARTIFACT_BUCKET: build-auth-deploy-pipeli-githubartifactsourcebuck-1o4hcrnik6ayv
   ARTIFACT_LOOKUP_TABLE: arn:aws:dynamodb:eu-west-2:114407264696:table/di-auth-production-artifact-lookup
 
+  JAVA_VERSION: 17
+  JAVA_DISTRIBUTION: temurin
+
 on:
   push:
     branches:
@@ -88,7 +91,6 @@ jobs:
                 owner: context.repo.owner,
                 name: context.repo.repo,
                 oid: context.sha,
-                shortSha: context.sha.slice(0, 7),
             }
 
             const result = await github.graphql(query, variables).then((response) => {
@@ -142,9 +144,33 @@ jobs:
             console.log(result);
             return result;
 
+  build-cache:
+    name: Set up build cache
+    runs-on: ubuntu-latest
+    outputs:
+      java_version: ${{ env.JAVA_VERSION }}
+      java_distribution: ${{ env.JAVA_DISTRIBUTION }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Set up JDK 17
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
+        with:
+          java-version: ${{ env.JAVA_VERSION}}
+          distribution: ${{ env.JAVA_DISTRIBUTION}}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: false
+      - name: Download dependencies for caching
+        run: ./gradlew --no-daemon --console=plain assemble
+
   build:
     name: Build modules
-    needs: set-up
+    needs:
+      - set-up
+      - build-cache
     strategy:
       matrix:
         module:
@@ -172,6 +198,8 @@ jobs:
       destination_bucket: ${{ needs.set-up.outputs.destination_bucket }}
       signing_profile: ${{ needs.set-up.outputs.signing_profile }}
       lookup_table: ${{ needs.set-up.outputs.artifact_lookup_table }}
+      java_version: ${{ needs.build-cache.outputs.java_version }}
+      java_distribution: ${{ needs.build-cache.outputs.java_distribution }}
 
   create-promotion-artifact-shared:
     name: Create Shared Promotion Artifact
@@ -273,7 +301,5 @@ jobs:
             --body authentication-api.zip \
             --metadata '${{ toJson(fromJson(needs.pr-data.outputs.data)) }}' \
             --query VersionId --output text)"
-
-          echo "Uploaded object version: $OBJECT_VERSION"
           echo "::endgroup::"
           echo "::notice title=Final artifact uploaded to S3::object: authentication-api.zip, version: $OBJECT_VERSION"

--- a/.github/workflows/deploy-api-modules.yml
+++ b/.github/workflows/deploy-api-modules.yml
@@ -10,7 +10,7 @@ env:
   ARTIFACT_LOOKUP_TABLE: arn:aws:dynamodb:eu-west-2:114407264696:table/di-auth-production-artifact-lookup
 
   JAVA_VERSION: 17
-  JAVA_DISTRIBUTION: temurin
+  JAVA_DISTRIBUTION: corretto
 
 on:
   push:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
         with:
           java-version: "17"
-          distribution: "temurin"
+          distribution: "corretto"
 
       - name: 🏗️ Set up Gradle
         uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -1,4 +1,7 @@
 name: Pre-merge checks
+env:
+  JAVA_VERSION: "17"
+  JAVA_DISTRIBUTION: "temurin"
 on:
   pull_request:
     types:
@@ -9,20 +12,6 @@ on:
   merge_group:
 
 jobs:
-  style-checks:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Set up JDK 17
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
-        with:
-          java-version: "17"
-          distribution: "temurin"
-          cache: "gradle"
-      - name: Run Spotless
-        run: ./gradlew --no-daemon spotlessCheck
-
   build:
     runs-on: ubuntu-latest
     steps:
@@ -31,9 +20,13 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
         with:
-          java-version: "17"
-          distribution: "temurin"
-          cache: "gradle"
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: false
       - name: Build Cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
@@ -46,6 +39,36 @@ jobs:
       - name: Run Build
         run: ./gradlew --parallel build -x test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck
 
+  style-checks:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Set up JDK 17
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Restore Build Cache
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
+
+      - name: Run Spotless
+        run: ./gradlew --no-daemon spotlessCheck
+
   run-unit-tests:
     runs-on: ubuntu-latest
     needs:
@@ -56,11 +79,15 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
         with:
-          java-version: "17"
-          distribution: "temurin"
-          cache: "gradle"
-      - name: Build Cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Restore Build Cache
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             .gradle/
@@ -72,6 +99,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew --parallel test jacocoTestReport -x integration-tests:test -x account-management-integration-tests:test -x delivery-receipts-integration-tests:test -x spotlessApply -x spotlessCheck
+
+      - name: Cache Unit Test Reports
+        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
+          path: |
+            */build/jacoco/
+            */build/reports/
+            !integration-tests/build/jacoco/
+            !integration-tests/build/reports/
+            !account-management-integration-tests/build/jacoco/
+            !account-management-integration-tests/build/reports/
+            !delivery-receipts-integration-tests/build/jacoco/
+            !delivery-receipts-integration-tests/build/reports/
       - name: Upload Unit Test Reports
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         if: failure()
@@ -84,19 +125,6 @@ jobs:
             !delivery-receipts-integration-tests/build/reports/
 
           retention-days: 5
-      - name: Cache Unit Test Reports
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
-          path: |
-            */build/jacoco/
-            */build/reports/
-            !integration-tests/build/jacoco/
-            !integration-tests/build/reports/
-            !account-management-integration-tests/build/jacoco/
-            !account-management-integration-tests/build/reports/
-            !delivery-receipts-integration-tests/build/jacoco/
-            !delivery-receipts-integration-tests/build/reports/
 
   run-integration-tests:
     runs-on: ubuntu-latest
@@ -139,11 +167,15 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
         with:
-          java-version: "17"
-          distribution: "temurin"
-          cache: "gradle"
-      - name: Build Cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Restore Build Cache
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             .gradle/
@@ -154,6 +186,14 @@ jobs:
       - name: Run Integration Tests
         run: |
           ./gradlew :integration-tests:test :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
+
+      - name: Cache Test Reports
+        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          key: ${{ runner.os }}-integration-test-reports-${{ github.sha }}
+          path: |
+            integration-tests/build/jacoco/
+            integration-tests/build/reports/
       - name: Upload Integration Test Reports
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         if: failure()
@@ -161,13 +201,6 @@ jobs:
           name: integration-test-reports
           path: integration-tests/build/reports/tests/test/
           retention-days: 5
-      - name: Cache Test Reports
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          key: ${{ runner.os }}-integration-test-reports-${{ github.sha }}
-          path: |
-            integration-tests/build/jacoco/
-            integration-tests/build/reports/
 
   run-account-management-and-delivery-receipts-tests:
     runs-on: ubuntu-latest
@@ -212,11 +245,15 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
         with:
-          java-version: "17"
-          distribution: "temurin"
-          cache: "gradle"
-      - name: Build Cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Restore Build Cache
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             .gradle/
@@ -224,6 +261,7 @@ jobs:
             !*/build/reports
             !*/build/jacoco
           key: ${{ runner.os }}-build-${{ github.sha }}
+
       - name: Run Account Management Integration Tests
         run: |
           ./gradlew :account-management-integration-tests:test :account-management-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
@@ -237,15 +275,9 @@ jobs:
       - name: Run Delivery Receipts Integration Tests
         run: |
           ./gradlew :delivery-receipts-integration-tests:test :delivery-receipts-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
-      - name: Upload Account Management Integration Test Reports
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
-        if: failure()
-        with:
-          name: delivery-receipts-integration-test-reports
-          path: delivery-receipts-integration-tests/build/reports/tests/test/
-          retention-days: 5
+
       - name: Cache Test Reports
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           key: ${{ runner.os }}-am-dr-integration-test-reports-${{ github.sha }}
           path: |
@@ -254,28 +286,38 @@ jobs:
             delivery-receipts-integration-tests/build/jacoco/
             delivery-receipts-integration-tests/build/reports/
 
+      - name: Upload Account Management Integration Test Reports
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        if: failure()
+        with:
+          name: delivery-receipts-integration-test-reports
+          path: delivery-receipts-integration-tests/build/reports/tests/test/
+          retention-days: 5
+
   run-sonar-analysis:
     runs-on: ubuntu-latest
     needs:
       - run-unit-tests
       - run-integration-tests
       - run-account-management-and-delivery-receipts-tests
+    if: github.event_name != 'merge_group'
     steps:
       - name: Check out repository code
-        if: github.event_name != 'merge_group'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
       - name: Set up JDK 17
-        if: github.event_name != 'merge_group'
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
         with:
-          java-version: "17"
-          distribution: "temurin"
-          cache: "gradle"
-      - name: Build Cache
-        if: github.event_name != 'merge_group'
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Restore Build Cache
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             .gradle/
@@ -283,9 +325,9 @@ jobs:
             !*/build/reports
             !*/build/jacoco
           key: ${{ runner.os }}-build-${{ github.sha }}
-      - name: Cache Unit Test Reports
-        if: github.event_name != 'merge_group'
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+
+      - name: Restore Cached Unit Test Reports
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
           path: |
@@ -297,17 +339,15 @@ jobs:
             !account-management-integration-tests/build/reports/
             !delivery-receipts-integration-tests/build/jacoco/
             !delivery-receipts-integration-tests/build/reports/
-      - name: Cache Integration Test Reports
-        if: github.event_name != 'merge_group'
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      - name: Restore Cached Integration Test Reports
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           key: ${{ runner.os }}-integration-test-reports-${{ github.sha }}
           path: |
             integration-tests/build/jacoco/
             integration-tests/build/reports/
-      - name: Cache AM DR Integration Test Reports
-        if: github.event_name != 'merge_group'
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      - name: Restore Cached AM DR Integration Test Reports
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           key: ${{ runner.os }}-am-dr-integration-test-reports-${{ github.sha }}
           path: |
@@ -316,7 +356,7 @@ jobs:
             delivery-receipts-integration-tests/build/jacoco/
             delivery-receipts-integration-tests/build/reports/
       - name: Run SonarCloud Analysis
-        if: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -1,7 +1,7 @@
 name: Pre-merge checks
 env:
   JAVA_VERSION: "17"
-  JAVA_DISTRIBUTION: "temurin"
+  JAVA_DISTRIBUTION: "corretto"
 on:
   pull_request:
     types:

--- a/.github/workflows/sonar-analysis-on-merge.yml
+++ b/.github/workflows/sonar-analysis-on-merge.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
         with:
           java-version: "17"
-          distribution: "temurin"
+          distribution: "corretto"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0

--- a/.github/workflows/sonar-analysis-on-merge.yml
+++ b/.github/workflows/sonar-analysis-on-merge.yml
@@ -19,15 +19,11 @@ jobs:
           java-version: "17"
           distribution: "temurin"
 
-      - name: Cache Gradle packages
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          gradle-version: wrapper
+          cache-read-only: false
 
       - name: Run Tests
         env:


### PR DESCRIPTION
## What

Improve dependency caching across our GHA workflows.

This will hopefully ensure that we retain a slightly more stable set of transitive dependencies and will reduce the number of unexpected rebuilds. Additionally, it will ensure that all subprojects receive the same set of cached dependencies.

Additionally, i've introduced dependency submission / review workflows - details in the commit.

Finally, use corretto instead of temurin, to ensure we are replicating the runtime environment as closely as possibly.

## How to review

- Ensure workflows have all successfully run on this branch
- Ensure that `deploy-api-modules-dev` workflow runs successfully against this branch. [I've already run this](https://github.com/govuk-one-login/authentication-api/actions/runs/9892363244), but it would likely be worth running again yourself.