### PR TITLE
BAU: Indicate whether account deleted manually in audit message

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -87,12 +87,12 @@ public class AccountDeletionService {
 
         String persistentSessionID = AuditService.UNKNOWN;
         String ipAddress = AuditService.UNKNOWN;
-        Boolean manualDeletion = Boolean.TRUE;
+        boolean manualDeletion = true;
         if (input.isPresent()) {
             ipAddress = PersistentIdHelper.extractPersistentIdFromHeaders(input.get().getHeaders());
             attachLogFieldToLogs(PERSISTENT_SESSION_ID, ipAddress);
             ipAddress = IpAddressHelper.extractIpAddress(input.get());
-            manualDeletion = Boolean.FALSE;
+            manualDeletion = false;
         }
 
         try {
@@ -116,10 +116,6 @@ public class AccountDeletionService {
                                             RequestHeaderHelper.getHeaderValueOrElse(
                                                     n.getHeaders(), SESSION_ID_HEADER, ""))
                             .orElse(AuditService.UNKNOWN);
-            var pairs =
-                    new AuditService.MetadataPair[] {
-                        pair("manualDeletion", manualDeletion.toString())
-                    };
             var auditContext =
                     new AuditContext(
                             clientId,
@@ -131,7 +127,8 @@ public class AccountDeletionService {
                             userProfile.getPhoneNumber(),
                             persistentSessionID,
                             txmaAuditEncoded);
-            auditService.submitAuditEvent(DELETE_ACCOUNT, auditContext, pairs);
+            auditService.submitAuditEvent(
+                    DELETE_ACCOUNT, auditContext, pair("manualDeletion", manualDeletion));
         } catch (Exception e) {
             LOG.error("Failed to audit account deletion: ", e);
         }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
@@ -216,7 +216,7 @@ class AccountDeletionServiceTest {
                                                     && Objects.equals(
                                                             auditContext.phoneNumber(),
                                                             EXPECTED_PHONE_NUMBER)),
-                            eq(buildMetadataPairs(false)));
+                            eq(pair("manualDeletion", false)));
         }
 
         @Test
@@ -238,7 +238,7 @@ class AccountDeletionServiceTest {
                                                     && Objects.equals(
                                                             auditContext.phoneNumber(),
                                                             EXPECTED_PHONE_NUMBER)),
-                            eq(buildMetadataPairs(true)));
+                            eq(pair("manualDeletion", true)));
         }
 
         @Test
@@ -253,12 +253,6 @@ class AccountDeletionServiceTest {
             assertThat(
                     logging.events(),
                     hasItem(withMessageContaining("Failed to audit account deletion")));
-        }
-
-        private AuditService.MetadataPair[] buildMetadataPairs(boolean isManualDeletion) {
-            return new AuditService.MetadataPair[] {
-                pair("manualDeletion", isManualDeletion ? "true" : "false")
-            };
         }
     }
 }


### PR DESCRIPTION
## What

Indicate whether account deleted manually in audit message.

HMRC have indicated that certain fields are missing from the AUTH_DELETE_ACCOUNT audit event.  Account deletion can either be triggered by users, or manually as required when we have to delete accounts.  For manual deletion many of the usual fields such as session ids will be missing as there is not a user session.  To make this explicit a new field has been added to the event stating whether the account was deleted manually or not.

## How to review

1. Code Review

