### PR TITLE
ATO-936: Make nonce optional for auth only rps

### DIFF
--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -199,8 +199,8 @@ class DocAppCallbackHandlerTest {
                         pair("internalSubjectId", AuditService.UNKNOWN),
                         pair("isNewAccount", session.isNewAccount()),
                         pair("rpPairwiseId", AuditService.UNKNOWN),
-                        pair("nonce", NONCE),
-                        pair("authCode", AUTH_CODE));
+                        pair("authCode", AUTH_CODE),
+                        pair("nonce", NONCE.getValue()));
 
         verifyNoMoreInteractions(auditService);
         verify(dynamoDocAppService)

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
@@ -47,7 +47,6 @@ public class RequestObjectToAuthRequestHelper {
                                     new ClientID(jwtClaimsSet.getClaim("client_id").toString()),
                                     URI.create((String) jwtClaimsSet.getClaim("redirect_uri")))
                             .state(new State(jwtClaimsSet.getClaim("state").toString()))
-                            .nonce(new Nonce(jwtClaimsSet.getClaim("nonce").toString()))
                             .requestObject(authRequest.getRequestObject());
 
             if (Objects.nonNull(jwtClaimsSet.getClaim("claims"))) {
@@ -76,6 +75,9 @@ public class RequestObjectToAuthRequestHelper {
             if (Objects.nonNull(jwtClaimsSet.getClaim("id_token_hint"))) {
                 builder.customParameter(
                         "id_token_hint", jwtClaimsSet.getStringClaim("id_token_hint"));
+            }
+            if (Objects.nonNull(jwtClaimsSet.getClaim("nonce"))) {
+                builder.nonce(Nonce.parse(jwtClaimsSet.getStringClaim("nonce")));
             }
             return builder.build();
         } catch (ParseException | com.nimbusds.oauth2.sdk.ParseException | Json.JsonException e) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -92,7 +92,7 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
                             redirectURI,
                             state));
         }
