### PR TITLE
Aut 3481/generic mfa

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -197,6 +197,8 @@ public class StartService {
                 .filter(Objects::nonNull)
                 .filter(not(List::isEmpty))
                 .flatMap(Collection::stream)
+                .filter(m -> m instanceof AuthAppMFAMethod)
+                .map(m -> (AuthAppMFAMethod) m)
                 .filter(AuthAppMFAMethod::isMethodVerified)
                 .map(AuthAppMFAMethod::getMfaMethodType)
                 .anyMatch(MFAMethodType.AUTH_APP.getValue()::equals);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -11,9 +11,9 @@ import uk.gov.di.authentication.frontendapi.entity.UserStartInfo;
 import uk.gov.di.authentication.shared.conditions.DocAppUserHelper;
 import uk.gov.di.authentication.shared.conditions.IdentityHelper;
 import uk.gov.di.authentication.shared.conditions.UpliftHelper;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -197,8 +197,8 @@ public class StartService {
                 .filter(Objects::nonNull)
                 .filter(not(List::isEmpty))
                 .flatMap(Collection::stream)
-                .filter(MFAMethod::isMethodVerified)
-                .map(MFAMethod::getMfaMethodType)
+                .filter(AuthAppMFAMethod::isMethodVerified)
+                .map(AuthAppMFAMethod::getMfaMethodType)
                 .anyMatch(MFAMethodType.AUTH_APP.getValue()::equals);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -4,10 +4,10 @@ import org.apache.commons.codec.CodecPolicy;
 import org.apache.commons.codec.binary.Base32;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -170,10 +170,10 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
                                 method ->
                                         method.getMfaMethodType()
                                                 .equals(MFAMethodType.AUTH_APP.getValue()))
-                        .filter(MFAMethod::isEnabled)
+                        .filter(AuthAppMFAMethod::isEnabled)
                         .findAny();
 
-        return mfaMethod.map(MFAMethod::getCredentialValue);
+        return mfaMethod.map(AuthAppMFAMethod::getCredentialValue);
     }
 
     private boolean checkCode(String secret, long code, long timestamp) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -8,6 +8,7 @@ import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -164,16 +165,18 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
             return Optional.empty();
         }
 
-        var mfaMethod =
+        var authAppMFAMethod =
                 userCredentials.getMfaMethods().stream()
                         .filter(
                                 method ->
                                         method.getMfaMethodType()
-                                                .equals(MFAMethodType.AUTH_APP.getValue()))
-                        .filter(AuthAppMFAMethod::isEnabled)
+                                                        .equals(MFAMethodType.AUTH_APP.getValue())
+                                                && method instanceof AuthAppMFAMethod)
+                        .map(m -> (AuthAppMFAMethod) m)
+                        .filter(MFAMethod::isEnabled)
                         .findAny();
 
-        return mfaMethod.map(AuthAppMFAMethod::getCredentialValue);
+        return authAppMFAMethod.map(AuthAppMFAMethod::getCredentialValue);
     }
 
     private boolean checkCode(String secret, long code, long timestamp) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -19,11 +19,11 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
@@ -155,11 +155,12 @@ class CheckUserExistsHandlerTest {
 
         @Test
         void shouldReturn200WithRelevantMfaMethod() {
-            MFAMethod mfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, false);
-            MFAMethod mfaMethod2 = verifiedMfaMethod(MFAMethodType.SMS, true);
+            AuthAppMFAMethod authAppMfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, false);
+            AuthAppMFAMethod authAppMfaMethod2 = verifiedMfaMethod(MFAMethodType.SMS, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(
-                            new UserCredentials().withMfaMethods(List.of(mfaMethod1, mfaMethod2)));
+                            new UserCredentials()
+                                    .withMfaMethods(List.of(authAppMfaMethod1, authAppMfaMethod2)));
 
             var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
             var phoneNumber = CommonTestVariables.UK_MOBILE_NUMBER;
@@ -227,9 +228,9 @@ class CheckUserExistsHandlerTest {
             when(codeStorageService.getIncorrectMfaCodeAttemptsCount(
                             EMAIL_ADDRESS, MFAMethodType.AUTH_APP))
                     .thenReturn(6);
-            MFAMethod mfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, true);
+            AuthAppMFAMethod authAppMfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
-                    .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod1)));
+                    .thenReturn(new UserCredentials().withMfaMethods(List.of(authAppMfaMethod1)));
             var event = userExistsRequest(EMAIL_ADDRESS);
 
             var result = handler.handleRequest(event, context);
@@ -252,9 +253,9 @@ class CheckUserExistsHandlerTest {
         void shouldReturnNoRedactedPhoneNumberIfNotPresent() throws Json.JsonException {
             setupUserProfileAndClient(Optional.of(generateUserProfile()));
 
-            MFAMethod mfaMethod = verifiedMfaMethod(MFAMethodType.SMS, true);
+            AuthAppMFAMethod authAppMfaMethod = verifiedMfaMethod(MFAMethodType.SMS, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
-                    .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod)));
+                    .thenReturn(new UserCredentials().withMfaMethods(List.of(authAppMfaMethod)));
 
             var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
 
@@ -418,8 +419,8 @@ class CheckUserExistsHandlerTest {
                 .withRequestContext(contextWithSourceIp(IP_ADDRESS));
     }
 
