### PR TITLE
Revert "AUT-3523: Add temporary logging for initial request time"

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
@@ -66,7 +66,6 @@ public class EmailCheckResultWriterHandler implements RequestHandler<SQSEvent, V
                 LOG.info(
                         "Message for email check reference {} written to database",
                         emailCheckResult.requestReference());
-                LOG.info("Time of initial request {}", emailCheckResult.timeOfInitialRequest());
                 var duration = now().getTime() - emailCheckResult.timeOfInitialRequest();
 
                 cloudwatchMetricsService.logEmailCheckDuration(duration);


### PR DESCRIPTION
This reverts commit 61c9886b23750697050437a7842cd1c48cf39e31.

Reverts some temporary logging that we added to debug why we were getting odd looking request durations for a cloudwatch metric. This was fixed [here](https://github.com/govuk-one-login/authentication-api/pull/5026), and so the logging can now be removed.