-        if (authRequest.getNonce() == null && !client.getPermitMissingNonce()) {
+        if (authRequest.getNonce() == null && !client.permitMissingNonce()) {
             LOG.error("Nonce is missing from authRequest");
             return Optional.of(
                     new AuthRequestError(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -92,7 +92,7 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
                             redirectURI,
                             state));
         }
-        if (authRequest.getNonce() == null) {
+        if (authRequest.getNonce() == null && !client.getPermitMissingNonce()) {
             LOG.error("Nonce is missing from authRequest");
             return Optional.of(
                     new AuthRequestError(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -159,7 +159,7 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                 LOG.error("Invalid scopes in request JWT");
                 return errorResponse(redirectURI, OAuth2Error.INVALID_SCOPE, state);
             }
-            if (Objects.isNull(jwtClaimsSet.getClaim("nonce"))) {
+            if (Objects.isNull(jwtClaimsSet.getClaim("nonce")) && !client.getPermitMissingNonce()) {
                 LOG.error("Nonce is missing from authRequest");
                 return errorResponse(
                         redirectURI,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -159,7 +159,7 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                 LOG.error("Invalid scopes in request JWT");
                 return errorResponse(redirectURI, OAuth2Error.INVALID_SCOPE, state);
             }
-            if (Objects.isNull(jwtClaimsSet.getClaim("nonce")) && !client.getPermitMissingNonce()) {
+            if (Objects.isNull(jwtClaimsSet.getClaim("nonce")) && !client.permitMissingNonce()) {
                 LOG.error("Nonce is missing from authRequest");
                 return errorResponse(
                         redirectURI,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
@@ -316,7 +316,7 @@ class RequestObjectToAuthRequestHelperTest {
                 .claim("redirect_uri", REDIRECT_URI.toString())
                 .claim("response_type", ResponseType.CODE.toString())
                 .claim("scope", scope.toString())
-                .claim("nonce", NONCE)
+                .claim("nonce", NONCE.getValue())
                 .claim("state", STATE)
                 .claim("client_id", CLIENT_ID.getValue())
                 .claim("claims", CLAIMS)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -305,8 +305,8 @@ class AuthCodeHandlerTest {
                         pair("internalSubjectId", SUBJECT.getValue()),
                         pair("isNewAccount", AccountState.NEW),
                         pair("rpPairwiseId", expectedRpPairwiseId),
-                        pair("nonce", NONCE),
-                        pair("authCode", authorizationCode));
+                        pair("authCode", authorizationCode),
+                        pair("nonce", NONCE.getValue()));
 
         var dimensions =
                 Map.of(
@@ -410,8 +410,8 @@ class AuthCodeHandlerTest {
                         pair("internalSubjectId", AuditService.UNKNOWN),
                         pair("isNewAccount", AccountState.UNKNOWN),
                         pair("rpPairwiseId", AuditService.UNKNOWN),
-                        pair("nonce", NONCE),
-                        pair("authCode", authorizationCode));
+                        pair("authCode", authorizationCode),
+                        pair("nonce", NONCE.getValue()));
 
         var expectedDimensions =
                 Map.of(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -245,8 +245,8 @@ class AuthenticationCallbackHandlerTest {
                         eq(pair("internalSubjectId", AuditService.UNKNOWN)),
                         eq(pair("isNewAccount", true)),
                         eq(pair("rpPairwiseId", PAIRWISE_SUBJECT_ID.getValue())),
-                        eq(pair("nonce", RP_NONCE)),
-                        eq(pair("authCode", AUTH_CODE_RP_TO_ORCH.getValue())));
+                        eq(pair("authCode", AUTH_CODE_RP_TO_ORCH.getValue())),
+                        eq(pair("nonce", RP_NONCE.getValue())));
     }
 
     @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
@@ -378,7 +378,27 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenNonceIsNotIncludedInAuthRequest() {
+    void shouldSuccessfullyValidateWhenNonceNotExpectedAndMissing() {
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        var clientRegitry =
+                generateClientRegistry(REDIRECT_URI.toString(), CLIENT_ID.toString())
+                        .withPermitMissingNonce(true);
+
+        when(dynamoClientService.getClient(CLIENT_ID.toString()))
+                .thenReturn(Optional.of(clientRegitry));
+
+        AuthenticationRequest authenticationRequest =
+                new AuthenticationRequest.Builder(ResponseType.CODE, scope, CLIENT_ID, REDIRECT_URI)
+                        .state(STATE)
+                        .build();
+        var errorObject = queryParamsAuthorizeValidator.validate(authenticationRequest);
+
+        assertTrue(errorObject.isEmpty());
+    }
+
+    @Test
+    void shouldReturnErrorWhenNonceIsExpectedAndMissing() {
         ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
         Scope scope = new Scope();
         scope.add(OIDCScopeValue.OPENID);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
@@ -47,6 +47,8 @@ public class ClientRegistry {
     private static final Set<String> RS256_MAPPINGS =
             Set.of(JWSAlgorithm.RS256.getName(), "RSA256");
 
+    private boolean permitMissingNonce = false;
+
     public ClientRegistry() {}
 
     @DynamoDbPartitionKey
@@ -449,6 +451,20 @@ public class ClientRegistry {
 
     public ClientRegistry withClientLoCs(List<String> clientLoCs) {
         this.clientLoCs = clientLoCs;
+        return this;
+    }
+
+    @DynamoDbAttribute("PermitMissingNonce")
+    public boolean getPermitMissingNonce() {
+        return !identityVerificationSupported && permitMissingNonce;
+    }
+
+    public void setPermitMissingNonce(boolean permitMissingNonce) {
+        this.permitMissingNonce = permitMissingNonce;
+    }
+
+    public ClientRegistry withPermitMissingNonce(boolean permitMissingNonce) {
+        this.permitMissingNonce = permitMissingNonce;
         return this;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
@@ -456,11 +456,15 @@ public class ClientRegistry {
 
     @DynamoDbAttribute("PermitMissingNonce")
     public boolean getPermitMissingNonce() {
-        return !identityVerificationSupported && permitMissingNonce;
+        return permitMissingNonce;
     }
 
     public void setPermitMissingNonce(boolean permitMissingNonce) {
         this.permitMissingNonce = permitMissingNonce;
+    }
+
+    public boolean permitMissingNonce() {
+        return !identityVerificationSupported && getPermitMissingNonce();
     }
 
     public ClientRegistry withPermitMissingNonce(boolean permitMissingNonce) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/ClientRegistryTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/ClientRegistryTest.java
@@ -2,8 +2,12 @@ package uk.gov.di.orchestration.shared.entity;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -123,5 +127,27 @@ class ClientRegistryTest {
         assertThat(clientRegistry.getPublicKey(), equalTo(null));
         assertThat(clientRegistry.getPublicKeySource(), equalTo(PublicKeySource.JWKS.getValue()));
         assertThat(clientRegistry.getJwksUrl(), equalTo(actualUrl));
+    }
+
+    private static Stream<Arguments> permutationsToCheck() {
+        return Stream.of(
+                Arguments.of(true, true),
+                Arguments.of(true, false),
+                Arguments.of(false, true),
+                Arguments.of(false, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("permutationsToCheck")
+    void shouldOnlyReturnPermitMissingNonceTrueWhenIdentityVerificationSupportedIsAlsoFalse(
+            boolean identityVerificationSupported, boolean permitMissingNonce) {
+        var clientRegistry = new ClientRegistry();
+        clientRegistry.setIdentityVerificationSupported(identityVerificationSupported);
+        clientRegistry.setPermitMissingNonce(permitMissingNonce);
+        if (identityVerificationSupported == false && permitMissingNonce == true) {
+            assertThat(clientRegistry.getPermitMissingNonce(), equalTo(true));
+        } else {
+            assertThat(clientRegistry.getPermitMissingNonce(), equalTo(false));
+        }
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/ClientRegistryTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/ClientRegistryTest.java
@@ -145,9 +145,9 @@ class ClientRegistryTest {
         clientRegistry.setIdentityVerificationSupported(identityVerificationSupported);
         clientRegistry.setPermitMissingNonce(permitMissingNonce);
         if (identityVerificationSupported == false && permitMissingNonce == true) {
-            assertThat(clientRegistry.getPermitMissingNonce(), equalTo(true));
+            assertThat(clientRegistry.permitMissingNonce(), equalTo(true));
         } else {
-            assertThat(clientRegistry.getPermitMissingNonce(), equalTo(false));
+            assertThat(clientRegistry.permitMissingNonce(), equalTo(false));
         }
     }
 }


### PR DESCRIPTION
## What

Make nonce optional for auth only rps. This is because several RPs identity platforms don't support Nonce out of the box.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
