### PR TITLE
ATO-991: Configure build-orch-be-pipeline for all-at-once lambda canary deployment

### DIFF
--- a/ci/stack-orchestration/configuration/build/build-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/build/build-orch-be-pipeline/parameters.json
@@ -90,5 +90,9 @@
   {
     "ParameterKey": "SlackNotificationType",
     "ParameterValue": "Failures"
+  },
+  {
+    "ParameterKey": "LambdaCanaryDeployment",
+    "ParameterValue": "AllAtOnce"
   }
 ]


### PR DESCRIPTION
## What

Configure build-orch-be-pipeline for all-at-once lambda canary deployment.

Note that merging this won't actually update the pipeline with the new parameter (deploying the pipeline is done manually), this is just for reference.


## Related PRs

Equivalent PR for dev: https://github.com/govuk-one-login/authentication-api/pull/5052
