### PR TITLE
ATO-911: Disable provisioned concurrency of old lambdas

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -39,11 +39,7 @@ module "auth-code" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-
-  memory_size                 = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).scaling_trigger
+  memory_size      = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -62,11 +62,7 @@ module "authentication_callback" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-
-  memory_size                 = lookup(var.performance_tuning, "orchestration-redirect", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "orchestration-redirect", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "orchestration-redirect", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "orchestration-redirect", local.default_performance_parameters).scaling_trigger
+  memory_size      = lookup(var.performance_tuning, "orchestration-redirect", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -64,11 +64,7 @@ module "authorize" {
   execution_arn         = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
   lambda_error_rate_alarm_disabled = true
-
-  memory_size                 = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).scaling_trigger
+  memory_size                      = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -50,11 +50,7 @@ module "doc-app-callback" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-
-  memory_size                 = lookup(var.performance_tuning, "doc-app-callback", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "doc-app-callback", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "doc-app-callback", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "doc-app-callback", local.default_performance_parameters).scaling_trigger
+  memory_size      = lookup(var.performance_tuning, "doc-app-callback", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.doc_checking_app_api_release_zip.key

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -62,11 +62,7 @@ module "ipv-callback" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-
-  memory_size                 = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).scaling_trigger
+  memory_size      = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -32,11 +32,7 @@ module "jwks" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_resource.wellknown_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-
-  memory_size                 = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).scaling_trigger
+  memory_size      = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -45,11 +45,7 @@ module "logout" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-
-  memory_size                 = lookup(var.performance_tuning, "logout", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "logout", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "logout", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "logout", local.default_performance_parameters).scaling_trigger
+  memory_size      = lookup(var.performance_tuning, "logout", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -36,11 +36,7 @@ module "register" {
   root_resource_id       = aws_api_gateway_resource.register_resource.id
   execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   authentication_vpc_arn = local.authentication_vpc_arn
-
-  memory_size                 = lookup(var.performance_tuning, "register", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "register", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "register", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "register", local.default_performance_parameters).scaling_trigger
+  memory_size            = lookup(var.performance_tuning, "register", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.client_api_release_zip.key

--- a/ci/terraform/oidc/storage-token-jwk.tf
+++ b/ci/terraform/oidc/storage-token-jwk.tf
@@ -29,11 +29,7 @@ module "storage_token_jwk" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_resource.wellknown_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-
-  memory_size                 = lookup(var.performance_tuning, "storage-token-jwk", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "storage-token-jwk", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "storage-token-jwk", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "storage-token-jwk", local.default_performance_parameters).scaling_trigger
+  memory_size      = lookup(var.performance_tuning, "storage-token-jwk", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -68,11 +68,7 @@ module "token" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-
-  memory_size                 = lookup(var.performance_tuning, "token", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "token", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "token", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "token", local.default_performance_parameters).scaling_trigger
+  memory_size      = lookup(var.performance_tuning, "token", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -26,11 +26,7 @@ module "trustmarks" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-
-  memory_size                 = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).scaling_trigger
+  memory_size      = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -47,11 +47,7 @@ module "userinfo" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-
-  memory_size                 = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).scaling_trigger
+  memory_size      = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -25,11 +25,7 @@ module "openid_configuration_discovery" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_resource.wellknown_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-
-  memory_size                 = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).memory
-  provisioned_concurrency     = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).concurrency
-  max_provisioned_concurrency = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).max_concurrency
-  scaling_trigger             = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).scaling_trigger
+  memory_size      = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).memory
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key


### PR DESCRIPTION
## What
Disable provisioned concurrency of old lambdas.
This a quick way to reduce running costs on lambdas that are no longer in use

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
