### PR TITLE
AUT-2906: Bump Ts and Cs version in shared variables

### DIFF
--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -36,7 +36,7 @@ variable "external_redis_host" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.10"
+  default = "1.11"
 }
 
 variable "external_redis_port" {


### PR DESCRIPTION


## What
Bumps Ts and Cs version in shared variables. This variable should have been included with the PR #4889 but was missed. I have updated the guidance for updates to include this specific file and to explain it's worth searching for the variable name when making updates.

## How to review

1. Code Review
2. Review the guidance for deploying a new Ts and Cs version to confirm updates make sense

## Checklist

- [ ] Impact on Orchestration and Authentication mutual dependencies has been checked.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/4889
