### PR TITLE
AUT-2788: implement logout instead of lockout for mfa in reauth

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -648,16 +648,16 @@ variable "support_email_check_enabled" {
   description = "Feature flag which toggles the Experian email check on and off"
 }
 
-variable "support_reauth_signout_enabled" {
-  default     = false
-  type        = bool
-  description = "Feature flag which toggles sign-out instead of lockout for reauth journeys"
-}
-
 variable "send_storage_token_to_ipv_enabled" {
   default     = false
   type        = bool
   description = "Feature flag which toggles whether signed VC storage token is included as claim in JAR sent to IPV"
+}
+
+variable "support_reauth_signout_enabled" {
+  default     = false
+  type        = bool
+  description = "Feature flag which toggles sign-out instead of lockout for reauth journeys"
 }
 
 variable "orch_account_id" {

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -45,6 +45,7 @@ module "verify_code" {
     LOCKOUT_COUNT_TTL                        = var.lockout_count_ttl
     EMAIL_ACCOUNT_CREATION_LOCKOUT_COUNT_TTL = var.account_creation_lockout_count_ttl
     SUPPORT_ACCOUNT_CREATION_COUNT_TTL       = var.support_account_creation_count_ttl
+    SUPPORT_REAUTH_SIGNOUT_ENABLED           = var.support_reauth_signout_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest"
 

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -47,6 +47,7 @@ module "verify_mfa_code" {
     CODE_MAX_RETRIES_INCREASED          = var.code_max_retries_increased
     REDUCED_LOCKOUT_DURATION            = var.reduced_lockout_duration
     SQS_ENDPOINT                        = var.use_localstack ? "http://localhost:45678/" : null
+    SUPPORT_REAUTH_SIGNOUT_ENABLED      = var.support_reauth_signout_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler::handleRequest"
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -288,9 +288,11 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             case ERROR_1027:
             case ERROR_1039:
             case ERROR_1048:
-                if (journeyType != JourneyType.REAUTHENTICATION) {
+                if (!configurationService.isReauthSignoutEnabled()
+                        || journeyType != JourneyType.REAUTHENTICATION) {
                     blockCodeForSession(session, codeBlockedKeyPrefix);
                 }
+
                 resetIncorrectMfaCodeAttemptsCount(session);
                 auditableEvent = FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED;
                 break;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -288,7 +288,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             case ERROR_1027:
             case ERROR_1039:
             case ERROR_1048:
-                blockCodeForSession(session, codeBlockedKeyPrefix);
+                if (journeyType != JourneyType.REAUTHENTICATION) {
+                    blockCodeForSession(session, codeBlockedKeyPrefix);
+                }
                 resetIncorrectMfaCodeAttemptsCount(session);
                 auditableEvent = FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED;
                 break;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -284,7 +284,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         ? configurationService.getReducedLockoutDuration()
                         : configurationService.getLockoutDuration();
 
-        if (journeyType != JourneyType.REAUTHENTICATION) {
+        if (!configurationService.isReauthSignoutEnabled()
+                || journeyType != JourneyType.REAUTHENTICATION) {
             codeStorageService.saveBlockedForEmail(
                     emailAddress, codeBlockedKeyPrefix, blockDuration);
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -276,7 +276,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         if (codeStorageService.isBlockedForEmail(emailAddress, codeBlockedKeyPrefix)) {
             return;
         }
-
         boolean reducedLockout =
                 List.of(CodeRequestType.SMS_REGISTRATION, CodeRequestType.SMS_ACCOUNT_RECOVERY)
                         .contains(CodeRequestType.getCodeRequestType(mfaMethodType, journeyType));
@@ -285,7 +284,10 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         ? configurationService.getReducedLockoutDuration()
                         : configurationService.getLockoutDuration();
 
-        codeStorageService.saveBlockedForEmail(emailAddress, codeBlockedKeyPrefix, blockDuration);
+        if (journeyType != JourneyType.REAUTHENTICATION) {
+            codeStorageService.saveBlockedForEmail(
+                    emailAddress, codeBlockedKeyPrefix, blockDuration);
+        }
 
         if (mfaMethodType == MFAMethodType.SMS) {
             codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -606,9 +606,11 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1027));
         assertThat(session.getRetryCount(), equalTo(0));
-        verify(codeStorageService)
-                .saveBlockedForEmail(
-                        EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, LOCKOUT_DURATION);
+        if (codeRequestType != CodeRequestType.SMS_REAUTHENTICATION) {
+            verify(codeStorageService)
+                    .saveBlockedForEmail(
+                            EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, LOCKOUT_DURATION);
+        }
         verifyNoInteractions(accountModifiersService);
         verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
         verify(auditService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -545,6 +545,7 @@ class VerifyCodeHandlerTest {
         when(codeStorageService.getOtpCode(EMAIL, MFA_SMS)).thenReturn(Optional.of(CODE));
         when(accountModifiersService.isAccountRecoveryBlockPresent(expectedCommonSubject))
                 .thenReturn(false);
+        when(configurationService.isReauthSignoutEnabled()).thenReturn(true);
         session.setNewAccount(Session.AccountState.EXISTING);
 
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
@@ -596,6 +597,7 @@ class VerifyCodeHandlerTest {
     @MethodSource("codeRequestTypes")
     void shouldReturnMaxReachedAndSetBlockedMfaCodeAttemptsWhenSignInExceedMaxRetryCount(
             CodeRequestType codeRequestType, JourneyType journeyType) {
+        when(configurationService.isReauthSignoutEnabled()).thenReturn(true);
         when(configurationService.getCodeMaxRetries()).thenReturn(0);
         when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         when(codeStorageService.getOtpCode(EMAIL, MFA_SMS)).thenReturn(Optional.of(CODE));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -521,8 +521,10 @@ class VerifyMfaCodeHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1042));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
-        verify(codeStorageService)
-                .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, 900L);
+        if (journeyType != JourneyType.REAUTHENTICATION) {
+            verify(codeStorageService)
+                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, 900L);
+        }
         verify(codeStorageService)
                 .deleteIncorrectMfaCodeAttemptsCount(EMAIL, MFAMethodType.AUTH_APP);
         verifyNoInteractions(cloudwatchMetricsService);
@@ -640,8 +642,11 @@ class VerifyMfaCodeHandlerTest {
                 .contains(codeRequestType)) {
             blockTime = 300L;
         }
-        verify(codeStorageService)
-                .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, blockTime);
+        if (journeyType != JourneyType.REAUTHENTICATION) {
+            verify(codeStorageService)
+                    .saveBlockedForEmail(
+                            EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, blockTime);
+        }
         verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
         verifyNoInteractions(cloudwatchMetricsService);
         assertAuditEventSubmittedWithMetadata(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -507,6 +507,7 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("blockedCodeForAuthAppOTPEnteredTooManyTimes")
     void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes(
             JourneyType journeyType, CodeRequestType codeRequestType) throws Json.JsonException {
+        when(configurationService.isReauthSignoutEnabled()).thenReturn(true);
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.of(ErrorResponse.ERROR_1042));
@@ -625,6 +626,7 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
     void shouldReturn400AndBlockCodeWhenUserEnteredInvalidPhoneNumberCodeTooManyTimes(
             JourneyType journeyType, CodeRequestType codeRequestType) throws Json.JsonException {
+        when(configurationService.isReauthSignoutEnabled()).thenReturn(true);
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeProcessor));
         when(phoneNumberCodeProcessor.validateCode())

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -273,7 +273,8 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
     }
 
     private static Stream<JourneyType> journeyTypes() {
-        return Stream.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA);
+        return Stream.of(
+                JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA, JourneyType.REAUTHENTICATION);
     }
 
     @ParameterizedTest
@@ -298,7 +299,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1027));
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
-                equalTo(true));
+                equalTo(journeyType != JourneyType.REAUTHENTICATION));
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_MAX_RETRIES_REACHED));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -62,7 +62,10 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     @BeforeEach
     void setup() {
-        handler = new VerifyCodeHandler(TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
+        handler =
+                new VerifyCodeHandler(
+                        REAUTH_SIGNOUT_AND_TXMA_ENABLED_CONFIGUARION_SERVICE,
+                        redisConnectionService);
         txmaAuditQueue.clear();
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -595,7 +595,11 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1042));
         assertEquals(0, redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS, MFAMethodType.AUTH_APP));
