### PR TITLE
AUT-3373: Fixed incorrect DELETE_ACCOUNT audit context

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -81,7 +81,8 @@ public class AccountDeletionService {
         String persistentSessionID = AuditService.UNKNOWN;
         String ipAddress = AuditService.UNKNOWN;
         if (input.isPresent()) {
-            ipAddress = PersistentIdHelper.extractPersistentIdFromHeaders(input.get().getHeaders());
+            persistentSessionID =
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.get().getHeaders());
             attachLogFieldToLogs(PERSISTENT_SESSION_ID, ipAddress);
             ipAddress = IpAddressHelper.extractIpAddress(input.get());
         }


### PR DESCRIPTION
## What

We were not correctly sending the persistent session ID in the audit context. This is because persistentSessionId was never being reassigned after initially being assigned to null, instead incorrectly calling the extractPersistentIdFromHeaders and assigning the result to ipAddress var.

This fixes that and makes sure that they are tested in the audit context

## How to review

1. Code Review
