### PR TITLE
AUT-2790: Update logic to not lock the user in the reauth journey whe…

### DIFF
--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -15,6 +15,7 @@ account_intervention_service_action_enabled = true
 account_intervention_service_abort_on_error = true
 send_storage_token_to_ipv_enabled           = true
 call_ticf_cri                               = true
+support_reauth_signout_enabled              = true
 
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -15,6 +15,7 @@ account_intervention_service_action_enabled = true
 account_intervention_service_abort_on_error = true
 send_storage_token_to_ipv_enabled           = true
 call_ticf_cri                               = true
+support_reauth_signout_enabled              = true
 
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -23,14 +23,15 @@ module "check_reauth_user" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    ENVIRONMENT          = var.environment
-    TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
-    REDIS_KEY            = local.redis_key
-    LOCKOUT_DURATION     = var.lockout_duration
-    LOCKOUT_COUNT_TTL    = var.lockout_count_ttl
+    DYNAMO_ENDPOINT                 = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT             = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT                     = var.environment
+    TXMA_AUDIT_QUEUE_URL            = module.oidc_txma_audit.queue_url
+    INTERNAl_SECTOR_URI             = var.internal_sector_uri
+    REDIS_KEY                       = local.redis_key
+    LOCKOUT_DURATION                = var.lockout_duration
+    LOCKOUT_COUNT_TTL               = var.lockout_count_ttl
+    SUPPORT_REAUTH_SIGNOUT_ENABLED  = var.support_reauth_signout_enabled
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.CheckReAuthUserHandler::handleRequest"

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -23,15 +23,15 @@ module "check_reauth_user" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DYNAMO_ENDPOINT                 = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT             = var.use_localstack ? var.localstack_endpoint : null
-    ENVIRONMENT                     = var.environment
-    TXMA_AUDIT_QUEUE_URL            = module.oidc_txma_audit.queue_url
-    INTERNAl_SECTOR_URI             = var.internal_sector_uri
-    REDIS_KEY                       = local.redis_key
-    LOCKOUT_DURATION                = var.lockout_duration
-    LOCKOUT_COUNT_TTL               = var.lockout_count_ttl
-    SUPPORT_REAUTH_SIGNOUT_ENABLED  = var.support_reauth_signout_enabled
+    DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT                    = var.environment
+    TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
+    INTERNAl_SECTOR_URI            = var.internal_sector_uri
+    REDIS_KEY                      = local.redis_key
+    LOCKOUT_DURATION               = var.lockout_duration
+    LOCKOUT_COUNT_TTL              = var.lockout_count_ttl
+    SUPPORT_REAUTH_SIGNOUT_ENABLED = var.support_reauth_signout_enabled
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.CheckReAuthUserHandler::handleRequest"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -648,6 +648,12 @@ variable "support_email_check_enabled" {
   description = "Feature flag which toggles the Experian email check on and off"
 }
 
+variable "support_reauth_signout_enabled" {
+  default     = false
+  type        = bool
+  description = "Feature flag which toggles sign-out instead of lockout for reauth journeys"
+}
+
 variable "send_storage_token_to_ipv_enabled" {
   default     = false
   type        = bool

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -93,11 +93,13 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
             UserContext userContext) {
         LOG.info("Processing CheckReAuthUser request");
 
+        var emailUserIsSignedInWith = userContext.getSession().getEmailAddress();
+
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
                         AuditService.UNKNOWN,
-                        request.email(),
+                        emailUserIsSignedInWith,
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
@@ -130,7 +132,7 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                                         auditContext);
                             })
                     .map(rpPairwiseId -> generateSuccessResponse())
