### PR TITLE
Aut-3046: Remove user lockout from requesting too many sms code

### DIFF
--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -38,6 +38,7 @@ module "mfa" {
     DYNAMO_ENDPOINT                        = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TEST_CLIENTS_ENABLED                   = var.test_clients_enabled
     INTERNAl_SECTOR_URI                    = var.internal_sector_uri
+    SUPPORT_REAUTH_SIGNOUT_ENABLED         = var.support_reauth_signout_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaHandler::handleRequest"
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -33,7 +33,6 @@ module "send_notification" {
     LOCKOUT_COUNT_TTL                      = var.lockout_count_ttl
     EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id
     PENDING_EMAIL_CHECK_QUEUE_URL          = local.pending_email_check_queue_id
-    SUPPORT_EMAIL_CHECK_ENABLED            = var.support_email_check_enabled
     TXMA_AUDIT_QUEUE_URL                   = module.oidc_txma_audit.queue_url
     LOCALSTACK_ENDPOINT                    = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                              = local.redis_key
@@ -42,6 +41,7 @@ module "send_notification" {
     EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
     INTERNAl_SECTOR_URI                    = var.internal_sector_uri
     SUPPORT_EMAIL_CHECK_ENABLED            = var.support_email_check_enabled
+    SUPPORT_REAUTH_SIGNOUT_ENABLED         = var.support_reauth_signout_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler::handleRequest"
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -371,7 +371,9 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                     newCodeRequestBlockPrefix);
             if (!configurationService.supportReauthSignoutEnabled()) {
                 codeStorageService.saveBlockedForEmail(
-                    email, newCodeRequestBlockPrefix, configurationService.getLockoutDuration());
+                        email,
+                        newCodeRequestBlockPrefix,
+                        configurationService.getLockoutDuration());
             }
 
             LOG.info("Resetting code request count");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -369,12 +369,8 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             LOG.info(
                     "User has requested too many OTP codes. Setting block with prefix: {}",
                     newCodeRequestBlockPrefix);
-            if (!configurationService.supportReauthSignoutEnabled()) {
-                codeStorageService.saveBlockedForEmail(
-                        email,
-                        newCodeRequestBlockPrefix,
-                        configurationService.getLockoutDuration());
-            }
+            codeStorageService.saveBlockedForEmail(
+                    email, newCodeRequestBlockPrefix, configurationService.getLockoutDuration());
 
             LOG.info("Resetting code request count");
             sessionService.save(session.resetCodeRequestCount(notificationType, journeyType));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -369,8 +369,10 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             LOG.info(
                     "User has requested too many OTP codes. Setting block with prefix: {}",
                     newCodeRequestBlockPrefix);
-            codeStorageService.saveBlockedForEmail(
+            if (!configurationService.supportReauthSignoutEnabled()) {
+                codeStorageService.saveBlockedForEmail(
                     email, newCodeRequestBlockPrefix, configurationService.getLockoutDuration());
+            }
 
             LOG.info("Resetting code request count");
             sessionService.save(session.resetCodeRequestCount(notificationType, journeyType));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -288,7 +288,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             case ERROR_1027:
             case ERROR_1039:
             case ERROR_1048:
-                if (!configurationService.isReauthSignoutEnabled()
+                if (!configurationService.supportReauthSignoutEnabled()
                         || journeyType != JourneyType.REAUTHENTICATION) {
                     blockCodeForSession(session, codeBlockedKeyPrefix);
                 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -284,7 +284,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         ? configurationService.getReducedLockoutDuration()
                         : configurationService.getLockoutDuration();
 
-        if (!configurationService.isReauthSignoutEnabled()
+        if (!configurationService.supportReauthSignoutEnabled()
                 || journeyType != JourneyType.REAUTHENTICATION) {
             codeStorageService.saveBlockedForEmail(
                     emailAddress, codeBlockedKeyPrefix, blockDuration);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -386,7 +386,8 @@ class MfaHandlerTest {
 
         checkReauthenticatingUserIsNotBlockedWhenReauthFeatureIsEnabled(journeyType, reauthEnabled);
 
-        checkReauthenticatingUserIsBlockedWhenReauthFeatureIsNotEnabled(journeyType, reauthEnabled, codeRequestType);
+        checkReauthenticatingUserIsBlockedWhenReauthFeatureIsNotEnabled(
+                journeyType, reauthEnabled, codeRequestType);
 
         checkUserIsBlockedWhenNotReAuthenticating(journeyType, codeRequestType);
 
@@ -398,7 +399,8 @@ class MfaHandlerTest {
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
 
-    private void checkUserIsBlockedWhenNotReAuthenticating(JourneyType journeyType, CodeRequestType codeRequestType) {
+    private void checkUserIsBlockedWhenNotReAuthenticating(
+            JourneyType journeyType, CodeRequestType codeRequestType) {
         if (journeyType != JourneyType.REAUTHENTICATION) {
             verify(codeStorageService)
                     .saveBlockedForEmail(
@@ -408,7 +410,8 @@ class MfaHandlerTest {
         }
     }
 
-    private void checkReauthenticatingUserIsBlockedWhenReauthFeatureIsNotEnabled(JourneyType journeyType, boolean reauthEnabled, CodeRequestType codeRequestType) {
+    private void checkReauthenticatingUserIsBlockedWhenReauthFeatureIsNotEnabled(
+            JourneyType journeyType, boolean reauthEnabled, CodeRequestType codeRequestType) {
         if (journeyType == JourneyType.REAUTHENTICATION && !reauthEnabled) {
             verify(codeStorageService)
                     .saveBlockedForEmail(
@@ -418,9 +421,10 @@ class MfaHandlerTest {
         }
     }
 
-    private void checkReauthenticatingUserIsNotBlockedWhenReauthFeatureIsEnabled(JourneyType journeyType, boolean reauthEnabled) {
+    private void checkReauthenticatingUserIsNotBlockedWhenReauthFeatureIsEnabled(
+            JourneyType journeyType, boolean reauthEnabled) {
         if (journeyType == JourneyType.REAUTHENTICATION && reauthEnabled) {
-                verifyNoInteractions(codeStorageService);
+            verifyNoInteractions(codeStorageService);
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -61,6 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -390,6 +391,14 @@ class MfaHandlerTest {
                 journeyType, reauthEnabled, codeRequestType);
 
         checkUserIsBlockedWhenNotReAuthenticating(journeyType, codeRequestType);
+
+        verify(sessionService)
+                .save(
+                        argThat(
+                                sessionForTestUser ->
+                                        sessionForTestUser.getCodeRequestCount(
+                                                        NotificationType.MFA_SMS, journeyType)
+                                                == 0));
 
         verify(auditService)
                 .submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -545,7 +545,7 @@ class VerifyCodeHandlerTest {
         when(codeStorageService.getOtpCode(EMAIL, MFA_SMS)).thenReturn(Optional.of(CODE));
         when(accountModifiersService.isAccountRecoveryBlockPresent(expectedCommonSubject))
                 .thenReturn(false);
-        when(configurationService.isReauthSignoutEnabled()).thenReturn(true);
+        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
         session.setNewAccount(Session.AccountState.EXISTING);
 
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
@@ -597,7 +597,7 @@ class VerifyCodeHandlerTest {
     @MethodSource("codeRequestTypes")
     void shouldReturnMaxReachedAndSetBlockedMfaCodeAttemptsWhenSignInExceedMaxRetryCount(
             CodeRequestType codeRequestType, JourneyType journeyType) {
-        when(configurationService.isReauthSignoutEnabled()).thenReturn(true);
+        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
         when(configurationService.getCodeMaxRetries()).thenReturn(0);
         when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         when(codeStorageService.getOtpCode(EMAIL, MFA_SMS)).thenReturn(Optional.of(CODE));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -507,7 +507,7 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("blockedCodeForAuthAppOTPEnteredTooManyTimes")
     void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes(
             JourneyType journeyType, CodeRequestType codeRequestType) throws Json.JsonException {
-        when(configurationService.isReauthSignoutEnabled()).thenReturn(true);
+        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.of(ErrorResponse.ERROR_1042));
@@ -626,7 +626,7 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
     void shouldReturn400AndBlockCodeWhenUserEnteredInvalidPhoneNumberCodeTooManyTimes(
             JourneyType journeyType, CodeRequestType codeRequestType) throws Json.JsonException {
-        when(configurationService.isReauthSignoutEnabled()).thenReturn(true);
+        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeProcessor));
         when(phoneNumberCodeProcessor.validateCode())

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -182,7 +182,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
                         }
 
                         @Override
-                        public boolean isReauthSignoutEnabled() {
+                        public boolean supportReauthSignoutEnabled() {
                             return true;
                         }
                     };

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -183,12 +183,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals(FEATURE_SWITCH_ON);
     }
 
-    public boolean isReauthSignoutEnabled() {
-        return System.getenv()
-                .getOrDefault("SUPPORT_REAUTH_SIGNOUT_ENABLED", FEATURE_SWITCH_OFF)
-                .equals("true");
-    }
-
     public boolean isBulkUserEmailEmailSendingEnabled() {
         return System.getenv()
                 .getOrDefault("BULK_USER_EMAIL_EMAIL_SENDING_ENABLED", FEATURE_SWITCH_OFF)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -602,11 +602,6 @@ class ConfigurationServiceTest {
         assertFalse(configurationService.supportReauthSignoutEnabled());
     }
 
-    @Test
-    void isReauthSignoutEnabledShouldEqualDefaultWhenEnvVarUnset() {
-        assertEquals(false, configurationService.isReauthSignoutEnabled());
-    }
-
     private static Stream<Arguments> commaSeparatedStringContains() {
         return Stream.of(
                 Arguments.of("1234", null, false),


### PR DESCRIPTION
## What
- Remove user's lockout action from requesting too many sms code

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
