### PR TITLE
Aut 3523/fix duration metric

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -211,7 +211,7 @@ public class SendOtpNotificationHandler
                                                     persistentSessionId,
                                                     IpAddressHelper.extractIpAddress(input),
                                                     JourneyType.ACCOUNT_MANAGEMENT,
-                                                    NowHelper.now().toInstant().getEpochSecond(),
+                                                    NowHelper.now().toInstant().toEpochMilli(),
                                                     isTestUserRequest)));
                             LOG.info("Email address check requested");
                         } else {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -245,7 +245,7 @@ class SendOtpNotificationHandlerTest {
                                             "some-persistent-session-id",
                                             "123.123.123.123",
                                             JourneyType.ACCOUNT_MANAGEMENT,
-                                            mockedDate.toInstant().getEpochSecond(),
+                                            mockedDate.toInstant().toEpochMilli(),
                                             false));
                 } else {
                     verifyNoInteractions(pendingEmailCheckSqsClient);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -320,7 +320,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                                         persistentSessionId,
                                         IpAddressHelper.extractIpAddress(input),
                                         JourneyType.REGISTRATION,
-                                        NowHelper.now().toInstant().getEpochSecond(),
+                                        NowHelper.now().toInstant().toEpochMilli(),
                                         testClientWithAllowedEmail)));
                 LOG.info("Email address check requested");
             } else {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -264,7 +264,7 @@ class SendNotificationHandlerTest {
                                             DI_PERSISTENT_SESSION_ID,
                                             IP_ADDRESS,
                                             JourneyType.REGISTRATION,
-                                            mockedDate.toInstant().getEpochSecond(),
+                                            mockedDate.toInstant().toEpochMilli(),
                                             false));
                 } else {
                     verifyNoInteractions(pendingEmailCheckSqsClient);
@@ -335,7 +335,7 @@ class SendNotificationHandlerTest {
                                         DI_PERSISTENT_SESSION_ID,
                                         IP_ADDRESS,
                                         JourneyType.REGISTRATION,
-                                        mockedDate.toInstant().getEpochSecond(),
+                                        mockedDate.toInstant().toEpochMilli(),
                                         false));
             } else {
                 verifyNoInteractions(pendingEmailCheckSqsClient);


### PR DESCRIPTION
## What

We record how long an email request takes and record this as a cloudwatch metric, so we can monitor performance.

This is currently logging incorrect durations. This is because we [currently treat the value we put on the initial event as seconds](https://github.com/govuk-one-login/authentication-api/blob/31f4300b17b7d029d632fa3391cb02a17b3642ba/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java#L323), but when we work out the duration when it comes back, it is [compared to a time in milliseconds](https://github.com/govuk-one-login/authentication-api/blob/31f4300b17b7d029d632fa3391cb02a17b3642ba/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java#L70) (getTime returns milliseconds since 1970). This results in very high and incorrect numbers.

I've chosen to go with milliseconds for both, since that level of granularity might be more useful.

## How to review

1. Code Review

