### PR TITLE
ATO-964: set domain of bsid cookie to be OIDC specific

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -861,7 +861,7 @@ public class AuthorisationHandler
                             CookieHelper.BROWSER_SESSION_COOKIE_NAME,
                             session.getBrowserSessionId(),
                             configurationService.getSessionCookieAttributes(),
-                            configurationService.getDomainName()));
+                            configurationService.getOidcDomainName()));
         }
 
         getPrimaryLanguageFromUILocales(authRequest, configurationService)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -247,6 +247,8 @@ class AuthorisationHandlerTest {
     public void setUp() {
         when(configService.getEnvironment()).thenReturn("test-env");
         when(configService.getDomainName()).thenReturn("auth.ida.digital.cabinet-office.gov.uk");
+        when(configService.getOidcDomainName())
+                .thenReturn("oidc.auth.ida.digital.cabinet-office.gov.uk");
         when(configService.getOrchestrationClientId()).thenReturn(TEST_ORCHESTRATOR_CLIENT_ID);
         when(configService.getSessionCookieAttributes()).thenReturn("Secure; HttpOnly;");
         when(configService.getSessionCookieMaxAge()).thenReturn(3600);
@@ -1591,7 +1593,7 @@ class AuthorisationHandlerTest {
                             .get(2)
                             .contains(
                                     format(
-                                            "%s=%s; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                                            "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
                                             BROWSER_SESSION_ID_COOKIE_NAME, BROWSER_SESSION_ID)));
         }
 
@@ -1713,7 +1715,7 @@ class AuthorisationHandlerTest {
             assertEquals(NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
             assertEquals(
                     format(
-                            "%s=%s; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                            "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
                             BROWSER_SESSION_ID_COOKIE_NAME, NEW_BROWSER_SESSION_ID),
                     browserSessionIdCookieFromResponse(response));
         }
@@ -1729,7 +1731,7 @@ class AuthorisationHandlerTest {
             assertEquals(NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
             assertEquals(
                     format(
-                            "%s=%s; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                            "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
                             BROWSER_SESSION_ID_COOKIE_NAME, NEW_BROWSER_SESSION_ID),
                     browserSessionIdCookieFromResponse(response));
         }
@@ -1746,7 +1748,7 @@ class AuthorisationHandlerTest {
             assertEquals(BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
             assertEquals(
                     format(
-                            "%s=%s; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                            "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
                             BROWSER_SESSION_ID_COOKIE_NAME, BROWSER_SESSION_ID),
                     browserSessionIdCookieFromResponse(response));
         }
@@ -1785,7 +1787,7 @@ class AuthorisationHandlerTest {
             assertEquals(BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
             assertEquals(
                     format(
-                            "%s=%s; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                            "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
                             BROWSER_SESSION_ID_COOKIE_NAME, BROWSER_SESSION_ID),
                     browserSessionIdCookieFromResponse(response));
         }
@@ -1803,7 +1805,7 @@ class AuthorisationHandlerTest {
             assertEquals(BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
             assertEquals(
                     format(
-                            "%s=%s; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                            "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
                             BROWSER_SESSION_ID_COOKIE_NAME, BROWSER_SESSION_ID),
                     browserSessionIdCookieFromResponse(response));
         }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -188,6 +188,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("DOMAIN_NAME");
     }
 
+    public String getOidcDomainName() {
+        return System.getenv("OIDC_SERVICE_DOMAIN");
+    }
+
     public Optional<String> getDynamoArnPrefix() {
         return Optional.ofNullable(System.getenv("DYNAMO_ARN_PREFIX"));
     }

--- a/template.yaml
+++ b/template.yaml
@@ -2134,6 +2134,14 @@ Resources:
                   !Ref Environment,
                   serviceDomain,
                 ]
+          OIDC_SERVICE_DOMAIN: !Sub
+            - oidc.${ServiceDomain}
+            - ServiceDomain:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  serviceDomain,
+                ]
           ORCH_CLIENT_ID: orchestrationAuth
           ORCH_REDIRECT_URI: !Sub
             - https://oidc.${ServiceDomain}/orchestration-redirect


### PR DESCRIPTION
## What
Instead of setting the bsid cookie domain to `account.gov.uk`, we set it to `oidc.account.gov.uk` so we're not passing it around to services that don't need it.

## How to review
Deployed to dev and tested: `configurationService.getOidcDomainName()` gives the domain `oidc.sandpit.account.gov.uk` as expected.

1. Code Review