### PR TITLE
AUT-3583: Added consistent read retry to access token store query

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.AccessTokenService;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
@@ -59,7 +60,9 @@ public class UserInfoHandler
         this.configurationService = configurationService;
         this.userInfoService =
                 new UserInfoService(new DynamoService(configurationService), configurationService);
-        this.accessTokenService = new AccessTokenService(configurationService);
+        this.accessTokenService =
+                new AccessTokenService(
+                        configurationService, new CloudwatchMetricsService(configurationService));
         this.auditService = new AuditService(configurationService);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -9,7 +9,13 @@ public enum CloudwatchMetrics {
     SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT("SignInExistingAccountByClient"),
     LOGOUT_SUCCESS("LogoutSuccess"),
     EMAIL_CHECK_DURATION("EmailCheckDuration"),
-    MFA_RESET_HANDOFF("MfaResetHandoff");
+    MFA_RESET_HANDOFF("MfaResetHandoff"),
+    ACCESS_TOKEN_SERVICE_INITIAL_QUERY_ATTEMPT("AccessTokenServiceInitialQueryAttempt"),
+    ACCESS_TOKEN_SERVICE_INITIAL_QUERY_SUCCESS("AccessTokenServiceInitialQuerySuccess"),
+    ACCESS_TOKEN_SERVICE_CONSISTENT_READ_QUERY_ATTEMPT(
+            "AccessTokenServiceConsistentReadQueryAttempt"),
+    ACCESS_TOKEN_SERVICE_CONSISTENT_READ_QUERY_SUCCESS(
+            "AccessTokenServiceConsistentReadQueryAttemptSuccess");
     private String value;
 
     CloudwatchMetrics(String value) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
@@ -30,6 +30,11 @@ public class BaseDynamoService<T> {
         warmUp();
     }
 
+    public BaseDynamoService(DynamoDbTable<T> dynamoTable, DynamoDbClient client) {
+        this.dynamoTable = dynamoTable;
+        this.client = client;
+    }
+
     public void update(T item) {
         dynamoTable.updateItem(item);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
@@ -16,7 +16,7 @@ import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.create
 
 public class BaseDynamoService<T> {
 
-    private final DynamoDbTable<T> dynamoTable;
+    protected final DynamoDbTable<T> dynamoTable;
     private final DynamoDbClient client;
 
     public BaseDynamoService(
@@ -39,6 +39,7 @@ public class BaseDynamoService<T> {
     }
 
     public Optional<T> get(String partition) {
+
         return Optional.ofNullable(
                 dynamoTable.getItem(Key.builder().partitionValue(partition).build()));
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccessTokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccessTokenServiceTest.java
@@ -1,0 +1,90 @@
+package uk.gov.di.authentication.shared.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AccessTokenServiceTest {
+    private final DynamoDbTable<AccessTokenStore> table = mock(DynamoDbTable.class);
+    private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final CloudwatchMetricsService cloudwatchMetricsService =
+            mock(CloudwatchMetricsService.class);
+    private final AccessTokenStore accessTokenStore = mock(AccessTokenStore.class);
+    public AccessTokenService accessTokenService;
+    private final Key testPartitionKey = Key.builder().partitionValue("test").build();
+    private static final String TEST_ENVIRONMENT = "test-environment";
+    private static final String TEST_PARTITION = "test";
+
+    @BeforeEach
+    void beforeEach() {
+        accessTokenService =
+                new AccessTokenService(
+                        cloudwatchMetricsService,
+                        configurationService,
+                        dynamoDbClient,
+                        table,
+                        100000L);
+
+        when(configurationService.getEnvironment()).thenReturn(TEST_ENVIRONMENT);
+    }
+
+    @Test
+    void shouldCallGetItemTwiceIfInitialQueryReturnsNull() {
+        when(table.getItem(testPartitionKey)).thenReturn(null);
+
+        accessTokenService.get(TEST_PARTITION);
+
+        verify(table, times(1)).getItem(any(Key.class));
+        verify(table, times(1)).getItem(any(GetItemEnhancedRequest.class));
+    }
+
+    @Test
+    void shouldIncrementCountersWhenInitialQueryFailsAndConsistentReadQuerySucceeds() {
+        when(table.getItem(testPartitionKey)).thenReturn(null);
+        when(table.getItem(any(GetItemEnhancedRequest.class))).thenReturn(accessTokenStore);
+
+        accessTokenService.get(TEST_PARTITION);
+
+        verify(cloudwatchMetricsService, times(1))
+                .incrementCounter(
+                        "AccessTokenServiceInitialQueryAttempt",
+                        Map.of("Environment", "test-environment"));
+        verify(cloudwatchMetricsService, times(1))
+                .incrementCounter(
+                        "AccessTokenServiceConsistentReadQueryAttempt",
+                        Map.of("Environment", "test-environment"));
+        verify(cloudwatchMetricsService, times(1))
+                .incrementCounter(
+                        "AccessTokenServiceConsistentReadQueryAttemptSuccess",
+                        Map.of("Environment", "test-environment"));
+    }
+
+    @Test
+    void shouldIncrementInitialAttemptAndInitialSuccessCounterWhenGetSucceeds() {
+        when(table.getItem(testPartitionKey)).thenReturn(accessTokenStore);
+
+        accessTokenService.get(TEST_PARTITION);
+
+        verify(cloudwatchMetricsService, times(1))
+                .incrementCounter(
+                        "AccessTokenServiceInitialQueryAttempt",
+                        Map.of("Environment", "test-environment"));
+        verify(cloudwatchMetricsService, times(1))
+                .incrementCounter(
+                        "AccessTokenServiceInitialQuerySuccess",
+                        Map.of("Environment", "test-environment"));
+    }
+}


### PR DESCRIPTION
## What

Added a consistent read retry when querying the access token store. This is to remedy a suspected race condition where the access token store was not being populated before the query was happening. 
This retry strategy aims to fix this by performing a second query with strongly consistent reading (as opposed to eventually consistent reading). This second query happens with a higher latency and cost but ensures up to date DB data.

Have also added cloudwatch metrics incrementing a counter for attempted and successful access token queries for both standard initial reads (eventually consistent reads) and the consistent reads, allowing us to see how often queries are failing. 

See docs here: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html

## How to review

1. Code Review
