### PR TITLE
AUT-3412: Ensure null values in Notify Delivery Receipts are handled correctly

### DIFF
--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
@@ -15,9 +15,9 @@ public class NotifyDeliveryReceipt {
 
     @Expose @Required private String createdAt;
 
-    @Expose @Required private String completedAt;
+    @Expose private String completedAt;
 
-    @Expose @Required private String sentAt;
+    @Expose private String sentAt;
 
     @Expose @Required private String notificationType;
 


### PR DESCRIPTION
## What

Change the `NotifyDeliveryReceipt` `completedAt` and `sentAt` fields to not required, allowing for `null` values that are can be sent by Notify.

https://docs.notifications.service.gov.uk/rest-api.html#delivery-receipts

We do not use the values anywhere, but errors were being thrown by the object mapper when values were expected but not found.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.

