### PR TITLE
Aut 3368/auth attempts store

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthenticationAttemptsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthenticationAttemptsServiceIntegrationTest.java
@@ -1,0 +1,34 @@
+package uk.gov.di.authentication.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationAttemptsService;
+import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DynamoAuthenticationAttemptsServiceIntegrationTest {
+
+    private static final String ATTEMPT_IDENTIFIER = "attempt-identifier-1234";
+
+    @RegisterExtension
+    protected static final AuthenticationAttemptsStoreExtension authCodeExtension =
+            new AuthenticationAttemptsStoreExtension();
+
+    DynamoAuthenticationAttemptsService dynamoAuthenticationAttemptsService =
+            new DynamoAuthenticationAttemptsService(ConfigurationService.getInstance());
+
+    private void setUpDynamo() {
+        authCodeExtension.addCode(ATTEMPT_IDENTIFIER);
+    }
+
+    @Test
+    void shoudAddCode() {
+        setUpDynamo();
+
+        var authenticationAttempts =
+                dynamoAuthenticationAttemptsService.getAuthenticationAttempts(ATTEMPT_IDENTIFIER);
+        assertTrue(authenticationAttempts.isPresent());
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthenticationAttemptsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthenticationAttemptsServiceIntegrationTest.java
@@ -6,11 +6,16 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAuthenticationAttemptsService;
 import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
 
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DynamoAuthenticationAttemptsServiceIntegrationTest {
 
     private static final String ATTEMPT_IDENTIFIER = "attempt-identifier-1234";
+    private static final String NON_EXISTENT_ATTEMPT_IDENTIFIER =
+            "non-existent-attempt-identifier-1234";
 
     @RegisterExtension
     protected static final AuthenticationAttemptsStoreExtension authCodeExtension =
@@ -24,11 +29,61 @@ class DynamoAuthenticationAttemptsServiceIntegrationTest {
     }
 
     @Test
-    void shoudAddCode() {
+    void shouldAddCode() {
         setUpDynamo();
 
         var authenticationAttempts =
                 dynamoAuthenticationAttemptsService.getAuthenticationAttempts(ATTEMPT_IDENTIFIER);
         assertTrue(authenticationAttempts.isPresent());
+    }
+
+    @Test
+    void shouldGetIncorrectReauthEmailCountForUser() {
+        var ttl = Instant.now().getEpochSecond() + 60L;
+
+        // Setup the count
+        dynamoAuthenticationAttemptsService.createOrIncrementCount(ATTEMPT_IDENTIFIER, ttl);
+
+        // Retrieve the count
+        var incorrectEmailCount =
+                dynamoAuthenticationAttemptsService
+                        .getAuthenticationAttempts(ATTEMPT_IDENTIFIER)
+                        .get()
+                        .getCount();
+
+        assertEquals(1, incorrectEmailCount);
+    }
+
+    @Test
+    void shouldNotRetrieveANonExistentCount() {
+        var count =
+                dynamoAuthenticationAttemptsService.getAuthenticationAttempts(
+                        NON_EXISTENT_ATTEMPT_IDENTIFIER);
+
+        assertTrue(count.isEmpty());
+    }
+
+    @Test
+    void shouldNotRetrieveACountWithAnExpiredTTL() {
+        var expiredTTL = Instant.now().getEpochSecond() - 1L;
+
+        // Setup the count
+        dynamoAuthenticationAttemptsService.createOrIncrementCount(ATTEMPT_IDENTIFIER, expiredTTL);
+
+        var count =
+                dynamoAuthenticationAttemptsService.getAuthenticationAttempts(ATTEMPT_IDENTIFIER);
+
+        assertTrue(count.isEmpty());
+    }
+
+    @Test
+    void shouldIncrementExistingCountWhenAuthenticationAttemptFails() {
+        var nonExpiredTTL = Instant.now().getEpochSecond() + 1000000L;
+
+        dynamoAuthenticationAttemptsService.createOrIncrementCount(ATTEMPT_IDENTIFIER, nonExpiredTTL);
+        dynamoAuthenticationAttemptsService.createOrIncrementCount(ATTEMPT_IDENTIFIER, nonExpiredTTL);
+
+        var count = dynamoAuthenticationAttemptsService.getAuthenticationAttempts(ATTEMPT_IDENTIFIER);
+        assertEquals(2, count.get().getCount());
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationAttemptsStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationAttemptsStoreExtension.java
@@ -49,10 +49,6 @@ public class AuthenticationAttemptsStoreExtension extends DynamoExtension
         }
     }
 
-    public void addCode(String attemptIdentifier) {
-        dynamoService.addCode(attemptIdentifier);
-    }
-
     public void createOrIncrementCount(String attemptIdentifier, long ttl) {
         dynamoService.createOrIncrementCount(attemptIdentifier, ttl);
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationAttemptsStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationAttemptsStoreExtension.java
@@ -32,11 +32,6 @@ public class AuthenticationAttemptsStoreExtension extends DynamoExtension
     }
 
     @Override
-    public void beforeAll(ExtensionContext context) throws Exception {
-        super.beforeAll(context);
-    }
-
-    @Override
     public void afterEach(ExtensionContext context) throws Exception {
         clearDynamoTable(
                 dynamoDB, AUTHENTICATION_ATTEMPTS_STORE_TABLE, AUTHENTICATION_ATTEMPTS_FIELD);
@@ -49,8 +44,9 @@ public class AuthenticationAttemptsStoreExtension extends DynamoExtension
         }
     }
 
-    public void createOrIncrementCount(String attemptIdentifier, long ttl) {
-        dynamoService.createOrIncrementCount(attemptIdentifier, ttl);
+    public void createOrIncrementCount(
+            String attemptIdentifier, long ttl, String authenticationMethod) {
+        dynamoService.createOrIncrementCount(attemptIdentifier, ttl, authenticationMethod);
     }
 
     public Optional<AuthenticationAttempts> getAuthenticationAttempts(String attemptIdentifier) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationAttemptsStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationAttemptsStoreExtension.java
@@ -53,6 +53,10 @@ public class AuthenticationAttemptsStoreExtension extends DynamoExtension
         dynamoService.addCode(attemptIdentifier);
     }
 
+    public void createOrIncrementCount(String attemptIdentifier, long ttl) {
+        dynamoService.createOrIncrementCount(attemptIdentifier, ttl);
+    }
+
     public Optional<AuthenticationAttempts> getAuthenticationAttempts(String attemptIdentifier) {
         return dynamoService.getAuthenticationAttempts(attemptIdentifier);
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationAttemptsStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationAttemptsStoreExtension.java
@@ -1,0 +1,79 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.authentication.shared.entity.AuthenticationAttempts;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationAttemptsService;
+import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
+
+import java.util.Optional;
+
+public class AuthenticationAttemptsStoreExtension extends DynamoExtension
+        implements AfterEachCallback {
+
+    public static final String AUTHENTICATION_ATTEMPTS_FIELD = "AttemptIdentifier";
+    public static final String AUTHENTICATION_ATTEMPTS_STORE_TABLE =
+            "local-authentication-attempts";
+
+    private DynamoAuthenticationAttemptsService dynamoService;
+    private final ConfigurationService configuration;
+
+    public AuthenticationAttemptsStoreExtension() {
+        createInstance();
+        this.configuration = new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT);
+        dynamoService = new DynamoAuthenticationAttemptsService(configuration);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(
+                dynamoDB, AUTHENTICATION_ATTEMPTS_STORE_TABLE, AUTHENTICATION_ATTEMPTS_FIELD);
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(AUTHENTICATION_ATTEMPTS_STORE_TABLE)) {
+            createAuthenticationAttemptsTable();
+        }
+    }
+
+    public void addCode(String attemptIdentifier) {
+        dynamoService.addCode(attemptIdentifier);
+    }
+
+    public Optional<AuthenticationAttempts> getAuthenticationAttempts(String attemptIdentifier) {
+        return dynamoService.getAuthenticationAttempts(attemptIdentifier);
+    }
+
+    private void createAuthenticationAttemptsTable() {
+        CreateTableRequest request =
+                CreateTableRequest.builder()
+                        .tableName(AUTHENTICATION_ATTEMPTS_STORE_TABLE)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.HASH)
+                                        .attributeName(AUTHENTICATION_ATTEMPTS_FIELD)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(AUTHENTICATION_ATTEMPTS_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .build();
+
+        dynamoDB.createTable(request);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthenticationAttempts.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthenticationAttempts.java
@@ -1,0 +1,121 @@
+package uk.gov.di.authentication.shared.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class AuthenticationAttempts {
+
+    private String attemptIdentifier;
+    private String email;
+    private String journeyType;
+    private String authenticationType;
+    private String code;
+    private Integer count;
+    private long timeToExist;
+    private String created;
+    private String updated;
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("AttemptIdentifier")
+    public String getAttemptIdentifier() {
+        return attemptIdentifier;
+    }
+
+    public void setAttemptIdentifier(String attemptIdentifier) {
+        this.attemptIdentifier = attemptIdentifier;
+    }
+
+    public AuthenticationAttempts withAttemptIdentifier(String attemptIdentifier) {
+        this.attemptIdentifier = attemptIdentifier;
+        return this;
+    }
+
+    @DynamoDbAttribute("Email")
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    @DynamoDbAttribute("JourneyType")
+    public String getJourneyType() {
+        return journeyType;
+    }
+
+    public void setJourneyType(String journeyType) {
+        this.journeyType = journeyType;
+    }
+
+    @DynamoDbAttribute("AuthenticationType")
+    public String getAuthenticationType() {
+        return authenticationType;
+    }
+
+    public void setAuthenticationType(String authenticationType) {
+        this.authenticationType = authenticationType;
+    }
+
+    @DynamoDbAttribute("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    @DynamoDbAttribute("Count")
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    @DynamoDbAttribute("TimeToExist")
+    public long getTimeToExist() {
+        return timeToExist;
+    }
+
+    public void setTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+    }
+
+    public AuthenticationAttempts withTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+        return this;
+    }
+
+    @DynamoDbAttribute("Created")
+    public String getCreated() {
+        return created;
+    }
+
+    public void setCreated(String created) {
+        this.created = created;
+    }
+
+    public AuthenticationAttempts withCreated(String created) {
+        this.created = created;
+        return this;
+    }
+
+    @DynamoDbAttribute("Updated")
+    public String getUpdated() {
+        return updated;
+    }
+
+    public void setUpdated(String updated) {
+        this.updated = updated;
+    }
+
+    public AuthenticationAttempts withUpdated(String updated) {
+        this.updated = updated;
+        return this;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthenticationAttempts.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthenticationAttempts.java
@@ -3,19 +3,19 @@ package uk.gov.di.authentication.shared.entity;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import uk.gov.di.authentication.shared.validation.Required;
 
 @DynamoDbBean
 public class AuthenticationAttempts {
 
-    private String attemptIdentifier;
-    private String email;
-    private String journeyType;
-    private String authenticationType;
-    private String code;
-    private Integer count;
-    private long timeToExist;
+    @Required private String attemptIdentifier;
+    @Required private String authenticationMethod;
+    @Required private String code;
+    @Required private Integer count;
     private String created;
     private String updated;
+    private long timeToLive;
+    private String journeyType;
 
     @DynamoDbPartitionKey
     @DynamoDbAttribute("AttemptIdentifier")
@@ -32,15 +32,6 @@ public class AuthenticationAttempts {
         return this;
     }
 
-    @DynamoDbAttribute("Email")
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
     @DynamoDbAttribute("JourneyType")
     public String getJourneyType() {
         return journeyType;
@@ -50,13 +41,23 @@ public class AuthenticationAttempts {
         this.journeyType = journeyType;
     }
 
-    @DynamoDbAttribute("AuthenticationType")
-    public String getAuthenticationType() {
-        return authenticationType;
+    public AuthenticationAttempts withJourneyType(String journeyType) {
+        this.journeyType = journeyType;
+        return this;
     }
 
-    public void setAuthenticationType(String authenticationType) {
-        this.authenticationType = authenticationType;
+    @DynamoDbAttribute("AuthenticationMethod")
+    public String getAuthenticationMethod() {
+        return authenticationMethod;
+    }
+
+    public void setAuthenticationMethod(String authenticationMethod) {
+        this.authenticationMethod = authenticationMethod;
+    }
+
+    public AuthenticationAttempts withAuthenticationMethod(String authenticationMethod) {
+        this.authenticationMethod = authenticationMethod;
+        return this;
     }
 
     @DynamoDbAttribute("Code")
@@ -68,6 +69,11 @@ public class AuthenticationAttempts {
         this.code = code;
     }
 
+    public AuthenticationAttempts withCode(String code) {
+        this.code = code;
+        return this;
+    }
+
     @DynamoDbAttribute("Count")
     public Integer getCount() {
         return count;
@@ -77,17 +83,22 @@ public class AuthenticationAttempts {
         this.count = count;
     }
 
-    @DynamoDbAttribute("TimeToExist")
-    public long getTimeToExist() {
-        return timeToExist;
+    public AuthenticationAttempts withCount(int count) {
+        this.count = count;
+        return this;
     }
 
-    public void setTimeToExist(long timeToExist) {
-        this.timeToExist = timeToExist;
+    @DynamoDbAttribute("TimeToLive")
+    public long getTimeToLive() {
+        return timeToLive;
     }
 
-    public AuthenticationAttempts withTimeToExist(long timeToExist) {
-        this.timeToExist = timeToExist;
+    public void setTimeToLive(long timeToLive) {
+        this.timeToLive = timeToLive;
+    }
+
+    public AuthenticationAttempts withTimeToLive(long timeToLive) {
+        this.timeToLive = timeToLive;
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthenticationMethod.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthenticationMethod.java
@@ -1,6 +1,6 @@
 package uk.gov.di.authentication.shared.entity;
 
-public enum AuthenticationType {
+public enum AuthenticationMethod {
     EMAIL("EMAIL"),
     PASSWORD("PASSWORD"),
     AUTH_APP("AUTH_APP"),
@@ -8,7 +8,7 @@ public enum AuthenticationType {
 
     private String value;
 
-    AuthenticationType(String value) {
+    AuthenticationMethod(String value) {
         this.value = value;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthenticationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthenticationType.java
@@ -1,0 +1,18 @@
+package uk.gov.di.authentication.shared.entity;
+
+public enum AuthenticationType {
+    EMAIL("EMAIL"),
+    PASSWORD("PASSWORD"),
+    AUTH_APP("AUTH_APP"),
+    SMS("SMS");
+
+    private String value;
+
+    AuthenticationType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationAttemptsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationAttemptsService.java
@@ -1,0 +1,36 @@
+package uk.gov.di.authentication.shared.services;
+
+import uk.gov.di.authentication.shared.entity.AuthenticationAttempts;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+public class DynamoAuthenticationAttemptsService extends BaseDynamoService<AuthenticationAttempts> {
+
+    private final NowHelper.NowClock clock;
+
+    public DynamoAuthenticationAttemptsService(ConfigurationService configurationService) {
+        super(AuthenticationAttempts.class, "authentication-attempts", configurationService);
+        this.clock = new NowHelper.NowClock(Clock.systemUTC());
+    }
+
+    public void addCode(String attemptIdentifier) {
+        var authenticationAttempt =
+                get(attemptIdentifier)
+                        .orElse(new AuthenticationAttempts())
+                        .withAttemptIdentifier(attemptIdentifier)
+                        .withTimeToExist(
+                                NowHelper.nowPlus(60, ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond());
+
+        update(authenticationAttempt);
+    }
+
+    public Optional<AuthenticationAttempts> getAuthenticationAttempts(String attemptIdentifier) {
+        return get(attemptIdentifier)
+                .filter(t -> t.getTimeToExist() > clock.now().toInstant().getEpochSecond());
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationAttemptsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationAttemptsService.java
@@ -3,20 +3,17 @@ package uk.gov.di.authentication.shared.services;
 import uk.gov.di.authentication.shared.entity.AuthenticationAttempts;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
-import java.time.Clock;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 public class DynamoAuthenticationAttemptsService extends BaseDynamoService<AuthenticationAttempts> {
 
-    private final NowHelper.NowClock clock;
-
     public DynamoAuthenticationAttemptsService(ConfigurationService configurationService) {
         super(AuthenticationAttempts.class, "authentication-attempts", configurationService);
-        this.clock = new NowHelper.NowClock(Clock.systemUTC());
     }
 
-    public void addCode(String attemptIdentifier, long ttlSeconds) {
+    public void addCode(
+            String attemptIdentifier, long ttlSeconds, String code, String authenticationMethod) {
         long ttlEpochSeconds =
                 NowHelper.nowPlus(ttlSeconds, ChronoUnit.SECONDS).toInstant().getEpochSecond();
 
@@ -24,13 +21,15 @@ public class DynamoAuthenticationAttemptsService extends BaseDynamoService<Authe
                 get(attemptIdentifier)
                         .orElse(new AuthenticationAttempts())
                         .withAttemptIdentifier(attemptIdentifier)
+                        .withCode(code)
+                        .withAuthenticationMethod(authenticationMethod)
                         .withTimeToLive(ttlEpochSeconds);
 
         update(authenticationAttempt);
     }
 
-    public void createOrIncrementCount(String attemptIdentifier, long ttl) {
-
+    public void createOrIncrementCount(
+            String attemptIdentifier, long ttl, String authenticationMethod) {
         Optional<AuthenticationAttempts> authenticationAttempt = get(attemptIdentifier);
         if (authenticationAttempt.isPresent()) {
             authenticationAttempt.get().setCount(authenticationAttempt.get().getCount() + 1);
@@ -41,13 +40,36 @@ public class DynamoAuthenticationAttemptsService extends BaseDynamoService<Authe
                             new AuthenticationAttempts()
                                     .withAttemptIdentifier(attemptIdentifier)
                                     .withCount(1)
+                                    .withAuthenticationMethod(authenticationMethod)
                                     .withTimeToLive(ttl));
         }
-        update(authenticationAttempt.get());
+        authenticationAttempt.ifPresent(this::update);
     }
 
     public Optional<AuthenticationAttempts> getAuthenticationAttempts(String attemptIdentifier) {
         long currentTimestamp = NowHelper.now().toInstant().getEpochSecond();
         return get(attemptIdentifier).filter(t -> t.getTimeToLive() > currentTimestamp);
+    }
+
+    public Optional<String> getCode(String attemptIdentifier) {
+        return get(attemptIdentifier).map(AuthenticationAttempts::getCode);
+    }
+
+    public void deleteCount(String attemptIdentifier) {
+        Optional<AuthenticationAttempts> attempt = get(attemptIdentifier);
+        attempt.ifPresent(
+                authAttempt -> {
+                    authAttempt.setCount(0);
+                    update(authAttempt);
+                });
+    }
+
+    public void deleteCode(String attemptIdentifier) {
+        Optional<AuthenticationAttempts> attempt = get(attemptIdentifier);
+        attempt.ifPresent(
+                authAttempt -> {
+                    authAttempt.setCode(null);
+                    update(authAttempt);
+                });
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/AuthenticationAttemptsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/AuthenticationAttemptsTest.java
@@ -1,10 +1,15 @@
 package uk.gov.di.authentication.shared.entity;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.validation.RequiredFieldValidator;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AuthenticationAttemptsTest {
+
     @Test
     void testFluentSetters() {
         AuthenticationAttempts attempts = new AuthenticationAttempts();
@@ -65,5 +70,36 @@ class AuthenticationAttemptsTest {
                 "2024-07-29T10:30:00Z",
                 attempts.getUpdated(),
                 "getUpdated should return '2024-07-29T10:30:00Z'");
+    }
+
+    @Test
+    void testValidationWithMissingRequiredFields() {
+        AuthenticationAttempts attempts = new AuthenticationAttempts();
+        // Intentionally not setting any fields to check for validation errors
+
+        RequiredFieldValidator validator = new RequiredFieldValidator();
+        List<String> violations = validator.validate(attempts);
+
+        // Check that all required fields are reported as missing
+        assertTrue(violations.contains("attemptIdentifier"));
+        assertTrue(violations.contains("authenticationMethod"));
+        assertTrue(violations.contains("code"));
+        assertTrue(violations.contains("count"));
+    }
+
+    @Test
+    void testValidationWithAllFieldsSet() {
+        AuthenticationAttempts attempts =
+                new AuthenticationAttempts()
+                        .withAttemptIdentifier("attempt-1234")
+                        .withAuthenticationMethod("email")
+                        .withCode("code-5678")
+                        .withCount(3)
+                        .withTimeToLive(42L);
+
+        RequiredFieldValidator validator = new RequiredFieldValidator();
+        List<String> violations = validator.validate(attempts);
+
+        assertTrue(violations.isEmpty());
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/AuthenticationAttemptsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/AuthenticationAttemptsTest.java
@@ -1,0 +1,69 @@
+package uk.gov.di.authentication.shared.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AuthenticationAttemptsTest {
+    @Test
+    void testFluentSetters() {
+        AuthenticationAttempts attempts = new AuthenticationAttempts();
+
+        AuthenticationAttempts result = attempts.withAttemptIdentifier("attempt-1234");
+        assertEquals("attempt-1234", result.getAttemptIdentifier());
+
+        result = attempts.withUpdated("2024-07-29T10:30:00Z");
+        assertEquals("2024-07-29T10:30:00Z", result.getUpdated());
+
+        result = attempts.withCreated("2024-07-29T10:00:00Z");
+        assertEquals("2024-07-29T10:00:00Z", result.getCreated());
+
+        result = attempts.withTimeToLive(1234567890L);
+        assertEquals(1234567890L, result.getTimeToLive());
+
+        result = attempts.withCode("code-5678");
+        assertEquals("code-5678", result.getCode());
+    }
+
+    @Test
+    void testGettersAndSetters() {
+        AuthenticationAttempts attempts = new AuthenticationAttempts();
+
+        attempts.setAttemptIdentifier("attempt-1234");
+        assertEquals(
+                "attempt-1234",
+                attempts.getAttemptIdentifier(),
+                "getAttemptIdentifier should return 'attempt-1234'");
+
+        attempts.setJourneyType("login");
+        assertEquals("login", attempts.getJourneyType(), "getJourneyType should return 'login'");
+
+        attempts.setAuthenticationMethod("email");
+        assertEquals(
+                "email",
+                attempts.getAuthenticationMethod(),
+                "getAuthenticationMethod should return 'email'");
+
+        attempts.setCode("code-5678");
+        assertEquals("code-5678", attempts.getCode(), "getCode should return 'code-5678'");
+
+        attempts.setCount(3);
+        assertEquals(3, attempts.getCount(), "getCount should return 3");
+
+        attempts.setTimeToLive(1234567890L);
+        assertEquals(
+                1234567890L, attempts.getTimeToLive(), "getTimeToLive should return 1234567890L");
+
+        attempts.setCreated("2024-07-29T10:00:00Z");
+        assertEquals(
+                "2024-07-29T10:00:00Z",
+                attempts.getCreated(),
+                "getCreated should return '2024-07-29T10:00:00Z'");
+
+        attempts.setUpdated("2024-07-29T10:30:00Z");
+        assertEquals(
+                "2024-07-29T10:30:00Z",
+                attempts.getUpdated(),
+                "getUpdated should return '2024-07-29T10:30:00Z'");
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/AuthenticationMethodTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/AuthenticationMethodTest.java
@@ -1,0 +1,32 @@
+package uk.gov.di.authentication.shared.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AuthenticationMethodTest {
+
+    @Test
+    void testEmailType() {
+        AuthenticationMethod type = AuthenticationMethod.EMAIL;
+        assertEquals("EMAIL", type.getValue(), "EMAIL type should return 'EMAIL'");
+    }
+
+    @Test
+    void testPasswordType() {
+        AuthenticationMethod type = AuthenticationMethod.PASSWORD;
+        assertEquals("PASSWORD", type.getValue(), "PASSWORD type should return 'PASSWORD'");
+    }
+
+    @Test
+    void testAuthAppType() {
+        AuthenticationMethod type = AuthenticationMethod.AUTH_APP;
+        assertEquals("AUTH_APP", type.getValue(), "AUTH_APP type should return 'AUTH_APP'");
+    }
+
+    @Test
+    void testSmsType() {
+        AuthenticationMethod type = AuthenticationMethod.SMS;
+        assertEquals("SMS", type.getValue(), "SMS type should return 'SMS'");
+    }
+}


### PR DESCRIPTION
## What

AUT-3368 and AUT-3369.

Transitioned the storage medium for TTL variables from Redis to DynamoDB. This required introducing the DynamoAuthenticationAttemptsService class and creating new DynamoDB tables to handle authentication codes and counts with TTL constraints.

Added logic for CRUD Operations: 

- Create: Add new codes and counts.
- Read: Retrieve codes and counts.
- Update: Modify existing codes and counts.
- Delete: Remove codes and counts.

Added a new integration test class to verify the functionality of CRUD operations and TTL management with DynamoDB.


## How to review


1. Code Review commit by commit


## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.
