### PR TITLE
Bau: add metric for notify delivery durations

### DIFF
--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
@@ -3,90 +3,14 @@ package uk.gov.di.authentication.deliveryreceiptsapi.entity;
 import com.google.gson.annotations.Expose;
 import uk.gov.di.authentication.shared.validation.Required;
 
-public class NotifyDeliveryReceipt {
-
-    @Expose @Required private String id;
-
-    @Expose private String reference;
-
-    @Expose @Required private String to;
-
-    @Expose @Required private String status;
-
-    @Expose @Required private String createdAt;
-
-    @Expose private String completedAt;
-
-    @Expose private String sentAt;
-
-    @Expose @Required private String notificationType;
-
-    @Expose @Required private String templateId;
-
-    @Expose @Required private int templateVersion;
-
-    public NotifyDeliveryReceipt() {}
-
-    public NotifyDeliveryReceipt(
-            String id,
-            String reference,
-            String to,
-            String status,
-            String createdAt,
-            String completedAt,
-            String sentAt,
-            String notificationType,
-            String templateId,
-            int templateVersion) {
-        this.id = id;
-        this.reference = reference;
-        this.to = to;
-        this.status = status;
-        this.createdAt = createdAt;
-        this.completedAt = completedAt;
-        this.sentAt = sentAt;
-        this.notificationType = notificationType;
-        this.templateId = templateId;
-        this.templateVersion = templateVersion;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getReference() {
-        return reference;
-    }
-
-    public String getTo() {
-        return to;
-    }
-
-    public String getStatus() {
-        return status;
-    }
-
-    public String getCreatedAt() {
-        return createdAt;
-    }
-
-    public String getCompletedAt() {
-        return completedAt;
-    }
-
-    public String getSentAt() {
-        return sentAt;
-    }
-
-    public String getNotificationType() {
-        return notificationType;
-    }
-
-    public String getTemplateId() {
-        return templateId;
-    }
-
-    public int getTemplateVersion() {
-        return templateVersion;
-    }
-}
+public record NotifyDeliveryReceipt(
+        @Expose @Required String id,
+        @Expose String reference,
+        @Expose @Required String to,
+        @Expose @Required String status,
+        @Expose @Required String createdAt,
+        @Expose String completedAt,
+        @Expose String sentAt,
+        @Expose @Required String notificationType,
+        @Expose @Required String templateId,
+        @Expose @Required int templateVersion) {}

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -154,14 +154,12 @@ public class NotifyCallbackHandler
             var completedAt = Instant.parse(deliveryReceipt.completedAt());
             var createdAt = Instant.parse(deliveryReceipt.createdAt());
             double duration = Duration.between(createdAt, completedAt).toMillis();
+            var metricsContext =
+                    Map.ofEntries(
+                            Map.entry("Environment", configurationService.getEnvironment()),
+                            Map.entry("NotificationType", deliveryReceipt.notificationType()));
             cloudwatchMetricsService.putEmbeddedValue(
-                    "NotifyDeliveryDuration",
-                    duration,
-                    Map.of(
-                            "Environment",
-                            configurationService.getEnvironment(),
-                            "NotificationType",
-                            deliveryReceipt.notificationType()));
+                    "NotifyDeliveryDuration", duration, metricsContext);
         } catch (DateTimeParseException e) {
             LOG.warn(
                     format(

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -81,14 +81,14 @@ public class NotifyCallbackHandler
         NotifyDeliveryReceipt deliveryReceipt;
         try {
             deliveryReceipt = objectMapper.readValue(input.getBody(), NotifyDeliveryReceipt.class);
-            if (deliveryReceipt.getNotificationType().equals("sms")) {
+            if (deliveryReceipt.notificationType().equals("sms")) {
                 LOG.info("Sms delivery receipt received");
-                var countryCode = getCountryCodeFromNumber(deliveryReceipt.getTo());
+                var countryCode = getCountryCodeFromNumber(deliveryReceipt.to());
                 LOG.info(
                         "SmsSent, NotifyStatus: {}, CountryCode: {}",
-                        deliveryReceipt.getStatus(),
+                        deliveryReceipt.status(),
                         countryCode);
-                var templateId = deliveryReceipt.getTemplateId();
+                var templateId = deliveryReceipt.templateId();
                 LOG.info("Template ID received in delivery receipt: {}", templateId);
                 var templateName = getTemplateName(templateId);
                 cloudwatchMetricsService.incrementCounter(
@@ -101,11 +101,11 @@ public class NotifyCallbackHandler
                                 "Environment",
                                 configurationService.getEnvironment(),
                                 "NotifyStatus",
-                                deliveryReceipt.getStatus()));
+                                deliveryReceipt.status()));
                 LOG.info("SMS callback request processed");
-            } else if (deliveryReceipt.getNotificationType().equals("email")) {
+            } else if (deliveryReceipt.notificationType().equals("email")) {
                 LOG.info("Email delivery receipt received");
-                var templateId = deliveryReceipt.getTemplateId();
+                var templateId = deliveryReceipt.templateId();
                 LOG.info("Template ID received in delivery receipt: {}", templateId);
                 var templateName = getTemplateName(templateId);
                 cloudwatchMetricsService.incrementCounter(
@@ -116,16 +116,16 @@ public class NotifyCallbackHandler
                                 "Environment",
                                 configurationService.getEnvironment(),
                                 "NotifyStatus",
-                                deliveryReceipt.getStatus()));
+                                deliveryReceipt.status()));
                 if (configurationService.isBulkUserEmailEnabled()
                         && templateName.equals(
                                 TERMS_AND_CONDITIONS_BULK_EMAIL.getTemplateAlias())) {
                     LOG.info("Updating bulk email table for delivery receipt");
                     var maybeProfile =
-                            dynamoService.getUserProfileByEmailMaybe(deliveryReceipt.getTo());
+                            dynamoService.getUserProfileByEmailMaybe(deliveryReceipt.to());
                     if (maybeProfile.isPresent()) {
                         bulkEmailUsersService.updateDeliveryReceiptStatus(
-                                maybeProfile.get().getSubjectID(), deliveryReceipt.getStatus());
+                                maybeProfile.get().getSubjectID(), deliveryReceipt.status());
                     } else {
                         LOG.info(
                                 "No profile found for email in delivery receipt: not updating bulk email users table");

--- a/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
+++ b/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
@@ -107,18 +107,14 @@ class NotifyCallbackHandlerTest {
         var deliveryReceipt = createDeliveryReceipt(number, status, "sms", TEMPLATE_ID);
         var response = handler.handleRequest(eventWithBody(deliveryReceipt), context);
 
-        verify(cloudwatchMetricsService)
-                .incrementCounter(
-                        "SmsSent",
-                        Map.of(
-                                "SmsType",
-                                VERIFY_PHONE_NUMBER.getTemplateAlias(),
-                                "CountryCode",
-                                expectedCountryCode,
-                                "Environment",
-                                ENVIRONMENT,
-                                "NotifyStatus",
-                                status));
+        var expectedContext =
+                Map.ofEntries(
+                        Map.entry("SmsType", VERIFY_PHONE_NUMBER.getTemplateAlias()),
+                        Map.entry("CountryCode", expectedCountryCode),
+                        Map.entry("Environment", ENVIRONMENT),
+                        Map.entry("NotifyStatus", status));
+
+        verify(cloudwatchMetricsService).incrementCounter("SmsSent", expectedContext);
 
         assertThat(response, hasStatus(204));
     }
@@ -135,11 +131,10 @@ class NotifyCallbackHandlerTest {
                         "sms", "delivered", createdAtDate, completedAt);
         var response = handler.handleRequest(eventWithBody(deliveryReceipt), context);
 
+        var expectedContext = Map.of("Environment", ENVIRONMENT, "NotificationType", "sms");
+
         verify(cloudwatchMetricsService)
-                .putEmbeddedValue(
-                        "NotifyDeliveryDuration",
-                        1000,
-                        Map.of("Environment", ENVIRONMENT, "NotificationType", "sms"));
+                .putEmbeddedValue("NotifyDeliveryDuration", 1000, expectedContext);
 
         assertThat(response, hasStatus(204));
     }
