### PR TITLE
BAU: Add script to prune lambda versions.

### DIFF
--- a/scripts/prune-lambdas.sh
+++ b/scripts/prune-lambdas.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------------------------------------------------------------
+# Description:
+# A script to remove old versions of lambdas.  The script requires AWS CLI credentials which should be set in the
+# environment variables.  These credentials can be retrieved from the AWS access portal using 'Access keys' link
+# and using 'Option 1: Set AWS environment variables', copy the export statements and paste them into the terminal
+# before executing the script.
+#
+# Usage:
+#   ./prune-lambdas.sh ENVIRONMENT
+#
+# Parameters:
+#   ENVIRONMENT   -   The name of the environment to prune.  If not provided all lambdas will be pruned.
+#
+# ----------------------------------------------------------------------------------------------------------------------
+
+set -euo pipefail
+
+function usage() {
+  cat << USAGE
+  A script to remove old versions of lambdas.
+  Requires AWS environment variables to be set:
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    AWS_SESSION_TOKEN
+
+  Usage:
+    $0 [-h|--help] ENVIRONMENT
+
+  Options:
+    -h, --help               displays this message
+USAGE
+}
+
+FUNCTION_PREFIX=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h | --help)
+      usage
+      exit 1
+      ;;
+    *)
+      if [ -z "${FUNCTION_PREFIX}" ]; then
+        FUNCTION_PREFIX="$1"
+      else
+        echo "Unexpected argument: $1"
+        exit 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+if [ -z "${FUNCTION_PREFIX}" ]; then
+  read -r -p "This will prune all lambdas, continue? (y/n) " response
+  case "${response}" in
+    [yY][eE][sS] | [yY])
+      echo "pruning all lambdas"
+      ;;
+    *)
+      echo "Operation aborted by user."
+      exit 1
+      ;;
+  esac
+else
+  echo "pruning lambdas with ${FUNCTION_PREFIX} prefix"
+fi
+
+VERSIONS_TO_KEEP=5
+
+FUNCTIONS="$(aws lambda list-functions | jq -r '.Functions[] | select(.FunctionName | startswith($environment) and (endswith("warmer") | not) ).FunctionName' --arg environment "${FUNCTION_PREFIX}")"
+
+echo "${FUNCTIONS}" | while IFS= read -r FUNCTION; do
+  echo "Getting versions for ${FUNCTION}"
+  VERSIONS="$(aws lambda list-versions-by-function --function-name "${FUNCTION}" | jq -rc '[.Versions[] | select(.Version != "$LATEST").Version | tonumber]')"
+  if [ "${VERSIONS}" != '[]' ]; then
+    PRUNE_VERSION="$(echo "${VERSIONS}" | jq -r 'max - ($keep | tonumber)' --arg keep "${VERSIONS_TO_KEEP}")"
+    VERSIONS_TO_PRUNE="$(echo "${VERSIONS}" | jq -c '[.[] | select( . <= ($max | tonumber))]' --arg max "${PRUNE_VERSION}")"
+    echo "Pruning $(echo "${VERSIONS_TO_PRUNE}" | jq -r length) version(s) prior to version ${PRUNE_VERSION}..."
+    echo "${VERSIONS_TO_PRUNE}" | jq -r '.[]' | xargs -r -n 1 aws lambda delete-function --output text --function-name "${FUNCTION}" --qualifier
+  fi
+done


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->
Re-instating the script that purges old versions of lambdas.  Doing local deploys to the authdev environments created lots of versions of the lambdas that needed pruning, this script is a safe way to do that.

## How to review

1. Code Review
2. Use the di-auth-development account and run with and without specifying an environment to prune. 
3. Check script can be terminated if no environment is specified.
4. Check the help options print a usage message that makes sense.

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
