### PR TITLE
BAU: Ignore pact json files with pre-commit cfn-python-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     rev: v0.86.2
     hooks:
       - id: cfn-python-lint
-        exclude: ^(ci|.github)/.*|docker-compose.*|.pre-commit-config.yaml|.*.approved.json|checkov-policies.*$
+        exclude: ^(ci|.github)/.*|docker-compose.*|.pre-commit-config.yaml|.*.approved.json|checkov-policies.*|.*/pacts/.*$
         files: ^.*\.(json|yml|yaml)$
 
   - repo: https://github.com/govuk-one-login/pre-commit-hooks.git


### PR DESCRIPTION
## What

Exclude pact files from cfn-python-lint pre-commit check.

These are not cfn templates and shouldn't be in scope!

## How to review

`pre-commit run cfn-python-lint --all-files` in this branch should return `Passed`
