### PR TITLE
AUT-3500: Use cached email check results

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -4,6 +4,7 @@ import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.SendNotificationRequest;
 import uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler;
@@ -12,6 +13,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
 import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.Collections;
@@ -37,6 +39,10 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                     PhoneNumberUtil.getInstance()
                             .getExampleNumberForType("GB", MOBILE)
                             .getNationalNumber());
+
+    @RegisterExtension
+    protected static final EmailCheckResultExtension emailCheckResultExtension =
+            new EmailCheckResultExtension();
 
     @BeforeEach
     void setup() {

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -12,7 +12,9 @@ module "account_management_api_send_notification_role" {
     module.account_management_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.user_profile_encryption_policy_arn,
-    local.pending_email_check_queue_access_policy_arn
+    local.pending_email_check_queue_access_policy_arn,
+    local.email_check_results_encryption_policy_arn,
+    aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -9,7 +9,11 @@ module "frontend_api_check_email_fraud_block_role" {
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.email_check_results_encryption_policy_arn,
+    aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
+    local.client_registry_encryption_policy_arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
   ]
 }
 
@@ -56,7 +60,7 @@ module "check_email_fraud_block" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.frontend_api_orch_auth_code_role.arn
+  lambda_role_arn                        = module.frontend_api_check_email_fraud_block_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -15,7 +15,9 @@ module "frontend_api_send_notification_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     local.user_profile_encryption_policy_arn,
-    local.pending_email_check_queue_access_policy_arn
+    local.pending_email_check_queue_access_policy_arn,
+    local.email_check_results_encryption_policy_arn,
+    aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
   ]
 }
 


### PR DESCRIPTION
## What

### Check cache before requesting email check
We currently send email check requests when a user enters a new email address in both account creation and account management (in practice this happens when we send the OTP email to the user).

We now check to see if we already have a result cached from a previous recent check, and if so we do not raise another request.

Only when no cached result exists for the email address do we request a new check.

This means allowing the notification lambdas access to the table. This is done by giving the lambda roles access to read, encrypt and decrypt the email check result table:
- Encrypt is given in this policy, but no ability to write.
- Policies:
  - `local.email_check_results_encryption_policy_arn`
  - `aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn`


### Correct access lambda role for `check-email-fraud-block`
A lambda role was declared for the lambda, but was not in use. This corrects the role used by the lambda and adds the required missing policies to the existing role.

`frontend-api-check-email-fraud-block-role` has the following policies attached:

- Access to write and encrypt to the TxMA audit queue
  - So audit events can be submitted
  - Policies:
    - `aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn`
    - `module.oidc_txma_audit.access_policy_arn`
- Access to get and decrypt redis parameters
  - So session data can be accessed
  - Policies:
    - `aws_iam_policy.redis_parameter_policy.arn`
- Access to read, decrypt and encrypt the user profile, user credentials and doc app cir credentials tables
  - So the request can be validated
  - Policies:
    - `aws_iam_policy.dynamo_user_read_access_policy.arn`
    - Encrypt is given in this policy, but no ability to write.
- Access to read, encrypt and decrypt the client registry table.
  - So client session data can be added to logs and audit events
  - Encrypt is given in this policy, but no ability to write.
  - Policies:
    - `aws_iam_policy.dynamo_client_registry_read_access_policy.arn`
    - `local.client_registry_encryption_policy_arn`
- Access to read, encrypt and decrypt the email check result table
  - So the result of an email check can be assessed
  - Encrypt is given in this policy, but no ability to write.
  - Policies:
    - `local.email_check_results_encryption_policy_arn`
    - `aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn`




## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.
