### PR TITLE
BAU: Add detect-secrets pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,12 @@ repos:
     hooks:
       - id: actionlint
 
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+
   - repo: local
     hooks:
       - id: shfmt

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,1550 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "account-management-api/docs/account-management-api.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "account-management-api/docs/account-management-api.md",
+        "hashed_secret": "5e33af1804c74bdee8c0867f9d2e4ce81c588de9",
+        "is_verified": false,
+        "line_number": 41,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "account-management-api/docs/account-management-api.md",
+        "hashed_secret": "f162013dc39e078ace0c7c3bee2cbdb7e932e91c",
+        "is_verified": false,
+        "line_number": 69,
+        "is_secret": false
+      }
+    ],
+    "account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java",
+        "hashed_secret": "d7b6dd7aaba4db62b1d7648911fc722566cc2825",
+        "is_verified": false,
+        "line_number": 32,
+        "is_secret": false
+      }
+    ],
+    "account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java",
+        "hashed_secret": "2aa60a8ff7fcd473d321e0146afd9e26df395147",
+        "is_verified": false,
+        "line_number": 64,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java",
+        "hashed_secret": "e38ad214943daad1d64c102faec29de4afe9da3d",
+        "is_verified": false,
+        "line_number": 65,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java",
+        "hashed_secret": "37fa265330ad83eaa879efb1e2db6380896cf639",
+        "is_verified": false,
+        "line_number": 66,
+        "is_secret": false
+      }
+    ],
+    "account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java",
+        "hashed_secret": "a91654caaf45e64dd239782015f1df8a084e3eab",
+        "is_verified": false,
+        "line_number": 43,
+        "is_secret": false
+      }
+    ],
+    "account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java",
+        "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
+        "is_verified": false,
+        "line_number": 30,
+        "is_secret": false
+      }
+    ],
+    "account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java",
+        "hashed_secret": "2be04fd128f455dc14c83d74ffe635c1ace6ca5d",
+        "is_verified": false,
+        "line_number": 87,
+        "is_secret": false
+      }
+    ],
+    "account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java",
+        "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
+        "is_verified": false,
+        "line_number": 70,
+        "is_secret": false
+      }
+    ],
+    "auth-external-api/src/test/java/uk/gov/di/authentication/external/validators/TokenRequestValidatorTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "auth-external-api/src/test/java/uk/gov/di/authentication/external/validators/TokenRequestValidatorTest.java",
+        "hashed_secret": "9399c146aac3566ef4a52403730d027e7f146dfd",
+        "is_verified": false,
+        "line_number": 204,
+        "is_secret": false
+      }
+    ],
+    "build.gradle": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build.gradle",
+        "hashed_secret": "1931e5c5e78ae2290598cd0a742cea9de6e44334",
+        "is_verified": false,
+        "line_number": 42,
+        "is_secret": false
+      }
+    ],
+    "ci/cloudfront-orchestration/cloudfront/deploy.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/cloudfront-orchestration/cloudfront/deploy.sh",
+        "hashed_secret": "34c6fceca75e456f25e7e99531e2425c6c1de443",
+        "is_verified": false,
+        "line_number": 33,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/account-management/kms-policies.tf": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ci/terraform/account-management/kms-policies.tf",
+        "hashed_secret": "e553aa43ab766e7c3a9c340dea045950f37e9322",
+        "is_verified": false,
+        "line_number": 64,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/account-management/localstack.tfvars": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/terraform/account-management/localstack.tfvars",
+        "hashed_secret": "4b2ec42e30786cc1af7385b9ec9eb09a7ccf0d82",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/auth-external-api/authdev1.tfvars": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ci/terraform/auth-external-api/authdev1.tfvars",
+        "hashed_secret": "a28f6783a522ada4871e6235d055576a67aedbed",
+        "is_verified": false,
+        "line_number": 11,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/auth-external-api/authdev2.tfvars": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ci/terraform/auth-external-api/authdev2.tfvars",
+        "hashed_secret": "c820751d5bf100ec26255639be4ffe7a67b79672",
+        "is_verified": false,
+        "line_number": 11,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/auth-external-api/build.tfvars": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ci/terraform/auth-external-api/build.tfvars",
+        "hashed_secret": "21b23dec80e7fcd23bb459cf771c2f4084a5de15",
+        "is_verified": false,
+        "line_number": 13,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/auth-external-api/dev.tfvars": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ci/terraform/auth-external-api/dev.tfvars",
+        "hashed_secret": "6b192b155ee389b0e2425f646bf3e28c56224ea7",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/auth-external-api/events.tf": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ci/terraform/auth-external-api/events.tf",
+        "hashed_secret": "e553aa43ab766e7c3a9c340dea045950f37e9322",
+        "is_verified": false,
+        "line_number": 28,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/auth-external-api/integration.tfvars": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ci/terraform/auth-external-api/integration.tfvars",
+        "hashed_secret": "e121d3ab71f8a63d6761930ff82d4469ba63d4f0",
+        "is_verified": false,
+        "line_number": 13,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/auth-external-api/production.tfvars": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ci/terraform/auth-external-api/production.tfvars",
+        "hashed_secret": "92223dc67b4cdd462da06b40410361b2a2d8d070",
+        "is_verified": false,
+        "line_number": 14,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/auth-external-api/sandpit.tfvars": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ci/terraform/auth-external-api/sandpit.tfvars",
+        "hashed_secret": "c820751d5bf100ec26255639be4ffe7a67b79672",
+        "is_verified": false,
+        "line_number": 11,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/auth-external-api/staging.tfvars": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ci/terraform/auth-external-api/staging.tfvars",
+        "hashed_secret": "062cc712e601b5c86abd5e629100acb4b60d13d7",
+        "is_verified": false,
+        "line_number": 13,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/modules/endpoint-module/dynatrace.tf": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/terraform/modules/endpoint-module/dynatrace.tf",
+        "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
+        "is_verified": false,
+        "line_number": 22,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/terraform/modules/endpoint-module/dynatrace.tf",
+        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
+        "is_verified": false,
+        "line_number": 23,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/modules/stub-endpoint-module/dynatrace.tf": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/terraform/modules/stub-endpoint-module/dynatrace.tf",
+        "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
+        "is_verified": false,
+        "line_number": 22,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/terraform/modules/stub-endpoint-module/dynatrace.tf",
+        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
+        "is_verified": false,
+        "line_number": 23,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/oidc/api-gateway.tf": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/terraform/oidc/api-gateway.tf",
+        "hashed_secret": "d3053d5db9cc8cb93b26db3c26c76bdfdff06ace",
+        "is_verified": false,
+        "line_number": 63,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/oidc/events-sns.tf": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ci/terraform/oidc/events-sns.tf",
+        "hashed_secret": "e553aa43ab766e7c3a9c340dea045950f37e9322",
+        "is_verified": false,
+        "line_number": 30,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/oidc/localstack.tfvars": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/terraform/oidc/localstack.tfvars",
+        "hashed_secret": "4b2ec42e30786cc1af7385b9ec9eb09a7ccf0d82",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/shared/authdev1.tfvars": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/terraform/shared/authdev1.tfvars",
+        "hashed_secret": "bf08a3d5088b333dc324400bc6f158f1e5c7582b",
+        "is_verified": false,
+        "line_number": 4,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/shared/authdev2.tfvars": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/terraform/shared/authdev2.tfvars",
+        "hashed_secret": "bf08a3d5088b333dc324400bc6f158f1e5c7582b",
+        "is_verified": false,
+        "line_number": 4,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/shared/localstack.tfvars": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/terraform/shared/localstack.tfvars",
+        "hashed_secret": "bf08a3d5088b333dc324400bc6f158f1e5c7582b",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      }
+    ],
+    "ci/terraform/shared/sandpit.tfvars": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ci/terraform/shared/sandpit.tfvars",
+        "hashed_secret": "bf08a3d5088b333dc324400bc6f158f1e5c7582b",
+        "is_verified": false,
+        "line_number": 4,
+        "is_secret": false
+      }
+    ],
+    "client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java",
+        "hashed_secret": "dff15b1ee7de37ff281e29e014b02cb74fec1b43",
+        "is_verified": false,
+        "line_number": 45,
+        "is_secret": false
+      }
+    ],
+    "doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawTokenTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawTokenTest.java",
+        "hashed_secret": "1f547512eed5606c962498fbeb18ad8d91d9b2a1",
+        "is_verified": false,
+        "line_number": 62,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawTokenTest.java",
+        "hashed_secret": "2d58554fe12bc7388ec8cd31baddfa6195af5292",
+        "is_verified": false,
+        "line_number": 62,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawTokenTest.java",
+        "hashed_secret": "e62c83cafb42bbe71468928a29edcb1ec1826fac",
+        "is_verified": false,
+        "line_number": 62,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawTokenTest.java",
+        "hashed_secret": "bf8c94b6257c2c06219b764f2a3bcf53e91e0925",
+        "is_verified": false,
+        "line_number": 66,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawTokenTest.java",
+        "hashed_secret": "a551a4be9a885ca4f4a9281bf70a2fc29638ec2d",
+        "is_verified": false,
+        "line_number": 68,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawTokenTest.java",
+        "hashed_secret": "8f085b412312d398710a85722c5646d20522913d",
+        "is_verified": false,
+        "line_number": 70,
+        "is_secret": false
+      }
+    ],
+    "doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java": [
+      {
+        "type": "JSON Web Token",
+        "filename": "doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java",
+        "hashed_secret": "8913b5c4e90ce40e96a978c1fc77b8b5298e67a7",
+        "is_verified": false,
+        "line_number": 54,
+        "is_secret": false
+      }
+    ],
+    "echo-int-test-vars.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "echo-int-test-vars.sh",
+        "hashed_secret": "1931e5c5e78ae2290598cd0a742cea9de6e44334",
+        "is_verified": false,
+        "line_number": 5,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "echo-int-test-vars.sh",
+        "hashed_secret": "715690a8edbc372090561734c8b5fd7f148b6d8d",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      }
+    ],
+    "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/CommonTestVariables.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/CommonTestVariables.java",
+        "hashed_secret": "72c112c55cb41d20df06b27e535428c78bee804d",
+        "is_verified": false,
+        "line_number": 14,
+        "is_secret": false
+      }
+    ],
+    "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java",
+        "hashed_secret": "243f19653d1afb343d12cb2f1edaf3cadb6e96d2",
+        "is_verified": false,
+        "line_number": 91,
+        "is_secret": false
+      }
+    ],
+    "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/JwtServiceTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/JwtServiceTest.java",
+        "hashed_secret": "e7451a5d89d2e9e5f35668721904c877cfb39d08",
+        "is_verified": false,
+        "line_number": 42,
+        "is_secret": false
+      }
+    ],
+    "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/MfaResetIPVAuthorizationServiceTest.java": [
+      {
+        "type": "JSON Web Token",
+        "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/MfaResetIPVAuthorizationServiceTest.java",
+        "hashed_secret": "b30b3723adc678cf5a5a649d0d12782697c96a48",
+        "is_verified": false,
+        "line_number": 85,
+        "is_secret": false
+      }
+    ],
+    "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/UserMigrationServiceTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/UserMigrationServiceTest.java",
+        "hashed_secret": "996e54174e83c3b51852e6ffb68b4a83906af72d",
+        "is_verified": false,
+        "line_number": 27,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/UserMigrationServiceTest.java",
+        "hashed_secret": "e4bb5706325c188733f237889dd60cbb9bba639c",
+        "is_verified": false,
+        "line_number": 28,
+        "is_secret": false
+      }
+    ],
+    "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java",
+        "hashed_secret": "243f19653d1afb343d12cb2f1edaf3cadb6e96d2",
+        "is_verified": false,
+        "line_number": 59,
+        "is_secret": false
+      }
+    ],
+    "frontend-api/src/test/resources/uk/gov/di/authentication/frontendapi/services/approvals/MfaResetIPVAuthorizationServiceTest.shouldReturn200WithAuthorizeUrlInBody.approved.json": [
+      {
+        "type": "JSON Web Token",
+        "filename": "frontend-api/src/test/resources/uk/gov/di/authentication/frontendapi/services/approvals/MfaResetIPVAuthorizationServiceTest.shouldReturn200WithAuthorizeUrlInBody.approved.json",
+        "hashed_secret": "b30b3723adc678cf5a5a649d0d12782697c96a48",
+        "is_verified": false,
+        "line_number": 14,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java",
+        "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
+        "is_verified": false,
+        "line_number": 52,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 60,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java",
+        "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
+        "is_verified": false,
+        "line_number": 41,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java",
+        "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
+        "is_verified": false,
+        "line_number": 27,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 34,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java",
+        "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
+        "is_verified": false,
+        "line_number": 54,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 90,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java",
+        "hashed_secret": "251c10082a6308fe3731846101d52f254a84491a",
+        "is_verified": false,
+        "line_number": 902,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 51,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java",
+        "hashed_secret": "dff15b1ee7de37ff281e29e014b02cb74fec1b43",
+        "is_verified": false,
+        "line_number": 36,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 60,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java",
+        "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
+        "is_verified": false,
+        "line_number": 77,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java",
+        "hashed_secret": "251c10082a6308fe3731846101d52f254a84491a",
+        "is_verified": false,
+        "line_number": 52,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java",
+        "hashed_secret": "49efef5f70d47adc2db2eb397fbef5f7bc560e29",
+        "is_verified": false,
+        "line_number": 31,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java",
+        "hashed_secret": "251c10082a6308fe3731846101d52f254a84491a",
+        "is_verified": false,
+        "line_number": 218,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 57,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java",
+        "hashed_secret": "78c87b0ed4de64f81776a289f8ccefe1d477ee01",
+        "is_verified": false,
+        "line_number": 37,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java",
+        "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
+        "is_verified": false,
+        "line_number": 46,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 44,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 68,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java",
+        "hashed_secret": "dff15b1ee7de37ff281e29e014b02cb74fec1b43",
+        "is_verified": false,
+        "line_number": 33,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java",
+        "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
+        "is_verified": false,
+        "line_number": 78,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 91,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java",
+        "hashed_secret": "382caa7c44ee23ee25616f7e303af33c591efc3a",
+        "is_verified": false,
+        "line_number": 63,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java",
+        "hashed_secret": "98fc2a759dbf05b32aeb1ebb747a6d29e0370b49",
+        "is_verified": false,
+        "line_number": 67,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java",
+        "hashed_secret": "243f19653d1afb343d12cb2f1edaf3cadb6e96d2",
+        "is_verified": false,
+        "line_number": 69,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 87,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java",
+        "hashed_secret": "243f19653d1afb343d12cb2f1edaf3cadb6e96d2",
+        "is_verified": false,
+        "line_number": 201,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java",
+        "hashed_secret": "37123d3f5672e70133f06645ae19d8f2cffde491",
+        "is_verified": false,
+        "line_number": 230,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java",
+        "hashed_secret": "b011bee4f9a67a67fda72ae26ab7eab16392257a",
+        "is_verified": false,
+        "line_number": 276,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/java/uk/gov/di/authentication/contract/ClientRegistryProviderTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/java/uk/gov/di/authentication/contract/ClientRegistryProviderTest.java",
+        "hashed_secret": "b9d28585a31d94afe5ea0e53e73a0d2e5a6d7c33",
+        "is_verified": false,
+        "line_number": 27,
+        "is_secret": false
+      }
+    ],
+    "integration-tests/src/test/resources/pacts/sseadminapiclient-clientregistryprovider.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/resources/pacts/sseadminapiclient-clientregistryprovider.json",
+        "hashed_secret": "b9d28585a31d94afe5ea0e53e73a0d2e5a6d7c33",
+        "is_verified": false,
+        "line_number": 21,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "integration-tests/src/test/resources/pacts/sseadminapiclient-clientregistryprovider.json",
+        "hashed_secret": "82458db25e12f1e0197ba1fb68fb1b4659403c2d",
+        "is_verified": false,
+        "line_number": 88,
+        "is_secret": false
+      }
+    ],
+    "ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java",
+        "hashed_secret": "85b64b6097e8bdbbf9c4e2cab9df0c237aae2dca",
+        "is_verified": false,
+        "line_number": 60,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java",
+        "hashed_secret": "90972d09acf28b39b53f2ea5a145b3fd5017167e",
+        "is_verified": false,
+        "line_number": 60,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java",
+        "hashed_secret": "c1305006857ab69a99734702cf8dbf6c71817857",
+        "is_verified": false,
+        "line_number": 60,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java",
+        "hashed_secret": "43eefd5b1772cb86a02b9ee60a26e88888b52937",
+        "is_verified": false,
+        "line_number": 65,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java",
+        "hashed_secret": "ff761636a34a6fda1f51311f3da3e9ebe97a5593",
+        "is_verified": false,
+        "line_number": 68,
+        "is_secret": false
+      }
+    ],
+    "ipv-api/src/test/java/uk/gov/di/authentication/ipv/entity/SPOTRequestTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ipv-api/src/test/java/uk/gov/di/authentication/ipv/entity/SPOTRequestTest.java",
+        "hashed_secret": "a91654caaf45e64dd239782015f1df8a084e3eab",
+        "is_verified": false,
+        "line_number": 25,
+        "is_secret": false
+      }
+    ],
+    "ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java",
+        "hashed_secret": "67d884a863b0285937f524022f511befce6912ee",
+        "is_verified": false,
+        "line_number": 95,
+        "is_secret": false
+      }
+    ],
+    "ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java",
+        "hashed_secret": "67d884a863b0285937f524022f511befce6912ee",
+        "is_verified": false,
+        "line_number": 154,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java",
+        "hashed_secret": "a91654caaf45e64dd239782015f1df8a084e3eab",
+        "is_verified": false,
+        "line_number": 162,
+        "is_secret": false
+      }
+    ],
+    "ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java": [
+      {
+        "type": "JSON Web Token",
+        "filename": "ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java",
+        "hashed_secret": "b30b3723adc678cf5a5a649d0d12782697c96a48",
+        "is_verified": false,
+        "line_number": 75,
+        "is_secret": false
+      }
+    ],
+    "ipv-api/src/test/resources/uk/gov/di/authentication/ipv/services/approvals/IPVAuthorisationServiceTest.SignedJwtRequest.shouldConstructASignedRequestJWT.approved.json": [
+      {
+        "type": "JSON Web Token",
+        "filename": "ipv-api/src/test/resources/uk/gov/di/authentication/ipv/services/approvals/IPVAuthorisationServiceTest.SignedJwtRequest.shouldConstructASignedRequestJWT.approved.json",
+        "hashed_secret": "b30b3723adc678cf5a5a649d0d12782697c96a48",
+        "is_verified": false,
+        "line_number": 20,
+        "is_secret": false
+      }
+    ],
+    "oidc-api/docs/AuthorisationHandler.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "oidc-api/docs/AuthorisationHandler.md",
+        "hashed_secret": "23921e053000479c452bef8c1c74f1f21c6afd9c",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java",
+        "hashed_secret": "c7f34260a5e53c434e0ce654792fc6d7dbec9bff",
+        "is_verified": false,
+        "line_number": 81,
+        "is_secret": false
+      }
+    ],
+    "oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java",
+        "hashed_secret": "100fa1fae93322d058a74e9cf027e13c8ecd3878",
+        "is_verified": false,
+        "line_number": 33,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java",
+        "hashed_secret": "169eb0606f9c9a7adc44508438721494435ba516",
+        "is_verified": false,
+        "line_number": 33,
+        "is_secret": false
+      }
+    ],
+    "oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java": [
+      {
+        "type": "JSON Web Token",
+        "filename": "oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java",
+        "hashed_secret": "8af27f4fdbcd1adf3c0694de74293a7c542f2df8",
+        "is_verified": false,
+        "line_number": 91,
+        "is_secret": false
+      }
+    ],
+    "orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IPVStubExtension.java": [
+      {
+        "type": "JSON Web Token",
+        "filename": "orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IPVStubExtension.java",
+        "hashed_secret": "69c1b96f46e66e1100392a01d2437152b949a74d",
+        "is_verified": false,
+        "line_number": 38,
+        "is_secret": false
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IPVStubExtension.java",
+        "hashed_secret": "9ac2a39cf66fae8a32a979917e2f426c5674a28b",
+        "is_verified": false,
+        "line_number": 38,
+        "is_secret": false
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IPVStubExtension.java",
+        "hashed_secret": "a303cce93958d7697653352052cc6f999313c4ad",
+        "is_verified": false,
+        "line_number": 38,
+        "is_secret": false
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IPVStubExtension.java",
+        "hashed_secret": "e8d63aecdc6bc83b9429e94a4ae06eecab59923b",
+        "is_verified": false,
+        "line_number": 38,
+        "is_secret": false
+      }
+    ],
+    "orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/IdentityTestData.java": [
+      {
+        "type": "JSON Web Token",
+        "filename": "orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/IdentityTestData.java",
+        "hashed_secret": "fd908b8dfcfeb53c2115698f23b18ec5786c76f1",
+        "is_verified": false,
+        "line_number": 24,
+        "is_secret": false
+      }
+    ],
+    "orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UserCredentials.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UserCredentials.java",
+        "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
+        "is_verified": false,
+        "line_number": 15,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UserCredentials.java",
+        "hashed_secret": "ff9f2eba1e479ba451c6b429088db61c8c51b6a4",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      }
+    ],
+    "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/UserCredentialsTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/UserCredentialsTest.java",
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/UserCredentialsTest.java",
+        "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
+        "is_verified": false,
+        "line_number": 17,
+        "is_secret": false
+      }
+    ],
+    "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/Argon2HelperTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/Argon2HelperTest.java",
+        "hashed_secret": "c81170f76e2b786b28dd82088a2fa793ddddc9b4",
+        "is_verified": false,
+        "line_number": 12,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/Argon2HelperTest.java",
+        "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
+        "is_verified": false,
+        "line_number": 22,
+        "is_secret": false
+      }
+    ],
+    "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java",
+        "hashed_secret": "1ede7b49b9ae9454bea40de29c0bc628b67a869c",
+        "is_verified": false,
+        "line_number": 34,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java",
+        "hashed_secret": "f9459731530d2c5a1dacd627a1269093bc3474d0",
+        "is_verified": false,
+        "line_number": 62,
+        "is_secret": false
+      }
+    ],
+    "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java",
+        "hashed_secret": "dd888a796666370b9523ef44581c34e19372116a",
+        "is_verified": false,
+        "line_number": 555,
+        "is_secret": false
+      }
+    ],
+    "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 64,
+        "is_secret": false
+      }
+    ],
+    "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CommonPasswordsExtension.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CommonPasswordsExtension.java",
+        "hashed_secret": "77a21cd6da738ee3f72be7500d6e2044e83229f1",
+        "is_verified": false,
+        "line_number": 22,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CommonPasswordsExtension.java",
+        "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
+        "is_verified": false,
+        "line_number": 23,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CommonPasswordsExtension.java",
+        "hashed_secret": "c37274ade33826cbab95efb0f9048a38d793068c",
+        "is_verified": false,
+        "line_number": 24,
+        "is_secret": false
+      }
+    ],
+    "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CommonPasswordsS3Extension.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CommonPasswordsS3Extension.java",
+        "hashed_secret": "77a21cd6da738ee3f72be7500d6e2044e83229f1",
+        "is_verified": false,
+        "line_number": 12,
+        "is_secret": false
+      }
+    ],
+    "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java": [
+      {
+        "type": "JSON Web Token",
+        "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java",
+        "hashed_secret": "69c1b96f46e66e1100392a01d2437152b949a74d",
+        "is_verified": false,
+        "line_number": 39,
+        "is_secret": false
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java",
+        "hashed_secret": "9ac2a39cf66fae8a32a979917e2f426c5674a28b",
+        "is_verified": false,
+        "line_number": 39,
+        "is_secret": false
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java",
+        "hashed_secret": "a303cce93958d7697653352052cc6f999313c4ad",
+        "is_verified": false,
+        "line_number": 39,
+        "is_secret": false
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java",
+        "hashed_secret": "e8d63aecdc6bc83b9429e94a4ae06eecab59923b",
+        "is_verified": false,
+        "line_number": 39,
+        "is_secret": false
+      }
+    ],
+    "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java",
+        "hashed_secret": "1fd9e025d7e996c325b21fd9a356835f8a84c948",
+        "is_verified": false,
+        "line_number": 50,
+        "is_secret": false
+      }
+    ],
+    "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/IdentityTestData.java": [
+      {
+        "type": "JSON Web Token",
+        "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/IdentityTestData.java",
+        "hashed_secret": "fd908b8dfcfeb53c2115698f23b18ec5786c76f1",
+        "is_verified": false,
+        "line_number": 24,
+        "is_secret": false
+      }
+    ],
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java",
+        "hashed_secret": "370441f34bf6065aa6eb19dcb476275f22ad6dae",
+        "is_verified": false,
+        "line_number": 19,
+        "is_secret": false
+      }
+    ],
+    "shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java",
+        "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
+        "is_verified": false,
+        "line_number": 15,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java",
+        "hashed_secret": "ff9f2eba1e479ba451c6b429088db61c8c51b6a4",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      }
+    ],
+    "shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java",
+        "hashed_secret": "a315c109a6f7c4276c089f2e5f7f186982b0506d",
+        "is_verified": false,
+        "line_number": 19,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java",
+        "hashed_secret": "0e72f1307e3cdb0f405fc7ab4d4f5ee5faff5031",
+        "is_verified": false,
+        "line_number": 32,
+        "is_secret": false
+      }
+    ],
+    "shared/src/main/java/uk/gov/di/authentication/shared/services/CommonPasswordsService.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "shared/src/main/java/uk/gov/di/authentication/shared/services/CommonPasswordsService.java",
+        "hashed_secret": "d4e0ae1b6950dbd672981c5735694def52cb6b96",
+        "is_verified": false,
+        "line_number": 22,
+        "is_secret": false
+      }
+    ],
+    "shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java",
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java",
+        "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
+        "is_verified": false,
+        "line_number": 17,
+        "is_secret": false
+      }
+    ],
+    "shared/src/test/java/uk/gov/di/authentication/shared/helpers/Argon2HelperTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "shared/src/test/java/uk/gov/di/authentication/shared/helpers/Argon2HelperTest.java",
+        "hashed_secret": "c81170f76e2b786b28dd82088a2fa793ddddc9b4",
+        "is_verified": false,
+        "line_number": 12,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "shared/src/test/java/uk/gov/di/authentication/shared/helpers/Argon2HelperTest.java",
+        "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
+        "is_verified": false,
+        "line_number": 21,
+        "is_secret": false
+      }
+    ],
+    "shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 31,
+        "is_secret": false
+      }
+    ],
+    "shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java",
+        "hashed_secret": "7aa14e2e5fc4e26808ed1c08a5ec7c61b337806a",
+        "is_verified": false,
+        "line_number": 28,
+        "is_secret": false
+      }
+    ],
+    "shared/src/test/java/uk/gov/di/authentication/shared/services/JwksServiceTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "shared/src/test/java/uk/gov/di/authentication/shared/services/JwksServiceTest.java",
+        "hashed_secret": "1ede7b49b9ae9454bea40de29c0bc628b67a869c",
+        "is_verified": false,
+        "line_number": 34,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "shared/src/test/java/uk/gov/di/authentication/shared/services/JwksServiceTest.java",
+        "hashed_secret": "f9459731530d2c5a1dacd627a1269093bc3474d0",
+        "is_verified": false,
+        "line_number": 62,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "shared/src/test/java/uk/gov/di/authentication/shared/services/JwksServiceTest.java",
+        "hashed_secret": "3ba23ce13b3a5b0ccc097bfd186ca3eda06c8200",
+        "is_verified": false,
+        "line_number": 90,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "shared/src/test/java/uk/gov/di/authentication/shared/services/JwksServiceTest.java",
+        "hashed_secret": "661d4de05188c0f3f25f8c29e4d6541e2946fe3c",
+        "is_verified": false,
+        "line_number": 124,
+        "is_secret": false
+      }
+    ],
+    "shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java",
+        "hashed_secret": "dd888a796666370b9523ef44581c34e19372116a",
+        "is_verified": false,
+        "line_number": 539,
+        "is_secret": false
+      }
+    ],
+    "template.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "template.yaml",
+        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
+        "is_verified": false,
+        "line_number": 64,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "template.yaml",
+        "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
+        "is_verified": false,
+        "line_number": 188,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "template.yaml",
+        "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
+        "is_verified": false,
+        "line_number": 230,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "template.yaml",
+        "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
+        "is_verified": false,
+        "line_number": 238,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "template.yaml",
+        "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
+        "is_verified": false,
+        "line_number": 246,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "template.yaml",
+        "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
+        "is_verified": false,
+        "line_number": 254,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "template.yaml",
+        "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
+        "is_verified": false,
+        "line_number": 262,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "template.yaml",
+        "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
+        "is_verified": false,
+        "line_number": 286,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "template.yaml",
+        "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
+        "is_verified": false,
+        "line_number": 4477,
+        "is_secret": false
+      }
+    ]
+  },
+  "generated_at": "2024-07-26T13:35:47Z"
+}


