### PR TITLE
AUT-2932: Enable email address checks

### DIFF
--- a/ci/terraform/account-management/build-overrides.tfvars
+++ b/ci/terraform/account-management/build-overrides.tfvars
@@ -8,5 +8,3 @@ scaling_trigger        = 0.6
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
-
-support_email_check_enabled = true

--- a/ci/terraform/account-management/sandpit.tfvars
+++ b/ci/terraform/account-management/sandpit.tfvars
@@ -15,5 +15,3 @@ lambda_min_concurrency = 0
 lockout_duration                          = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
-
-support_email_check_enabled = true

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -30,7 +30,6 @@ module "send_otp_notification" {
     ENVIRONMENT                            = var.environment
     EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id
     PENDING_EMAIL_CHECK_QUEUE_URL          = local.pending_email_check_queue_id
-    SUPPORT_EMAIL_CHECK_ENABLED            = var.support_email_check_enabled
     DYNAMO_ENDPOINT                        = var.use_localstack ? var.lambda_dynamo_endpoint : null
     LOCALSTACK_ENDPOINT                    = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                              = local.redis_key

--- a/ci/terraform/account-management/staging-overrides.tfvars
+++ b/ci/terraform/account-management/staging-overrides.tfvars
@@ -20,5 +20,3 @@ logging_endpoint_arns = [
 ]
 
 common_state_bucket = "di-auth-staging-tfstate"
-
-support_email_check_enabled = true

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -219,7 +219,7 @@ variable "test_clients_enabled" {
 }
 
 variable "support_email_check_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "Feature flag which toggles the Experian email check on and off"
 }

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -54,5 +54,3 @@ lambda_max_concurrency = 0
 lambda_min_concurrency = 1
 endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
-
-support_email_check_enabled = true

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -57,8 +57,6 @@ orch_frontend_api_gateway_integration_enabled = true
 orch_redirect_uri                  = "https://oidc.sandpit.account.gov.uk/orchestration-redirect"
 authorize_protected_subnet_enabled = true
 
-support_email_check_enabled = true
-
 contra_state_bucket = "digital-identity-dev-tfstate"
 
 orch_openid_configuration_enabled    = true

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -35,7 +35,6 @@ module "send_notification" {
     LOCKOUT_COUNT_TTL                      = var.lockout_count_ttl
     EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id
     PENDING_EMAIL_CHECK_QUEUE_URL          = local.pending_email_check_queue_id
-    SUPPORT_EMAIL_CHECK_ENABLED            = var.support_email_check_enabled
     TXMA_AUDIT_QUEUE_URL                   = module.oidc_txma_audit.queue_url
     LOCALSTACK_ENDPOINT                    = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                              = local.redis_key

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -44,7 +44,7 @@ locals {
   deploy_account_interventions_count   = 1
   deploy_ticf_cri_count                = contains(["sandpit", "authdev1", "authdev2", "dev", "build", "staging", "integration"], var.environment) ? 1 : 0
   deploy_reauth_user_count             = contains(["build", "sandpit", "authdev1", "authdev2", "staging", "integration"], var.environment) ? 1 : 0
-  deploy_check_email_fraud_block_count = contains(["build", "sandpit", "authdev1", "authdev2", "staging"], var.environment) ? 1 : 0
+  deploy_check_email_fraud_block_count = 1
 
   access_logging_template = jsonencode({
     requestId            = "$context.requestId"

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -98,5 +98,3 @@ logging_endpoint_arns = [
 ]
 
 shared_state_bucket = "di-auth-staging-tfstate"
-
-support_email_check_enabled = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -643,7 +643,7 @@ variable "authorize_protected_subnet_enabled" {
 }
 
 variable "support_email_check_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "Feature flag which toggles the Experian email check on and off"
 }

--- a/ci/terraform/utils/build-overrides.tfvars
+++ b/ci/terraform/utils/build-overrides.tfvars
@@ -16,5 +16,3 @@ bulk_user_email_email_sending_enabled = false
 bulk_user_email_batch_query_limit     = 25
 bulk_user_email_max_batch_count       = 100
 bulk_user_email_batch_pause_duration  = 0
-
-support_email_check_enabled = true

--- a/ci/terraform/utils/sandpit.tfvars
+++ b/ci/terraform/utils/sandpit.tfvars
@@ -15,4 +15,3 @@ performance_tuning = {
     timeout = 300
   }
 }
-support_email_check_enabled = true

--- a/ci/terraform/utils/staging-overrides.tfvars
+++ b/ci/terraform/utils/staging-overrides.tfvars
@@ -9,5 +9,3 @@ allow_bulk_test_users = true
 shared_state_bucket = "di-auth-staging-tfstate"
 
 bulk_user_email_included_terms_and_conditions = "1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8"
-
-support_email_check_enabled = true

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -186,7 +186,7 @@ variable "email_check_results_sqs_queue_encryption_key_arn" {
 }
 
 variable "support_email_check_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "Feature flag which toggles the Experian email check on and off"
 }


### PR DESCRIPTION
## What

Enables the `support_email_check_enabled` feature switch in all environments which enables the API side logic for handling email checks during account creation and email address updates.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.


## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/1898