-                    .orElseGet(() -> generateErrorResponse(request.email(), auditContext));
+                    .orElseGet(() -> generateErrorResponse(emailUserIsSignedInWith, auditContext));
         } catch (AccountLockedException e) {
 
             auditService.submitAuditEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -108,6 +108,7 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                     .flatMap(
                             userProfile -> {
                                 if (hasEnteredIncorrectEmailTooManyTimes(userProfile.getEmail())) {
+                                    removeEmailCountLock(userProfile.getEmail());
                                     throw new AccountLockedException(
                                             "Account is locked due to too many failed attempts.",
                                             ErrorResponse.ERROR_1057);
@@ -181,6 +182,7 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
     private APIGatewayProxyResponseEvent generateErrorResponse(
             String email, AuditContext auditContext) {
         if (hasEnteredIncorrectEmailTooManyTimes(email)) {
+            removeEmailCountLock(email);
             throw new AccountLockedException(
                     "Account is locked due to too many failed attempts.", ErrorResponse.ERROR_1057);
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -108,7 +108,9 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                     .flatMap(
                             userProfile -> {
                                 if (hasEnteredIncorrectEmailTooManyTimes(userProfile.getEmail())) {
-                                    removeEmailCountLock(userProfile.getEmail());
+                                    if (configurationService.supportReauthSignoutEnabled()) {
+                                        removeEmailCountLock(userProfile.getEmail());
+                                    }
                                     throw new AccountLockedException(
                                             "Account is locked due to too many failed attempts.",
                                             ErrorResponse.ERROR_1057);
@@ -182,7 +184,9 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
     private APIGatewayProxyResponseEvent generateErrorResponse(
             String email, AuditContext auditContext) {
         if (hasEnteredIncorrectEmailTooManyTimes(email)) {
-            removeEmailCountLock(email);
+            if (configurationService.supportReauthSignoutEnabled()) {
+                removeEmailCountLock(email);
+            }
             throw new AccountLockedException(
                     "Account is locked due to too many failed attempts.", ErrorResponse.ERROR_1057);
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -29,8 +29,8 @@ import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;
@@ -54,12 +54,14 @@ class CheckReAuthUserHandlerTest {
     private final ClientService clientService = mock(ClientService.class);
 
     private static final String CLIENT_ID = "test-client-id";
-    private static final String EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String EMAIL_USED_TO_SIGN_IN = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String DIFFERENT_EMAIL_USED_TO_REAUTHENTICATE =
+            "not.signedin.email@digital.cabinet-office.gov.uk";
     private static final String TEST_SUBJECT_ID = "subject-id";
     private static final String INTERNAL_SECTOR_URI = "http://www.example.com";
     private static final String TEST_RP_PAIRWISE_ID = "TEST_RP_PAIRWISE_ID";
 
-    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL_ADDRESS);
+    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL_USED_TO_SIGN_IN);
 
     private final AuditContext testAuditContextWithoutAuditEncoded =
             new AuditContext(
@@ -67,7 +69,7 @@ class CheckReAuthUserHandlerTest {
                     CLIENT_SESSION_ID,
                     SESSION_ID,
                     AuditService.UNKNOWN,
-                    EMAIL_ADDRESS,
+                    EMAIL_USED_TO_SIGN_IN,
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
@@ -87,18 +89,11 @@ class CheckReAuthUserHandlerTest {
 
     @BeforeEach
     public void setUp() {
-        when(context.getAwsRequestId()).thenReturn("aws-session-id");
-
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
-
         var userProfile = generateUserProfile();
         userProfile.setSubjectID(TEST_SUBJECT_ID);
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL_ADDRESS))
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL_USED_TO_SIGN_IN))
                 .thenReturn(Optional.of(userProfile));
         when(authenticationService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
-
-        when(clientRegistry.getClientID()).thenReturn(CLIENT_ID);
 
         when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
         when(userContext.getClientId()).thenReturn(CLIENT_ID);
@@ -106,10 +101,10 @@ class CheckReAuthUserHandlerTest {
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(userContext.getTxmaAuditEncoded()).thenReturn(ENCODED_DEVICE_DETAILS);
 
-        when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.of(clientRegistry));
-
         when(configurationService.getMaxEmailReAuthRetries()).thenReturn(5);
         when(configurationService.getMaxPasswordRetries()).thenReturn(6);
+
+        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
 
         handler =
                 new CheckReAuthUserHandler(
@@ -124,11 +119,9 @@ class CheckReAuthUserHandlerTest {
 
     @Test
     void shouldReturn200ForSuccessfulReAuthRequest() {
-        var body = format("{ \"email\": \"%s\" }", EMAIL_ADDRESS);
+        var body = format("{ \"email\": \"%s\" }", EMAIL_USED_TO_SIGN_IN);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
 
-        when(configurationService.getEnvironment()).thenReturn("build");
-        when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
         when(clientRegistry.getRedirectUrls()).thenReturn(List.of(INTERNAL_SECTOR_URI));
 
         var userProfile = generateUserProfile();
@@ -144,7 +137,7 @@ class CheckReAuthUserHandlerTest {
                 handler.handleRequestWithUserContext(
                         event,
                         context,
-                        new CheckReauthUserRequest(EMAIL_ADDRESS, expectedRpPairwiseSub),
+                        new CheckReauthUserRequest(EMAIL_USED_TO_SIGN_IN, expectedRpPairwiseSub),
                         userContext);
 
         assertEquals(200, result.getStatusCode());
@@ -153,15 +146,26 @@ class CheckReAuthUserHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
                         testAuditContextWithAuditEncoded);
+
+        verify(authenticationService).getUserProfileByEmailMaybe(EMAIL_USED_TO_SIGN_IN);
+        verify(authenticationService, times(2)).getOrGenerateSalt(any(UserProfile.class));
+
+        verify(userContext).getClient();
+        verify(userContext, times(2)).getSession();
+        verify(userContext).getClientSessionId();
+        verify(userContext).getTxmaAuditEncoded();
+
+        verify(configurationService).getMaxEmailReAuthRetries();
+        verify(configurationService).getMaxPasswordRetries();
+        verify(configurationService).getInternalSectorUri();
+        verify(clientRegistry, times(4)).getRedirectUrls();
     }
 
     @Test
     void checkAuditEventStillEmittedWhenTICFHeaderNotProvided() {
-        var body = format("{ \"email\": \"%s\" }", EMAIL_ADDRESS);
+        var body = format("{ \"email\": \"%s\" }", EMAIL_USED_TO_SIGN_IN);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS_WITHOUT_AUDIT_ENCODED, body);
 
-        when(configurationService.getEnvironment()).thenReturn("build");
-        when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
         when(clientRegistry.getRedirectUrls()).thenReturn(List.of(INTERNAL_SECTOR_URI));
         when(userContext.getTxmaAuditEncoded()).thenReturn(null);
 
@@ -179,7 +183,7 @@ class CheckReAuthUserHandlerTest {
                 handler.handleRequestWithUserContext(
                         event,
                         context,
-                        new CheckReauthUserRequest(EMAIL_ADDRESS, expectedRpPairwiseSub),
+                        new CheckReauthUserRequest(EMAIL_USED_TO_SIGN_IN, expectedRpPairwiseSub),
                         userContext);
 
         assertEquals(200, result.getStatusCode());
@@ -188,39 +192,55 @@ class CheckReAuthUserHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_SUCCESSFUL,
                         testAuditContextWithoutAuditEncoded);
+
+        verify(userContext).getClient();
+        verify(userContext, times(2)).getSession();
+        verify(userContext).getClientSessionId();
+        verify(userContext).getTxmaAuditEncoded();
+
+        verify(configurationService).getMaxEmailReAuthRetries();
+        verify(configurationService).getMaxPasswordRetries();
     }
 
     @Test
     void shouldReturn404ForWhenUserNotFound() {
-        var body = format("{ \"email\": \"%s\" }", EMAIL_ADDRESS);
+        var body = format("{ \"email\": \"%s\" }", EMAIL_USED_TO_SIGN_IN);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
 
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL_ADDRESS))
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL_USED_TO_SIGN_IN))
                 .thenReturn(Optional.empty());
 
         var result =
                 handler.handleRequestWithUserContext(
                         event,
                         context,
-                        new CheckReauthUserRequest(EMAIL_ADDRESS, TEST_RP_PAIRWISE_ID),
+                        new CheckReauthUserRequest(EMAIL_USED_TO_SIGN_IN, TEST_RP_PAIRWISE_ID),
                         userContext);
 
         assertEquals(404, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1056));
 
+        verify(authenticationService).getUserProfileByEmailMaybe(EMAIL_USED_TO_SIGN_IN);
+
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_INVALID,
                         testAuditContextWithAuditEncoded);
+
+        verify(userContext, times(2)).getSession();
+        verify(userContext).getClientSessionId();
+        verify(userContext).getTxmaAuditEncoded();
+
+        verify(configurationService).getMaxEmailReAuthRetries();
     }
 
     @Test
     void shouldReturn400WhenUserHasEnteredEmailTooManyTimes() {
-        var body = format("{ \"email\": \"%s\" }", EMAIL_ADDRESS);
+        var body = format("{ \"email\": \"%s\" }", EMAIL_USED_TO_SIGN_IN);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
         var userProfile = generateUserProfile();
 
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL_ADDRESS))
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL_USED_TO_SIGN_IN))
                 .thenReturn(Optional.of(userProfile));
         when(codeStorageService.getIncorrectEmailCount(any())).thenReturn(5);
 
@@ -228,11 +248,14 @@ class CheckReAuthUserHandlerTest {
                 handler.handleRequestWithUserContext(
                         event,
                         context,
-                        new CheckReauthUserRequest(EMAIL_ADDRESS, TEST_RP_PAIRWISE_ID),
+                        new CheckReauthUserRequest(EMAIL_USED_TO_SIGN_IN, TEST_RP_PAIRWISE_ID),
                         userContext);
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1057));
+
+        verify(authenticationService).getUserProfileByEmailMaybe(EMAIL_USED_TO_SIGN_IN);
+        verify(codeStorageService, times(2)).getIncorrectEmailCount(any());
 
         verify(auditService)
                 .submitAuditEvent(
@@ -240,43 +263,66 @@ class CheckReAuthUserHandlerTest {
                         testAuditContextWithAuditEncoded,
                         AuditService.MetadataPair.pair(
                                 "number_of_attempts_user_allowed_to_login", 5));
+
+        verify(userContext, times(2)).getSession();
+        verify(userContext).getClientSessionId();
+        verify(userContext).getTxmaAuditEncoded();
+
+        verify(configurationService, times(2)).getMaxEmailReAuthRetries();
     }
 
     @Test
     void shouldReturn400WhenUserHasBeenBlockedForPasswordRetries() {
-        var body = format("{ \"email\": \"%s\" }", EMAIL_ADDRESS);
+        var body = format("{ \"email\": \"%s\" }", EMAIL_USED_TO_SIGN_IN);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
         var userProfile = generateUserProfile();
 
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL_ADDRESS))
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL_USED_TO_SIGN_IN))
                 .thenReturn(Optional.of(userProfile));
         when(codeStorageService.getIncorrectPasswordCountReauthJourney(any())).thenReturn(6);
