### PR TITLE
BAU: Enable snapstart on FetchJwksFunction

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -396,19 +396,8 @@ Resources:
       Handler: uk.gov.di.authentication.oidc.lambda.FetchJwksHandler::handleRequest
       LoggingConfig:
         LogGroup: !Ref FetchJwksFunctionLogGroup
-      ProvisionedConcurrencyConfig: !If
-        - EnableProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap
-            - ProvisionedConcurrency
-            - !Ref Environment
-            - FetchJwksFunction
-            - DefaultValue:
-                !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  defaultProvisionedConcurrency,
-                ]
-        - !Ref AWS::NoValue
+      SnapStart:
+        ApplyOn: PublishedVersions
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_117
 


### PR DESCRIPTION
This was previously applied but [reverting](https://github.com/govuk-one-login/authentication-api/pull/4937) back to provisioned concurrency caused the orch pipeline to fail
