### PR TITLE
BAU: Fix Lambda HTTP Server Git Ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,6 @@ logs/
 *.received.json
 
 # Contract Tests
-pact/
+/*/src/test/pact/
 node_modules
 .infracost


### PR DESCRIPTION
## What

Gitignore file entry added to ignore pact test outputs was ignoring java class files in `orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/pact/`.
## How to review

Code Review
## Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.

