### PR TITLE
ATO-993: Enable canary deployments in integration

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -198,7 +198,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/e34095ae-a65b-4609-99b3-9c1f407eff73
       defaultProvisionedConcurrency: 1
       aisUriSecretId: ""
-      canaryDeploymentEnabled: false
+      canaryDeploymentEnabled: true
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       authApiId: "s4gj268zy6"


### PR DESCRIPTION
Enable canary deployments in integration

Integration pipeline parameter has been updated (LambdaCanaryDeployment: AllAtOnce), see https://github.com/govuk-one-login/authentication-api/pull/5084
