### PR TITLE
ATO-522: add ability to disable RPs

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
@@ -93,8 +94,12 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
         var clientResponse =
                 objectMapper.readValue(response.getBody(), ClientRegistrationResponse.class);
 
+        Optional<ClientRegistry> client = clientStore.getClient(clientResponse.getClientId());
+
         assertThat(response, hasStatus(200));
         assertTrue(clientStore.clientExists(clientResponse.getClientId()));
+        assertTrue(client.isPresent());
+        assertTrue(client.get().isActive());
         assertThat(clientResponse.getClaims(), equalTo(claims));
         assertThat(clientResponse.getBackChannelLogoutUri(), equalTo(backChannelLogoutUri));
         assertThat(clientResponse.getClientType(), equalTo(ClientType.WEB.getValue()));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -334,7 +334,7 @@ public class AuthorisationHandler
                             authRequest.getState(),
                             authRequest.getResponseMode());
             return generateApiGatewayProxyResponse(
-                    400,
+                    401,
                     "",
                     Map.of(ResponseHeaders.LOCATION, errorResponse.toURI().toString()),
                     null);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -326,17 +326,14 @@ public class AuthorisationHandler
         if (!client.getIsActive()) {
             String errorMsg = "Client configured as not active in Client Registry";
             LOG.error(errorMsg);
-            var errorResponse =
-                    new AuthenticationErrorResponse(
-                            authRequest.getRedirectionURI(),
-                            new ErrorObject(UNAUTHORIZED_CLIENT_CODE, errorMsg),
-                            authRequest.getState(),
-                            authRequest.getResponseMode());
-            return generateApiGatewayProxyResponse(
-                    401,
-                    "",
-                    Map.of(ResponseHeaders.LOCATION, errorResponse.toURI().toString()),
-                    null);
+            LOG.warn("Redirecting");
+            return generateErrorResponse(
+                    authRequest.getRedirectionURI(),
+                    authRequest.getState(),
+                    authRequest.getResponseMode(),
+                    new ErrorObject(UNAUTHORIZED_CLIENT_CODE, errorMsg),
+                    authRequest.getClientID().getValue(),
+                    user);
         }
 
         try {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -323,7 +323,7 @@ public class AuthorisationHandler
             }
         }
 
