### PR TITLE
BAU: Move pr-data to reusable workflow

### DIFF
--- a/.github/workflows/call_get_pr_data.yml
+++ b/.github/workflows/call_get_pr_data.yml
@@ -1,0 +1,107 @@
+name: Get PR Data
+on:
+  workflow_call:
+    outputs:
+      data:
+        description: "Object containing PR data"
+        value: ${{ jobs.get-pr-data.outputs.data }}
+
+jobs:
+  get-pr-data:
+    name: Get data for merged PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      data: ${{ steps.get_pr_data.outputs.result }}
+    steps:
+      - name: Get PR data
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: get_pr_data
+        with:
+          script: |
+            const query = `query($owner: String!, $name: String!, $oid: GitObjectID!) {
+                repository(owner: $owner, name: $name) {
+                  object(oid: $oid) {
+                    ... on Commit {
+                      oid
+                      message
+                      associatedPullRequests(first: 1) {
+                        nodes {
+                          number
+                          title
+                          merged
+                          mergedAt
+                          mergeCommit {
+                            oid
+                          }
+                        }
+                      }
+                    }
+                  }
+                  owner {
+                    login
+                  }
+                  name
+                  nameWithOwner
+                }
+              }`
+            const variables = {
+                owner: context.repo.owner,
+                name: context.repo.repo,
+                oid: context.sha,
+            }
+
+            const result = await github.graphql(query, variables).then((response) => {
+                const firstLineOfCommitMessage = response.repository.object.message.slice(0, response.repository.object.message.indexOf("\n"));
+                const shortCommitSha = context.sha.slice(0, 7);
+                const res = {
+                    pr_number: null,
+                    pr_title: null,
+                    pr_merged_at: null,
+                    pr_merge_commit_sha: null,
+
+                    commit_message: firstLineOfCommitMessage,
+
+                    repo_full_name: response.repository.nameWithOwner,
+                    repo_owner: response.repository.owner.login,
+                    repo_name: response.repository.name,
+
+                    repository: response.repository.nameWithOwner,
+                    commitsha: context.sha,
+                    commitmessage: firstLineOfCommitMessage,
+                }
+                res["codepipeline-artifact-revision-summary"] = `${shortCommitSha}: ${firstLineOfCommitMessage}`;
+
+                if (response.repository.object.associatedPullRequests.nodes.length > 0 && response.repository.object.associatedPullRequests.nodes[0].merged) {
+                    const prData = response.repository.object.associatedPullRequests.nodes[0];
+                    const shortMergeCommitSha = prData.mergeCommit.oid.slice(0, 7);
+                    res.pr_number = prData.number.toString();
+                    res.pr_title = prData.title;
+                    res.pr_merged_at = prData.mergedAt;
+                    res.pr_merge_commit_sha = prData.mergeCommit.oid;
+                    res.commitmessage = prData.title;
+
+                    res["codepipeline-artifact-revision-summary"] = `${shortMergeCommitSha}: #${prData.number} (${response.repository.nameWithOwner}) - ${prData.title}`;
+                }
+
+                if (res["codepipeline-artifact-revision-summary"].length > 2048) {
+                    res["codepipeline-artifact-revision-summary"] = res["codepipeline-artifact-revision-summary"].slice(0, 2048);
+                }
+
+                return res;
+            }).catch((error) => {
+                throw error;
+            });
+
+            for (const key in result) {
+                if (result[key] == null) {
+                    result[key] = "";
+                }
+                // strip non-ascii characters from all values
+                result[key] = result[key].replace(/[^\x20-\x7E]/g, '');
+            }
+
+            console.log(result);
+            return result;

--- a/.github/workflows/deploy-api-modules-dev.yml
+++ b/.github/workflows/deploy-api-modules-dev.yml
@@ -46,100 +46,10 @@ jobs:
 
   pr-data:
     name: Get data for merged PR
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
-    outputs:
-      data: ${{ steps.get_pr_data.outputs.result }}
-    steps:
-      - name: Get PR data
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        id: get_pr_data
-        with:
-          script: |
-            const query = `query($owner: String!, $name: String!, $oid: GitObjectID!) {
-                repository(owner: $owner, name: $name) {
-                  object(oid: $oid) {
-                    ... on Commit {
-                      oid
-                      message
-                      associatedPullRequests(first: 1) {
-                        nodes {
-                          number
-                          title
-                          merged
-                          mergedAt
-                          mergeCommit {
-                            oid
-                          }
-                        }
-                      }
-                    }
-                  }
-                  owner {
-                    login
-                  }
-                  name
-                  nameWithOwner
-                }
-              }`
-            const variables = {
-                owner: context.repo.owner,
-                name: context.repo.repo,
-                oid: context.sha,
-            }
-
-            const result = await github.graphql(query, variables).then((response) => {
-                const firstLineOfCommitMessage = response.repository.object.message.slice(0, response.repository.object.message.indexOf("\n"));
-                const res = {
-                    pr_number: null,
-                    pr_title: null,
-                    pr_merged_at: null,
-                    pr_merge_commit_sha: null,
-
-                    commit_message: firstLineOfCommitMessage,
-
-                    repo_full_name: response.repository.nameWithOwner,
-                    repo_owner: response.repository.owner.login,
-                    repo_name: response.repository.name,
-
-                    repository: response.repository.nameWithOwner,
-                    commitsha: context.sha,
-                    commitmessage: firstLineOfCommitMessage,
-                }
-                res["codepipeline-artifact-revision-summary"] = `${context.sha}: ${firstLineOfCommitMessage}`;
-
-                if (response.repository.object.associatedPullRequests.nodes.length > 0 && response.repository.object.associatedPullRequests.nodes[0].merged) {
-                    const prData = response.repository.object.associatedPullRequests.nodes[0];
-                    res.pr_number = prData.number.toString();
-                    res.pr_title = prData.title;
-                    res.pr_merged_at = prData.mergedAt;
-                    res.pr_merge_commit_sha = prData.mergeCommit.oid;
-                    res.commitmessage = prData.title;
-
-                    res["codepipeline-artifact-revision-summary"] = `${prData.mergeCommit.oid}: ${response.repository.nameWithOwner}#${prData.number} ${prData.title}`;
-                }
-
-                if (res["codepipeline-artifact-revision-summary"].length > 2048) {
-                    res["codepipeline-artifact-revision-summary"] = res["codepipeline-artifact-revision-summary"].slice(0, 2048);
-                }
-
-                return res;
-            }).catch((error) => {
-                throw error;
-            });
-
-            for (const key in result) {
-                if (result[key] == null) {
-                    result[key] = "";
-                }
-                // strip non-ascii characters from all values
-                result[key] = result[key].replace(/[^\x20-\x7E]/g, '');
-            }
-
-            console.log(result);
-            return result;
+    uses: ./.github/workflows/call_get_pr_data.yml
 
   build-cache:
     name: Set up build cache

