### PR TITLE
AUT-3523: Add temporary logging for initial request time

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
@@ -66,6 +66,7 @@ public class EmailCheckResultWriterHandler implements RequestHandler<SQSEvent, V
                 LOG.info(
                         "Message for email check reference {} written to database",
                         emailCheckResult.requestReference());
+                LOG.info("Time of initial request {}", emailCheckResult.timeOfInitialRequest());
                 var duration = now().getTime() - emailCheckResult.timeOfInitialRequest();
 
                 cloudwatchMetricsService.logEmailCheckDuration(duration);


### PR DESCRIPTION
The duration sent to cloudwatch is incorrect so this is some temp logging to debug.


