### PR TITLE
Bau/fix login attempts

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -221,7 +221,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             JourneyType journeyType,
             AuditContext auditContext) {
         var notificationType = codeRequest.notificationType();
-        int loginFailureCount = session.getRetryCount();
+        int loginFailureCount =
+                codeStorageService.getIncorrectMfaCodeAttemptsCount(session.getEmailAddress());
         var clientSession = userContext.getClientSession();
         var clientId = userContext.getClient().get().getClientID();
         var levelOfConfidence =
@@ -282,7 +283,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         var notificationType = codeRequest.notificationType();
         var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
         var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-        int loginFailureCount = session.getRetryCount();
         AuditableEvent auditableEvent;
         switch (errorResponse) {
             case ERROR_1027:
@@ -300,6 +300,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 auditableEvent = FrontendAuditableEvent.INVALID_CODE_SENT;
                 break;
         }
+        var loginFailureCount =
+                codeStorageService.getIncorrectMfaCodeAttemptsCount(session.getEmailAddress());
         var metadataPairArray =
                 metadataPairs(notificationType, journeyType, codeRequest, loginFailureCount, true);
         auditService.submitAuditEvent(auditableEvent, auditContext, metadataPairArray);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -415,7 +415,6 @@ class VerifyCodeHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1033));
-        assertThat(session.getRetryCount(), equalTo(0));
         verifyNoInteractions(accountModifiersService);
         verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
         verify(codeStorageService, never())
@@ -608,7 +607,6 @@ class VerifyCodeHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1027));
-        assertThat(session.getRetryCount(), equalTo(0));
         verify(codeStorageService)
                 .saveBlockedForEmail(
                         EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, LOCKOUT_DURATION);
@@ -641,7 +639,6 @@ class VerifyCodeHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1039));
-        assertThat(session.getRetryCount(), equalTo(0));
         verify(codeStorageService)
                 .saveBlockedForEmail(
                         EMAIL,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -503,6 +503,7 @@ class VerifyCodeHandlerTest {
             CodeRequestType codeRequestType, JourneyType journeyType) {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(codeStorageService.getOtpCode(EMAIL, MFA_SMS)).thenReturn(Optional.of(CODE));
+        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(4);
         when(accountModifiersService.isAccountRecoveryBlockPresent(anyString())).thenReturn(true);
         session.setNewAccount(Session.AccountState.EXISTING);
 
@@ -527,7 +528,7 @@ class VerifyCodeHandlerTest {
                                 "journey-type",
                                 journeyType != null ? String.valueOf(journeyType) : "SIGN_IN"),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
-                        pair("loginFailureCount", 0),
+                        pair("loginFailureCount", 4),
                         pair("MFACodeEntered", "123456"));
         verify(auditService)
                 .submitAuditEvent(
@@ -543,6 +544,7 @@ class VerifyCodeHandlerTest {
     void shouldReturn204ForValidMfaSmsRequestAndNotRemoveAccountRecoveryBlockWhenNotPresent() {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(codeStorageService.getOtpCode(EMAIL, MFA_SMS)).thenReturn(Optional.of(CODE));
+        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(4);
         when(accountModifiersService.isAccountRecoveryBlockPresent(expectedCommonSubject))
                 .thenReturn(false);
         session.setNewAccount(Session.AccountState.EXISTING);
@@ -562,7 +564,7 @@ class VerifyCodeHandlerTest {
                         pair("account-recovery", false),
                         pair("journey-type", "SIGN_IN"),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
-                        pair("loginFailureCount", 0),
+                        pair("loginFailureCount", 4),
                         pair("MFACodeEntered", "123456"));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
@@ -573,6 +575,7 @@ class VerifyCodeHandlerTest {
     void shouldReturnMfaCodeNotValidWhenCodeIsInvalid() {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(codeStorageService.getOtpCode(EMAIL, MFA_SMS)).thenReturn(Optional.of(CODE));
+        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(4);
 
         APIGatewayProxyResponseEvent result = makeCallWithCode(INVALID_CODE, MFA_SMS.toString());
 
@@ -587,7 +590,7 @@ class VerifyCodeHandlerTest {
                         pair("account-recovery", false),
                         pair("journey-type", "SIGN_IN"),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
-                        pair("loginFailureCount", 0),
+                        pair("loginFailureCount", 4),
                         pair("MFACodeEntered", "6543221"),
                         pair("MaxSmsCount", configurationService.getCodeMaxRetries()));
     }
@@ -621,7 +624,7 @@ class VerifyCodeHandlerTest {
                                 "journey-type",
                                 journeyType != null ? String.valueOf(journeyType) : "SIGN_IN"),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
-                        pair("loginFailureCount", 0),
+                        pair("loginFailureCount", 1),
                         pair("MFACodeEntered", "6543221"),
                         pair("MaxSmsCount", configurationService.getCodeMaxRetries()));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -586,6 +586,8 @@ class VerifyMfaCodeHandlerTest {
                         ? null
                         : AUTH_APP_SECRET;
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.of(ErrorResponse.ERROR_1043));
+        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL, MFAMethodType.AUTH_APP))
+                .thenReturn(3);
         var codeRequest =
                 new VerifyMfaCodeRequest(
                         MFAMethodType.AUTH_APP, CODE, journeyType, profileInformation);
@@ -607,7 +609,7 @@ class VerifyMfaCodeHandlerTest {
                 pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                 pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
                 pair("journey-type", journeyType),
-                pair("loginFailureCount", 0),
+                pair("loginFailureCount", 3),
                 pair("MFACodeEntered", CODE));
     }
 
@@ -692,6 +694,8 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.of(phoneNumberCodeProcessor));
         when(phoneNumberCodeProcessor.validateCode())
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1037));
+        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL, MFAMethodType.AUTH_APP))
+                .thenReturn(3);
         var codeRequest =
                 new VerifyMfaCodeRequest(
                         MFAMethodType.SMS, CODE, journeyType, CommonTestVariables.UK_MOBILE_NUMBER);
