### PR TITLE
Revert "Adding lifecycle ignore for provisioned_concurrent_executions"

### DIFF
--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -77,11 +77,6 @@ resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrenc
   qualifier     = aws_lambda_alias.authorizer_alias.name
 
   provisioned_concurrent_executions = local.authorizer_provisioned_concurrency
-
-  lifecycle {
-    ignore_changes = [provisioned_concurrent_executions] # Ignoring as this is targeted by aws_app_autoscaling_target.lambda_target resource
-  }
-
 }
 
 resource "aws_appautoscaling_target" "lambda_target" {

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -76,11 +76,6 @@ resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrenc
   qualifier     = aws_lambda_alias.endpoint_lambda.name
 
   provisioned_concurrent_executions = var.provisioned_concurrency
-
-  lifecycle {
-    ignore_changes = [provisioned_concurrent_executions] # Ignoring as this is targeted by aws_app_autoscaling_target.lambda_target resource
-  }
-
 }
 
 resource "aws_appautoscaling_target" "lambda_target" {

--- a/ci/terraform/modules/stub-endpoint-module/lambda.tf
+++ b/ci/terraform/modules/stub-endpoint-module/lambda.tf
@@ -76,11 +76,6 @@ resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrenc
   qualifier     = aws_lambda_alias.endpoint_lambda.name
 
   provisioned_concurrent_executions = var.provisioned_concurrency
-
-  lifecycle {
-    ignore_changes = [provisioned_concurrent_executions] # Ignoring as this is targeted by aws_app_autoscaling_target.lambda_target resource
-  }
-
 }
 
 resource "aws_appautoscaling_target" "lambda_target" {

--- a/ci/terraform/utils/email_check_results_writer_lambda.tf
+++ b/ci/terraform/utils/email_check_results_writer_lambda.tf
@@ -74,11 +74,6 @@ resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrenc
   qualifier     = aws_lambda_alias.email_check_results_writer_lambda.name
 
   provisioned_concurrent_executions = var.email_check_results_writer_provisioned_concurrency
-
-  lifecycle {
-    ignore_changes = [provisioned_concurrent_executions]
-  }
-
 }
 
 resource "aws_cloudwatch_log_group" "lambda_log_group" {


### PR DESCRIPTION
Reverts govuk-one-login/authentication-api#4267

This does the work but we have a small concern when lambda Deployment fails the concurrency is not shifted to next good version we have to manually delete the  Provisioned concurrency configurations to fix

we have better solution for Lambda throttling to be tested  

