### PR TITLE
BAU: Enable DynamoDB deletion protection

### DIFF
--- a/ci/terraform/interventions-api-stub/dynamodb.tf
+++ b/ci/terraform/interventions-api-stub/dynamodb.tf
@@ -4,6 +4,8 @@ resource "aws_dynamodb_table" "stub_account_interventions_table" {
 
   hash_key = "InternalPairwiseId"
 
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
+
   attribute {
     name = "InternalPairwiseId"
     type = "S"

--- a/ci/terraform/interventions-api-stub/variables.tf
+++ b/ci/terraform/interventions-api-stub/variables.tf
@@ -65,6 +65,11 @@ variable "orchestration_vpc_endpoint_id" {
   default     = ""
 }
 
+variable "dynamo_deletion_protection_enabled" {
+  type    = bool
+  default = false
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -6,6 +6,8 @@ resource "aws_dynamodb_table" "user_credentials_table" {
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
 
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
+
   attribute {
     name = "Email"
     type = "S"
@@ -62,6 +64,8 @@ resource "aws_dynamodb_table" "user_profile_table" {
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
 
   attribute {
     name = "Email"
@@ -146,6 +150,8 @@ resource "aws_dynamodb_table" "client_registry_table" {
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
 
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
+
   attribute {
     name = "ClientID"
     type = "S"
@@ -188,6 +194,8 @@ resource "aws_dynamodb_table" "identity_credentials_table" {
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
 
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
+
   attribute {
     name = "SubjectID"
     type = "S"
@@ -221,6 +229,8 @@ resource "aws_dynamodb_table" "doc_app_credential_table" {
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
 
   attribute {
     name = "SubjectID"
@@ -281,6 +291,8 @@ resource "aws_dynamodb_table" "common_passwords_table" {
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
 
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
+
   attribute {
     name = "Password"
     type = "S"
@@ -308,6 +320,8 @@ resource "aws_dynamodb_table" "account_modifiers_table" {
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
 
   attribute {
     name = "InternalCommonSubjectIdentifier"
@@ -337,6 +351,8 @@ resource "aws_dynamodb_table" "access_token_store" {
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
 
   attribute {
     name = "AccessToken"
@@ -371,6 +387,8 @@ resource "aws_dynamodb_table" "auth_code_store" {
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
 
   attribute {
     name = "AuthCode"
@@ -407,6 +425,8 @@ resource "aws_dynamodb_table" "bulk_email_users" {
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
 
   attribute {
     name = "SubjectID"
@@ -463,6 +483,8 @@ resource "aws_dynamodb_table" "authentication_callback_userinfo" {
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
 
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
+
   attribute {
     name = "SubjectID"
     type = "S"
@@ -510,6 +532,8 @@ resource "aws_dynamodb_table" "email-check-result" {
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
 
   attribute {
     name = "Email"

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -120,6 +120,11 @@ variable "dynamo_default_write_capacity" {
   default = 20
 }
 
+variable "dynamo_deletion_protection_enabled" {
+  type    = bool
+  default = true
+}
+
 variable "test_client_email_allowlist" {
   type = string
 }

--- a/ci/terraform/ticf-cri-stub/dynamodb.tf
+++ b/ci/terraform/ticf-cri-stub/dynamodb.tf
@@ -4,6 +4,8 @@ resource "aws_dynamodb_table" "stub_ticf_cri_table" {
 
   hash_key = "InternalPairwiseId"
 
+  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
+
   attribute {
     name = "InternalPairwiseId"
     type = "S"

--- a/ci/terraform/ticf-cri-stub/variables.tf
+++ b/ci/terraform/ticf-cri-stub/variables.tf
@@ -59,6 +59,11 @@ variable "ticf_cri_stub_release_zip_file" {
   type        = string
 }
 
+variable "dynamo_deletion_protection_enabled" {
+  type    = bool
+  default = false
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What

Enable deletion protection for all dynamodb tables. This is configured
via variables, which default to true (enabled) for all service tables,
and false for stub tables.

Previously, we had terraform's lifecycle.prevent_destroy set for all tables, but this wouldn't prevent accidental deletion from the API or console (ie. outside of terraform).

## How to review

- Code review
- Sanity check if a variable makes sense here, or if it should be hardcoded.
