### PR TITLE
ATO-992: Configure staging-orch-be-pipeline for all-at-once lambda canary deployment

### DIFF
--- a/ci/stack-orchestration/configuration/staging/staging-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/staging/staging-orch-be-pipeline/parameters.json
@@ -78,5 +78,9 @@
   {
     "ParameterKey": "VpcStackName",
     "ParameterValue": "vpc"
+  },
+  {
+    "ParameterKey": "LambdaCanaryDeployment",
+    "ParameterValue": "AllAtOnce"
   }
 ]


### PR DESCRIPTION
## What

Configure staging-orch-be-pipeline for all-at-once lambda canary deployment.

Note that merging this won't actually update the pipeline with the new parameter, this is just for reference. Deploying the pipeline is done manually, and will be done after this is merged.


## Related PRs

Equivalent PR for:
- dev: https://github.com/govuk-one-login/authentication-api/pull/5052
- build: https://github.com/govuk-one-login/authentication-api/pull/5075
