### PR TITLE
ATO-917: Return bad requests in authorisation handler for incorrect requests

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -75,7 +75,6 @@ import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISAT
 import static uk.gov.di.orchestration.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.orchestration.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.orchestration.shared.entity.ValidClaims.CORE_IDENTITY_JWT;
-import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.orchestration.shared.helpers.CookieHelper.getHttpCookieFromMultiValueResponseHeaders;
 import static uk.gov.di.orchestration.shared.helpers.PersistentIdHelper.isValidPersistentSessionCookieWithDoubleDashedTimestamp;
 import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
@@ -842,7 +841,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void
-            shouldReturnBadRequestGivenAnInvalidRequestWhenJARIsRequiredButRequestObjectIsMissingAndRedirectUriIsNotInClientRegistry() throws Json.JsonException {
+            shouldReturnBadRequestGivenAnInvalidRequestWhenJARIsRequiredButRequestObjectIsMissingAndRedirectUriIsNotInClientRegistry() {
         registerClient(CLIENT_ID, "test-client", singletonList("openid"), ClientType.WEB, true);
         handler = new AuthorisationHandler(configuration);
         txmaAuditQueue.clear();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -35,7 +35,6 @@ import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.ServiceType;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
-import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.extensions.DocAppJwksExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
@@ -836,7 +835,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(locationHeaderUri.toString(), containsString(RP_REDIRECT_URI.toString()));
         assertThat(locationHeaderUri.getQuery(), matchesPattern(expectedQueryStringRegex));
 
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
     }
 
     @Test
@@ -859,11 +860,11 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Optional.of("GET"));
 
         assertThat(response, hasStatus(400));