-    private MFAMethod verifiedMfaMethod(MFAMethodType mfaMethodType, Boolean enabled) {
-        return new MFAMethod(
+    private AuthAppMFAMethod verifiedMfaMethod(MFAMethodType mfaMethodType, Boolean enabled) {
+        return new AuthAppMFAMethod(
                 mfaMethodType.getValue(),
                 "some-credential-value",
                 true,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -25,12 +25,12 @@ import uk.gov.di.authentication.frontendapi.entity.PasswordResetType;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.frontendapi.helpers.FrontendApiPhoneNumberHelper;
 import uk.gov.di.authentication.frontendapi.services.UserMigrationService;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
@@ -108,8 +108,8 @@ class LoginHandlerTest {
     private static final String CLIENT_NAME = "client-name";
     private static final Subject INTERNAL_SUBJECT_ID = new Subject();
     private static final byte[] SALT = SaltHelper.generateNewSalt();
-    private static final MFAMethod AUTH_APP_MFA_METHOD =
-            new MFAMethod()
+    private static final AuthAppMFAMethod AUTH_APP_MFA_METHOD =
+            new AuthAppMFAMethod()
                     .withMfaMethodType(MFAMethodType.AUTH_APP.getValue())
                     .withMethodVerified(true)
                     .withEnabled(true);
@@ -333,7 +333,7 @@ class LoginHandlerTest {
                         .withEmail(EMAIL)
                         .withPassword(CommonTestVariables.PASSWORD)
                         .setMfaMethod(
-                                new MFAMethod()
+                                new AuthAppMFAMethod()
                                         .withMfaMethodType(MFAMethodType.AUTH_APP.getValue())
                                         .withMethodVerified(false)
                                         .withEnabled(true));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -16,10 +16,10 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
@@ -421,7 +421,7 @@ class ResetPasswordHandlerTest {
     private UserCredentials generateUserCredentialsWithVerifiedAuthApp() {
         return generateUserCredentials()
                 .setMfaMethod(
-                        new MFAMethod(
+                        new AuthAppMFAMethod(
                                 MFAMethodType.AUTH_APP.getValue(),
                                 "auth-app-credential",
                                 true,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -22,12 +22,12 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.PasswordResetType;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
@@ -218,14 +218,14 @@ class ResetPasswordRequestHandlerTest {
             when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                     .thenReturn(Optional.of(getClientSession()));
             var disabledMfaMethod =
-                    new MFAMethod(
+                    new AuthAppMFAMethod(
                             MFAMethodType.AUTH_APP.getValue(),
                             "first-value",
                             true,
                             false,
                             NowHelper.nowMinus(50, ChronoUnit.DAYS).toString());
             var enabledMfaMethod =
-                    new MFAMethod(
+                    new AuthAppMFAMethod(
                             MFAMethodType.SMS.getValue(),
                             "second-value",
                             true,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -21,12 +21,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -283,7 +283,7 @@ class StartServiceTest {
                 new UserCredentials()
                         .withEmail(EMAIL)
                         .setMfaMethod(
-                                (new MFAMethod(
+                                (new AuthAppMFAMethod(
                                         MFAMethodType.AUTH_APP.getValue(),
                                         "rubbish-value",
                                         true,
@@ -295,7 +295,7 @@ class StartServiceTest {
                 new UserCredentials()
                         .withEmail(EMAIL)
                         .setMfaMethod(
-                                (new MFAMethod(
+                                (new AuthAppMFAMethod(
                                         MFAMethodType.AUTH_APP.getValue(),
                                         "rubbish-value",
                                         false,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -364,8 +365,7 @@ class AuthAppCodeProcessorTest {
         when(mockAuthAppMfaMethod.getMfaMethodType()).thenReturn(MFAMethodType.AUTH_APP.getValue());
         when(mockAuthAppMfaMethod.getCredentialValue()).thenReturn(AUTH_APP_SECRET);
         when(mockAuthAppMfaMethod.isEnabled()).thenReturn(true);
-        List<AuthAppMFAMethod> mockAuthAppMfaMethodList =
-                Collections.singletonList(mockAuthAppMfaMethod);
+        List<MFAMethod> mockAuthAppMfaMethodList = Collections.singletonList(mockAuthAppMfaMethod);
         when(mockUserCredentials.getMfaMethods()).thenReturn(mockAuthAppMfaMethodList);
         when(mockDynamoService.getUserCredentialsFromEmail("email-address"))
                 .thenReturn(mockUserCredentials);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -10,10 +10,10 @@ import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -360,12 +360,13 @@ class AuthAppCodeProcessorTest {
         when(mockConfigurationService.getAuthAppCodeWindowLength()).thenReturn(30);
 
         UserCredentials mockUserCredentials = mock(UserCredentials.class);
-        MFAMethod mockMfaMethod = mock(MFAMethod.class);
-        when(mockMfaMethod.getMfaMethodType()).thenReturn(MFAMethodType.AUTH_APP.getValue());
-        when(mockMfaMethod.getCredentialValue()).thenReturn(AUTH_APP_SECRET);
-        when(mockMfaMethod.isEnabled()).thenReturn(true);
-        List<MFAMethod> mockMfaMethodList = Collections.singletonList(mockMfaMethod);
-        when(mockUserCredentials.getMfaMethods()).thenReturn(mockMfaMethodList);
+        AuthAppMFAMethod mockAuthAppMfaMethod = mock(AuthAppMFAMethod.class);
+        when(mockAuthAppMfaMethod.getMfaMethodType()).thenReturn(MFAMethodType.AUTH_APP.getValue());
+        when(mockAuthAppMfaMethod.getCredentialValue()).thenReturn(AUTH_APP_SECRET);
+        when(mockAuthAppMfaMethod.isEnabled()).thenReturn(true);
+        List<AuthAppMFAMethod> mockAuthAppMfaMethodList =
+                Collections.singletonList(mockAuthAppMfaMethod);
+        when(mockUserCredentials.getMfaMethods()).thenReturn(mockAuthAppMfaMethodList);
         when(mockDynamoService.getUserCredentialsFromEmail("email-address"))
                 .thenReturn(mockUserCredentials);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -1,8 +1,6 @@
 package uk.gov.di.authentication.services;
 
-import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.core.SdkBytes;
@@ -11,7 +9,6 @@ import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
@@ -19,7 +16,6 @@ import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,13 +27,7 @@ class DynamoServiceIntegrationTest {
     private static final String UPDATED_TEST_EMAIL = "user.one@test.com";
     private static final String PHONE_NUMBER = "+447700900000";
     private static final String ALTERNATIVE_PHONE_NUMBER = "+447316763843";
-    private static final String CLIENT_ID = "client-id";
     private static final LocalDateTime CREATED_DATE_TIME = LocalDateTime.now();
-    private static final Scope SCOPES =
-            new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
-    private static final Set<String> CLAIMS =
-            ValidScopes.getClaimsForListOfScopes(SCOPES.toStringList());
-
     private static final String TEST_MFA_APP_CREDENTIAL = "test-mfa-app-credential";
     private static final String ALTERNATIVE_TEST_MFA_APP_CREDENTIAL =
             "alternative-test-mfa-app-credential";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -6,7 +6,7 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.core.SdkBytes;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -140,11 +140,11 @@ class DynamoServiceIntegrationTest {
                 dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
 
         assertThat(updatedUserCredentials.getMfaMethods().size(), equalTo(1));
-        MFAMethod mfaMethod = updatedUserCredentials.getMfaMethods().get(0);
-        assertThat(mfaMethod.getMfaMethodType(), equalTo(MFAMethodType.AUTH_APP.getValue()));
-        assertThat(mfaMethod.isMethodVerified(), equalTo(true));
-        assertThat(mfaMethod.isEnabled(), equalTo(true));
-        assertThat(mfaMethod.getCredentialValue(), equalTo(TEST_MFA_APP_CREDENTIAL));
+        AuthAppMFAMethod authAppMfaMethod = updatedUserCredentials.getMfaMethods().get(0);
+        assertThat(authAppMfaMethod.getMfaMethodType(), equalTo(MFAMethodType.AUTH_APP.getValue()));
+        assertThat(authAppMfaMethod.isMethodVerified(), equalTo(true));
+        assertThat(authAppMfaMethod.isEnabled(), equalTo(true));
+        assertThat(authAppMfaMethod.getCredentialValue(), equalTo(TEST_MFA_APP_CREDENTIAL));
     }
 
     @Test
@@ -159,11 +159,11 @@ class DynamoServiceIntegrationTest {
         var updatedUserProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
 
         assertThat(updatedUserCredentials.getMfaMethods().size(), equalTo(1));
-        MFAMethod mfaMethod = updatedUserCredentials.getMfaMethods().get(0);
-        assertThat(mfaMethod.getMfaMethodType(), equalTo(MFAMethodType.AUTH_APP.getValue()));
-        assertThat(mfaMethod.isMethodVerified(), equalTo(true));
-        assertThat(mfaMethod.isEnabled(), equalTo(false));
-        assertThat(mfaMethod.getCredentialValue(), equalTo(TEST_MFA_APP_CREDENTIAL));
+        AuthAppMFAMethod authAppMfaMethod = updatedUserCredentials.getMfaMethods().get(0);
+        assertThat(authAppMfaMethod.getMfaMethodType(), equalTo(MFAMethodType.AUTH_APP.getValue()));
+        assertThat(authAppMfaMethod.isMethodVerified(), equalTo(true));
+        assertThat(authAppMfaMethod.isEnabled(), equalTo(false));
+        assertThat(authAppMfaMethod.getCredentialValue(), equalTo(TEST_MFA_APP_CREDENTIAL));
         assertThat(updatedUserProfile.getAccountVerified(), equalTo(1));
         assertThat(updatedUserProfile.getPhoneNumber(), equalTo("+447316763843"));
         assertThat(updatedUserProfile.isPhoneNumberVerified(), equalTo(true));
@@ -245,11 +245,11 @@ class DynamoServiceIntegrationTest {
 
         var updatedUserCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
         var updatedUserProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
-        List<MFAMethod> mfaMethods = updatedUserCredentials.getMfaMethods();
-        assertThat(mfaMethods.size(), equalTo(1));
-        assertThat(mfaMethods.get(0).isMethodVerified(), equalTo(true));
-        assertThat(mfaMethods.get(0).isEnabled(), equalTo(true));
-        assertThat(mfaMethods.get(0).getCredentialValue(), equalTo(TEST_MFA_APP_CREDENTIAL));
+        List<AuthAppMFAMethod> authAppMfaMethods = updatedUserCredentials.getMfaMethods();
+        assertThat(authAppMfaMethods.size(), equalTo(1));
+        assertThat(authAppMfaMethods.get(0).isMethodVerified(), equalTo(true));
+        assertThat(authAppMfaMethods.get(0).isEnabled(), equalTo(true));
+        assertThat(authAppMfaMethods.get(0).getCredentialValue(), equalTo(TEST_MFA_APP_CREDENTIAL));
         assertThat(updatedUserProfile.getAccountVerified(), equalTo(1));
         assertThat(updatedUserProfile.getPhoneNumber(), equalTo(null));
         assertThat(updatedUserProfile.isPhoneNumberVerified(), equalTo(false));
@@ -267,12 +267,12 @@ class DynamoServiceIntegrationTest {
 
         var updatedUserCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
         var updatedUserProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
-        List<MFAMethod> mfaMethods = updatedUserCredentials.getMfaMethods();
-        assertThat(mfaMethods.size(), equalTo(1));
-        assertThat(mfaMethods.get(0).isMethodVerified(), equalTo(true));
-        assertThat(mfaMethods.get(0).isEnabled(), equalTo(true));
+        List<AuthAppMFAMethod> authAppMfaMethods = updatedUserCredentials.getMfaMethods();
+        assertThat(authAppMfaMethods.size(), equalTo(1));
+        assertThat(authAppMfaMethods.get(0).isMethodVerified(), equalTo(true));
+        assertThat(authAppMfaMethods.get(0).isEnabled(), equalTo(true));
         assertThat(
-                mfaMethods.get(0).getCredentialValue(),
+                authAppMfaMethods.get(0).getCredentialValue(),
                 equalTo(ALTERNATIVE_TEST_MFA_APP_CREDENTIAL));
         assertThat(updatedUserProfile.getAccountVerified(), equalTo(1));
         assertThat(updatedUserProfile.getPhoneNumber(), equalTo(null));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.core.SdkBytes;
 import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
+import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -140,7 +141,7 @@ class DynamoServiceIntegrationTest {
                 dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
 
         assertThat(updatedUserCredentials.getMfaMethods().size(), equalTo(1));
-        AuthAppMFAMethod authAppMfaMethod = updatedUserCredentials.getMfaMethods().get(0);
+        var authAppMfaMethod = (AuthAppMFAMethod) updatedUserCredentials.getMfaMethods().get(0);
         assertThat(authAppMfaMethod.getMfaMethodType(), equalTo(MFAMethodType.AUTH_APP.getValue()));
         assertThat(authAppMfaMethod.isMethodVerified(), equalTo(true));
         assertThat(authAppMfaMethod.isEnabled(), equalTo(true));
@@ -159,7 +160,7 @@ class DynamoServiceIntegrationTest {
         var updatedUserProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
 
         assertThat(updatedUserCredentials.getMfaMethods().size(), equalTo(1));
-        AuthAppMFAMethod authAppMfaMethod = updatedUserCredentials.getMfaMethods().get(0);
+        var authAppMfaMethod = (AuthAppMFAMethod) updatedUserCredentials.getMfaMethods().get(0);
         assertThat(authAppMfaMethod.getMfaMethodType(), equalTo(MFAMethodType.AUTH_APP.getValue()));
         assertThat(authAppMfaMethod.isMethodVerified(), equalTo(true));
         assertThat(authAppMfaMethod.isEnabled(), equalTo(false));
@@ -193,7 +194,7 @@ class DynamoServiceIntegrationTest {
         var updatedUserProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
 
         assertThat(updatedUserCredentials.getMfaMethods().size(), equalTo(1));
-        var mfaMethod = updatedUserCredentials.getMfaMethods().get(0);
+        var mfaMethod = (AuthAppMFAMethod) updatedUserCredentials.getMfaMethods().get(0);
         assertThat(mfaMethod.getMfaMethodType(), equalTo(MFAMethodType.AUTH_APP.getValue()));
         assertThat(mfaMethod.isMethodVerified(), equalTo(true));
         assertThat(mfaMethod.isEnabled(), equalTo(true));
@@ -245,11 +246,12 @@ class DynamoServiceIntegrationTest {
 
         var updatedUserCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
         var updatedUserProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
-        List<AuthAppMFAMethod> authAppMfaMethods = updatedUserCredentials.getMfaMethods();
+        List<MFAMethod> authAppMfaMethods = updatedUserCredentials.getMfaMethods();
         assertThat(authAppMfaMethods.size(), equalTo(1));
-        assertThat(authAppMfaMethods.get(0).isMethodVerified(), equalTo(true));
-        assertThat(authAppMfaMethods.get(0).isEnabled(), equalTo(true));
-        assertThat(authAppMfaMethods.get(0).getCredentialValue(), equalTo(TEST_MFA_APP_CREDENTIAL));
+        var authAppMfaMethod = (AuthAppMFAMethod) updatedUserCredentials.getMfaMethods().get(0);
+        assertThat(authAppMfaMethod.isMethodVerified(), equalTo(true));
+        assertThat(authAppMfaMethod.isEnabled(), equalTo(true));
+        assertThat(authAppMfaMethod.getCredentialValue(), equalTo(TEST_MFA_APP_CREDENTIAL));
         assertThat(updatedUserProfile.getAccountVerified(), equalTo(1));
         assertThat(updatedUserProfile.getPhoneNumber(), equalTo(null));
         assertThat(updatedUserProfile.isPhoneNumberVerified(), equalTo(false));
@@ -267,12 +269,13 @@ class DynamoServiceIntegrationTest {
 
         var updatedUserCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
         var updatedUserProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
-        List<AuthAppMFAMethod> authAppMfaMethods = updatedUserCredentials.getMfaMethods();
-        assertThat(authAppMfaMethods.size(), equalTo(1));
-        assertThat(authAppMfaMethods.get(0).isMethodVerified(), equalTo(true));
-        assertThat(authAppMfaMethods.get(0).isEnabled(), equalTo(true));
+        List<MFAMethod> mfaMethods = updatedUserCredentials.getMfaMethods();
+        assertThat(mfaMethods.size(), equalTo(1));
+        var authAppMfaMethod = (AuthAppMFAMethod) mfaMethods.get(0);
+        assertThat(authAppMfaMethod.isMethodVerified(), equalTo(true));
+        assertThat(authAppMfaMethod.isEnabled(), equalTo(true));
         assertThat(
-                authAppMfaMethods.get(0).getCredentialValue(),
+                authAppMfaMethod.getCredentialValue(),
                 equalTo(ALTERNATIVE_TEST_MFA_APP_CREDENTIAL));
         assertThat(updatedUserProfile.getAccountVerified(), equalTo(1));
         assertThat(updatedUserProfile.getPhoneNumber(), equalTo(null));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/BulkTestUserCsvHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/BulkTestUserCsvHelper.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.testsupport.helpers;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
 import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
+import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -104,7 +105,7 @@ public class BulkTestUserCsvHelper {
 
         if (isAuthAppSecondAuthFactor) {
             String authAppSecret = testUser.get(4);
-            List<AuthAppMFAMethod> authAppMfaMethods = new ArrayList<>();
+            List<MFAMethod> authAppMfaMethods = new ArrayList<>();
             var authAppMfaMethod =
                     new AuthAppMFAMethod(
                             MFAMethodType.AUTH_APP.getValue(), authAppSecret, true, true, dateTime);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/BulkTestUserCsvHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/BulkTestUserCsvHelper.java
@@ -1,7 +1,7 @@
 package uk.gov.di.authentication.testsupport.helpers;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -104,12 +104,12 @@ public class BulkTestUserCsvHelper {
 
         if (isAuthAppSecondAuthFactor) {
             String authAppSecret = testUser.get(4);
-            List<MFAMethod> mfaMethods = new ArrayList<>();
+            List<AuthAppMFAMethod> authAppMfaMethods = new ArrayList<>();
             var authAppMfaMethod =
-                    new MFAMethod(
+                    new AuthAppMFAMethod(
                             MFAMethodType.AUTH_APP.getValue(), authAppSecret, true, true, dateTime);
-            mfaMethods.add(authAppMfaMethod);
-            userCredentials.setMfaMethods(mfaMethods);
+            authAppMfaMethods.add(authAppMfaMethod);
+            userCredentials.setMfaMethods(authAppMfaMethods);
         }
 
         return userCredentials;

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -144,7 +144,7 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
         dynamoService.setAccountVerified(email);
     }
 
-    public List<MFAMethod> getMfaMethod(String email) {
+    public List<AuthAppMFAMethod> getMfaMethod(String email) {
         return dynamoService.getUserCredentialsFromEmail(email).getMfaMethods();
     }
 
@@ -177,7 +177,7 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
                                                                 .equals(
                                                                         MFAMethodType.AUTH_APP
                                                                                 .getValue()))
-                                        .anyMatch(MFAMethod::isMethodVerified))
+                                        .anyMatch(AuthAppMFAMethod::isMethodVerified))
                 .orElse(false);
     }
 
@@ -186,7 +186,7 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
         return mfaMethods != null
                 && mfaMethods.stream()
                         .filter(t -> t.getMfaMethodType().equals(MFAMethodType.AUTH_APP.getValue()))
-                        .anyMatch(MFAMethod::isEnabled);
+                        .anyMatch(AuthAppMFAMethod::isEnabled);
     }
 
     public void addMfaMethod(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
-import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
+import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -144,7 +144,7 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
         dynamoService.setAccountVerified(email);
     }
 
-    public List<AuthAppMFAMethod> getMfaMethod(String email) {
+    public List<MFAMethod> getMfaMethod(String email) {
         return dynamoService.getUserCredentialsFromEmail(email).getMfaMethods();
     }
 
@@ -177,7 +177,7 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
                                                                 .equals(
                                                                         MFAMethodType.AUTH_APP
                                                                                 .getValue()))
-                                        .anyMatch(AuthAppMFAMethod::isMethodVerified))
+                                        .anyMatch(MFAMethod::isMethodVerified))
                 .orElse(false);
     }
 
@@ -186,7 +186,7 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
         return mfaMethods != null
                 && mfaMethods.stream()
                         .filter(t -> t.getMfaMethodType().equals(MFAMethodType.AUTH_APP.getValue()))
-                        .anyMatch(AuthAppMFAMethod::isEnabled);
+                        .anyMatch(MFAMethod::isEnabled);
     }
 
     public void addMfaMethod(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
@@ -37,7 +37,12 @@ public class MfaHelper {
                 .flatMap(
                         mfaMethods ->
                                 mfaMethods.stream()
-                                        .filter(AuthAppMFAMethod::isEnabled)
+                                        .filter(
+                                                mfaMethod ->
+                                                        mfaMethod.isEnabled()
+                                                                && mfaMethod
+                                                                        instanceof AuthAppMFAMethod)
+                                        .map(mfaMethod -> (AuthAppMFAMethod) mfaMethod)
                                         .findFirst());
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
@@ -3,7 +3,7 @@ package uk.gov.di.authentication.shared.conditions;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import uk.gov.di.authentication.entity.UserMfaDetail;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
@@ -32,10 +32,13 @@ public class MfaHelper {
         return !vectorOfTrust.getCredentialTrustLevel().equals(LOW_LEVEL);
     }
 
-    public static Optional<MFAMethod> getPrimaryMFAMethod(UserCredentials userCredentials) {
+    public static Optional<AuthAppMFAMethod> getPrimaryMFAMethod(UserCredentials userCredentials) {
         return Optional.ofNullable(userCredentials.getMfaMethods())
                 .flatMap(
-                        mfaMethods -> mfaMethods.stream().filter(MFAMethod::isEnabled).findFirst());
+                        mfaMethods ->
+                                mfaMethods.stream()
+                                        .filter(AuthAppMFAMethod::isEnabled)
+                                        .findFirst());
     }
 
     public static UserMfaDetail getUserMFADetail(
@@ -48,7 +51,7 @@ public class MfaHelper {
         var mfaMethodType = isPhoneNumberVerified ? MFAMethodType.SMS : MFAMethodType.NONE;
 
         var mfaMethod = getPrimaryMFAMethod(userCredentials);
-        if (mfaMethod.filter(MFAMethod::isMethodVerified).isPresent()) {
+        if (mfaMethod.filter(AuthAppMFAMethod::isMethodVerified).isPresent()) {
             mfaMethodVerified = true;
             mfaMethodType = MFAMethodType.valueOf(mfaMethod.get().getMfaMethodType());
         } else if (!isPhoneNumberVerified && mfaMethod.isPresent()) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/MfaMethodListConverter.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/MfaMethodListConverter.java
@@ -1,0 +1,70 @@
+package uk.gov.di.authentication.shared.dynamodb;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import uk.gov.di.authentication.shared.entity.MFAMethod;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MfaMethodListConverter implements AttributeConverter<List<MFAMethod>> {
+
+    private static final Gson gson = new Gson();
+
+    @Override
+    public AttributeValue transformFrom(List<MFAMethod> input) {
+        if (input == null) {
+            return AttributeValue.builder().nul(true).build();
+        }
+        List<Map<String, String>> serializedList =
+                input.stream()
+                        .map(
+                                obj ->
+                                        Map.of(
+                                                "type", obj.getClass().getName(),
+                                                "data", gson.toJson(obj)))
+                        .collect(Collectors.toList());
+        String json = gson.toJson(serializedList);
+        return AttributeValue.builder().s(json).build();
+    }
+
+    @Override
+    public List<MFAMethod> transformTo(AttributeValue input) {
+        if (input == null || input.s() == null || input.s().isEmpty()) {
+            return new ArrayList<>(); // Return an empty list if the input is null or empty
+        }
+
+        String json = input.s();
+        List<Map<String, String>> deserializedList =
+                gson.fromJson(json, new TypeToken<List<Map<String, String>>>() {}.getType());
+        List<MFAMethod> result = new ArrayList<>();
+        for (Map<String, String> item : deserializedList) {
+            String type = item.get("type");
+            String data = item.get("data");
+            try {
+                Class<?> clazz = Class.forName(type);
+                MFAMethod obj = (MFAMethod) gson.fromJson(data, clazz);
+                result.add(obj);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("Failed to deserialize MyInterface", e);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public EnhancedType<List<MFAMethod>> type() {
+        return EnhancedType.listOf(EnhancedType.of(MFAMethod.class));
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.L;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthAppMFAMethod.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthAppMFAMethod.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 
 @DynamoDbBean
-public class AuthAppMFAMethod {
+public class AuthAppMFAMethod implements MFAMethod {
 
     public static final String ATTRIBUTE_MFA_METHOD_TYPE = "MfaMethodType";
     public static final String ATTRIBUTE_CREDENTIAL_VALUE = "CredentialValue";
@@ -40,6 +40,7 @@ public class AuthAppMFAMethod {
     }
 
     @DynamoDbAttribute(ATTRIBUTE_MFA_METHOD_TYPE)
+    @Override
     public String getMfaMethodType() {
         return mfaMethodType;
     }
@@ -69,6 +70,7 @@ public class AuthAppMFAMethod {
 
     @DynamoDbConvertedBy(BooleanToIntAttributeConverter.class)
     @DynamoDbAttribute(ATTRIBUTE_METHOD_VERIFIED)
+    @Override
     public boolean isMethodVerified() {
         return methodVerified;
     }
@@ -84,6 +86,7 @@ public class AuthAppMFAMethod {
 
     @DynamoDbConvertedBy(BooleanToIntAttributeConverter.class)
     @DynamoDbAttribute(ATTRIBUTE_ENABLED)
+    @Override
     public boolean isEnabled() {
         return enabled;
     }
@@ -98,6 +101,7 @@ public class AuthAppMFAMethod {
     }
 
     @DynamoDbAttribute(ATTRIBUTE_UPDATED)
+    @Override
     public String getUpdated() {
         return updated;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthAppMFAMethod.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthAppMFAMethod.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 
 @DynamoDbBean
-public class MFAMethod {
+public class AuthAppMFAMethod {
 
     public static final String ATTRIBUTE_MFA_METHOD_TYPE = "MfaMethodType";
     public static final String ATTRIBUTE_CREDENTIAL_VALUE = "CredentialValue";
@@ -24,9 +24,9 @@ public class MFAMethod {
     private boolean enabled;
     private String updated;
 
-    public MFAMethod() {}
+    public AuthAppMFAMethod() {}
 
-    public MFAMethod(
+    public AuthAppMFAMethod(
             String mfaMethodType,
             String credentialValue,
             boolean methodVerified,
@@ -48,7 +48,7 @@ public class MFAMethod {
         this.mfaMethodType = mfaMethodType;
     }
 
-    public MFAMethod withMfaMethodType(String mfaMethodType) {
+    public AuthAppMFAMethod withMfaMethodType(String mfaMethodType) {
         this.mfaMethodType = mfaMethodType;
         return this;
     }
@@ -62,7 +62,7 @@ public class MFAMethod {
         this.credentialValue = credentialValue;
     }
 
-    public MFAMethod withCredentialValue(String credentialValue) {
+    public AuthAppMFAMethod withCredentialValue(String credentialValue) {
         this.credentialValue = credentialValue;
         return this;
     }
@@ -77,7 +77,7 @@ public class MFAMethod {
         this.methodVerified = methodVerified;
     }
 
-    public MFAMethod withMethodVerified(boolean methodVerified) {
+    public AuthAppMFAMethod withMethodVerified(boolean methodVerified) {
         this.methodVerified = methodVerified;
         return this;
     }
@@ -92,7 +92,7 @@ public class MFAMethod {
         this.enabled = enabled;
     }
 
-    public MFAMethod withEnabled(boolean enabled) {
+    public AuthAppMFAMethod withEnabled(boolean enabled) {
         this.enabled = enabled;
         return this;
     }
@@ -106,7 +106,7 @@ public class MFAMethod {
         this.updated = updated;
     }
 
-    public MFAMethod withUpdated(String updated) {
+    public AuthAppMFAMethod withUpdated(String updated) {
         this.updated = updated;
         return this;
     }
@@ -131,7 +131,7 @@ public class MFAMethod {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        MFAMethod that = (MFAMethod) o;
+        AuthAppMFAMethod that = (AuthAppMFAMethod) o;
         return Objects.equals(mfaMethodType, that.mfaMethodType)
                 && Objects.equals(credentialValue, that.credentialValue)
                 && Objects.equals(methodVerified, that.methodVerified)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
@@ -1,0 +1,11 @@
+package uk.gov.di.authentication.shared.entity;
+
+public interface MFAMethod {
+    String getMfaMethodType();
+
+    boolean isMethodVerified();
+
+    boolean isEnabled();
+
+    String getUpdated();
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
@@ -8,4 +8,8 @@ public interface MFAMethod {
     boolean isEnabled();
 
     String getUpdated();
+
+    MFAMethod withEnabled(boolean enabled);
+
+    MFAMethod withUpdated(String updated);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java
@@ -25,7 +25,7 @@ public class UserCredentials {
     private String created;
     private String updated;
     private String migratedPassword;
-    private List<MFAMethod> mfaMethods;
+    private List<AuthAppMFAMethod> authAppMfaMethods;
     private int testUser;
 
     public UserCredentials() {}
@@ -65,8 +65,8 @@ public class UserCredentials {
         this.migratedPassword = migratedPassword;
     }
 
-    public void setMfaMethods(List<MFAMethod> mfaMethods) {
-        this.mfaMethods = mfaMethods;
+    public void setMfaMethods(List<AuthAppMFAMethod> authAppMfaMethods) {
+        this.authAppMfaMethods = authAppMfaMethods;
     }
 
     @DynamoDbSecondaryPartitionKey(indexNames = {"SubjectIDIndex"})
@@ -121,31 +121,31 @@ public class UserCredentials {
     }
 
     @DynamoDbAttribute(ATTRIBUTE_MFA_METHODS)
-    public List<MFAMethod> getMfaMethods() {
-        return mfaMethods;
+    public List<AuthAppMFAMethod> getMfaMethods() {
+        return authAppMfaMethods;
     }
 
-    public UserCredentials withMfaMethods(List<MFAMethod> mfaMethods) {
-        this.mfaMethods = mfaMethods;
+    public UserCredentials withMfaMethods(List<AuthAppMFAMethod> authAppMfaMethods) {
+        this.authAppMfaMethods = authAppMfaMethods;
         return this;
     }
 
-    public UserCredentials setMfaMethod(MFAMethod mfaMethod) {
-        if (this.mfaMethods == null) {
-            this.mfaMethods = List.of(mfaMethod);
+    public UserCredentials setMfaMethod(AuthAppMFAMethod authAppMfaMethod) {
+        if (this.authAppMfaMethods == null) {
+            this.authAppMfaMethods = List.of(authAppMfaMethod);
         } else {
-            this.mfaMethods.removeIf(
-                    t -> t.getMfaMethodType().equals(mfaMethod.getMfaMethodType()));
-            this.mfaMethods.add(mfaMethod);
+            this.authAppMfaMethods.removeIf(
+                    t -> t.getMfaMethodType().equals(authAppMfaMethod.getMfaMethodType()));
+            this.authAppMfaMethods.add(authAppMfaMethod);
         }
         return this;
     }
 
     public UserCredentials removeAuthAppByCredentialIfPresent(String authAppCredential) {
-        if (this.mfaMethods == null) {
+        if (this.authAppMfaMethods == null) {
             return this;
         } else {
-            this.mfaMethods.removeIf(t -> t.getCredentialValue().equals(authAppCredential));
+            this.authAppMfaMethods.removeIf(t -> t.getCredentialValue().equals(authAppCredential));
             return this;
         }
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -400,8 +400,11 @@ public class DynamoService implements AuthenticationService {
                                                                                 MFAMethodType
                                                                                         .AUTH_APP
                                                                                         .getValue())
+                                                                && method
+                                                                        instanceof AuthAppMFAMethod
                                                                 && method.isEnabled()
                                                                 && method.isMethodVerified())
+                                        .map(method -> (AuthAppMFAMethod) method)
                                         .findFirst())
                 .ifPresent(
                         t -> {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -16,7 +16,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.User;
@@ -433,8 +433,8 @@ public class DynamoService implements AuthenticationService {
             boolean enabled,
             String credentialValue) {
         String dateTime = NowHelper.toTimestampString(NowHelper.now());
-        MFAMethod mfaMethod =
-                new MFAMethod(
+        AuthAppMFAMethod authAppMfaMethod =
+                new AuthAppMFAMethod(
                         MFAMethodType.AUTH_APP.getValue(),
                         credentialValue,
                         methodVerified,
@@ -446,14 +446,14 @@ public class DynamoService implements AuthenticationService {
                                 Key.builder()
                                         .partitionValue(email.toLowerCase(Locale.ROOT))
                                         .build())
-                        .setMfaMethod(mfaMethod));
+                        .setMfaMethod(authAppMfaMethod));
     }
 
     @Override
     public void setAuthAppAndAccountVerified(String email, String credentialValue) {
         var dateTime = NowHelper.toTimestampString(NowHelper.now());
         var mfaMethod =
-                new MFAMethod(
+                new AuthAppMFAMethod(
                         MFAMethodType.AUTH_APP.getValue(), credentialValue, true, true, dateTime);
         var userCredentials =
                 dynamoUserCredentialsTable
@@ -483,7 +483,7 @@ public class DynamoService implements AuthenticationService {
     public void setVerifiedAuthAppAndRemoveExistingMfaMethod(String email, String credentialValue) {
         var dateTime = NowHelper.toTimestampString(NowHelper.now());
         var mfaMethod =
-                new MFAMethod(
+                new AuthAppMFAMethod(
                         MFAMethodType.AUTH_APP.getValue(), credentialValue, true, true, dateTime);
         var userCredentials =
                 dynamoUserCredentialsTable

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandler.java
@@ -11,7 +11,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import uk.gov.di.authentication.shared.entity.MFAMethod;
+import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -183,12 +183,12 @@ public class BulkTestUserCreateHandler implements RequestHandler<S3Event, Void> 
 
         if (isAuthAppSecondAuthFactor) {
             String authAppSecret = testUser[5];
-            List<MFAMethod> mfaMethods = new ArrayList<>();
+            List<AuthAppMFAMethod> authAppMfaMethods = new ArrayList<>();
             var authAppMfaMethod =
-                    new MFAMethod(
+                    new AuthAppMFAMethod(
                             MFAMethodType.AUTH_APP.getValue(), authAppSecret, true, true, dateTime);
-            mfaMethods.add(authAppMfaMethod);
-            userCredentials.setMfaMethods(mfaMethods);
+            authAppMfaMethods.add(authAppMfaMethod);
+            userCredentials.setMfaMethods(authAppMfaMethods);
         }
 
         return userCredentials;

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandler.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import uk.gov.di.authentication.shared.entity.AuthAppMFAMethod;
+import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -183,7 +184,7 @@ public class BulkTestUserCreateHandler implements RequestHandler<S3Event, Void> 
 
         if (isAuthAppSecondAuthFactor) {
             String authAppSecret = testUser[5];
-            List<AuthAppMFAMethod> authAppMfaMethods = new ArrayList<>();
+            List<MFAMethod> authAppMfaMethods = new ArrayList<>();
             var authAppMfaMethod =
                     new AuthAppMFAMethod(
                             MFAMethodType.AUTH_APP.getValue(), authAppSecret, true, true, dateTime);


### PR DESCRIPTION
## What

We will be storing both AuthAppMfa and SmsMfa as mfa methods in the user credentials table.

Currently, we only store AuthAppMfa methods. This commit is an initial step, which should have no behavioural impact on anything, to make mfa methods generic.

This will allow us to store and work with types that are specific to the data being stored - for example, auth app mfa data has a credential value, whereas sms doesn't. Being able to work with different types means less annoying null handling.

We had to define a custom converter for the serialisation and deserialisation from the dynamo db objects, since we're now deserialising an interface which may take multiple forms

## How to review

1. Code Review commit by commit

