### PR TITLE
ATO-994: Enable canary deployments in production

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -230,7 +230,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:172348255554:key/0e5c92f4-26a1-442d-a57b-87db810a40d1
       defaultProvisionedConcurrency: 3
       aisUriSecretId: ""
-      canaryDeploymentEnabled: false
+      canaryDeploymentEnabled: true
   ProvisionedConcurrency:
     staging:
       TrustmarkFunction: 1


### PR DESCRIPTION
Enable canary deployments in production

Production pipeline parameter has been updated (LambdaCanaryDeployment: AllAtOnce), see https://github.com/govuk-one-login/authentication-api/pull/5124