-        assertTrue(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix));
+        if (journeyType != JourneyType.REAUTHENTICATION) {
+            assertTrue(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix));
+        } else {
+            assertFalse(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix));
+        }
         assertTrue(userStore.isAccountVerified(EMAIL_ADDRESS));
         assertTrue(userStore.isAuthAppVerified(EMAIL_ADDRESS));
     }
@@ -811,7 +815,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var isAccountVerified = journeyType.equals(JourneyType.ACCOUNT_RECOVERY);
         var expectedPhoneNumber =
                 journeyType.equals(JourneyType.ACCOUNT_RECOVERY) ? PHONE_NUMBER : null;
-        ;
+
         assertThat(
                 userStore.getPhoneNumberForUser(EMAIL_ADDRESS).orElse(null),
                 equalTo(expectedPhoneNumber));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -90,7 +90,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void beforeEachSetup() throws Json.JsonException {
         handler =
                 new VerifyMfaCodeHandler(
-                        TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
+                        REAUTH_SIGNOUT_AND_TXMA_ENABLED_CONFIGUARION_SERVICE,
+                        redisConnectionService);
 
         txmaAuditQueue.clear();
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -169,6 +169,24 @@ public abstract class HandlerIntegrationTest<Q, S> {
                 }
             };
 