-        if (!client.getIsActive()) {
+        if (!client.isActive()) {
             String errorMsg = "Client configured as not active in Client Registry";
             LOG.error(errorMsg);
             LOG.warn("Redirecting");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -324,14 +324,12 @@ public class AuthorisationHandler
         }
 
         if (!client.isActive()) {
-            String errorMsg = "Client configured as not active in Client Registry";
-            LOG.error(errorMsg);
-            LOG.warn("Redirecting");
+            LOG.error("Client configured as not active in Client Registry");
             return generateErrorResponse(
                     authRequest.getRedirectionURI(),
                     authRequest.getState(),
                     authRequest.getResponseMode(),
-                    new ErrorObject(UNAUTHORIZED_CLIENT_CODE, errorMsg),
+                    new ErrorObject(UNAUTHORIZED_CLIENT_CODE, "client deactivated"),
                     authRequest.getClientID().getValue(),
                     user);
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -92,7 +92,6 @@ import static com.nimbusds.oauth2.sdk.OAuth2Error.INVALID_REQUEST;
 import static com.nimbusds.oauth2.sdk.OAuth2Error.SERVER_ERROR;
 import static com.nimbusds.oauth2.sdk.OAuth2Error.UNAUTHORIZED_CLIENT_CODE;
 import static com.nimbusds.oauth2.sdk.OAuth2Error.VALIDATION_FAILED;
-import static java.lang.String.format;
 import static java.util.Objects.isNull;
 import static uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService.VTR_PARAM;
 import static uk.gov.di.orchestration.shared.conditions.IdentityHelper.identityRequired;
@@ -262,11 +261,11 @@ public class AuthorisationHandler
                         case "POST" -> parseRequestBody(input.getBody());
                         default -> {
                             LOG.warn(
-                                    format(
+                                    String.format(
                                             "Authentication request sent with invalid HTTP method %s",
                                             input.getHttpMethod()));
                             throw new InvalidHttpMethodException(
-                                    format(
+                                    String.format(
                                             "Authentication request does not support %s requests",
                                             input.getHttpMethod()));
                         }
@@ -325,7 +324,8 @@ public class AuthorisationHandler
         }
 
         if (!client.getIsActive()) {
-            String errorMsg = format("Client not active for ClientId: %s", client.getClientID());
+            String errorMsg =
+                    String.format("Client not active for ClientId: %s", client.getClientID());
             LOG.error(errorMsg);
             var errorResponse =
                     new AuthenticationErrorResponse(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -324,7 +324,7 @@ public class AuthorisationHandler
         }
 
         if (!client.getIsActive()) {
-            String errorMsg = String.format("Client not active", client.getClientID());
+            String errorMsg = "Client configured as not active in Client Registry";
             LOG.error(errorMsg);
             var errorResponse =
                     new AuthenticationErrorResponse(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -324,8 +324,7 @@ public class AuthorisationHandler
         }
 
         if (!client.getIsActive()) {
-            String errorMsg =
-                    String.format("Client not active for ClientId: %s", client.getClientID());
+            String errorMsg = String.format("Client not active", client.getClientID());
             LOG.error(errorMsg);
             var errorResponse =
                     new AuthenticationErrorResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -998,7 +998,7 @@ class AuthorisationHandlerTest {
                             .withIdentity(new RequestIdentity().withSourceIp("123.123.123.123")));
             var response = makeHandlerRequest(event);
 
-            assertThat(response, hasStatus(401));
+            assertThat(response, hasStatus(302));
             assertThat(
                     logging.events(),
                     hasItem(withMessage("Client configured as not active in Client Registry")));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1006,7 +1006,7 @@ class AuthorisationHandlerTest {
                     response.getHeaders().get(ResponseHeaders.LOCATION),
                     equalTo(
                             REDIRECT_URI
-                                    + "?error=unauthorized_client&error_description=Client+configured+as+not+active+in+Client+Registry"));
+                                    + "?error=unauthorized_client&error_description=client+deactivated"));
         }
 
         @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1004,7 +1004,7 @@ class AuthorisationHandlerTest {
                     response.getHeaders().get(ResponseHeaders.LOCATION),
                     equalTo(
                             REDIRECT_URI
-                                    + "?error=unauthorized_client&error_description=Client+not+active+for+ClientId%3A+test-id"));
+                                    + "?error=unauthorized_client&error_description=Client+not+active"));
         }
 
         @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -979,7 +979,7 @@ class AuthorisationHandlerTest {
         @Test
         void shouldThrowErrorWhenClientIsNotActive() {
             when(clientService.getClient(CLIENT_ID.toString()))
-                    .thenReturn(Optional.of(generateClientRegistry().withIsActive(false)));
+                    .thenReturn(Optional.of(generateClientRegistry().withActive(false)));
 
             var event = new APIGatewayProxyRequestEvent();
             event.setQueryStringParameters(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -998,7 +998,7 @@ class AuthorisationHandlerTest {
                             .withIdentity(new RequestIdentity().withSourceIp("123.123.123.123")));
             var response = makeHandlerRequest(event);
 
-            assertThat(response, hasStatus(400));
+            assertThat(response, hasStatus(401));
             assertThat(
                     logging.events(),
                     hasItem(withMessage("Client not active for ClientId: test-id")));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -999,12 +999,14 @@ class AuthorisationHandlerTest {
             var response = makeHandlerRequest(event);
 
             assertThat(response, hasStatus(401));
-            assertThat(logging.events(), hasItem(withMessage("Client not active")));
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessage("Client configured as not active in Client Registry")));
             assertThat(
                     response.getHeaders().get(ResponseHeaders.LOCATION),
                     equalTo(
                             REDIRECT_URI
-                                    + "?error=unauthorized_client&error_description=Client+not+active"));
+                                    + "?error=unauthorized_client&error_description=Client+configured+as+not+active+in+Client+Registry"));
         }
 
         @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -977,7 +977,7 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldThrowErrorWhenClientIsNotActive() {
+        void shouldRedirectToRPWhenClientIsNotActive() {
             when(clientService.getClient(CLIENT_ID.toString()))
                     .thenReturn(Optional.of(generateClientRegistry().withActive(false)));
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -999,9 +999,7 @@ class AuthorisationHandlerTest {
             var response = makeHandlerRequest(event);
 
             assertThat(response, hasStatus(401));
-            assertThat(
-                    logging.events(),
-                    hasItem(withMessage("Client not active for ClientId: test-id")));
+            assertThat(logging.events(), hasItem(withMessage("Client not active")));
             assertThat(
                     response.getHeaders().get(ResponseHeaders.LOCATION),
                     equalTo(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
@@ -234,15 +234,15 @@ public class ClientRegistry {
     }
 
     @DynamoDbAttribute("IsActive")
-    public Boolean getIsActive() {
+    public boolean getIsActive() {
         return isActive;
     }
 
-    public void setIsActive(Boolean isActive) {
+    public void setIsActive(boolean isActive) {
         this.isActive = isActive;
     }
 
-    public ClientRegistry withIsActive(Boolean isActive) {
+    public ClientRegistry withIsActive(boolean isActive) {
         this.isActive = isActive;
         return this;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
@@ -234,15 +234,15 @@ public class ClientRegistry {
     }
 
     @DynamoDbAttribute("IsActive")
-    public boolean getIsActive() {
+    public boolean isActive() {
         return isActive;
     }
 
-    public void setIsActive(boolean isActive) {
+    public void setActive(boolean isActive) {
         this.isActive = isActive;
     }
 
-    public ClientRegistry withIsActive(boolean isActive) {
+    public ClientRegistry withActive(boolean isActive) {
         this.isActive = isActive;
         return this;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
@@ -27,6 +27,7 @@ public class ClientRegistry {
     private String serviceType;
     private String sectorIdentifierUri;
     private String subjectType;
+    private boolean isActive = true;
     private boolean cookieConsentShared = false;
     private boolean jarValidationRequired = false;
     private boolean testClient = false;
@@ -229,6 +230,20 @@ public class ClientRegistry {
 
     public ClientRegistry withSubjectType(String subjectType) {
         this.subjectType = subjectType;
+        return this;
+    }
+
+    @DynamoDbAttribute("IsActive")
+    public Boolean getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    public ClientRegistry withIsActive(Boolean isActive) {
+        this.isActive = isActive;
         return this;
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
@@ -99,7 +99,8 @@ public class DynamoClientService implements ClientService {
                         .withClientType(clientType)
                         .withIdentityVerificationSupported(identityVerificationSupported)
                         .withIdTokenSigningAlgorithm(idTokenSigningAlgorithm)
-                        .withTokenAuthMethod(tokenAuthMethod);
+                        .withTokenAuthMethod(tokenAuthMethod)
+                        .withActive(true);
         if (Objects.nonNull(clientSecret)) {
             clientRegistry.withClientSecret(Argon2EncoderHelper.argon2Hash(clientSecret));
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -196,15 +196,15 @@ public class ClientRegistry {
     }
 
     @DynamoDbAttribute("IsActive")
-    public Boolean getIsActive() {
+    public boolean getIsActive() {
         return isActive;
     }
 
-    public void setIsActive(Boolean isActive) {
+    public void setIsActive(boolean isActive) {
         this.isActive = isActive;
     }
 
-    public ClientRegistry withIsActive(Boolean isActive) {
+    public ClientRegistry withIsActive(boolean isActive) {
         this.isActive = isActive;
         return this;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -22,6 +22,7 @@ public class ClientRegistry {
     private String serviceType;
     private String sectorIdentifierUri;
     private String subjectType;
+    private boolean isActive = true;
     private boolean cookieConsentShared = false;
     private boolean testClient = false;
     private List<String> testClientEmailAllowlist = new ArrayList<>();
@@ -191,6 +192,20 @@ public class ClientRegistry {
 
     public ClientRegistry withSubjectType(String subjectType) {
         this.subjectType = subjectType;
+        return this;
+    }
+
+    @DynamoDbAttribute("IsActive")
+    public Boolean getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    public ClientRegistry withIsActive(Boolean isActive) {
+        this.isActive = isActive;
         return this;
     }
 


### PR DESCRIPTION
## What

Added `isActive` property to `ClientRegistry`, which defaults to true if it is null.
If an RP is not active, redirect back to RP with unauthorised user error.

## How to review

1. Code Review
2. Deploy and check that the authentication journey is unchanged by default and when `isActive` is true, but fails with a redirect and descriptive message when `isActive` is false.

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.