### PR TITLE
Aut 2498/switch on ticf feature flag

### DIFF
--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -8,6 +8,7 @@ logging_endpoint_arns                = []
 shared_state_bucket                  = "digital-identity-dev-tfstate"
 test_clients_enabled                 = false
 internal_sector_uri                  = "https://identity.integration.account.gov.uk"
+call_ticf_cri                        = true
 
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -15,7 +15,7 @@ reduced_lockout_duration             = 900
 incorrect_password_lockout_count_ttl = 7200
 support_account_creation_count_ttl   = true
 call_ticf_cri                        = true
-ticf_cri_service_call_timeout        = 20000
+ticf_cri_service_call_timeout        = 10000
 
 orch_account_id                     = "590183975515"
 cmk_for_back_channel_logout_enabled = true


### PR DESCRIPTION
## What

Switches on calls to the TICF CRI in integration.

Note that since this is done in a "fire and forget" way (async lambda invocation), there should be negligible impact on user journeys.

Also reduces the http timeout for the call to the TICF CRI in staging. We're working on bringing this down further, but we no longer need it to be this high. Note that the integration timeout will be the default of 2 seconds so we can observe behaviour (but again, these timeouts will not affect user journeys).