### PR TITLE
BAU: Increase visibility timeout for pending_email_check_queue

### DIFF
--- a/ci/terraform/shared/sqs.tf
+++ b/ci/terraform/shared/sqs.tf
@@ -1,9 +1,10 @@
 resource "aws_sqs_queue" "pending_email_check_queue" {
-  name                      = "${var.environment}-pending-email-check-queue"
-  delay_seconds             = 10
-  max_message_size          = 2048
-  message_retention_seconds = 1209600
-  receive_wait_time_seconds = 10
+  name                       = "${var.environment}-pending-email-check-queue"
+  delay_seconds              = 10
+  max_message_size           = 2048
+  message_retention_seconds  = 1209600
+  receive_wait_time_seconds  = 10
+  visibility_timeout_seconds = 46
 
   kms_master_key_id                 = var.use_localstack ? null : aws_kms_key.pending_email_check_queue_encryption_key.arn
   kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300


### PR DESCRIPTION
## What

During deployments of `authentication-check-experian` we sometimes see warnings when deploying a SQS Lambda trigger from this queue. The error warns that the lambda timeout is more than the visibility timeout of the queue.

For example `Resource handler returned message: "Invalid request provided: Queue visibility timeout: 30 seconds is less than Function timeout: 45 seconds`

The visibility timeout should be more than the lambda timeout, to prevent a second lambda being triggered by the same message while the first is still processing it.

This increases the queue visibility timeout past the lambda timeout of 45 seconds.

## How to review

See the value is more than is set as the lambda timeout at https://github.com/govuk-one-login/authentication-check-experian/blob/f4319a15cebeff8299c4d1e5fb9ba778cd00c02d/deploy/template.yaml#L310

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

- The lambda timeout was set in https://github.com/govuk-one-login/authentication-check-experian/pull/101