### PR TITLE
ATO-694: Set build VPC and pipeline parameters

### DIFF
--- a/ci/stack-orchestration/configuration/build/build-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/build/build-orch-be-pipeline/parameters.json
@@ -24,6 +24,10 @@
     "ParameterValue": "EC2"
   },
   {
+    "ParameterKey": "AllowedServiceFive",
+    "ParameterValue": "Lambda"
+  },
+  {
     "ParameterKey": "AdditionalCodeSigningVersionArns",
     "ParameterValue": "arn:aws:signer:eu-west-2:216552277552:/signing-profiles/DynatraceSigner/5uwzCCGTPq"
   },

--- a/ci/stack-orchestration/configuration/build/vpc/parameters.json
+++ b/ci/stack-orchestration/configuration/build/vpc/parameters.json
@@ -30,5 +30,9 @@
   {
     "ParameterKey": "DynamoDBApiEnabled",
     "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "LambdaApiEnabled",
+    "ParameterValue": "Yes"
   }
 ]


### PR DESCRIPTION
## What

Set parameters to allow (in build env):
- communication with AWS Lambda API
- Lambda as a service in the permissions boundary

Note that merging this PR will not trigger deployment of these stacks as that is handled manually. In this case the stacks will be updated in the AWS console, and this PR is just to keep the code up to date.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/4939
