### PR TITLE
ATO-952: Parse post logout url as part of validation

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -19,7 +19,6 @@ import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.shared.services.TokenValidationService;
 
-import java.net.URI;
 import java.util.Map;
 
 import static uk.gov.di.orchestration.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
@@ -107,7 +106,7 @@ public class LogoutHandler
         return logoutService.handleLogout(
                 logoutRequest.session(),
                 logoutRequest.errorObject(),
-                logoutRequest.postLogoutRedirectUri().map(URI::create),
+                logoutRequest.postLogoutRedirectUri(),
                 logoutRequest.state(),
                 logoutRequest.auditUser(),
                 logoutRequest.clientId(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
@@ -139,8 +139,7 @@ class LogoutRequestTest {
         assertEquals(Optional.empty(), logoutRequest.errorObject());
         assertEquals(Optional.of("client-id"), logoutRequest.clientId());
         assertEquals(Optional.of(rpPairwiseId), logoutRequest.rpPairwiseId());
-        assertEquals(
-                Optional.of(CLIENT_LOGOUT_URI.toString()), logoutRequest.postLogoutRedirectUri());
+        assertEquals(Optional.of(CLIENT_LOGOUT_URI), logoutRequest.postLogoutRedirectUri());
         assertEquals(Optional.of(clientRegistry), logoutRequest.clientRegistry());
     }
 
@@ -198,8 +197,7 @@ class LogoutRequestTest {
         assertEquals(Optional.empty(), logoutRequest.errorObject());
         assertEquals(Optional.of("client-id"), logoutRequest.clientId());
         assertEquals(Optional.of(rpPairwiseId), logoutRequest.rpPairwiseId());
-        assertEquals(
-                Optional.of(CLIENT_LOGOUT_URI.toString()), logoutRequest.postLogoutRedirectUri());
+        assertEquals(Optional.of(CLIENT_LOGOUT_URI), logoutRequest.postLogoutRedirectUri());
         assertEquals(Optional.of(clientRegistry), logoutRequest.clientRegistry());
     }
 
@@ -414,9 +412,7 @@ class LogoutRequestTest {
                 logoutRequest.errorObject());
         assertEquals(Optional.of("client-id"), logoutRequest.clientId());
         assertEquals(Optional.of(rpPairwiseId), logoutRequest.rpPairwiseId());
-        assertEquals(
-                Optional.of("http://localhost/invalidlogout"),
-                logoutRequest.postLogoutRedirectUri());
+        assertEquals(Optional.empty(), logoutRequest.postLogoutRedirectUri());
         assertEquals(Optional.of(clientRegistry), logoutRequest.clientRegistry());
     }
 


### PR DESCRIPTION
An invalid URL should be handled like any other input error.

It would have likely been sufficient to keep the url empty on the request object in the case the provided value did not match the client registry, but the chosen approach also protects against bad values in the client registry.

