### PR TITLE
BAU: Fix Missing OIDC_API_BASE_URL Env Var

### DIFF
--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -29,6 +29,7 @@ module "ipv-capacity" {
     IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
+    OIDC_API_BASE_URL              = local.api_base_url
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCapacityHandler::handleRequest"
 

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -29,6 +29,7 @@ module "update" {
     DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
+    OIDC_API_BASE_URL    = local.api_base_url
   }
   handler_function_name = "uk.gov.di.authentication.clientregistry.lambda.UpdateClientConfigHandler::handleRequest"
 


### PR DESCRIPTION
## What

IPV Capacity and Update Client Config Lambdas are both missing OIDC_API_BASE_URL env var due to it's use by AuditService

## How to review

Code Review


## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.