+    protected static final ConfigurationService
+            REAUTH_SIGNOUT_AND_TXMA_ENABLED_CONFIGUARION_SERVICE =
+                    new IntegrationTestConfigurationService(
+                            notificationsQueue,
+                            tokenSigner,
+                            docAppPrivateKeyJwtSigner,
+                            configurationParameters) {
+                        @Override
+                        public String getTxmaAuditQueueUrl() {
+                            return txmaAuditQueue.getQueueUrl();
+                        }
+
+                        @Override
+                        public boolean isReauthSignoutEnabled() {
+                            return true;
+                        }
+                    };
+
     protected RequestHandler<Q, S> handler;
     protected final Json objectMapper = SerializationService.getInstance();
     protected final Context context = mock(Context.class);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -183,6 +183,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals(FEATURE_SWITCH_ON);
     }
 
+    public boolean isReauthSignoutEnabled() {
+        return System.getenv()
+                .getOrDefault("SUPPORT_REAUTH_SIGNOUT_ENABLED", FEATURE_SWITCH_OFF)
+                .equals("true");
+    }
+
     public boolean isBulkUserEmailEmailSendingEnabled() {
         return System.getenv()
                 .getOrDefault("BULK_USER_EMAIL_EMAIL_SENDING_ENABLED", FEATURE_SWITCH_OFF)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -602,6 +602,11 @@ class ConfigurationServiceTest {
         assertFalse(configurationService.supportReauthSignoutEnabled());
     }
 
+    @Test
+    void isReauthSignoutEnabledShouldEqualDefaultWhenEnvVarUnset() {
+        assertEquals(false, configurationService.isReauthSignoutEnabled());
+    }
+
     private static Stream<Arguments> commaSeparatedStringContains() {
         return Stream.of(
                 Arguments.of("1234", null, false),


### PR DESCRIPTION
## What
In the reauth journey, we want to redirect the user to the client redirectUri when he enters six invalid otp codes, instead of locking them out for six hours. This requires the BE not to implement a 2hr lock in the BE after 6 incorrect attempts.

## How to review

1. Code Review

## Checklist

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/1829

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