@@ -713,7 +717,7 @@ class VerifyMfaCodeHandlerTest {
                 pair("mfa-type", MFAMethodType.SMS.getValue()),
                 pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
                 pair("journey-type", journeyType),
-                pair("loginFailureCount", 0),
+                pair("loginFailureCount", 3),
                 pair("MFACodeEntered", CODE));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -354,7 +354,6 @@ class AuthAppCodeProcessorTest {
     private void setUpValidAuthCode(CodeRequest codeRequest) {
         when(mockUserContext.getSession().getEmailAddress()).thenReturn("email-address");
         when(mockSession.getEmailAddress()).thenReturn("email-address");
-        when(mockSession.getRetryCount()).thenReturn(0);
         when(mockCodeStorageService.isBlockedForEmail("email-address", CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
         when(mockConfigurationService.getAuthAppCodeAllowedWindows()).thenReturn(9);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -83,10 +83,6 @@ public class Session {
         return this;
     }
 
-    public int getRetryCount() {
-        return retryCount;
-    }
-
     public int getPasswordResetCount() {
         return passwordResetCount;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -84,10 +84,6 @@ public class Session {
         return this;
     }
 
-    public int getRetryCount() {
-        return retryCount;
-    }
-
     public int getPasswordResetCount() {
         return passwordResetCount;
     }


### PR DESCRIPTION
## What

Fixes a field on audit events for mfa codes which was always set to zero.

We were previously setting the "loginFailureCount" field based on a field on the session that is no longer used: https://github.com/govuk-one-login/authentication-api/commit/924bff0fdc2d4d793143df6f59f019b01cdf3caa. This meant that the count stayed at zero on audit events, despite repeated failures.

This fixes this, and also removes the getter so that this cannot cause future confusion.

I'm not sure about the implications of removing the field entirely from the session - will this cause any deserialisation errors?

## How to review

1. Code Review