@@ -195,16 +190,13 @@ class NotifyCallbackHandlerTest {
         var deliveryReceipt = createDeliveryReceipt(EMAIL, "delivered", "email", TEMPLATE_ID);
         handler.handleRequest(eventWithBody(deliveryReceipt), context);
 
-        verify(cloudwatchMetricsService)
-                .incrementCounter(
-                        "EmailSent",
-                        Map.of(
-                                "EmailName",
-                                type.getTemplateAlias(),
-                                "Environment",
-                                ENVIRONMENT,
-                                "NotifyStatus",
-                                "delivered"));
+        var expectedMetricsContext =
+                Map.ofEntries(
+                        Map.entry("EmailName", type.getTemplateAlias()),
+                        Map.entry("Environment", ENVIRONMENT),
+                        Map.entry("NotifyStatus", "delivered"));
+
+        verify(cloudwatchMetricsService).incrementCounter("EmailSent", expectedMetricsContext);
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -6,7 +6,6 @@ import software.amazon.cloudwatchlogs.emf.model.Unit;
 import uk.gov.di.authentication.shared.entity.Session;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ACCOUNT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.CLIENT;
@@ -19,10 +18,7 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTIC
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_EXISTING_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_NEW_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.EMAIL_CHECK_DURATION;
-import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.LOGOUT_SUCCESS;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_HANDOFF;
-import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT;
-import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SIGN_IN_NEW_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.entity.Session.AccountState.EXISTING;
 import static uk.gov.di.authentication.shared.entity.Session.AccountState.NEW;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -57,35 +53,6 @@ public class CloudwatchMetricsService {
 
     public void incrementCounter(String name, Map<String, String> dimensions) {
         putEmbeddedValue(name, 1, dimensions);
-    }
-
-    public void incrementSignInByClient(
-            Session.AccountState accountState,
-            String clientId,
-            String clientName,
-            boolean isTestJourney) {
-        if (NEW.equals(accountState) && !isTestJourney) {
-            incrementCounter(
-                    SIGN_IN_NEW_ACCOUNT_BY_CLIENT.getValue(),
-                    Map.of(
-                            ENVIRONMENT.getValue(),
-                            configurationService.getEnvironment(),
-                            CLIENT.getValue(),
-                            clientId,
-                            CLIENT_NAME.getValue(),
-                            clientName));
-        }
-        if (EXISTING.equals(accountState) && !isTestJourney) {
-            incrementCounter(
-                    SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT.getValue(),
-                    Map.of(
-                            ENVIRONMENT.getValue(),
-                            configurationService.getEnvironment(),
-                            CLIENT.getValue(),
-                            clientId,
-                            CLIENT_NAME.getValue(),
-                            clientName));
-        }
     }
 
     public void incrementAuthenticationSuccess(
@@ -134,16 +101,6 @@ public class CloudwatchMetricsService {
                             CLIENT_NAME.getValue(),
                             clientName));
         }
-    }
-
-    public void incrementLogout(Optional<String> clientId) {
-        incrementCounter(
-                LOGOUT_SUCCESS.getValue(),
-                Map.of(
-                        ENVIRONMENT.getValue(),
-                        configurationService.getEnvironment(),
-                        CLIENT.getValue(),
-                        clientId.orElse("unknown")));
     }
 
     public void logEmailCheckDuration(long duration) {


### PR DESCRIPTION
## What

It's useful for us to be able to see the length of time it's taken notify to successfully send out emails and texts as it gives us visibility as to whether there are any widespread issues when reports of slow sms / emails come to us, and notify already give us this information via their delivery receipts. This will also aid us in identifying, in the case of a widespread issue, whether the problem is on our side (e.g. delayed async processing) or on Notify's.

Notify send us ([docs link](https://docs.notifications.service.gov.uk/java.html#delivery-receipts)):
* created at timestamp
* completed at timestamp
* sent at timestamp

I think the relevant time difference here is the duration between created at (when notify sends the request to its deliverer partners) and updated at (which for a delivered notification should be the time it got delivered). My understanding is that sent at happens between these two things, but isn't as relevant to us looking at the end to end response time.

Also contains a few small refactors / code removals while I was in the area.

## How to review

1. Code Review commit by commit