-        assertThat(
-                response.getBody(),
-                equalTo(OAuth2Error.INVALID_REQUEST.getDescription()));
+        assertThat(response.getBody(), equalTo(OAuth2Error.INVALID_REQUEST.getDescription()));
 
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
     }
 
     private Map<String, String> constructQueryStringParameters(

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -20,6 +20,7 @@ dependencies {
             configurations.bouncycastle,
             configurations.cloudwatch,
             configurations.apache,
+            configurations.jetbrains_annotations,
             project(":orchestration-shared"),
             project(":client-registry-api"),
             project(":doc-checking-app-api")

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/IncorrectRedirectUriException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/IncorrectRedirectUriException.java
@@ -2,11 +2,9 @@ package uk.gov.di.authentication.oidc.exceptions;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
 
-import static java.lang.String.format;
-
 public class IncorrectRedirectUriException extends Exception {
 
     public IncorrectRedirectUriException(ErrorObject error) {
-        super(format(error.getDescription()));
+        super(error.getDescription());
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/IncorrectRedirectUriException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/IncorrectRedirectUriException.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+
+import static java.lang.String.format;
+
+public class IncorrectRedirectUriException extends Exception {
+
+    public IncorrectRedirectUriException(ErrorObject error) {
+        super(format(error.getDescription()));
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/InvalidAuthenticationRequestException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/InvalidAuthenticationRequestException.java
@@ -1,0 +1,16 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+
+public class InvalidAuthenticationRequestException extends Exception {
+
+    private final ErrorObject error;
+
+    public InvalidAuthenticationRequestException(ErrorObject error) {
+        this.error = error;
+    }
+
+    public ErrorObject getError() {
+        return error;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/MissingClientIDException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/MissingClientIDException.java
@@ -1,0 +1,16 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+
+public class MissingClientIDException extends Exception {
+
+    private final ErrorObject error;
+
+    public MissingClientIDException(ErrorObject error) {
+        this.error = error;
+    }
+
+    public ErrorObject getError() {
+        return error;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/MissingRedirectUriException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/MissingRedirectUriException.java
@@ -1,0 +1,16 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+
+public class MissingRedirectUriException extends Exception {
+
+    private final ErrorObject error;
+
+    public MissingRedirectUriException(ErrorObject error) {
+        this.error = error;
+    }
+
+    public ErrorObject getError() {
+        return error;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -318,10 +318,7 @@ public class AuthorisationHandler
                         client.getClientID(),
                         user);
             } else {
-                LOG.warn(
-                        "Redirect URI {} is invalid for client {}",
-                        authRequest.getRedirectionURI(),
-                        client.getClientID());
+                LOG.warn("Redirect URI {} is invalid for client", authRequest.getRedirectionURI());
                 return generateBadRequestResponse(user, errorMsg, client.getClientID());
             }
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -320,7 +320,7 @@ public class AuthorisationHandler
             } else {
                 LOG.warn(
                         "Redirect URI {} is invalid for client {}",
-                        authRequest.getRedirectionURI().toString(),
+                        authRequest.getRedirectionURI(),
                         client.getClientID());
                 return generateBadRequestResponse(user, errorMsg, client.getClientID());
             }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -94,7 +94,6 @@ import static com.nimbusds.oauth2.sdk.OAuth2Error.VALIDATION_FAILED;
 import static java.util.Objects.isNull;
 import static uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService.VTR_PARAM;
 import static uk.gov.di.orchestration.shared.conditions.IdentityHelper.identityRequired;
-import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.orchestration.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -707,7 +706,7 @@ public class AuthorisationHandler
                 clientId == null ? AuditService.UNKNOWN : clientId,
                 user,
                 pair("description", errorDescription));
-        return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+        return generateApiGatewayProxyResponse(400, ErrorResponse.ERROR_1001.getMessage());
     }
 
     private APIGatewayProxyResponseEvent generateParseExceptionResponse(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -284,7 +284,8 @@ public class AuthorisationHandler
             LOG.warn(
                     "No parameters are present in the Authentication request query string or body",
                     e);
-            throw new RuntimeException(
+            return generateMissingParametersResponse(
+                    user,
                     "No parameters are present in the Authentication request query string or body",
                     null);
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorisationService.java
@@ -15,7 +15,7 @@ import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
 public class AuthorisationService {
     private final ClientService clientService;
-    private static final Logger LOG = LogManager.getLogger(AuthorisationHandler.class);
+    private static final Logger LOG = LogManager.getLogger(AuthorisationService.class);
 
     public AuthorisationService(ClientService clientService) {
         this.clientService = clientService;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorisationService.java
@@ -1,0 +1,58 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.oauth2.sdk.ParseException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.oidc.exceptions.IncorrectRedirectUriException;
+import uk.gov.di.authentication.oidc.exceptions.InvalidAuthenticationRequestException;
+import uk.gov.di.authentication.oidc.exceptions.MissingClientIDException;
+import uk.gov.di.authentication.oidc.exceptions.MissingRedirectUriException;
+import uk.gov.di.authentication.oidc.lambda.AuthorisationHandler;
+import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
+import uk.gov.di.orchestration.shared.services.ClientService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.DynamoClientService;
+
+public class AuthorisationService {
+    private final ClientService clientService;
+    private static final Logger LOG = LogManager.getLogger(AuthorisationHandler.class);
+
+    public AuthorisationService(ClientService clientService) {
+        this.clientService = clientService;
+    }
+
+    public AuthorisationService(ConfigurationService configurationService) {
+        this.clientService = new DynamoClientService(configurationService);
+    }
+
+    public void classifyParseException(ParseException error)
+            throws MissingClientIDException,
+                    IncorrectRedirectUriException,
+                    ClientNotFoundException,
+                    InvalidAuthenticationRequestException,
+                    MissingRedirectUriException {
+        if (error.getClientID() == null) {
+            throw new MissingClientIDException(error.getErrorObject());
+        }
+
+        if (error.getRedirectionURI() == null) {
+            throw new MissingRedirectUriException(error.getErrorObject());
+        }
+
+        var client =
+                clientService
+                        .getClient(error.getClientID().getValue())
+                        .orElseThrow(
+                                () -> new ClientNotFoundException(error.getClientID().getValue()));
+
+        if (client.getRedirectUrls().contains(error.getRedirectionURI().toString())) {
+            throw new InvalidAuthenticationRequestException(error.getErrorObject());
+        }
+
+        LOG.warn(
+                "Redirect URI {} is invalid for client {}",
+                error.getRedirectionURI(),
+                client.getClientID());
+        throw new IncorrectRedirectUriException(error.getErrorObject());
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorisationService.java
@@ -7,7 +7,6 @@ import uk.gov.di.authentication.oidc.exceptions.IncorrectRedirectUriException;
 import uk.gov.di.authentication.oidc.exceptions.InvalidAuthenticationRequestException;
 import uk.gov.di.authentication.oidc.exceptions.MissingClientIDException;
 import uk.gov.di.authentication.oidc.exceptions.MissingRedirectUriException;
-import uk.gov.di.authentication.oidc.lambda.AuthorisationHandler;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.services.ClientService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -49,10 +48,7 @@ public class AuthorisationService {
             throw new InvalidAuthenticationRequestException(error.getErrorObject());
         }
 
-        LOG.warn(
-                "Redirect URI {} is invalid for client {}",
-                error.getRedirectionURI(),
-                client.getClientID());
+        LOG.warn("Redirect URI {} is invalid for client", error.getRedirectionURI());
         throw new IncorrectRedirectUriException(error.getErrorObject());
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -975,9 +975,7 @@ class AuthorisationHandlerTest {
                             withMessage(
                                     "JAR required for client but request does not contain Request Object"),
                             withMessage(
-                                    String.format(
-                                            "Redirect URI invalid-redirect-uri is invalid for client %s",
-                                            CLIENT_ID.getValue()))));
+                                    "Redirect URI invalid-redirect-uri is invalid for client")));
         }
 
         @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -781,8 +781,7 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldReturnBadRequestWhenNoQueryStringParametersArePresent()
-                throws Json.JsonException {
+        void shouldReturnBadRequestWhenNoQueryStringParametersArePresent() {
             APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
             event.setHttpMethod("GET");
             event.setRequestContext(
@@ -800,8 +799,7 @@ class AuthorisationHandlerTest {
                                     "No parameters are present in the Authentication request query string or body"));
 
             assertThat(response, hasStatus(400));
-            assertThat(
-                    response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
+            assertThat(response, hasBody(ErrorResponse.ERROR_1001.getMessage()));
         }
 
         @ParameterizedTest
@@ -1774,7 +1772,6 @@ class AuthorisationHandlerTest {
                     ClientNotFoundException,
                     MissingClientIDException,
                     IncorrectRedirectUriException,
-                    Json.JsonException,
                     MissingRedirectUriException {
         doThrow(new MissingClientIDException(OAuth2Error.INVALID_REQUEST))
                 .when(authorisationService)
@@ -1783,7 +1780,7 @@ class AuthorisationHandlerTest {
         var response = makeHandlerRequest(withRequestEvent(Map.of()));
 
         assertThat(response, hasStatus(400));
-        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
+        assertThat(response, hasBody(ErrorResponse.ERROR_1001.getMessage()));
 
         verify(auditService)
                 .submitAuditEvent(
@@ -1799,7 +1796,6 @@ class AuthorisationHandlerTest {
                     ClientNotFoundException,
                     MissingClientIDException,
                     IncorrectRedirectUriException,
-                    Json.JsonException,
                     MissingRedirectUriException {
         doThrow(new MissingRedirectUriException(OAuth2Error.INVALID_REQUEST))
                 .when(authorisationService)
@@ -1809,7 +1805,7 @@ class AuthorisationHandlerTest {
                 makeHandlerRequest(withRequestEvent(Map.of("client_id", CLIENT_ID.getValue())));
 
         assertThat(response, hasStatus(400));
-        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
+        assertThat(response, hasBody(ErrorResponse.ERROR_1001.getMessage()));
 
         verify(auditService)
                 .submitAuditEvent(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -188,7 +188,6 @@ class AuthorisationHandlerTest {
             URI.create("https://example.com/authorize?prompt=login");
     private static final URI FRONT_END_AUTHORIZE_SIGN_IN_URI =
             URI.create("https://example.com/authorize?result=sign-in");
-    private static final String ERROR_PAGE_REDIRECT_PATH = "error";
     private static final String AWS_REQUEST_ID = "aws-request-id";
     private static final ClientID CLIENT_ID = new ClientID("test-id");
     private static final String SESSION_ID = "a-session-id";
@@ -685,8 +684,8 @@ class AuthorisationHandlerTest {
 
             verify(authorisationService).classifyParseException(parseExceptionArgument.capture());
             assertEquals(
-                    parseExceptionArgument.getValue().getMessage(),
-                    "Missing response_type parameter");
+                    "Missing response_type parameter",
+                    parseExceptionArgument.getValue().getMessage());
         }
 
         @Test
@@ -858,8 +857,8 @@ class AuthorisationHandlerTest {
 
             verify(authorisationService).classifyParseException(parseExceptionArgument.capture());
             assertEquals(
-                    parseExceptionArgument.getValue().getMessage(),
-                    "Invalid prompt parameter: Unknown prompt type: unrecognised");
+                    "Invalid prompt parameter: Unknown prompt type: unrecognised",
+                    parseExceptionArgument.getValue().getMessage());
         }
 
         @Test
@@ -1828,7 +1827,6 @@ class AuthorisationHandlerTest {
                     ClientNotFoundException,
                     MissingClientIDException,
                     IncorrectRedirectUriException,
-                    Json.JsonException,
                     MissingRedirectUriException {
         doThrow(new IncorrectRedirectUriException(OAuth2Error.INVALID_REQUEST))
                 .when(authorisationService)
@@ -1860,7 +1858,6 @@ class AuthorisationHandlerTest {
                     ClientNotFoundException,
                     MissingClientIDException,
                     IncorrectRedirectUriException,
-                    Json.JsonException,
                     MissingRedirectUriException {
         doThrow(new ClientNotFoundException(CLIENT_ID.getValue()))
                 .when(authorisationService)
@@ -1894,7 +1891,6 @@ class AuthorisationHandlerTest {
                     ClientNotFoundException,
                     MissingClientIDException,
                     IncorrectRedirectUriException,
-                    Json.JsonException,
                     MissingRedirectUriException {
         doThrow(new InvalidAuthenticationRequestException(INVALID_REQUEST))
                 .when(authorisationService)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorisationServiceTest.java
@@ -1,0 +1,124 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.oidc.exceptions.IncorrectRedirectUriException;
+import uk.gov.di.authentication.oidc.exceptions.InvalidAuthenticationRequestException;
+import uk.gov.di.authentication.oidc.exceptions.MissingClientIDException;
+import uk.gov.di.authentication.oidc.exceptions.MissingRedirectUriException;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
+import uk.gov.di.orchestration.shared.services.ClientService;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuthorisationServiceTest {
+    private AuthorisationService authorisationService;
+    private final ClientService clientService = mock(ClientService.class);
+
+    private static final ClientID CLIENT_ID = new ClientID("test-id");
+    private static final URI REDIRECT_URI = URI.create("https://localhost:8080");
+
+    @BeforeEach
+    void setUp() {
+        authorisationService = new AuthorisationService(clientService);
+
+        when(clientService.getClient(anyString()))
+                .thenReturn(
+                        Optional.of(
+                                new ClientRegistry()
+                                        .withClientID(CLIENT_ID.getValue())
+                                        .withRedirectUrls(List.of(REDIRECT_URI.toString()))));
+    }
+
+    @Test
+    void classifyParseExceptionShouldReturnMissingRedirectUriExceptionWhenNoRedirectUri() {
+        assertThrows(
+                MissingRedirectUriException.class,
+                () ->
+                        authorisationService.classifyParseException(
+                                new ParseException(
+                                        "Missing redirect_uri parameter",
+                                        OAuth2Error.INVALID_REQUEST,
+                                        CLIENT_ID,
+                                        null,
+                                        null,
+                                        null)));
+    }
+
+    @Test
+    void classifyParseExceptionShouldReturnMissingClientIDExceptionWhenNoClientId() {
+        assertThrows(
+                MissingClientIDException.class,
+                () ->
+                        authorisationService.classifyParseException(
+                                new ParseException(
+                                        "Missing client_id parameter",
+                                        OAuth2Error.INVALID_REQUEST,
+                                        null,
+                                        REDIRECT_URI,
+                                        null,
+                                        null)));
+    }
+
+    @Test
+    void classifyParseExceptionShouldReturnClientNotFoundExceptionWhenClientIdButNoClient() {
+        when(clientService.getClient(CLIENT_ID.getValue())).thenReturn(Optional.empty());
+
+        assertThrows(
+                ClientNotFoundException.class,
+                () ->
+                        authorisationService.classifyParseException(
+                                new ParseException(
+                                        "Invalid request",
+                                        OAuth2Error.INVALID_REQUEST,
+                                        CLIENT_ID,
+                                        REDIRECT_URI,
+                                        null,
+                                        null)),
+                format("No Client found for ClientID: %s", CLIENT_ID));
+    }
+
+    @Test
+    void
+            classifyParseExceptionShouldReturnInvalidAuthenticationRequestExceptionWhenRedirectUrlIsCorrect() {
+        assertThrows(
+                InvalidAuthenticationRequestException.class,
+                () ->
+                        authorisationService.classifyParseException(
+                                new ParseException(
+                                        "Invalid request",
+                                        OAuth2Error.INVALID_REQUEST,
+                                        CLIENT_ID,
+                                        REDIRECT_URI,
+                                        null,
+                                        null)));
+    }
+
+    @Test
+    void
+            classifyParseExceptionShouldReturnIncorrectRedirectUriExceptionWhenRedirectUrlIsIncorrect() {
+        assertThrows(
+                IncorrectRedirectUriException.class,
+                () ->
+                        authorisationService.classifyParseException(
+                                new ParseException(
+                                        "Invalid request",
+                                        OAuth2Error.INVALID_REQUEST,
+                                        CLIENT_ID,
+                                        URI.create("invalid-uri"),
+                                        null,
+                                        null)));
+    }
+}


### PR DESCRIPTION
## What

We are currently throwing exceptions when a user sends a bad request to the authorise endpoint that can't be parsed properly. This PR classifies the parse exceptions, and then returns a bad request which is what the OIDC spec recommends when there is not enough information to redirect back. 

## How to review

I've tried to make the changes commit by commit, so probably worth checking these

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
