### PR TITLE
ATO-954: Set default value for LambdaDeploymentPreference

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -25,6 +25,7 @@ Parameters:
   LambdaDeploymentPreference:
     Type: String
     Description: Specifies the configuration to enable gradual Lambda deployments
+    Default: AllAtOnce
 
 Conditions:
   UsePermissionsBoundary: !Not [!Equals [none, !Ref PermissionsBoundary]]


### PR DESCRIPTION
## What

- The parameter needs to be set, otherwise deployments fail with `Parameters: [LambdaDeploymentPreference] must have values`

