### PR TITLE
ATO-906: Fix casing of cloudfront header name

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelper.java
@@ -14,6 +14,7 @@ import static uk.gov.di.orchestration.shared.helpers.RequestHeaderHelper.getHead
 import static uk.gov.di.orchestration.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
 
 public class IpAddressHelper {
+    private static final String cloudFrontViewerAddressHeaderName = "Cloudfront-Viewer-Address";
 
     private static final Logger LOG = LogManager.getLogger(IpAddressHelper.class);
 
@@ -23,8 +24,8 @@ public class IpAddressHelper {
                         .map(APIGatewayProxyRequestEvent::getHeaders)
                         .orElse(emptyMap());
 
-        if (headersContainValidHeader(headers, "CloudFront-Viewer-Address", true)) {
-            return getHeaderValueFromHeaders(headers, "CloudFront-Viewer-Address", true)
+        if (headersContainValidHeader(headers, cloudFrontViewerAddressHeaderName, true)) {
+            return getHeaderValueFromHeaders(headers, cloudFrontViewerAddressHeaderName, true)
                     .split(":")[0]
                     .trim();
         } else if (headersContainValidHeader(headers, "X-Forwarded-For", true)) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/IpAddressHelperTest.java
@@ -22,7 +22,7 @@ class IpAddressHelperTest {
                 Map.of(
                         "X-Forwarded-For",
                         "234.234.234.234, 123.123.123.123, 111.111.111.111",
-                        "CloudFront-Viewer-Address",
+                        "Cloudfront-Viewer-Address",
                         "222.222.222.222:222"));
         request.setRequestContext(stubContextWithSourceIp());
 
@@ -43,7 +43,7 @@ class IpAddressHelperTest {
     void shouldAcceptCloudfrontViewerWithoutSourcePort() {
         var request = new APIGatewayProxyRequestEvent();
 
-        request.setHeaders(Map.of("CloudFront-Viewer-Address", "222.222.222.222"));
+        request.setHeaders(Map.of("Cloudfront-Viewer-Address", "222.222.222.222"));
         request.setRequestContext(stubContextWithSourceIp());
 
         assertThat(extractIpAddress(request), is("222.222.222.222"));


### PR DESCRIPTION
This is causing lots of log noise. Really these should be matched entirely case insensitively, but that's a bigger change because of the way the headers are structured in the request

