### PR TITLE
AUT-3497: primaryKey refactoring to use partition and sort keys

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthenticationAttempts.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthenticationAttempts.java
@@ -3,32 +3,35 @@ package uk.gov.di.authentication.shared.entity;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
 import uk.gov.di.authentication.shared.validation.Required;
 
 @DynamoDbBean
 public class AuthenticationAttempts {
 
-    @Required private String attemptIdentifier;
+    @Required private String internalSubjectId;
     @Required private String authenticationMethod;
     @Required private String code;
     @Required private Integer count;
+    @Required private String journeyType;
+
+    private String authMethodJourneyType;
     private String created;
     private String updated;
     private long timeToLive;
-    private String journeyType;
 
     @DynamoDbPartitionKey
-    @DynamoDbAttribute("AttemptIdentifier")
-    public String getAttemptIdentifier() {
-        return attemptIdentifier;
+    @DynamoDbAttribute("InternalSubjectId")
+    public String getInternalSubjectId() {
+        return internalSubjectId;
     }
 
-    public void setAttemptIdentifier(String attemptIdentifier) {
-        this.attemptIdentifier = attemptIdentifier;
+    public void setInternalSubjectId(String internalSubjectId) {
+        this.internalSubjectId = internalSubjectId;
     }
 
-    public AuthenticationAttempts withAttemptIdentifier(String attemptIdentifier) {
-        this.attemptIdentifier = attemptIdentifier;
+    public AuthenticationAttempts withInternalSubjectId(String internalSubjectId) {
+        this.internalSubjectId = internalSubjectId;
         return this;
     }
 
@@ -39,10 +42,11 @@ public class AuthenticationAttempts {
 
     public void setJourneyType(String journeyType) {
         this.journeyType = journeyType;
+        setAuthMethodJourneyType();
     }
 
     public AuthenticationAttempts withJourneyType(String journeyType) {
-        this.journeyType = journeyType;
+        setJourneyType(journeyType);
         return this;
     }
 
@@ -53,11 +57,26 @@ public class AuthenticationAttempts {
 
     public void setAuthenticationMethod(String authenticationMethod) {
         this.authenticationMethod = authenticationMethod;
+        setAuthMethodJourneyType();
     }
 
     public AuthenticationAttempts withAuthenticationMethod(String authenticationMethod) {
-        this.authenticationMethod = authenticationMethod;
+        setAuthenticationMethod(authenticationMethod);
         return this;
+    }
+
+    @DynamoDbSortKey
+    @DynamoDbAttribute("AuthMethodJourneyType")
+    public String getAuthMethodJourneyType() {
+        return authMethodJourneyType;
+    }
+
+    public void setAuthMethodJourneyType() {
+        this.authMethodJourneyType = authenticationMethod + "_" + journeyType;
+    }
+
+    public void setAuthMethodJourneyType(String authMethodJourneyType) {
+        this.authMethodJourneyType = authMethodJourneyType;
     }
 
     @DynamoDbAttribute("Code")

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
@@ -43,6 +43,12 @@ public class BaseDynamoService<T> {
                 dynamoTable.getItem(Key.builder().partitionValue(partition).build()));
     }
 
+    public Optional<T> get(String partition, String sortKey) {
+        return Optional.ofNullable(
+                dynamoTable.getItem(
+                        Key.builder().partitionValue(partition).sortValue(sortKey).build()));
+    }
+
     public void delete(String partition) {
         get(partition).ifPresent(dynamoTable::deleteItem);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationAttemptsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationAttemptsService.java
@@ -13,24 +13,30 @@ public class DynamoAuthenticationAttemptsService extends BaseDynamoService<Authe
     }
 
     public void addCode(
-            String attemptIdentifier, long ttlSeconds, String code, String authenticationMethod) {
+            String internalSubjectId,
+            long ttlSeconds,
+            String code,
+            String authenticationMethod,
+            String journeyType) {
         long ttlEpochSeconds =
                 NowHelper.nowPlus(ttlSeconds, ChronoUnit.SECONDS).toInstant().getEpochSecond();
 
         var authenticationAttempt =
-                get(attemptIdentifier)
+                get(internalSubjectId, buildSortKey(authenticationMethod, journeyType))
                         .orElse(new AuthenticationAttempts())
-                        .withAttemptIdentifier(attemptIdentifier)
+                        .withInternalSubjectId(internalSubjectId)
                         .withCode(code)
                         .withAuthenticationMethod(authenticationMethod)
-                        .withTimeToLive(ttlEpochSeconds);
+                        .withTimeToLive(ttlEpochSeconds)
+                        .withJourneyType(journeyType);
 
         update(authenticationAttempt);
     }
 
     public void createOrIncrementCount(
-            String attemptIdentifier, long ttl, String authenticationMethod) {
-        Optional<AuthenticationAttempts> authenticationAttempt = get(attemptIdentifier);
+            String internalSubjectId, long ttl, String authenticationMethod, String journeyType) {
+        Optional<AuthenticationAttempts> authenticationAttempt =
+                get(internalSubjectId, buildSortKey(authenticationMethod, journeyType));
         if (authenticationAttempt.isPresent()) {
             authenticationAttempt.get().setCount(authenticationAttempt.get().getCount() + 1);
             authenticationAttempt.get().setTimeToLive(ttl);
@@ -38,25 +44,32 @@ public class DynamoAuthenticationAttemptsService extends BaseDynamoService<Authe
             authenticationAttempt =
                     Optional.ofNullable(
                             new AuthenticationAttempts()
-                                    .withAttemptIdentifier(attemptIdentifier)
+                                    .withInternalSubjectId(internalSubjectId)
                                     .withCount(1)
                                     .withAuthenticationMethod(authenticationMethod)
+                                    .withJourneyType(journeyType)
                                     .withTimeToLive(ttl));
         }
         authenticationAttempt.ifPresent(this::update);
     }
 
-    public Optional<AuthenticationAttempts> getAuthenticationAttempts(String attemptIdentifier) {
+    public Optional<AuthenticationAttempts> getAuthenticationAttempt(
+            String internalSubjectId, String authenticationMethod, String journeyType) {
         long currentTimestamp = NowHelper.now().toInstant().getEpochSecond();
-        return get(attemptIdentifier).filter(t -> t.getTimeToLive() > currentTimestamp);
+        return get(internalSubjectId, buildSortKey(authenticationMethod, journeyType))
+                .filter(t -> t.getTimeToLive() > currentTimestamp);
     }
 
-    public Optional<String> getCode(String attemptIdentifier) {
-        return get(attemptIdentifier).map(AuthenticationAttempts::getCode);
+    public Optional<String> getCode(
+            String internalSubjectId, String authenticationMethod, String journeyType) {
+        return get(internalSubjectId, buildSortKey(authenticationMethod, journeyType))
+                .map(AuthenticationAttempts::getCode);
     }
 
-    public void deleteCount(String attemptIdentifier) {
-        Optional<AuthenticationAttempts> attempt = get(attemptIdentifier);
+    public void deleteCount(
+            String internalSubjectId, String authenticationMethod, String journeyType) {
+        Optional<AuthenticationAttempts> attempt =
+                get(internalSubjectId, buildSortKey(authenticationMethod, journeyType));
         attempt.ifPresent(
                 authAttempt -> {
                     authAttempt.setCount(0);
@@ -64,12 +77,18 @@ public class DynamoAuthenticationAttemptsService extends BaseDynamoService<Authe
                 });
     }
 
-    public void deleteCode(String attemptIdentifier) {
-        Optional<AuthenticationAttempts> attempt = get(attemptIdentifier);
+    public void deleteCode(
+            String internalSubjectId, String authenticationMethod, String journeyType) {
+        Optional<AuthenticationAttempts> attempt =
+                get(internalSubjectId, buildSortKey(authenticationMethod, journeyType));
         attempt.ifPresent(
                 authAttempt -> {
                     authAttempt.setCode(null);
                     update(authAttempt);
                 });
+    }
+
+    public static String buildSortKey(String authenticationMethod, String journeyType){
+        return authenticationMethod + "_" + journeyType;
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/AuthenticationAttemptsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/AuthenticationAttemptsTest.java
@@ -9,67 +9,77 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AuthenticationAttemptsTest {
+    private static final String INTERNAL_SUB_ID = "internalSubjectId";
+    private static final String JOURNEY_TYPE = "sign-in";
+    private static final String CREATED_DATE = "2024-07-29T10:00:00Z";
+    private static final String UPDATED_DATE = "2024-07-29T10:30:00Z";
+    private static final String MFA_CODE = "123456";
+    private static final String MFA_METHOD = "AUTH_APP";
+    private static final long TTL = 1234567890L;
 
     @Test
     void testFluentSetters() {
         AuthenticationAttempts attempts = new AuthenticationAttempts();
 
-        AuthenticationAttempts result = attempts.withAttemptIdentifier("attempt-1234");
-        assertEquals("attempt-1234", result.getAttemptIdentifier());
+        AuthenticationAttempts result = attempts.withInternalSubjectId(INTERNAL_SUB_ID);
+        assertEquals(INTERNAL_SUB_ID, result.getInternalSubjectId());
 
-        result = attempts.withUpdated("2024-07-29T10:30:00Z");
-        assertEquals("2024-07-29T10:30:00Z", result.getUpdated());
+        result = attempts.withUpdated(UPDATED_DATE);
+        assertEquals(UPDATED_DATE, result.getUpdated());
 
-        result = attempts.withCreated("2024-07-29T10:00:00Z");
-        assertEquals("2024-07-29T10:00:00Z", result.getCreated());
+        result = attempts.withCreated(CREATED_DATE);
+        assertEquals(CREATED_DATE, result.getCreated());
 
-        result = attempts.withTimeToLive(1234567890L);
-        assertEquals(1234567890L, result.getTimeToLive());
+        result = attempts.withTimeToLive(TTL);
+        assertEquals(TTL, result.getTimeToLive());
 
-        result = attempts.withCode("code-5678");
-        assertEquals("code-5678", result.getCode());
+        result = attempts.withCode(MFA_CODE);
+        assertEquals(MFA_CODE, result.getCode());
     }
 
     @Test
     void testGettersAndSetters() {
         AuthenticationAttempts attempts = new AuthenticationAttempts();
 
-        attempts.setAttemptIdentifier("attempt-1234");
+        attempts.withInternalSubjectId(INTERNAL_SUB_ID);
         assertEquals(
-                "attempt-1234",
-                attempts.getAttemptIdentifier(),
-                "getAttemptIdentifier should return 'attempt-1234'");
+                INTERNAL_SUB_ID,
+                attempts.getInternalSubjectId(),
+                "getAttemptIdentifier should return " + INTERNAL_SUB_ID);
 
-        attempts.setJourneyType("login");
-        assertEquals("login", attempts.getJourneyType(), "getJourneyType should return 'login'");
-
-        attempts.setAuthenticationMethod("email");
+        attempts.setJourneyType(JOURNEY_TYPE);
         assertEquals(
-                "email",
+                JOURNEY_TYPE,
+                attempts.getJourneyType(),
+                "getJourneyType should return " + JOURNEY_TYPE);
+
+        attempts.setAuthenticationMethod(MFA_METHOD);
+        assertEquals(
+                MFA_METHOD,
                 attempts.getAuthenticationMethod(),
-                "getAuthenticationMethod should return 'email'");
+                "getAuthenticationMethod should return " + MFA_METHOD);
 
-        attempts.setCode("code-5678");
-        assertEquals("code-5678", attempts.getCode(), "getCode should return 'code-5678'");
+        attempts.setCode(MFA_CODE);
+        assertEquals(MFA_CODE, attempts.getCode(), "getCode should return " + MFA_CODE);
 
         attempts.setCount(3);
         assertEquals(3, attempts.getCount(), "getCount should return 3");
 
-        attempts.setTimeToLive(1234567890L);
-        assertEquals(
-                1234567890L, attempts.getTimeToLive(), "getTimeToLive should return 1234567890L");
+        attempts.setTimeToLive(TTL);
+        assertEquals(TTL, attempts.getTimeToLive(), "getTimeToLive should return " + TTL);
 
-        attempts.setCreated("2024-07-29T10:00:00Z");
+        attempts.setCreated(CREATED_DATE);
         assertEquals(
-                "2024-07-29T10:00:00Z",
-                attempts.getCreated(),
-                "getCreated should return '2024-07-29T10:00:00Z'");
+                CREATED_DATE, attempts.getCreated(), "getCreated should return " + CREATED_DATE);
 
-        attempts.setUpdated("2024-07-29T10:30:00Z");
+        attempts.setUpdated(UPDATED_DATE);
         assertEquals(
-                "2024-07-29T10:30:00Z",
-                attempts.getUpdated(),
-                "getUpdated should return '2024-07-29T10:30:00Z'");
+                UPDATED_DATE, attempts.getUpdated(), "getUpdated should return " + UPDATED_DATE);
+
+        assertEquals(
+                MFA_METHOD + "_" + JOURNEY_TYPE,
+                attempts.getAuthMethodJourneyType(),
+                "getAuthMethodJourneyType should return " + MFA_METHOD + "_" + JOURNEY_TYPE);
     }
 
     @Test
@@ -81,21 +91,23 @@ class AuthenticationAttemptsTest {
         List<String> violations = validator.validate(attempts);
 
         // Check that all required fields are reported as missing
-        assertTrue(violations.contains("attemptIdentifier"));
+        assertTrue(violations.contains("internalSubjectId"));
         assertTrue(violations.contains("authenticationMethod"));
         assertTrue(violations.contains("code"));
         assertTrue(violations.contains("count"));
+        assertTrue(violations.contains("journeyType"));
     }
 
     @Test
     void testValidationWithAllFieldsSet() {
         AuthenticationAttempts attempts =
                 new AuthenticationAttempts()
-                        .withAttemptIdentifier("attempt-1234")
-                        .withAuthenticationMethod("email")
-                        .withCode("code-5678")
+                        .withInternalSubjectId(INTERNAL_SUB_ID)
+                        .withAuthenticationMethod(MFA_METHOD)
+                        .withCode(MFA_CODE)
+                        .withJourneyType(JOURNEY_TYPE)
                         .withCount(3)
-                        .withTimeToLive(42L);
+                        .withTimeToLive(TTL);
 
         RequiredFieldValidator validator = new RequiredFieldValidator();
         List<String> violations = validator.validate(attempts);


### PR DESCRIPTION
## What

Add dynamoDb range key to the AuthenticationAttempt table. This way, the primary key of the table will be composed of 
a partition key: internalSubjectID
and a composite range key: mfaMethd + journeyType


## How to review


1. Code Review


