### PR TITLE
ATO-954: Set LambdaCanaryDeployment parameter to AllAtOnce for pipelines in all envs

### DIFF
--- a/ci/stack-orchestration/configuration/build/build-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/build/build-orch-be-pipeline/parameters.json
@@ -90,5 +90,9 @@
   {
     "ParameterKey": "SlackNotificationType",
     "ParameterValue": "Failures"
+  },
+  {
+    "ParameterKey": "LambdaCanaryDeployment",
+    "ParameterValue": "AllAtOnce"
   }
 ]

--- a/ci/stack-orchestration/configuration/integration/integration-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/integration/integration-orch-be-pipeline/parameters.json
@@ -74,5 +74,9 @@
   {
     "ParameterKey": "VpcStackName",
     "ParameterValue": "vpc"
+  },
+  {
+    "ParameterKey": "LambdaCanaryDeployment",
+    "ParameterValue": "AllAtOnce"
   }
 ]

--- a/ci/stack-orchestration/configuration/production/production-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/production/production-orch-be-pipeline/parameters.json
@@ -74,5 +74,9 @@
   {
     "ParameterKey": "VpcStackName",
     "ParameterValue": "vpc"
+  },
+  {
+    "ParameterKey": "LambdaCanaryDeployment",
+    "ParameterValue": "AllAtOnce"
   }
 ]

--- a/ci/stack-orchestration/configuration/staging/staging-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/staging/staging-orch-be-pipeline/parameters.json
@@ -78,5 +78,9 @@
   {
     "ParameterKey": "VpcStackName",
     "ParameterValue": "vpc"
+  },
+  {
+    "ParameterKey": "LambdaCanaryDeployment",
+    "ParameterValue": "AllAtOnce"
   }
 ]


### PR DESCRIPTION
## What
- The parameter needs to be set, otherwise deployments fail with "Parameters: [LambdaDeploymentPreference] must have values"
- Deploying this change will not affect the pipelines as the pipelines are deployed manually.
- Canary deployment can still be rolled out one env at a time, using `canaryDeploymentEnabled` mapping in the template


## Related PRs

ATO-990: Configure Orchestration dev lambdas to use AllAtOnce canary deployment: https://github.com/govuk-one-login/authentication-api/pull/5054
