### PR TITLE
ATO-954: Configure dev-orch-be-pipeline for all-at-once lambda canary deployment

### DIFF
--- a/ci/stack-orchestration/configuration/dev/dev-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/dev-orch-be-pipeline/parameters.json
@@ -70,5 +70,9 @@
   {
     "ParameterKey": "VpcStackName",
     "ParameterValue": "vpc"
+  },
+  {
+    "ParameterKey": "LambdaCanaryDeployment",
+    "ParameterValue": "AllAtOnce"
   }
 ]


### PR DESCRIPTION
## What

Configure dev-orch-be-pipeline for all-at-once lambda canary deployment. See [guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3823436177/Lambda+-+Canary+Deployment+Migration+Guidance#Pipeline) (under Pre-requisites heading) which describes this config. 

Currently the value is "none":
<img width="545" alt="image" src="https://github.com/user-attachments/assets/2d671de1-7db0-436e-8490-3f290030ad75">


Note that merging this won't actually update the pipeline with the new parameter as deploying the pipeline is done manually. This code change is just for reference.

A further PR will configure dev Orch lambdas to use all-at-once deployment.

## How to review

Check I've followed the guide correctly.