### PR DESCRIPTION
## What

This will scan for potential secrets inadvertently added to code.

`.secrets.baseline` contains an initial baseline of all existing
'violations' in the repository, so we don't immediately have hook
failures. These are all false positives.

A lot of these false positives are coming from the java tests. To avoid
creating new detections in future, there are a few options:

1. Move all the test passwords to a single file in `shared` and import
   them in the tests. Using these variables will stop the detections.
2. Add the 'ignore secret' comments when something is detected: https://github.com/Yelp/detect-secrets/tree/master?tab=readme-ov-file#inline-allowlisting

## How to review

1. Ensure the pre-commit action on this PR has completed successfully
2. Check out the branch
3. Create a file with a 'secret':

```sh
#!/usr/bin/env bash

PASSWORD="test-pw"
TEST="f572d396fae9206628714fb2ce00f72e94f2258f"
```

4. ensure [pre-commit is set up](https://pre-commit.com/#install)
5. install it in your local checkout: `pre-commit install`
6. Attempt to commit the file you created: `git add $file; git commit`
7. Ensure pre-commit reports an error:

```
Detect secrets...........................................................Failed
- hook id: detect-secrets
- exit code: 1

ERROR: Potential secrets about to be committed to git repo!

Secret Type: Secret Keyword
Location:    test.sh:3

Secret Type: Hex High Entropy String
Location:    test.sh:4
```
