### PR TITLE
BAU: delete unused auth createSession

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -42,10 +42,6 @@ public class SessionService {
                         configurationService.getRedisPassword()));
     }
 
-    public Session createSession() {
-        return new Session(IdGenerator.generate());
-    }
-
     public void save(Session session) {
         try {
             redisConnectionService.saveWithExpiry(


### PR DESCRIPTION
## What
Delete the unused method in shared authentication `createSession`. This should only be called in Orchestration, so this PR deletes it for clarity that this should not be used by authentication.

This is raised now, as `createSession` in orchestration would be out of sync with authentication's version as a result of https://github.com/govuk-one-login/authentication-api/pull/5053. Instead of updating it, we delete it instead.

## How to review
1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