+
+        when(clientRegistry.getRedirectUrls()).thenReturn(List.of(INTERNAL_SECTOR_URI));
+
+        var expectedRpPairwiseSub =
+                ClientSubjectHelper.getSubject(
+                                userProfile,
+                                clientRegistry,
+                                authenticationService,
+                                INTERNAL_SECTOR_URI)
+                        .getValue();
 
         var result =
                 handler.handleRequestWithUserContext(
                         event,
                         context,
-                        new CheckReauthUserRequest(EMAIL_ADDRESS, TEST_RP_PAIRWISE_ID),
+                        new CheckReauthUserRequest(EMAIL_USED_TO_SIGN_IN, expectedRpPairwiseSub),
                         userContext);
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1045));
+
+        verify(authenticationService).getUserProfileByEmailMaybe(EMAIL_USED_TO_SIGN_IN);
+        verify(codeStorageService).getIncorrectPasswordCountReauthJourney(any());
+        verify(clientRegistry, times(2)).getRedirectUrls();
+
+        verify(userContext, times(2)).getSession();
+        verify(userContext).getClientSessionId();
+        verify(userContext).getTxmaAuditEncoded();
+
+        verify(configurationService).getMaxEmailReAuthRetries();
+        verify(configurationService, times(2)).getMaxPasswordRetries();
     }
 
     @Test
     void shouldReturn404ForWhenUserDoesNotMatch() {
-        var body = format("{ \"email\": \"%s\" }", EMAIL_ADDRESS);
-        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
-
-        when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
-        when(configurationService.getEnvironment()).thenReturn("build");
-        when(clientRegistry.getRedirectUrls()).thenReturn(List.of("http://test.example.com"));
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, null);
 
         var result =
                 handler.handleRequestWithUserContext(
                         event,
                         context,
-                        new CheckReauthUserRequest(EMAIL_ADDRESS, TEST_RP_PAIRWISE_ID),
+                        new CheckReauthUserRequest(
+                                DIFFERENT_EMAIL_USED_TO_REAUTHENTICATE, TEST_RP_PAIRWISE_ID),
                         userContext);
 
         assertEquals(404, result.getStatusCode());
@@ -286,11 +332,17 @@ class CheckReAuthUserHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.REAUTHENTICATION_INVALID,
                         testAuditContextWithAuditEncoded);
