### PR TITLE
Re-apply: ATO-489: Remove resource field in token request to IPV

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -77,7 +77,7 @@ public class IPVTokenService {
                 generatePrivateKeyJwt(claimsSet),
                 codeGrant,
                 null,
-                singletonList(ipvTokenURI),
+                null,
                 Map.of(
                         "client_id",
                         singletonList(configurationService.getIPVAuthorisationClientId())));

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvTokenTest.java
@@ -88,9 +88,6 @@ public class IpvTokenTest {
                         "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&"
                                 + "code=dummyAuthCode&"
                                 + "grant_type=authorization_code&"
-                                + "resource="
-                                + "http://localhost:1234/token"
-                                + "&"
                                 + "client_assertion="
                                 + CLIENT_ASSERTION_HEADER
                                 + "."
@@ -158,9 +155,6 @@ public class IpvTokenTest {
                         "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&"
                                 + "code=dummyInvalidAuthCode&"
                                 + "grant_type=authorization_code&"
-                                + "resource="
-                                + "http://localhost:1234/token"
-                                + "&"
                                 + "client_assertion="
                                 + CLIENT_ASSERTION_HEADER
                                 + "."

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -112,6 +112,8 @@ class IPVTokenServiceTest {
         assertThat(
                 tokenRequest.toHTTPRequest().getQueryParameters().get("client_id").get(0),
                 equalTo(CLIENT_ID.getValue()));
+        assertThat(
+                tokenRequest.toHTTPRequest().getQueryParameters().get("resource"), equalTo(null));
     }
 
     @Test


### PR DESCRIPTION
## What

Re-applies  https://github.com/govuk-one-login/authentication-api/pull/5041 which was initially reverted out of caution, due to not being able to run through the identity journey in staging. However this issue was unrelated and the logs indicated the token request to IPV was successful 

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
