### PR TITLE
ATO-none: update method to allow signatures of base64url when using j…

### DIFF
--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java
@@ -212,7 +212,7 @@ public class IpvTokenTest {
         try {
             signature_bytes =
                     ECDSA.transcodeSignatureToDER(
-                            Base64.getDecoder().decode(CLIENT_ASSERTION_SIGNATURE));
+                            Base64.getUrlDecoder().decode(CLIENT_ASSERTION_SIGNATURE));
         } catch (JOSEException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Update to allow for base64url signatures which jwt.io generates