### PR TITLE
ATO-964: create new browser session cookie

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -18,9 +18,13 @@ class AuthOrchSerializationServicesIntegrationTest {
     void sessionsSerializedByAuthCanBeDeserializedByOrch()
             throws Json.JsonException,
                     uk.gov.di.orchestration.shared.serialization.Json.JsonException {
-        var authSession = new Session("session-id").addClientSession("client-session-id");
+        var authSession =
+                new Session("session-id")
+                        .withBrowserSessionId("browser-session-id")
+                        .addClientSession("client-session-id");
         var orchSession =
                 new uk.gov.di.orchestration.shared.entity.Session("session-id")
+                        .withBrowserSessionId("browser-session-id")
                         .addClientSession("client-session-id");
 
         var authSerializedSession = authObjectMapper.writeValueAsString(authSession);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -854,6 +854,15 @@ public class AuthorisationHandler
                         configurationService.getSessionCookieAttributes(),
                         configurationService.getDomainName()));
 
+        if (configurationService.isBrowserSessionCookieEnabled()) {
+            cookies.add(
+                    CookieHelper.buildCookieString(
+                            CookieHelper.BROWSER_SESSION_COOKIE_NAME,
+                            session.getBrowserSessionId(),
+                            configurationService.getSessionCookieAttributes(),
+                            configurationService.getDomainName()));
+        }
+
         getPrimaryLanguageFromUILocales(authRequest, configurationService)
                 .ifPresent(
                         primaryLanguage -> {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -67,6 +67,10 @@ public class Session {
         return browserSessionId;
     }
 
+    public void setBrowserSessionId(String browserSessionId) {
+        this.browserSessionId = browserSessionId;
+    }
+
     public Session withBrowserSessionId(String browserSessionId) {
         this.browserSessionId = browserSessionId;
         return this;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -3,7 +3,6 @@ package uk.gov.di.orchestration.shared.entity;
 import com.google.gson.annotations.Expose;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -49,7 +48,6 @@ public class Session {
 
     public Session(String sessionId) {
         this.sessionId = sessionId;
-        this.browserSessionId = IdGenerator.generate();
         this.clientSessions = new ArrayList<>();
         this.isNewAccount = AccountState.UNKNOWN;
         this.processingIdentityAttempts = 0;
@@ -67,6 +65,11 @@ public class Session {
 
     public String getBrowserSessionId() {
         return browserSessionId;
+    }
+
+    public Session withBrowserSessionId(String browserSessionId) {
+        this.browserSessionId = browserSessionId;
+        return this;
     }
 
     public List<String> getClientSessions() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -3,6 +3,7 @@ package uk.gov.di.orchestration.shared.entity;
 import com.google.gson.annotations.Expose;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -21,6 +22,8 @@ public class Session {
     }
 
     @Expose private String sessionId;
+
+    @Expose private String browserSessionId;
 
     @Expose private List<String> clientSessions;
 
@@ -46,6 +49,7 @@ public class Session {
 
     public Session(String sessionId) {
         this.sessionId = sessionId;
+        this.browserSessionId = IdGenerator.generate();
         this.clientSessions = new ArrayList<>();
         this.isNewAccount = AccountState.UNKNOWN;
         this.processingIdentityAttempts = 0;
@@ -59,6 +63,10 @@ public class Session {
 
     public void setSessionId(String sessionId) {
         this.sessionId = sessionId;
+    }
+
+    public String getBrowserSessionId() {
+        return browserSessionId;
     }
 
     public List<String> getClientSessions() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
@@ -103,6 +103,18 @@ public class CookieHelper {
                 });
     }
 
+    public static Optional<String> parseBrowserSessionCookie(Map<String, String> headers) {
+        Optional<HttpCookie> httpCookie =
+                getHttpCookieFromRequestHeaders(headers, BROWSER_SESSION_COOKIE_NAME);
+        if (httpCookie.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String cookieValues = httpCookie.get().getValue();
+
+        return Optional.of(cookieValues);
+    }
+
     public static Optional<String> parsePersistentCookie(Map<String, String> headers) {
         Optional<HttpCookie> httpCookie =
                 getHttpCookieFromRequestHeaders(headers, PERSISTENT_COOKIE_NAME);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
@@ -17,6 +17,7 @@ public class CookieHelper {
     public static final String RESPONSE_COOKIE_HEADER = "Set-Cookie";
     public static final String PERSISTENT_COOKIE_NAME = "di-persistent-session-id";
     public static final String SESSION_COOKIE_NAME = "gs";
+    public static final String BROWSER_SESSION_COOKIE_NAME = "browser-session-id";
 
     public static final String LANGUAGE_COOKIE_NAME = "lng";
 
@@ -169,6 +170,11 @@ public class CookieHelper {
         return format(
                 "%s=%s; Max-Age=%d; Domain=%s; %s",
                 cookieName, cookieValue, maxAge, domain, attributes);
+    }
+
+    public static String buildCookieString(
+            String cookieName, String cookieValue, String attributes, String domain) {
+        return format("%s=%s; Domain=%s; %s", cookieName, cookieValue, domain, attributes);
     }
 
     public static String appendTimestampToCookieValue(String cookieValue) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -200,6 +200,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("FETCH_RP_PUBLIC_KEY_FROM_JWKS_ENABLED");
     }
 
+    public boolean isBrowserSessionCookieEnabled() {
+        return getFlagOrFalse("IS_BROWSER_SESSION_COOKIE_ENABLED");
+    }
+
     public String getSpotQueueURI() {
         return System.getenv("SPOT_QUEUE_URL");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -44,7 +44,12 @@ public class SessionService {
     }
 
     public Session createSession() {
-        return new Session(IdGenerator.generate()).withBrowserSessionId(IdGenerator.generate());
+        Session session = new Session(IdGenerator.generate());
+        if (configurationService.isBrowserSessionCookieEnabled()) {
+            session.setBrowserSessionId(IdGenerator.generate());
+        }
+
+        return session;
     }
 
     public void save(Session session) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -44,7 +44,7 @@ public class SessionService {
     }
 
     public Session createSession() {
-        return new Session(IdGenerator.generate());
+        return new Session(IdGenerator.generate()).withBrowserSessionId(IdGenerator.generate());
     }
 
     public void save(Session session) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/CookieHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/CookieHelperTest.java
@@ -20,6 +20,7 @@ import static uk.gov.di.orchestration.shared.helpers.CookieHelper.REQUEST_COOKIE
 import static uk.gov.di.orchestration.shared.helpers.CookieHelper.RESPONSE_COOKIE_HEADER;
 import static uk.gov.di.orchestration.shared.helpers.CookieHelper.getHttpCookieFromMultiValueResponseHeaders;
 import static uk.gov.di.orchestration.shared.helpers.CookieHelper.getHttpCookieFromResponseHeaders;
+import static uk.gov.di.orchestration.shared.helpers.CookieHelper.parseBrowserSessionCookie;
 import static uk.gov.di.orchestration.shared.helpers.CookieHelper.parsePersistentCookie;
 
 class CookieHelperTest {
@@ -36,6 +37,7 @@ class CookieHelperTest {
     private static final String ARBITRARY_UNIX_TIMESTAMP = "1700558480962";
     private static final String PERSISTENT_SESSION_ID_COOKIE_VALUE =
             IdGenerator.generate() + "--" + ARBITRARY_UNIX_TIMESTAMP;
+    private static final String BROWSER_SESSION_ID_COOKIE_VALUE = IdGenerator.generate();
 
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
@@ -86,6 +88,17 @@ class CookieHelperTest {
         String id = parsePersistentCookie(headers).orElseThrow();
 
         assertEquals(PERSISTENT_SESSION_ID_COOKIE_VALUE, id);
+    }
+
+    @ParameterizedTest(name = "with header {0}")
+    @MethodSource("inputs")
+    void shouldReturnIdFromBrowserSessionCookie(String header) {
+        HttpCookie cookie = new HttpCookie("browser-session-id", BROWSER_SESSION_ID_COOKIE_VALUE);
+        Map<String, String> headers = Map.ofEntries(Map.entry(header, cookie.toString()));
+
+        String id = parseBrowserSessionCookie(headers).orElseThrow();
+
+        assertEquals(BROWSER_SESSION_ID_COOKIE_VALUE, id);
     }
 
     @Test

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/CookieHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/CookieHelperTest.java
@@ -168,6 +168,14 @@ class CookieHelperTest {
 
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
+    void shouldReturnEmptyIfBrowserSessionCookieMalformed(String header) {
+        assertEmpty(parseBrowserSessionCookie(null));
+        assertEmpty(parseBrowserSessionCookie(Map.of(header, "")));
+        assertEmpty(parseBrowserSessionCookie(Map.of(header, "invalid value")));
+    }
+
+    @ParameterizedTest(name = "with header {0}")
+    @MethodSource("inputs")
     void shouldReturnCookiePrefsFromValidSessionCookieStringWithMultipleCookies(String header) {
         String cookieString =
                 "Version=1; gs=session-id.456;cookies_preferences_set={\"analytics\":false};name=ts";

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
@@ -2,8 +2,10 @@ package uk.gov.di.orchestration.shared.services;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
+import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.serialization.Json;
 
 import java.util.Collections;
@@ -19,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,6 +33,18 @@ class SessionServiceTest {
     private final Json objectMapper = SerializationService.getInstance();
 
     private final SessionService sessionService = new SessionService(configuration, redis);
+
+    @Test
+    void shouldCreateSessionWithNewSessionIdAndBrowserSessionId() {
+        try (MockedStatic<IdGenerator> idGenerator = mockStatic(IdGenerator.class)) {
+            when(configuration.isBrowserSessionCookieEnabled()).thenReturn(true);
+            idGenerator.when(IdGenerator::generate).thenReturn("id-1", "id-2");
+            Session session = sessionService.createSession();
+
+            assertEquals("id-1", session.getSessionId());
+            assertEquals("id-2", session.getBrowserSessionId());
+        }
+    }
 
     @Test
     void shouldPersistSessionToRedisWithExpiry() throws Json.JsonException {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -22,6 +22,8 @@ public class Session {
 
     @Expose private String sessionId;
 
+    @Expose private String browserSessionId;
+
     @Expose private List<String> clientSessions;
 
     @Expose private String emailAddress;
@@ -55,6 +57,15 @@ public class Session {
 
     public String getSessionId() {
         return sessionId;
+    }
+
+    public String getBrowserSessionId() {
+        return browserSessionId;
+    }
+
+    public Session withBrowserSessionId(String browserSessionId) {
+        this.browserSessionId = browserSessionId;
+        return this;
     }
 
     public Session setSessionId(String sessionId) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -63,6 +63,10 @@ public class Session {
         return browserSessionId;
     }
 
+    public void setBrowserSessionId(String browserSessionId) {
+        this.browserSessionId = browserSessionId;
+    }
+
     public Session withBrowserSessionId(String browserSessionId) {
         this.browserSessionId = browserSessionId;
         return this;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -43,7 +43,7 @@ public class SessionService {
     }
 
     public Session createSession() {
-        return new Session(IdGenerator.generate());
+        return new Session(IdGenerator.generate()).withBrowserSessionId(IdGenerator.generate());
     }
 
     public void save(Session session) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -43,7 +43,7 @@ public class SessionService {
     }
 
     public Session createSession() {
-        return new Session(IdGenerator.generate()).withBrowserSessionId(IdGenerator.generate());
+        return new Session(IdGenerator.generate());
     }
 
     public void save(Session session) {

--- a/template.yaml
+++ b/template.yaml
@@ -67,6 +67,7 @@ Conditions:
       !Equals [integration, !Ref Environment],
     ]
   IsIntegration: !Equals [!Ref Environment, integration]
+  EnableBrowserSessionCookie: !Equals [dev, !Ref Environment]
 
 Mappings:
   EnvironmentConfiguration:
@@ -2154,6 +2155,10 @@ Resources:
           TXMA_AUDIT_ENCODED_ENABLED: true
           FETCH_RP_PUBLIC_KEY_FROM_JWKS_ENABLED: !If
             - EnableFetchJwks
+            - true
+            - false
+          IS_BROWSER_SESSION_COOKIE_ENABLED: !If
+            - EnableBrowserSessionCookie
             - true
             - false
 


### PR DESCRIPTION
## What
Adds a browser session id to cookie, and stores it in Redis. This can be used to check that a user hasn't closed their browser, and use this to have them only signed in with that browser.

Currently nothing is done with the browser session id, so there is no functional change. It is also feature flagged to true only on dev.

## How to review
1. Code Review
