### PR TITLE
AUT-2906: Bumps Terms and Conditions version number

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -142,7 +142,7 @@ variable "use_localstack" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.10"
+  default = "1.11"
 }
 
 variable "localstack_endpoint" {

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -63,7 +63,7 @@ variable "cloudwatch_log_retention" {
 
 variable "terms_and_conditions" {
   type        = string
-  default     = "1.10"
+  default     = "1.11"
   description = "The latest Terms and Conditions version number"
 }
 


### PR DESCRIPTION
## What

Bumps the Terms and Conditions version number for changes relating to Dynatrace. 

## How to review

1. Code Review

## Related PRs

This bump is in relation to updates in the following PRs:

- https://github.com/govuk-one-login/authentication-frontend/pull/1704
- https://github.com/govuk-one-login/authentication-frontend/pull/1784
