### PR TITLE
BAU: Add SonarCloud break glass mechanism 

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -300,23 +300,29 @@ jobs:
       - run-unit-tests
       - run-integration-tests
       - run-account-management-and-delivery-receipts-tests
+    env:
+      RUN: ${{ !contains(github.event.pull_request.labels.*.name , 'bypass-sonarcloud') && github.actor != 'dependabot[bot]' }}
     if: github.event_name != 'merge_group'
     steps:
       - name: Check out repository code
+        if: ${{ env.RUN == 'true' }}
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
       - name: Set up JDK 17
+        if: ${{ env.RUN == 'true' }}
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #v4.2.1
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Set up Gradle
+        if: ${{ env.RUN == 'true' }}
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
         with:
           gradle-version: wrapper
           cache-read-only: true
       - name: Restore Build Cache
+        if: ${{ env.RUN == 'true' }}
         uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
@@ -325,8 +331,8 @@ jobs:
             !*/build/reports
             !*/build/jacoco
           key: ${{ runner.os }}-build-${{ github.sha }}
-
       - name: Restore Cached Unit Test Reports
+        if: ${{ env.RUN == 'true' }}
         uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
@@ -340,6 +346,7 @@ jobs:
             !delivery-receipts-integration-tests/build/jacoco/
             !delivery-receipts-integration-tests/build/reports/
       - name: Restore Cached Integration Test Reports
+        if: ${{ env.RUN == 'true' }}
         uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           key: ${{ runner.os }}-integration-test-reports-${{ github.sha }}
@@ -347,6 +354,7 @@ jobs:
             integration-tests/build/jacoco/
             integration-tests/build/reports/
       - name: Restore Cached AM DR Integration Test Reports
+        if: ${{ env.RUN == 'true' }}
         uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           key: ${{ runner.os }}-am-dr-integration-test-reports-${{ github.sha }}
@@ -356,7 +364,7 @@ jobs:
             delivery-receipts-integration-tests/build/jacoco/
             delivery-receipts-integration-tests/build/reports/
       - name: Run SonarCloud Analysis
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ env.RUN == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -9,6 +9,8 @@ on:
       - reopened
       - ready_for_review
       - synchronize
+      - labeled
+      - unlabeled
   merge_group:
 
 jobs:


### PR DESCRIPTION
## What

Now that a successful SonarCloud analysis run is required to merge a PR, we have discovered a need to have a "break glass" mechanism to bypass the analysis in cases where we must push code quickly without an analysis on code smells / code coverage.

This means we can merge PRs that revert previously merged work that would now by hit by the failed analysis.

This is implemented by allowing the GitHub `run-sonar-analysis` job to be skipped if the PR has the label `bypass-sonarcloud`.

Various ways to do this were explored and discounted:

- Using the `if` key within a job would mean the job is skipped if true, which would fail the branch protection rule that requires a pass
- Trying to exit a job early didn't work either:
  - Having a step with a `run` key that used `exit 0` didn't work, as the step completed and the next step was started.
    - We could make it exit with an error code, but that would fail the job, thus fail the branch protection rule.
  - Using the `gh` CLI tool in `run` block to cancel the job failed, as it didn't have the right permission, also the job needs to succeed for the branch protection rule.
- Instead each step needs to check if it can be run with the new job environment variable.
  - Here we elevate the `github.actor != 'dependabot[bot]` condition that was in the last step into all steps, as the intent behind the condition is the same as the new label (skip the check but mark as soccess)

Also this will now re-trigger pre-merge-checks when the pull request labels change. Instead of requiring the PR author to jump through some hoops to get jobs to re-run after they assess the need to bypass, this will now trigger the checks when the label is added/removed.

## How to review

1. Code Review
1. Look at the logs of this PR's `run-sonar-analysis` job run to see it was bypassed due to having the label.

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.
