### PR TITLE
ATO-877: Update Log4j logging format to replace deprecated JsonLayout

### DIFF
--- a/account-management-api/src/main/resources/log4j2.xml
+++ b/account-management-api/src/main/resources/log4j2.xml
@@ -1,9 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/auth-external-api/src/main/resources/log4j2.xml
+++ b/auth-external-api/src/main/resources/log4j2.xml
@@ -1,9 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/auth-external-api/src/test/resources/log4j2.xml
+++ b/auth-external-api/src/test/resources/log4j2.xml
@@ -1,9 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ subprojects {
         libphonenumber "com.googlecode.libphonenumber:libphonenumber:8.13.42"
 
         logging_runtime "com.amazonaws:aws-lambda-java-log4j2:1.6.0",
-                "org.slf4j:slf4j-nop:2.0.13"
+                "org.slf4j:slf4j-nop:2.0.13", 'org.apache.logging.log4j:log4j-layout-template-json:2.23.1'
 
         nimbus "com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
                 "com.nimbusds:nimbus-jose-jwt:${dependencyVersions.nimbusds_jwt_version}"

--- a/client-registry-api/src/main/resources/log4j2.xml
+++ b/client-registry-api/src/main/resources/log4j2.xml
@@ -1,9 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/delivery-receipts-api/src/main/resources/log4j2.xml
+++ b/delivery-receipts-api/src/main/resources/log4j2.xml
@@ -1,9 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/doc-checking-app-api/src/main/resources/log4j2.xml
+++ b/doc-checking-app-api/src/main/resources/log4j2.xml
@@ -1,14 +1,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-                <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
-                <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
-                <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
-                <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
-                <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+                <EventTemplateAdditionalField key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
+                <EventTemplateAdditionalField key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <EventTemplateAdditionalField key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
+                <EventTemplateAdditionalField key="client-id" value="$${ctx:clientId:-}"/>
+                <EventTemplateAdditionalField key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/frontend-api/src/main/resources/log4j2.xml
+++ b/frontend-api/src/main/resources/log4j2.xml
@@ -1,14 +1,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-                <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
-                <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
-                <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
-                <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
-                <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+                <EventTemplateAdditionalField key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
+                <EventTemplateAdditionalField key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <EventTemplateAdditionalField key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
+                <EventTemplateAdditionalField key="client-id" value="$${ctx:clientId:-}"/>
+                <EventTemplateAdditionalField key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/interventions-api-stub/src/main/resources/log4j2.xml
+++ b/interventions-api-stub/src/main/resources/log4j2.xml
@@ -1,14 +1,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-                <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
-                <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
-                <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
-                <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
-                <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+                <EventTemplateAdditionalField key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
+                <EventTemplateAdditionalField key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <EventTemplateAdditionalField key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
+                <EventTemplateAdditionalField key="client-id" value="$${ctx:clientId:-}"/>
+                <EventTemplateAdditionalField key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/ipv-api/src/main/resources/log4j2.xml
+++ b/ipv-api/src/main/resources/log4j2.xml
@@ -1,14 +1,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-                <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
-                <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
-                <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
-                <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
-                <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+                <EventTemplateAdditionalField key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
+                <EventTemplateAdditionalField key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
+                <EventTemplateAdditionalField key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <EventTemplateAdditionalField key="client-id" value="$${ctx:clientId:-}"/>
+                <EventTemplateAdditionalField key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/oidc-api/src/main/resources/log4j2.xml
+++ b/oidc-api/src/main/resources/log4j2.xml
@@ -1,14 +1,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-                <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
-                <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
-                <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
-                <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
-                <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+                <EventTemplateAdditionalField key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
+                <EventTemplateAdditionalField key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <EventTemplateAdditionalField key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
+                <EventTemplateAdditionalField key="client-id" value="$${ctx:clientId:-}"/>
+                <EventTemplateAdditionalField key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/oidc-api/src/test/resources/log4j2.xml
+++ b/oidc-api/src/test/resources/log4j2.xml
@@ -1,11 +1,11 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-                <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
-                <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+                <EventTemplateAdditionalField key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
+                <EventTemplateAdditionalField key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/orchestration-shared/src/test/resources/log4j2.xml
+++ b/orchestration-shared/src/test/resources/log4j2.xml
@@ -1,9 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/shared/src/test/resources/log4j2.xml
+++ b/shared/src/test/resources/log4j2.xml
@@ -1,9 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/test-services-api/src/main/resources/log4j2.xml
+++ b/test-services-api/src/main/resources/log4j2.xml
@@ -1,9 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+                <EventTemplateAdditionalField key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/utils/src/main/resources/log4j2.xml
+++ b/utils/src/main/resources/log4j2.xml
@@ -1,8 +1,8 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" >
+            </JsonTemplateLayout>
         </Lambda>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
_Note this is a follow-up PR since the original was reverted: https://github.com/govuk-one-login/authentication-api/pull/4964_

## What

Update Log4j logging format to replace deprecated JsonLayout.

This needs to be tested in build, so deployment promotions to higher envs will be paused.

This PR contains fixes for the [original PR](https://github.com/govuk-one-login/authentication-api/pull/4963) which was reverted:
- Add `log4j-layout-template-json` to build.gradle
- Change `LambdaJsonLayout.json` to `LambdaLayout.json`

Documentation 
https://docs.powertools.aws.dev/lambda/java/core/logging/#upgrade-to-jsontemplatelayout-from-deprecated-lambdajsonlayout-configuration-in-log4j2xml

https://logging.apache.org/log4j/2.x/manual/json-template-layout.html
