### PR TITLE
AUT-2298 - updated script to only run when email address exists in db

### DIFF
--- a/scripts/export-ics.sh
+++ b/scripts/export-ics.sh
@@ -2,19 +2,18 @@
 
 set -eu
 
-if [ $# -ne 2 ]
-  then
-    echo "Usage: export-ics.sh email environment"
-    exit 1
+if [ $# -ne 2 ]; then
+  echo "Usage: export-ics.sh email environment"
+  exit 1
 fi
 
 export AWS_REGION=eu-west-2
 
 sector="identity.$2.account.gov.uk"
 
-echo -e "Exporting internalCommonSubjectId for Email = $1 Environment = $2 Sector = $sector"
+echo -e "Exporting internalCommonSubjectId for Email = $1 Environment = $2 Sector = ${sector}"
 
-if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+if [[ -z ${AWS_ACCESS_KEY_ID:-} || -z ${AWS_SECRET_ACCESS_KEY:-} ]]; then
   echo "!! AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set in the environment." >&2
   echo "!! Perhaps you meant: gds aws digital-identity-dev -- ${0}" >&2
   exit 1
@@ -25,14 +24,18 @@ up="$(
     --table-name "$2-user-profile" \
     --key "{\"Email\": {\"S\": \"$1\"}}" \
     --projection-expression "#E, #ST, #S, #PS, #LS" \
-    --expression-attribute-names "{\"#E\": \"Email\", \"#ST\": \"salt\", \"#S\": \"SubjectID\", \"#PS\": \"PublicSubjectID\", \"#LS\": \"LegacySubjectId\"}" \
+    --expression-attribute-names '{"#E": "Email", "#ST": "salt", "#S": "SubjectID", "#PS": "PublicSubjectID", "#LS": "LegacySubjectId"}' \
     --region "${AWS_REGION}" \
     --no-paginate
 )"
 
-ics="$(echo -n "$up" | jq -r '.Item.SubjectID.S')"
-salt="$(echo -n "$up" | jq -r '.Item.salt.B' | base64 -d)"
-digest="$(echo -n "$sector$ics$salt" | openssl dgst -sha256 -binary | base64 | tr '/+' '_-' | tr -d '=')"
-pwid="urn:fdc:gov.uk:2022:$digest"
+if [ -n "${up}" ]; then
+  ics="$(echo -n "${up}" | jq -r '.Item.SubjectID.S')"
+  salt="$(echo -n "${up}" | jq -r '.Item.salt.B' | base64 -d)"
+  digest="$(echo -n "${sector}${ics}${salt}" | openssl dgst -sha256 -binary | base64 | tr '/+' '_-' | tr -d '=')"
+  pwid="urn:fdc:gov.uk:2022:${digest}"
 
-echo "$pwid"
+  echo "${pwid}"
+else
+  echo "Email address $1 does not exist in $2 environment"
+fi


### PR DESCRIPTION
## What

Updated export-ics.sh script to only run when the email address specified exists in the database. Previously the script would generate the same pwid whenever an email address did not exist.

## How to review

1. Code Review
2. Pull down export-ics.sh script
3. Run the script with an email address that is known to exist in the environment db
e.g. gds aws digital-identity-dev/scripts/export-ics.sh existing-email-address build
ID generated
4.  Run the script with an email address that does NOT exist in the environment db
e.g. gds aws digital-identity-dev/scripts/export-ics.sh unknown-email-address build
ID not generated