+
+        verify(userContext, times(2)).getSession();
+        verify(userContext).getClientSessionId();
+        verify(userContext).getTxmaAuditEncoded();
+
+        verify(configurationService).getMaxEmailReAuthRetries();
     }
 
     private UserProfile generateUserProfile() {
         return new UserProfile()
-                .withEmail(EMAIL_ADDRESS)
+                .withEmail(EMAIL_USED_TO_SIGN_IN)
                 .withEmailVerified(true)
                 .withPhoneNumberVerified(true)
                 .withPublicSubjectID(new Subject().getValue())

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
@@ -52,7 +52,7 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
 
     @BeforeEach
     void setup() throws Json.JsonException {
-        var sessionId = redis.createSession();
+        var sessionId = redis.createAuthenticatedSessionWithEmail(TEST_EMAIL);
         headers = createHeaders(sessionId);
         redis.createClientSession(CLIENT_SESSION_ID, createClientSession());
         handler =
@@ -178,13 +178,14 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
 
         var randomEmail = "random_email@email.com";
 
-        redis.incrementEmailCount(randomEmail);
-        redis.incrementEmailCount(randomEmail);
-        redis.incrementEmailCount(randomEmail);
-        redis.incrementEmailCount(randomEmail);
-        redis.incrementEmailCount(randomEmail);
+        redis.incrementEmailCount(TEST_EMAIL);
+        redis.incrementEmailCount(TEST_EMAIL);
+        redis.incrementEmailCount(TEST_EMAIL);
+        redis.incrementEmailCount(TEST_EMAIL);
+        redis.incrementEmailCount(TEST_EMAIL);
 
         var request = new CheckReauthUserRequest(randomEmail, "random-pairwise-id");
+
         var response =
                 makeRequest(
                         Optional.of(request),
@@ -192,6 +193,7 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
                         Collections.emptyMap(),
                         Collections.emptyMap(),
                         Map.of());
+
         assertThat(response, hasStatus(400));
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -87,6 +87,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals("true");
     }
 
+    public boolean supportReauthSignoutEnabled() {
+        return System.getenv()
+                .getOrDefault("SUPPORT_REAUTH_SIGNOUT_ENABLED", String.valueOf(false))
+                .equals("true");
+    }
+
     public long getLockoutDuration() {
         return Long.parseLong(System.getenv().getOrDefault("LOCKOUT_DURATION", "900"));
     }
@@ -292,16 +298,16 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
     }
 
+    public Optional<String> getNotifyApiUrl() {
+        return Optional.ofNullable(System.getenv("NOTIFY_URL"));
+    }
+
     public String getInternalSectorUri() {
         return System.getenv("INTERNAl_SECTOR_URI");
     }
 
     public String getNotifyApiKey() {
         return System.getenv("NOTIFY_API_KEY");
-    }
-
-    public Optional<String> getNotifyApiUrl() {
-        return Optional.ofNullable(System.getenv("NOTIFY_URL"));
     }
 
     public String getNotifyCallbackBearerToken() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.services;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -9,43 +10,596 @@ import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
 import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
 import uk.gov.di.authentication.shared.entity.DeliveryReceiptsNotificationType;
 
