### PR TITLE
Revert "ATO-489: Remove resource field in token request to IPV"

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -77,7 +77,7 @@ public class IPVTokenService {
                 generatePrivateKeyJwt(claimsSet),
                 codeGrant,
                 null,
-                null,
+                singletonList(ipvTokenURI),
                 Map.of(
                         "client_id",
                         singletonList(configurationService.getIPVAuthorisationClientId())));

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java
@@ -88,6 +88,9 @@ public class IpvTokenTest {
                         "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&"
                                 + "code=dummyAuthCode&"
                                 + "grant_type=authorization_code&"
+                                + "resource="
+                                + "http://localhost:1234/token"
+                                + "&"
                                 + "client_assertion="
                                 + CLIENT_ASSERTION_HEADER
                                 + "."
@@ -155,6 +158,9 @@ public class IpvTokenTest {
                         "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&"
                                 + "code=dummyInvalidAuthCode&"
                                 + "grant_type=authorization_code&"
+                                + "resource="
+                                + "http://localhost:1234/token"
+                                + "&"
                                 + "client_assertion="
                                 + CLIENT_ASSERTION_HEADER
                                 + "."

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -112,8 +112,6 @@ class IPVTokenServiceTest {
         assertThat(
                 tokenRequest.toHTTPRequest().getQueryParameters().get("client_id").get(0),
                 equalTo(CLIENT_ID.getValue()));
-        assertThat(
-                tokenRequest.toHTTPRequest().getQueryParameters().get("resource"), equalTo(null));
     }
 
     @Test


### PR DESCRIPTION
Reverts govuk-one-login/authentication-api#5041