### PR TITLE
ATO-964: add tests for different journeys

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -854,7 +854,8 @@ public class AuthorisationHandler
                         configurationService.getSessionCookieAttributes(),
                         configurationService.getDomainName()));
 
-        if (configurationService.isBrowserSessionCookieEnabled()) {
+        if (configurationService.isBrowserSessionCookieEnabled()
+                && session.getBrowserSessionId() != null) {
             cookies.add(
                     CookieHelper.buildCookieString(
                             CookieHelper.BROWSER_SESSION_COOKIE_NAME,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1564,7 +1564,7 @@ class AuthorisationHandlerTest {
         void shouldSetTheRelevantCookiesInTheHeader() {
             when(configService.isBrowserSessionCookieEnabled()).thenReturn(true);
             Session sessionWithBrowserSessionId =
-                    new Session("a-session-id").withBrowserSessionId("a-browser-session-id");
+                    new Session(SESSION_ID).withBrowserSessionId(BROWSER_SESSION_ID);
             when(sessionService.createSession()).thenReturn(sessionWithBrowserSessionId);
 
             Map<String, String> requestParams = buildRequestParams(null);
@@ -1589,7 +1589,9 @@ class AuthorisationHandlerTest {
                             .get(ResponseHeaders.SET_COOKIE)
                             .get(2)
                             .contains(
-                                    "browser-session-id=a-browser-session-id; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;"));
+                                    format(
+                                            "browser-session-id=%s; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                                            BROWSER_SESSION_ID)));
         }
 
         @Test


### PR DESCRIPTION
## What
- Added a null check for the session's `browser-session-id`, so that if it's null, nothing is sent back in the cookies. This means if a user is already in an existing session when this change is deployed, their journey will continue unaffected - only new journeys will have a browser session id be created.
- Added tests for expected journeys through `/authorize` for specifically browser session ids. Currently, browser session id has essentially no effect on the journey, so these will need updating in ATO-967

## How to review

1. Code Review

## Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