+import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ConfigurationServiceTest {
-
+    private static ConfigurationService configurationService;
     private final SystemService systemService = mock(SystemService.class);
+
+    @BeforeAll
+    static void beforeAll() {
+        configurationService = ConfigurationService.getInstance();
+    }
+
+    @Test
+    void checkIsSingleton() {
+        var configurationServiceInstance = ConfigurationService.getInstance();
+        assertEquals(configurationService, configurationServiceInstance);
+    }
+
+    @Test
+    void getAccessTokenExpiryShouldDefault() {
+        assertEquals(180, configurationService.getAccessTokenExpiry());
+    }
+
+    @Test
+    void getAccountManagementURIShouldDefault() {
+        assertNull(configurationService.getAccountManagementURI());
+    }
+
+    @Test
+    void getAuthCodeExpiryShouldDefault() {
+        assertEquals(300, configurationService.getAuthCodeExpiry());
+    }
+
+    @Test
+    void getIncorrectPasswordLockoutCountTTLShouldDefault() {
+        assertEquals(900, configurationService.getIncorrectPasswordLockoutCountTTL());
+    }
+
+    @Test
+    void getLockoutCountTTLShouldDefault() {
+        assertEquals(900, configurationService.getLockoutCountTTL());
+    }
+
+    @Test
+    void getLockoutDurationShouldDefault() {
+        assertEquals(900, configurationService.getLockoutDuration());
+    }
+
+    @Test
+    void getBulkUserEmailBatchQueryLimitShouldDefault() {
+        assertEquals(25, configurationService.getBulkUserEmailBatchQueryLimit());
+    }
+
+    @Test
+    void getBulkUserEmailMaxBatchCountShouldDefault() {
+        assertEquals(20, configurationService.getBulkUserEmailMaxBatchCount());
+    }
+
+    @Test
+    void getBulkUserEmailMaxAudienceLoadUserCountShouldDefault() {
+        assertEquals(0, configurationService.getBulkUserEmailMaxAudienceLoadUserCount());
+    }
+
+    @Test
+    void getBulkUserEmailAudienceLoadUserBatchSizeShouldDefault() {
+        assertEquals(0, configurationService.getBulkUserEmailAudienceLoadUserBatchSize());
+    }
+
+    @Test
+    void getBulkUserEmailBatchPauseDurationShouldDefault() {
+        assertEquals(0, configurationService.getBulkUserEmailBatchPauseDuration());
+    }
+
+    @Test
+    void shouldReadTermsAndConditionsVersionCSVList() {
+        when(systemService.getOrDefault("BULK_USER_EMAIL_INCLUDED_TERMS_AND_CONDITIONS", ""))
+                .thenReturn("1.1,1.3,1.5");
+
+        ConfigurationService configurationServiceWithMockedSystemService =
+                new ConfigurationService();
+        configurationServiceWithMockedSystemService.setSystemService(systemService);
+
+        assertEquals(
+                List.of("1.1", "1.3", "1.5"),
+                configurationServiceWithMockedSystemService
+                        .getBulkUserEmailIncludedTermsAndConditions());
+    }
+
+    @Test
+    void shouldReadEmptyTermsAndConditionsVersionCSVList() {
+        when(systemService.getOrDefault("BULK_USER_EMAIL_INCLUDED_TERMS_AND_CONDITIONS", ""))
+                .thenReturn("");
+
+        ConfigurationService configurationServiceWithMockedSystemService =
+                new ConfigurationService();
+        configurationServiceWithMockedSystemService.setSystemService(systemService);
+
+        assertEquals(
+                Collections.EMPTY_LIST,
+                configurationServiceWithMockedSystemService
+                        .getBulkUserEmailIncludedTermsAndConditions());
+    }
+
+    @Test
+    void getBulkEmailUserSendModeShouldDefault() {
+        when(systemService.getOrDefault("BULK_USER_EMAIL_SEND_MODE", "PENDING"))
+                .thenReturn("1.1,1.3,1.5");
+
+        ConfigurationService configurationServiceWithMockedSystemService =
+                new ConfigurationService();
+        configurationServiceWithMockedSystemService.setSystemService(systemService);
+
+        assertEquals(
+                "1.1,1.3,1.5",
+                configurationServiceWithMockedSystemService.getBulkEmailUserSendMode());
+    }
+
+    @Test
+    void isBulkUserEmailEnabledShouldDefault() {
+        assertFalse(configurationService.isBulkUserEmailEnabled());
+    }
+
+    @Test
+    void getDefaultOtpCodeExpiryShouldDefault() {
+        assertEquals(900, configurationService.getDefaultOtpCodeExpiry());
+    }
+
+    @Test
+    void getEmailAccountCreationOtpCodeExpiryShouldDefault() {
+        assertEquals(3600, configurationService.getEmailAccountCreationOtpCodeExpiry());
+    }
+
+    @Test
+    void getCodeMaxRetriesShouldDefault() {
+        assertEquals(5, configurationService.getCodeMaxRetries());
+    }
+
+    @Test
+    void getIncreasedCodeMaxRetriesShouldDefault() {
+        assertEquals(999999, configurationService.getIncreasedCodeMaxRetries());
+    }
+
+    @Test
+    void getAuthAppCodeWindowLengthShouldDefault() {
+        assertEquals(30, configurationService.getAuthAppCodeWindowLength());
+    }
+
+    @Test
+    void getAuthAppCodeAllowedWindowsShouldDefault() {
+        assertEquals(9, configurationService.getAuthAppCodeAllowedWindows());
+    }
+
+    @Test
+    void isEmailCheckEnabledShouldDefault() {
+        assertFalse(configurationService.isEmailCheckEnabled());
+    }
+
+    @Test
+    void isBulkUserEmailEmailSendingEnabledShouldDefault() {
+        assertFalse(configurationService.isBulkUserEmailEmailSendingEnabled());
+    }
+
+    @Test
+    void getBulkEmailLoaderLambdaNameShouldDefault() {
+        assertEquals("", configurationService.getBulkEmailLoaderLambdaName());
+    }
+
+    @Test
+    void getTicfCRILambdaNameShouldDefault() {
+        assertEquals("", configurationService.getTicfCRILambdaName());
+    }
+
+    @Test
+    void isInvokeTicfCRILambdaEnabledShouldDefault() {
+        assertFalse(configurationService.isInvokeTicfCRILambdaEnabled());
+    }
+
+    @Test
+    void getAuthenticationAuthCallbackURIShouldDefault() {
+        assertEquals(URI.create(""), configurationService.getAuthenticationAuthCallbackURI());
+    }
+
+    @Test
+    void getAuthenticationBackendURIShouldDefault() {
+        assertEquals(URI.create(""), configurationService.getAuthenticationBackendURI());
+    }
+
+    @Test
+    void getOrchestrationBackendURIShouldDefault() {
+        assertEquals(URI.create(""), configurationService.getOrchestrationBackendURI());
+    }
+
+    @Test
+    void getContactUsLinkRouteShouldDefault() {
+        assertEquals("", configurationService.getContactUsLinkRoute());
+    }
+
+    @Test
+    void getMaxPasswordRetriesShouldDefault() {
+        assertEquals(6, configurationService.getMaxPasswordRetries());
+    }
+
+    @Test
+    void getMaxEmailReAuthRetriesShouldDefault() {
+        assertEquals(5, configurationService.getMaxEmailReAuthRetries());
+    }
+
+    @Test
+    void isCustomDocAppClaimEnabledShouldDefault() {
+        assertFalse(configurationService.isCustomDocAppClaimEnabled());
+    }
+
+    @Test
+    void getDocAppAuthorisationURIShouldDefault() {
+        assertEquals(URI.create(""), configurationService.getDocAppAuthorisationURI());
+    }
+
+    @Test
+    void getDocAppAuthorisationCallbackURIShouldDefault() {
+        assertEquals(URI.create(""), configurationService.getDocAppAuthorisationCallbackURI());
+    }
+
+    @Test
+    void getDocAppAuthorisationClientIdShouldDefault() {
+        assertEquals("", configurationService.getDocAppAuthorisationClientId());
+    }
+
+    @Test
+    void getDocAppEncryptionKeyIDShouldDefault() {
+        assertEquals("", configurationService.getDocAppEncryptionKeyID());
+    }
+
+    @Test
+    void getDocAppJwksUriShouldDefault() {
+        assertEquals(URI.create(""), configurationService.getDocAppJwksUri());
+    }
+
+    @Test
+    void getDocAppTokenSigningKeyAliasShouldNotDefault() {
+        assertNull(configurationService.getDocAppTokenSigningKeyAlias());
+    }
+
+    @Test
+    void getDynamoEndpointUriShouldDefault() {
+        assertFalse(configurationService.getDynamoEndpointUri().isPresent());
+    }
+
+    @Test
+    void getEmailQueueUriShouldNotDefault() {
+        assertNull(configurationService.getEmailQueueUri());
+    }
+
+    @Test
+    void getPendingEmailCheckQueueUriShouldNotDefault() {
+        assertNull(configurationService.getPendingEmailCheckQueueUri());
+    }
+
+    @Test
+    void getExperianPhoneCheckerQueueUriShouldNotDefault() {
+        assertNull(configurationService.getExperianPhoneCheckerQueueUri());
+    }
+
+    @Test
+    void getFrontendBaseUrlShouldDefault() {
+        assertEquals("", configurationService.getFrontendBaseUrl());
+    }
+
+    @Test
+    void getOrchestrationToAuthenticationSigningPublicKeyShouldNotDefault() {
+        assertNull(configurationService.getOrchestrationToAuthenticationSigningPublicKey());
+    }
+
+    @Test
+    void getOrchestrationClientIdShouldDefault() {
+        assertEquals("UNKNOWN", configurationService.getOrchestrationClientId());
+    }
+
+    @Test
+    void getGovUKAccountsURLShouldDefault() {
+        assertEquals(URI.create(""), configurationService.getGovUKAccountsURL());
+    }
+
+    @Test
+    void getHeadersCaseInsensitiveAlwaysFalse() {
+        assertFalse(configurationService.getHeadersCaseInsensitive());
+    }
+
+    @Test
+    void isIdentityEnabledShouldDefault() {
+        assertFalse(configurationService.isIdentityEnabled());
+    }
+
+    @Test
+    void getIDTokenExpiryShouldDefault() {
+        assertEquals(120, configurationService.getIDTokenExpiry());
+    }
+
+    @Test
+    void getNotifyApiUrlShouldDefault() {
+        assertFalse(configurationService.getNotifyApiUrl().isPresent());
+    }
+
+    @Test
+    void getInternalSectorUriShouldNotDefault() {
+        assertNull(configurationService.getInternalSectorUri());
+    }
+
+    @Test
+    void getNotifyApiKeyShouldNotDefault() {
+        assertNull(configurationService.getNotifyApiKey());
+    }
+
+    @Test
+    void shoulCacheTheNotifyBearerTokenAfterTheFirstCall() {
+        var mock = mock(SsmClient.class);
+        ConfigurationService configurationServiceMockedSsmClient = new ConfigurationService(mock);
+
+        String ssmParamName = "test-notify-callback-bearer-token";
+        String ssmParamValue = "bearer-token";
+
+        var request = parameterRequest(ssmParamName);
+        var response = parameterResponse(ssmParamName, ssmParamValue);
+
+        when(mock.getParameter(parameterRequest(ssmParamName))).thenReturn(response);
+
+        assertEquals(
+                configurationServiceMockedSsmClient.getNotifyCallbackBearerToken(), ssmParamValue);
+        assertEquals(
+                configurationServiceMockedSsmClient.getNotifyCallbackBearerToken(), ssmParamValue);
+        verify(mock, times(1)).getParameter(request);
+    }
+
+    @Test
+    void getNotifyTestDestinationsShouldDefault() {
+        assertEquals(new ArrayList<>(), configurationService.getNotifyTestDestinations());
+    }
+
+    @Test
+    void shouldGetNotificationTypeFromTemplateId() {
+        when(systemService.getenv("VERIFY_EMAIL_TEMPLATE_ID")).thenReturn("1234-abcd");
+        when(systemService.getenv("EMAIL_UPDATED_TEMPLATE_ID")).thenReturn("1234-efgh,4567-ijkl");
+        when(systemService.getenv("TERMS_AND_CONDITIONS_BULK_EMAIL_TEMPLATE_ID"))
+                .thenReturn("1234-bulk");
+        when(systemService.getenv("REPORT_SUSPICIOUS_ACTIVITY_EMAIL_TEMPLATE_ID"))
+                .thenReturn("report-template-id");
+
+        ConfigurationService configurationServiceWithSystemService = new ConfigurationService();
+        configurationServiceWithSystemService.setSystemService(systemService);
+
+        assertEquals(
+                Optional.of(DeliveryReceiptsNotificationType.VERIFY_EMAIL),
+                configurationServiceWithSystemService.getNotificationTypeFromTemplateId(
+                        "1234-abcd"));
+        assertEquals(
+                Optional.empty(),
+                configurationServiceWithSystemService.getNotificationTypeFromTemplateId(
+                        "1234-wxyz"));
+        assertEquals(
+                Optional.of(DeliveryReceiptsNotificationType.EMAIL_UPDATED),
+                configurationServiceWithSystemService.getNotificationTypeFromTemplateId(
+                        "4567-ijkl"));
+        assertEquals(
+                Optional.of(DeliveryReceiptsNotificationType.EMAIL_UPDATED),
+                configurationServiceWithSystemService.getNotificationTypeFromTemplateId(
+                        "1234-efgh"));
+        assertEquals(
+                Optional.of(DeliveryReceiptsNotificationType.TERMS_AND_CONDITIONS_BULK_EMAIL),
+                configurationServiceWithSystemService.getNotificationTypeFromTemplateId(
+                        "1234-bulk"));
+        assertEquals(
+                Optional.of(DeliveryReceiptsNotificationType.REPORT_SUSPICIOUS_ACTIVITY),
+                configurationServiceWithSystemService.getNotificationTypeFromTemplateId(
+                        "report-template-id"));
+    }
+
+    @Test
+    void getOidcApiBaseURLShouldNotDefault() {
+        assertTrue(configurationService.getOidcApiBaseURL().isEmpty());
+    }
+
+    @Test
+    void getReducedLockoutDurationShouldDefault() {
+        assertEquals(900, configurationService.getReducedLockoutDuration());
+    }
 
     @Test
     void sessionCookieMaxAgeShouldEqualDefaultWhenEnvVarUnset() {
-        ConfigurationService configurationService = new ConfigurationService();
         assertEquals(3600, configurationService.getSessionCookieMaxAge());
     }
 
     @Test
+    void getSessionExpiryShouldDefault() {
+        assertEquals(3600, configurationService.getSessionExpiry());
+    }
+
+    @Test
+    void getSmoketestBucketNameShouldNotDefault() {
+        assertNull(configurationService.getSmoketestBucketName());
+    }
+
+    @Test
+    void getSqsEndpointUriShouldNotDefault() {
+        assertTrue(configurationService.getSqsEndpointUri().isEmpty());
+    }
+
+    @Test
+    void getTermsAndConditionsVersionShouldNotDefault() {
+        assertNull(configurationService.getTermsAndConditionsVersion());
+    }
+
+    @Test
+    void getTestClientVerifyEmailOTPShouldNotDefault() {
+        assertTrue(configurationService.getTestClientVerifyEmailOTP().isEmpty());
+    }
+
+    @Test
+    void getTestClientVerifyPhoneNumberOTPShouldNotDefault() {
+        assertTrue(configurationService.getTestClientVerifyPhoneNumberOTP().isEmpty());
+    }
+
+    @Test
+    void isTestClientsEnabledShouldDefault() {
+        assertFalse(configurationService.isTestClientsEnabled());
+    }
+
+    @Test
+    void isPhoneCheckerWithReplyEnabledShouldDefault() {
+        assertFalse(configurationService.isPhoneCheckerWithReplyEnabled());
+    }
+
+    @Test
+    void getSyntheticsUsersShouldDefault() {
+        assertEquals("", configurationService.getSyntheticsUsers());
+    }
+
+    @Test
+    void getTokenSigningKeyAliasShouldNotDefault() {
+        assertNull(configurationService.getTokenSigningKeyAlias());
+    }
+
+    @Test
+    void getTokenSigningKeyRsaAliasShouldNotDefault() {
+        assertNull(configurationService.getTokenSigningKeyRsaAlias());
+    }
+
+    @Test
+    void isRsaSigningAvailableShouldNotDefault() {
+        assertFalse(configurationService.isRsaSigningAvailable());
+    }
+
+    @Test
+    void getNotifyTemplateIdShouldNotDefault() {
+        assertNull(configurationService.getNotifyTemplateId("not_there"));
+    }
+
+    @Test
+    void getTicfCriServiceURIShouldNotDefault() {
+        assertNull(configurationService.getTicfCriServiceURI());
+    }
+
+    @Test
+    void abortOnAccountInterventionsErrorResponseShouldDefault() {
+        assertFalse(configurationService.abortOnAccountInterventionsErrorResponse());
+    }
+
+    @Test
+    void accountInterventionsServiceActionEnabledShouldDefault() {
+        assertFalse(configurationService.accountInterventionsServiceActionEnabled());
+    }
+
+    @Test
+    void isAccountInterventionServiceCallEnabledShouldDefault() {
+        assertFalse(configurationService.isAccountInterventionServiceCallEnabled());
+    }
+
+    @Test
+    void getAccountInterventionServiceCallTimeoutShouldDefault() {
+        assertEquals(3000, configurationService.getAccountInterventionServiceCallTimeout());
+    }
+
+    @Test
+    void getTicfCriServiceCallTimeoutShouldDefault() {
+        assertEquals(2000, configurationService.getTicfCriServiceCallTimeout());
+    }
+
+    @Test
+    void getAccountInterventionsErrorMetricNameShouldDefault() {
+        assertEquals("", configurationService.getAccountInterventionsErrorMetricName());
+    }
+
+    @Test
+    void getIPVAudienceShouldDefault() {
+        assertEquals("", configurationService.getIPVAudience());
+    }
+
+    @Test
+    void getMfaResetStorageTokenSigningKeyAliasShouldNotDefault() {
+        assertNull(configurationService.getMfaResetStorageTokenSigningKeyAlias());
+    }
+
+    @Test
+    void getMfaResetJarSigningKeyAliasShouldNotDefault() {
+        assertNull(configurationService.getMfaResetJarSigningKeyAlias());
+    }
+
+    @Test
+    void getMfaResetJarSigningKeyIdShouldNotDefault() {
+        assertNull(configurationService.getMfaResetJarSigningKeyId());
+    }
+
+    @Test
+    void getCredentialStoreURIShouldDefault() {
+        assertEquals(
+                URI.create("https://credential-store.account.gov.uk"),
+                configurationService.getCredentialStoreURI());
+    }
+
+    @Test
+    void getLegacyAccountDeletionTopicArnShouldNotDefault() {
+        assertNull(configurationService.getLegacyAccountDeletionTopicArn());
+    }
+
+    @Test
+    void getStorageTokenClaimNameShouldDefault() {
+        assertEquals(
+                "https://vocab.account.gov.uk/v1/storageAccessToken",
+                configurationService.getStorageTokenClaimName());
+    }
+
+    @Test
+    void getAuthIssuerClaimShouldNotDefault() {
+        assertEquals("", configurationService.getAuthIssuerClaim());
+    }
+
+    @Test
+    void getMfaResetCallbackURIShouldDefault() {
+        assertEquals(URI.create(""), configurationService.getMfaResetCallbackURI());
+    }
+
+    @Test
+    void getIPVAuthorisationURIShouldDefault() {
+        assertEquals(URI.create(""), configurationService.getIPVAuthorisationURI());
+    }
+
+    @Test
+    void getIPVBackendURIShouldDefault() {
+        assertEquals(URI.create(""), configurationService.getIPVBackendURI());
+    }
+
+    @Test
+    void getIPVAuthorisationCallbackURIShouldDefault() {
+        assertEquals(URI.create(""), configurationService.getIPVAuthorisationCallbackURI());
+    }
+
+    @Test
+    void getIPVAuthorisationClientIdShouldDefault() {
+        assertEquals("", configurationService.getIPVAuthorisationClientId());
+    }
+
+    @Test
     void getSessionCookieAttributesShouldEqualDefaultWhenEnvVarUnset() {
-        ConfigurationService configurationService = new ConfigurationService();
         assertEquals("Secure; HttpOnly;", configurationService.getSessionCookieAttributes());
     }
 
     @Test
     void getAccountCreationLockoutCountTTLShouldEqualDefaultWhenEnvVarUnset() {
-        ConfigurationService configurationService = new ConfigurationService();
         assertEquals(3600, configurationService.getAccountCreationLockoutCountTTL());
     }
 
     @Test
     void supportAccountCreationTTLShouldEqualDefaultWhenEnvVarUnset() {
-        ConfigurationService configurationService = new ConfigurationService();
-        assertEquals(false, configurationService.supportAccountCreationTTL());
+        assertFalse(configurationService.supportAccountCreationTTL());
+    }
+
+    @Test
+    void supportReauthSignoutEnabledShouldEqualDefaultWhenEnvVarUnset() {
+        assertFalse(configurationService.supportReauthSignoutEnabled());
     }
 
     private static Stream<Arguments> commaSeparatedStringContains() {
@@ -76,85 +630,8 @@ class ConfigurationServiceTest {
     @MethodSource("commaSeparatedStringContains")
     void shouldCheckCommaSeparatedStringContains(
             String searchTerm, String searchString, boolean result) {
-        ConfigurationService configurationService = new ConfigurationService();
         assertEquals(
                 result, configurationService.commaSeparatedListContains(searchTerm, searchString));
-    }
-
-    @Test
-    void shouldGetNotificationTypeFromTemplateId() {
-        when(systemService.getenv("VERIFY_EMAIL_TEMPLATE_ID")).thenReturn("1234-abcd");
-        when(systemService.getenv("EMAIL_UPDATED_TEMPLATE_ID")).thenReturn("1234-efgh,4567-ijkl");
-        when(systemService.getenv("TERMS_AND_CONDITIONS_BULK_EMAIL_TEMPLATE_ID"))
-                .thenReturn("1234-bulk");
-        when(systemService.getenv("REPORT_SUSPICIOUS_ACTIVITY_EMAIL_TEMPLATE_ID"))
-                .thenReturn("report-template-id");
-
-        ConfigurationService configurationService = new ConfigurationService();
-        configurationService.setSystemService(systemService);
-
-        assertEquals(
-                Optional.of(DeliveryReceiptsNotificationType.VERIFY_EMAIL),
-                configurationService.getNotificationTypeFromTemplateId("1234-abcd"));
-        assertEquals(
-                Optional.empty(),
-                configurationService.getNotificationTypeFromTemplateId("1234-wxyz"));
-        assertEquals(
-                Optional.of(DeliveryReceiptsNotificationType.EMAIL_UPDATED),
-                configurationService.getNotificationTypeFromTemplateId("4567-ijkl"));
-        assertEquals(
-                Optional.of(DeliveryReceiptsNotificationType.EMAIL_UPDATED),
-                configurationService.getNotificationTypeFromTemplateId("1234-efgh"));
-        assertEquals(
-                Optional.of(DeliveryReceiptsNotificationType.TERMS_AND_CONDITIONS_BULK_EMAIL),
-                configurationService.getNotificationTypeFromTemplateId("1234-bulk"));
-        assertEquals(
-                Optional.of(DeliveryReceiptsNotificationType.REPORT_SUSPICIOUS_ACTIVITY),
-                configurationService.getNotificationTypeFromTemplateId("report-template-id"));
-    }
-
-    @Test
-    void shouldReadTermsAndConditionsVersionCSVList() {
-        when(systemService.getOrDefault("BULK_USER_EMAIL_INCLUDED_TERMS_AND_CONDITIONS", ""))
-                .thenReturn("1.1,1.3,1.5");
-
-        ConfigurationService configurationService = new ConfigurationService();
-        configurationService.setSystemService(systemService);
-
-        assertEquals(
-                List.of("1.1", "1.3", "1.5"),
-                configurationService.getBulkUserEmailIncludedTermsAndConditions());
-    }
-
-    @Test
-    void shouldReadEmptyTermsAndConditionsVersionCSVList() {
-        when(systemService.getOrDefault("BULK_USER_EMAIL_INCLUDED_TERMS_AND_CONDITIONS", ""))
-                .thenReturn("");
-
-        ConfigurationService configurationService = new ConfigurationService();
-        configurationService.setSystemService(systemService);
-
-        assertEquals(
-                Collections.EMPTY_LIST,
-                configurationService.getBulkUserEmailIncludedTermsAndConditions());
-    }
-
-    @Test
-    void shoulCacheTheNotifyBearerTokenAfterTheFirstCall() {
-        var mock = mock(SsmClient.class);
-        ConfigurationService configurationService = new ConfigurationService(mock);
-
-        String ssmParamName = "test-notify-callback-bearer-token";
-        String ssmParamValue = "bearer-token";
-
-        var request = parameterRequest(ssmParamName);
-        var response = parameterResponse(ssmParamName, ssmParamValue);
-
-        when(mock.getParameter(parameterRequest(ssmParamName))).thenReturn(response);
-
-        assertEquals(configurationService.getNotifyCallbackBearerToken(), ssmParamValue);
-        assertEquals(configurationService.getNotifyCallbackBearerToken(), ssmParamValue);
-        verify(mock, times(1)).getParameter(request);
     }
 
     private GetParameterRequest parameterRequest(String name) {


### PR DESCRIPTION


## What
AUT-2790: Reset the emailCountLock before we send the response so the user can be logged out instead of locked out.


## How to review

1. Code Review


## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/1805
