### PR TITLE
AUT-3370: Create authentication-attempt DynamoDB table, KMS key and access policies

### DIFF
--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -11,7 +11,9 @@ module "frontend_api_check_reauth_user_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
-    aws_iam_policy.dynamo_client_registry_read_access_policy.arn
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_authentication_attempt_write_policy.arn,
+    aws_iam_policy.dynamo_authentication_attempt_read_policy.arn
   ]
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -84,6 +84,7 @@ locals {
   pending_email_check_queue_id                        = data.terraform_remote_state.shared.outputs.pending_email_check_queue_id
   pending_email_check_queue_access_policy_arn         = data.terraform_remote_state.shared.outputs.pending_email_check_queue_access_policy_arn
   user_profile_kms_key_arn                            = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
+  authentication_attempt_kms_key_arn                  = data.terraform_remote_state.shared.outputs.authentication_attempt_kms_key_arn
   email_check_results_encryption_policy_arn           = data.terraform_remote_state.shared.outputs.email_check_results_encryption_policy_arn
   experian_phone_check_sqs_queue_id                   = data.terraform_remote_state.contra.outputs.aws_experian_phone_check_sqs_id
   experian_phone_check_sqs_queue_policy_arn           = data.terraform_remote_state.contra.outputs.aws_experian_phone_check_sqs_policy_arn

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -561,6 +561,44 @@ resource "aws_dynamodb_table" "email-check-result" {
   tags = local.default_tags
 }
 
+resource "aws_dynamodb_table" "authentication_attempt_table" {
+  name         = "${var.environment}-authentication-attempt"
+  billing_mode = "PAY_PER_REQUEST"
+
+  hash_key  = "InternalSubjectId"
+  range_key = "AuthMethodJourneyType"
+
+  attribute {
+    name = "InternalSubjectId"
+    type = "S"
+  }
+
+  attribute {
+    name = "AuthMethodJourneyType"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "TimeToLive"
+    enabled        = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.authentication_attempt_encryption_key.arn
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = local.default_tags
+}
+
 resource "aws_dynamodb_resource_policy" "authentication_callback_userinfo_table_policy" {
   resource_arn = aws_dynamodb_table.authentication_callback_userinfo.arn
   policy       = data.aws_iam_policy_document.cross_account_table_resource_policy_document.json

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -831,3 +831,34 @@ resource "aws_kms_key" "pending_email_check_queue_encryption_key" {
 
   tags = local.default_tags
 }
+
+resource "aws_kms_key" "authentication_attempt_encryption_key" {
+  description              = "KMS encryption key for authentication attempt table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "authentication_attempt_encryption_key_alias" {
+  name          = "alias/${var.environment}-authentication-attempt-table-encryption-key"
+  target_key_id = aws_kms_key.authentication_attempt_encryption_key.key_id
+}

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -248,3 +248,7 @@ output "identity_credentials_encryption_key_arn" {
 output "user_profile_kms_key_arn" {
   value = aws_kms_key.user_profile_table_encryption_key.arn
 }
+
+output "authentication_attempt_kms_key_arn" {
+  value = aws_kms_key.authentication_attempt_encryption_key.arn
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationAttemptsStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationAttemptsStoreExtension.java
@@ -20,8 +20,7 @@ public class AuthenticationAttemptsStoreExtension extends DynamoExtension
 
     public static final String AUTHENTICATION_INTERNAL_SUB_ID_FIELD = "InternalSubjectId";
     public static final String AUTHENTICATION_AUTH_METHOD_JOURNEY_TYPE = "AuthMethodJourneyType";
-    public static final String AUTHENTICATION_ATTEMPTS_STORE_TABLE =
-            "local-authentication-attempts";
+    public static final String AUTHENTICATION_ATTEMPTS_STORE_TABLE = "local-authentication-attempt";
 
     private DynamoAuthenticationAttemptsService dynamoService;
     private final ConfigurationService configuration;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationAttemptsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationAttemptsService.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public class DynamoAuthenticationAttemptsService extends BaseDynamoService<AuthenticationAttempts> {
 
     public DynamoAuthenticationAttemptsService(ConfigurationService configurationService) {
-        super(AuthenticationAttempts.class, "authentication-attempts", configurationService);
+        super(AuthenticationAttempts.class, "authentication-attempt", configurationService);
     }
 
     public void addCode(


### PR DESCRIPTION
## What

### Create KMS key for upcoming `authentication-attempt` table
We will need to encrypt data stored in the upcoming `authentication-attempt` table. This is outputted in terraform state so it can be used by the OIDC module.


### Create `authentication-attempt` DynamoDB table
For the reauth work we are refactoring how we store auth codes and counts. This table will store them going forward.

- It is encrypted and has a ttl attribute defined (allowing DynamoDB native record removal once a code or count has expired).
- We pay per request for this table until we know our workload. Then we can think on moving to provisioned capacity.
- The `InternalSubjectId` attribute is the hash key for the table.
- The `AuthMethodJourneyType` attribute is the range key for the table.
- Point in time recovery is also enabled, with the consideration that while this table holds temporary data, the counts specifically form part of a security mitigation and need to be preserved for when data loss occurs (e.g. auth locks).
- For the same consideration, we also prevent terraform from destroying the table.


### Create IAM policies to access the authentication attempt table
- Two policies, one for read and once for write
- Both also giving access to the relevant actions for the KMS key encrypting the table

These will be applied to lambdas that need to use the table (for example the upcoming changes to `check-reauth-user`.


### `check-reauth-user` can access `authentication-attempt`
Giving both read and write access to both get codes and counts and update the counts as needed.


## How to review

For example:

1. Code Review, commit-by-commit will be easier
1. To prove access to the table, apply the following test patch (copy to clipboard, including the last blank line, then `pbpaste | git apply`):
```
diff --git a/ci/terraform/shared/dynamodb.tf b/ci/terraform/shared/dynamodb.tf
index 861ee8cab..0420f9fe8 100644
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -595,7 +595,7 @@ resource "aws_dynamodb_table" "authentication_attempt_table" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 
   tags = local.default_tags
diff --git a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
index 1729c9257..6b918d2c2 100644
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -10,7 +10,10 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckReauthUserRequest;
 import uk.gov.di.authentication.frontendapi.exceptions.AccountLockedException;
+import uk.gov.di.authentication.shared.entity.AuthenticationAttempts;
+import uk.gov.di.authentication.shared.entity.AuthenticationMethod;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
@@ -22,6 +25,7 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
@@ -93,6 +97,48 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
             UserContext userContext) {
         LOG.info("Processing CheckReAuthUser request");
 
+        String internalSubjectId = "testInternalSubjectId";
+        String authenticationMethod = AuthenticationMethod.EMAIL.toString();
+        String journeyType = JourneyType.REAUTHENTICATION.toString();
+
+        var authenticationAttemptsService =
+                new DynamoAuthenticationAttemptsService(this.configurationService);
+        Optional<AuthenticationAttempts> authenticationAttempt1 =
+                authenticationAttemptsService.getAuthenticationAttempt(
+                        internalSubjectId, authenticationMethod, journeyType);
+        authenticationAttempt1.ifPresent(
+                authenticationAttempts ->
+                        LOG.info("Auth Attempt 1 %s".formatted(authenticationAttempts.getCode())));
+        if (authenticationAttempt1.isEmpty()) {
+            LOG.info("Auth Attempt 1: No result");
+        }
+
+        authenticationAttemptsService.addCode(
+                internalSubjectId, 300, "abcdef", authenticationMethod, journeyType);
+
+        Optional<AuthenticationAttempts> authenticationAttempt2 =
+                authenticationAttemptsService.getAuthenticationAttempt(
+                        internalSubjectId, authenticationMethod, journeyType);
+        authenticationAttempt2.ifPresent(
+                authenticationAttempts ->
+                        LOG.info("Auth Attempt 2 %s".formatted(authenticationAttempts.getCode())));
+        if (authenticationAttempt2.isEmpty()) {
+            LOG.info("Auth Attempt 2: No result");
+        }
+
+        authenticationAttemptsService.deleteCode(
+                internalSubjectId, authenticationMethod, journeyType);
+
+        Optional<AuthenticationAttempts> authenticationAttempt3 =
+                authenticationAttemptsService.getAuthenticationAttempt(
+                        internalSubjectId, authenticationMethod, journeyType);
+        authenticationAttempt3.ifPresent(
+                authenticationAttempts ->
+                        LOG.info("Auth Attempt 3 %s".formatted(authenticationAttempts.getCode())));
+        if (authenticationAttempt3.isEmpty()) {
+            LOG.info("Auth Attempt 3: No result");
+        }
+
         var emailUserIsSignedInWith = userContext.getSession().getEmailAddress();
 
         var auditContext =

```
1. Deploy to a dev environment
1. Follow ["How to trigger reauthentication" guidance](https://govukverify.atlassian.net/wiki/spaces/LO/pages/4317446229/How+to+trigger+reauthentication)
1. See you can successfully reauth

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

The was originally done in https://github.com/govuk-one-login/authentication-api/pull/4980, then reverted https://github.com/govuk-one-login/authentication-api/pull/5045 because there were resources using the table that was not deployed due to the feature flag.