### PR TITLE
ATO-991: Enable canary deployments in build

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -133,7 +133,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/5fdfad8b-ca31-4afc-a948-59fd498c0f3c
       defaultProvisionedConcurrency: 1
       aisUriSecretId: fd6ef1f1-7d31-40ca-978d-2180199141d8
-      canaryDeploymentEnabled: false
+      canaryDeploymentEnabled: true
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "1rvwudxmbk"


### PR DESCRIPTION
Enable canary deployments in build

Build pipeline parameter has been updated (LambdaCanaryDeployment: AllAtOnce), see https://github.com/govuk-one-login/authentication-api/pull/5075/files
