### PR TITLE
ATO-694: Throw ClientSignatureValidationException when PublicKeySource is static but PublicKey is null

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
@@ -132,12 +132,20 @@ public class ClientSignatureValidationService {
     }
 
     private PublicKey retrievePublicKey(ClientRegistry client, String kid)
-            throws NoSuchAlgorithmException, InvalidKeySpecException, JwksException {
+            throws NoSuchAlgorithmException,
+                    InvalidKeySpecException,
+                    JwksException,
+                    ClientSignatureValidationException {
         LOG.info("kid: " + kid);
         try {
             if (client.getPublicKeySource().equals(PublicKeySource.STATIC.getValue())) {
                 LOG.info("returning static");
-                return convertPemToPublicKey(client.getPublicKey());
+                String publicKey = client.getPublicKey();
+                if (publicKey == null) {
+                    throw new ClientSignatureValidationException(
+                            "PublicKeySource is static but PublicKey is null");
+                }
+                return convertPemToPublicKey(publicKey);
             }
             if (kid == null) {
                 String error = "Key ID is null but is required to fetch JWKS";

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationServiceTest.java
@@ -112,6 +112,16 @@ class ClientSignatureValidationServiceTest {
                             clientSignatureValidationService.validateTokenClientAssertion(
                                     privateKeyJWT, client));
         }
+
+        @Test
+        void shouldThrowExceptionWhenPublicKeySourceIsStaticButPublicKeyIsNull() {
+            var client = generateClientWithStaticPublicKeySourceAndNullPublicKey();
+            var signedJWT = generateSignedJWT(keyPair.getPrivate());
+
+            assertThrows(
+                    ClientSignatureValidationException.class,
+                    () -> clientSignatureValidationService.validate(signedJWT, client));
+        }
     }
 
     @Nested
@@ -268,5 +278,12 @@ class ClientSignatureValidationServiceTest {
                 .withClientID(CLIENT_ID.getValue())
                 .withPublicKeySource(PublicKeySource.JWKS.getValue())
                 .withJwksUrl("https://some-url");
+    }
+
+    private static ClientRegistry generateClientWithStaticPublicKeySourceAndNullPublicKey() {
+        return new ClientRegistry()
+                .withClientID(CLIENT_ID.getValue())
+                .withPublicKeySource(PublicKeySource.STATIC.getValue())
+                .withPublicKey(null);
     }
 }


### PR DESCRIPTION
## What

Previously, when PublicKeySource = static and PublicKey is not provided, a NullPointerException was thrown. Instead throw more useful ClientSignatureValidationException with error message.

## How to review

1. Code Review only

