### PR TITLE
BAU: Correct access lambda role for `check-reauth-user`

### DIFF
--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -9,7 +9,9 @@ module "frontend_api_check_reauth_user_role" {
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn
   ]
 }
 
@@ -56,7 +58,7 @@ module "check_reauth_user" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.frontend_api_orch_auth_code_role.arn
+  lambda_role_arn                        = module.frontend_api_check_reauth_user_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention


### PR DESCRIPTION
## What

A lambda role was declared for the lambda, but was not in use. This corrects the role used by the lambda and adds the required missing policies to the existing role:
- Access to read, encrypt and decrypt the client registry table.
  - So client session data can be added to logs and audit events
  - Encrypt is given in this policy, but no ability to write.
  - Policies:
    - `aws_iam_policy.dynamo_client_registry_read_access_policy.arn`
    - `local.client_registry_encryption_policy_arn`

## How to review

1. Code Review
1. Deploy to a dev environment
1. Follow ["How to trigger reauthentication" guidance](https://govukverify.atlassian.net/wiki/spaces/LO/pages/4317446229/How+to+trigger+reauthentication)
1. See you can successfully reauth

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.
