### PR TITLE
ATO-1005: Create dynamo table for auth session

### DIFF
--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -85,6 +85,7 @@ locals {
   pending_email_check_queue_access_policy_arn         = data.terraform_remote_state.shared.outputs.pending_email_check_queue_access_policy_arn
   user_profile_kms_key_arn                            = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
   authentication_attempt_kms_key_arn                  = data.terraform_remote_state.shared.outputs.authentication_attempt_kms_key_arn
+  auth_session_table_encryption_key_arn               = data.terraform_remote_state.shared.outputs.auth_session_table_encryption_key_arn
   email_check_results_encryption_policy_arn           = data.terraform_remote_state.shared.outputs.email_check_results_encryption_policy_arn
   experian_phone_check_sqs_queue_id                   = data.terraform_remote_state.contra.outputs.aws_experian_phone_check_sqs_id
   experian_phone_check_sqs_queue_policy_arn           = data.terraform_remote_state.contra.outputs.aws_experian_phone_check_sqs_policy_arn

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -660,3 +660,35 @@ data "aws_iam_policy_document" "cross_account_identity_credentials_table_resourc
     resources = ["*"]
   }
 }
+
+resource "aws_dynamodb_table" "auth_session_table" {
+  name         = "${var.environment}-auth-session"
+  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
+
+  hash_key = "SessionId"
+
+  attribute {
+    name = "SessionId"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "TimeToLive"
+    enabled        = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.auth_session_table_encryption_key.arn
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = local.default_tags
+}

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -862,3 +862,34 @@ resource "aws_kms_alias" "authentication_attempt_encryption_key_alias" {
   name          = "alias/${var.environment}-authentication-attempt-table-encryption-key"
   target_key_id = aws_kms_key.authentication_attempt_encryption_key.key_id
 }
+
+resource "aws_kms_key" "auth_session_table_encryption_key" {
+  description              = "KMS encryption key for auth session table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "auth_session_table_encryption_key_alias" {
+  name          = "alias/${var.environment}-auth-session-table-encryption-key"
+  target_key_id = aws_kms_key.auth_session_table_encryption_key.key_id
+}

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -252,3 +252,7 @@ output "user_profile_kms_key_arn" {
 output "authentication_attempt_kms_key_arn" {
   value = aws_kms_key.authentication_attempt_encryption_key.arn
 }
+
+output "auth_session_table_encryption_key_arn" {
+  value = aws_kms_key.auth_session_table_encryption_key.arn
+}


### PR DESCRIPTION
## What

Create a new DynamoDB table which will be used to store the Auth session.

## How to review

- Ensure table is setup correctly
- Ensure kms key is setup correctly
- Ensure policies allow correct access (and only from auth)

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