--- a/.github/workflows/deploy-api-modules.yml
+++ b/.github/workflows/deploy-api-modules.yml
@@ -49,100 +49,10 @@ jobs:
 
   pr-data:
     name: Get data for merged PR
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
-    outputs:
-      data: ${{ steps.get_pr_data.outputs.result }}
-    steps:
-      - name: Get PR data
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        id: get_pr_data
-        with:
-          script: |
-            const query = `query($owner: String!, $name: String!, $oid: GitObjectID!) {
-                repository(owner: $owner, name: $name) {
-                  object(oid: $oid) {
-                    ... on Commit {
-                      oid
-                      message
-                      associatedPullRequests(first: 1) {
-                        nodes {
-                          number
-                          title
-                          merged
-                          mergedAt
-                          mergeCommit {
-                            oid
-                          }
-                        }
-                      }
-                    }
-                  }
-                  owner {
-                    login
-                  }
-                  name
-                  nameWithOwner
-                }
-              }`
-            const variables = {
-                owner: context.repo.owner,
-                name: context.repo.repo,
-                oid: context.sha,
-            }
-
-            const result = await github.graphql(query, variables).then((response) => {
-                const firstLineOfCommitMessage = response.repository.object.message.slice(0, response.repository.object.message.indexOf("\n"));
-                const res = {
-                    pr_number: null,
-                    pr_title: null,
-                    pr_merged_at: null,
-                    pr_merge_commit_sha: null,
-
-                    commit_message: firstLineOfCommitMessage,
-
-                    repo_full_name: response.repository.nameWithOwner,
-                    repo_owner: response.repository.owner.login,
-                    repo_name: response.repository.name,
-
-                    repository: response.repository.nameWithOwner,
-                    commitsha: context.sha,
-                    commitmessage: firstLineOfCommitMessage,
-                }
-                res["codepipeline-artifact-revision-summary"] = `${context.sha}: ${firstLineOfCommitMessage}`;
-
-                if (response.repository.object.associatedPullRequests.nodes.length > 0 && response.repository.object.associatedPullRequests.nodes[0].merged) {
-                    const prData = response.repository.object.associatedPullRequests.nodes[0];
-                    res.pr_number = prData.number.toString();
-                    res.pr_title = prData.title;
-                    res.pr_merged_at = prData.mergedAt;
-                    res.pr_merge_commit_sha = prData.mergeCommit.oid;
-                    res.commitmessage = prData.title;
-
-                    res["codepipeline-artifact-revision-summary"] = `${prData.mergeCommit.oid}: ${response.repository.nameWithOwner}#${prData.number} ${prData.title}`;
-                }
-
-                if (res["codepipeline-artifact-revision-summary"].length > 2048) {
-                    res["codepipeline-artifact-revision-summary"] = res["codepipeline-artifact-revision-summary"].slice(0, 2048);
-                }
-
-                return res;
-            }).catch((error) => {
-                throw error;
-            });
-
-            for (const key in result) {
-                if (result[key] == null) {
-                    result[key] = "";
-                }
-                // strip non-ascii characters from all values
-                result[key] = result[key].replace(/[^\x20-\x7E]/g, '');
-            }
-
-            console.log(result);
-            return result;
+    uses: ./.github/workflows/call_get_pr_data.yml
 
   build-cache:
     name: Set up build cache


### PR DESCRIPTION
## What

Rather than duplicating the same step in both prod and dev workflows,
move it to a reusable workflow instead.

Also, use the short commit sha in the summary, to reduce the length of
the string in AWS - it is annoying when it's truncated. For the same
reason, swap the order of PR number and repository name - so we
front-load as much 'useful' stuff as possible.

## How to review

- Code Review
- Run the dev deploy pipeline from this branch and ensure that the metadata is present. [done once here](https://github.com/govuk-one-login/authentication-api/actions/runs/10110652880).
