### PR TITLE
ATO-1006: Make Auth and Orch Sessions Independent (1/2)

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -203,7 +203,7 @@ public class DocAppCallbackHandler
             }
             var session =
                     sessionService
-                            .readSessionFromRedis(sessionCookiesIds.getSessionId())
+                            .getSession(sessionCookiesIds.getSessionId())
                             .orElseThrow(
                                     () -> {
                                         throw new DocAppCallbackException("Session not found");

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -562,7 +562,7 @@ class DocAppCallbackHandlerTest {
     }
 
     private void usingValidSession() {
-        when(sessionService.readSessionFromRedis(SESSION_ID)).thenReturn(Optional.of(session));
+        when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
     }
 
     private void usingValidClientSession() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
@@ -34,7 +34,7 @@ public class SessionHelper {
                                         authenticationService)
                                 .getValue();
         LOG.info("Setting internal common subject identifier in user session");
-        sessionService.save(
+        sessionService.storeOrUpdateSession(
                 userContext
                         .getSession()
                         .setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -135,7 +135,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                     emailAddress,
                     CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.PASSWORD_RESET)) {
                 LOG.info("User account is locked");
-                sessionService.save(userContext.getSession());
+                sessionService.storeOrUpdateSession(userContext.getSession());
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.AUTH_ACCOUNT_TEMPORARILY_LOCKED,
@@ -212,7 +212,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                             userMfaDetail.getMfaMethodType(),
                             getLastDigitsOfPhoneNumber(userMfaDetail),
                             lockoutInformation);
-            sessionService.save(userContext.getSession());
+            sessionService.storeOrUpdateSession(userContext.getSession());
 
             LOG.info("Successfully processed request");
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -243,7 +243,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             UserCredentials userCredentials,
             UserProfile userProfile,
             AuditContext auditContext) {
-        sessionService.save(
+        sessionService.storeOrUpdateSession(
                 userContext
                         .getSession()
                         .setNewAccount(EXISTING)

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -209,7 +209,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                                     });
 
             LOG.info("Incrementing code request count");
-            sessionService.save(
+            sessionService.storeOrUpdateSession(
                     userContext
                             .getSession()
                             .incrementCodeRequestCount(NotificationType.MFA_SMS, journeyType));
@@ -302,6 +302,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
 
     private void clearCountOfFailedCodeRequests(JourneyType journeyType, Session session) {
         LOG.info("Resetting code request count");
-        sessionService.save(session.resetCodeRequestCount(NotificationType.MFA_SMS, journeyType));
+        sessionService.storeOrUpdateSession(
+                session.resetCodeRequestCount(NotificationType.MFA_SMS, journeyType));
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -191,7 +191,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                                             RESET_PASSWORD_WITH_CODE);
                                     return newCode;
                                 });
-        sessionService.save(userContext.getSession().incrementPasswordResetCount());
+        sessionService.storeOrUpdateSession(userContext.getSession().incrementPasswordResetCount());
 
         if (isTestClient) {
             LOG.info("User is a TestClient so will NOT place message on queue");
@@ -254,7 +254,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                     userContext.getSession().getEmailAddress(),
                     codeRequestBlockedKeyPrefix,
                     configurationService.getLockoutDuration());
-            sessionService.save(userContext.getSession().resetPasswordResetCount());
+            sessionService.storeOrUpdateSession(userContext.getSession().resetPasswordResetCount());
             return Optional.of(ErrorResponse.ERROR_1022);
         }
         if (codeStorageService.isBlockedForEmail(email, codeRequestBlockedKeyPrefix)) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -292,7 +292,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                                                         notificationType));
 
         LOG.info("Incrementing code request count");
-        sessionService.save(
+        sessionService.storeOrUpdateSession(
                 session.incrementCodeRequestCount(
                         request.getNotificationType(), request.getJourneyType()));
         var testClientWithAllowedEmail =
@@ -389,7 +389,8 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                     email, newCodeRequestBlockPrefix, configurationService.getLockoutDuration());
 
             LOG.info("Resetting code request count");
-            sessionService.save(session.resetCodeRequestCount(notificationType, journeyType));
+            sessionService.storeOrUpdateSession(
+                    session.resetCodeRequestCount(notificationType, journeyType));
             return Optional.of(getErrorResponseForCodeRequestLimitReached(notificationType));
         }
         if (codeStorageService.isBlockedForEmail(email, newCodeRequestBlockPrefix)) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -163,7 +163,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                     pair("rpPairwiseId", rpPairwiseId));
 
             LOG.info("Setting internal common subject identifier in user session");
-            sessionService.save(
+            sessionService.storeOrUpdateSession(
                     userContext
                             .getSession()
                             .setEmailAddress(request.getEmail())

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -186,7 +186,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
             }
 
-            sessionService.save(session);
+            sessionService.storeOrUpdateSession(session);
 
             if (errorResponse.isPresent()) {
                 handleInvalidVerificationCode(
@@ -323,7 +323,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     "MFA code has been successfully verified for MFA type: {}. RegistrationJourney: {}",
                     MFAMethodType.SMS.getValue(),
                     false);
-            sessionService.save(session.setVerifiedMfaMethodType(MFAMethodType.SMS));
+            sessionService.storeOrUpdateSession(
+                    session.setVerifiedMfaMethodType(MFAMethodType.SMS));
             clearAccountRecoveryBlockIfPresent(session, auditContext);
             cloudwatchMetricsService.incrementAuthenticationSuccess(
                     session.isNewAccount(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -249,7 +249,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 codeRequest,
                 mfaCodeProcessor);
 
-        sessionService.save(session);
+        sessionService.storeOrUpdateSession(session);
 
         return errorResponseMaybe
                 .map(response -> generateApiGatewayProxyErrorResponse(400, response))
@@ -270,7 +270,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                                     codeRequest.getMfaMethodType().getValue(),
                                     journeyType);
 
-                            sessionService.save(
+                            sessionService.storeOrUpdateSession(
                                     session.setCurrentCredentialStrength(
                                                     CredentialTrustLevel.MEDIUM_LEVEL)
                                             .setVerifiedMfaMethodType(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -76,7 +76,7 @@ public class StartService {
                     "Session is authenticated but user profile is empty. Creating new session with existing sessionID");
             session = new Session(session.getSessionId());
             session.addClientSession(clientSessionId);
-            sessionService.save(session);
+            sessionService.storeOrUpdateSession(session);
         }
         return session;
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -273,7 +273,7 @@ class CheckUserExistsHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.ERROR_1045));
-            verify(sessionService, times(1)).save(any());
+            verify(sessionService, times(1)).storeOrUpdateSession(any());
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_ACCOUNT_TEMPORARILY_LOCKED,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -223,7 +223,7 @@ class LoginHandlerReauthenticationRedisTest {
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).save(any());
+        verify(sessionService, never()).storeOrUpdateSession(any());
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -233,7 +233,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).save(any());
+        verify(sessionService, never()).storeOrUpdateSession(any());
     }
 
     private static Stream<Arguments> reauthCountTypes() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -445,7 +445,7 @@ class LoginHandlerTest {
 
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1028));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).save(any());
+        verify(sessionService, never()).storeOrUpdateSession(any());
 
         verify(codeStorageService).getIncorrectPasswordCount(EMAIL);
         verify(codeStorageService).deleteIncorrectPasswordCount(EMAIL);
@@ -502,7 +502,7 @@ class LoginHandlerTest {
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).save(any());
+        verify(sessionService, never()).storeOrUpdateSession(any());
     }
 
     @ParameterizedTest
@@ -539,7 +539,7 @@ class LoginHandlerTest {
                                 configurationService.getMaxPasswordRetries()));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).save(any());
+        verify(sessionService, never()).storeOrUpdateSession(any());
     }
 
     @ParameterizedTest
@@ -594,7 +594,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1008));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).save(any());
+        verify(sessionService, never()).storeOrUpdateSession(any());
     }
 
     @ParameterizedTest
@@ -645,7 +645,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1008));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).save(any());
+        verify(sessionService, never()).storeOrUpdateSession(any());
     }
 
     @Test
@@ -660,7 +660,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).save(any());
+        verify(sessionService, never()).storeOrUpdateSession(any());
     }
 
     @Test
@@ -675,7 +675,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1000));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).save(any());
+        verify(sessionService, never()).storeOrUpdateSession(any());
     }
 
     @Test
@@ -697,7 +697,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).save(any(Session.class));
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class));
     }
 
     @Test
@@ -832,7 +832,7 @@ class LoginHandlerTest {
 
     private void verifySessionIsSaved() {
         verify(sessionService, atLeastOnce())
-                .save(
+                .storeOrUpdateSession(
                         argThat(
                                 t ->
                                         t.getInternalCommonSubjectIdentifier()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -393,7 +393,7 @@ class MfaHandlerTest {
         checkUserIsBlockedWhenNotReAuthenticating(journeyType, codeRequestType);
 
         verify(sessionService)
-                .save(
+                .storeOrUpdateSession(
                         argThat(
                                 sessionForTestUser ->
                                         sessionForTestUser.getCodeRequestCount(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -251,7 +251,7 @@ class ResetPasswordRequestHandlerTest {
                             TEST_SIX_DIGIT_CODE,
                             CODE_EXPIRY_TIME,
                             RESET_PASSWORD_WITH_CODE);
-            verify(sessionService).save(argThat(this::isSessionWithEmailSent));
+            verify(sessionService).storeOrUpdateSession(argThat(this::isSessionWithEmailSent));
         }
 
         @Test
@@ -341,7 +341,7 @@ class ResetPasswordRequestHandlerTest {
                             TEST_SIX_DIGIT_CODE,
                             CODE_EXPIRY_TIME,
                             RESET_PASSWORD_WITH_CODE);
-            verify(sessionService).save(argThat(this::isSessionWithEmailSent));
+            verify(sessionService).storeOrUpdateSession(argThat(this::isSessionWithEmailSent));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -490,7 +490,7 @@ class ResetPasswordRequestHandlerTest {
             verify(awsSqsClient, never()).send(anyString());
             verify(codeStorageService, never())
                     .saveOtpCode(anyString(), anyString(), anyLong(), any(NotificationType.class));
-            verify(sessionService, never()).save(any());
+            verify(sessionService, never()).storeOrUpdateSession(any());
             verifyNoInteractions(awsSqsClient);
         }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -276,7 +276,7 @@ class SendNotificationHandlerTest {
                                 EMAIL, TEST_SIX_DIGIT_CODE, CODE_EXPIRY_TIME, notificationType);
                 verify(codeStorageService).getOtpCode(EMAIL, notificationType);
                 verify(sessionService)
-                        .save(
+                        .storeOrUpdateSession(
                                 argThat(
                                         session ->
                                                 isSessionWithEmailSent(
@@ -462,7 +462,7 @@ class SendNotificationHandlerTest {
         verify(codeStorageService)
                 .saveOtpCode(EMAIL, TEST_SIX_DIGIT_CODE, CODE_EXPIRY_TIME, notificationType);
         verify(sessionService)
-                .save(
+                .storeOrUpdateSession(
                         argThat(
                                 session ->
                                         isSessionWithEmailSent(
@@ -494,7 +494,7 @@ class SendNotificationHandlerTest {
         verifyNoInteractions(emailSqsClient);
         verifyNoInteractions(codeStorageService);
         verify(sessionService, never())
-                .save(
+                .storeOrUpdateSession(
                         argThat(
                                 session ->
                                         isSessionWithEmailSent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -162,7 +162,8 @@ class SignUpHandlerTest {
 
         verify(authenticationService)
                 .signUp(eq(EMAIL), eq(PASSWORD), any(Subject.class), any(TermsAndConditions.class));
-        verify(sessionService).save(argThat((session) -> session.getEmailAddress().equals(EMAIL)));
+        verify(sessionService)
+                .storeOrUpdateSession(argThat(s -> s.getEmailAddress().equals(EMAIL)));
 
         assertThat(result, hasStatus(200));
         verify(authenticationService)
@@ -182,9 +183,9 @@ class SignUpHandlerTest {
                         pair("rpPairwiseId", expectedRpPairwiseId));
 
         verify(sessionService)
-                .save(argThat(session -> session.isNewAccount() == Session.AccountState.NEW));
+                .storeOrUpdateSession(argThat(s -> s.isNewAccount() == Session.AccountState.NEW));
         verify(sessionService, atLeastOnce())
-                .save(
+                .storeOrUpdateSession(
                         argThat(
                                 t ->
                                         t.getInternalCommonSubjectIdentifier()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -254,7 +254,7 @@ class VerifyCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         verify(codeStorageService).deleteOtpCode(EMAIL, emailNotificationType);
-        verify(sessionService).save(session);
+        verify(sessionService).storeOrUpdateSession(session);
         verifyNoInteractions(accountModifiersService);
         verify(auditService)
                 .submitAuditEvent(
@@ -527,7 +527,7 @@ class VerifyCodeHandlerTest {
         verify(codeStorageService).deleteOtpCode(EMAIL, MFA_SMS);
         verify(accountModifiersService).removeAccountRecoveryBlockIfPresent(expectedCommonSubject);
         var saveSessionCount = journeyType == JourneyType.PASSWORD_RESET_MFA ? 3 : 2;
-        verify(sessionService, times(saveSessionCount)).save(session);
+        verify(sessionService, times(saveSessionCount)).storeOrUpdateSession(session);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -566,7 +566,7 @@ class VerifyCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         verify(codeStorageService).deleteOtpCode(EMAIL, MFA_SMS);
         verify(accountModifiersService, never()).removeAccountRecoveryBlockIfPresent(anyString());
-        verify(sessionService, times(2)).save(session);
+        verify(sessionService, times(2)).storeOrUpdateSession(session);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_VERIFIED,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -130,7 +130,7 @@ class StartServiceTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         assertTrue(session.getClientSessions().contains("some-client-session-id"));
         assertFalse(session.getClientSessions().contains("previous-session-client-session-id"));
-        verify(sessionService).save(session);
+        verify(sessionService).storeOrUpdateSession(session);
     }
 
     @Test

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -214,7 +214,7 @@ public class IPVCallbackHandler
             }
             var session =
                     sessionService
-                            .readSessionFromRedis(sessionCookiesIds.getSessionId())
+                            .getSession(sessionCookiesIds.getSessionId())
                             .orElseThrow(
                                     () -> new IPVCallbackNoSessionException("Session not found"));
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -162,7 +162,7 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
                             .orElse(AuditService.UNKNOWN),
                     user);
 
-            sessionService.save(userSession.getSession());
+            sessionService.storeOrUpdateSession(userSession.getSession());
 
             LOG.info(
                     "Generating IdentityProgressResponse with IdentityProgressStatus: {}",

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -173,7 +173,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
 
             auditService.submitAuditEvent(
                     IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST, auditContext);
-            sessionService.save(userContext.getSession());
+            sessionService.storeOrUpdateSession(userContext.getSession());
             LOG.info(
                     "Generating ProcessingIdentityResponse with ProcessingIdentityStatus: {}",
                     processingStatus);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -584,7 +584,7 @@ class IPVCallbackHandlerTest {
         request.setQueryStringParameters(Collections.emptyMap());
         request.setHeaders(Map.of(COOKIE, buildCookieString()));
 
-        when(sessionService.readSessionFromRedis(SESSION_ID)).thenReturn(Optional.empty());
+        when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.empty());
 
         var response = handler.handleRequest(request, context);
         assertDoesRedirectToFrontendPage(response, FRONT_END_IPV_CALLBACK_ERROR_URI);
@@ -907,7 +907,7 @@ class IPVCallbackHandlerTest {
     }
 
     private void usingValidSession() {
-        when(sessionService.readSessionFromRedis(SESSION_ID)).thenReturn(Optional.of(session));
+        when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
     }
 
     private void usingValidClientSession() {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -248,7 +248,7 @@ public class AuthenticationCallbackHandler
 
             Session userSession =
                     sessionService
-                            .readSessionFromRedis(sessionCookiesIds.getSessionId())
+                            .getSession(sessionCookiesIds.getSessionId())
                             .orElseThrow(
                                     () ->
                                             new AuthenticationCallbackException(
@@ -470,7 +470,8 @@ public class AuthenticationCallbackHandler
                         new AuthenticationSuccessResponse(
                                 clientRedirectURI, authCode, null, null, state, null, responseMode);
 
-                sessionService.save(userSession.setAuthenticated(true).setNewAccount(EXISTING));
+                sessionService.storeOrUpdateSession(
+                        userSession.setAuthenticated(true).setNewAccount(EXISTING));
 
                 cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
                 cloudwatchMetricsService.incrementSignInByClient(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -487,7 +487,7 @@ public class AuthorisationHandler
             String persistentSessionId,
             TxmaAuditUser user) {
 
-        var session = existingSession.orElseGet(sessionService::createSession);
+        var session = existingSession.orElseGet(sessionService::generateSession);
         attachSessionIdToLogs(session);
 
         if (existingSession.isEmpty()) {
@@ -495,7 +495,7 @@ public class AuthorisationHandler
             LOG.info("Created session");
         } else {
             var previousSessionId = session.getSessionId();
-            sessionService.updateSessionId(session);
+            sessionService.updateWithNewSessionId(session);
             updateAttachedSessionIdToLogs(session.getSessionId());
             LOG.info("Updated session id from {} - new", previousSessionId);
         }
@@ -514,7 +514,7 @@ public class AuthorisationHandler
         session.addClientSession(clientSessionId);
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         updateAttachedLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
-        sessionService.save(session);
+        sessionService.storeOrUpdateSession(session);
         LOG.info("Session saved successfully");
 
         var state = new State();
@@ -577,7 +577,7 @@ public class AuthorisationHandler
                     authenticationRequest.getClientID().getValue(),
                     user);
         }
-        var session = existingSession.orElseGet(sessionService::createSession);
+        var session = existingSession.orElseGet(sessionService::generateSession);
         attachSessionIdToLogs(session);
 
         Optional<String> previousSessionId = existingSession.map(Session::getSessionId);
@@ -586,7 +586,7 @@ public class AuthorisationHandler
             LOG.info("Created session");
         } else {
             previousSessionId = Optional.of(session.getSessionId());
-            sessionService.updateSessionId(session);
+            sessionService.updateWithNewSessionId(session);
             updateAttachedSessionIdToLogs(session.getSessionId());
             LOG.info("Updated session id from {} - new", previousSessionId);
         }
@@ -604,7 +604,7 @@ public class AuthorisationHandler
         session.addClientSession(clientSessionId);
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         updateAttachedLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
-        sessionService.save(session);
+        sessionService.storeOrUpdateSession(session);
         LOG.info("Session saved successfully");
         return generateAuthRedirect(
                 session,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -198,7 +198,7 @@ class AuthenticationCallbackHandlerTest {
                 equalTo(REDIRECT_URI + "?code=" + AUTH_CODE_RP_TO_ORCH + "&state=" + RP_STATE));
         var savedSession = ArgumentCaptor.forClass(Session.class);
         verifyUserInfoRequest();
-        verify(sessionService).save(savedSession.capture());
+        verify(sessionService).storeOrUpdateSession(savedSession.capture());
         assertTrue(savedSession.getValue().isAuthenticated());
         assertEquals(savedSession.getValue().isNewAccount(), Session.AccountState.EXISTING);
 
@@ -659,7 +659,7 @@ class AuthenticationCallbackHandlerTest {
     }
 
     private void usingValidSession() {
-        when(sessionService.readSessionFromRedis(SESSION_ID)).thenReturn(Optional.of(session));
+        when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
     }
 
     private void usingValidClientSession() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -292,7 +292,7 @@ class AuthorisationHandlerTest {
                         authFrontend,
                         authorisationService);
         session = new Session("a-session-id");
-        when(sessionService.createSession()).thenReturn(session);
+        when(sessionService.generateSession()).thenReturn(session);
         when(clientSessionService.generateClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(clientSessionService.generateClientSession(any(), any(), any(), any()))
                 .thenReturn(clientSession);
@@ -327,7 +327,7 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).save(eq(session));
+            verify(sessionService).storeOrUpdateSession(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
             inOrder.verify(auditService)
@@ -465,7 +465,7 @@ class AuthorisationHandlerTest {
                                 .contains("lng="));
             }
 
-            verify(sessionService).save(session);
+            verify(sessionService).storeOrUpdateSession(session);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
             inOrder.verify(auditService)
@@ -504,7 +504,7 @@ class AuthorisationHandlerTest {
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
-            verify(sessionService).save(eq(session));
+            verify(sessionService).storeOrUpdateSession(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
             inOrder.verify(auditService)
@@ -573,7 +573,7 @@ class AuthorisationHandlerTest {
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
-            verify(sessionService).save(eq(session));
+            verify(sessionService).storeOrUpdateSession(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
             inOrder.verify(auditService)
@@ -614,7 +614,7 @@ class AuthorisationHandlerTest {
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
-            verify(sessionService).save(eq(session));
+            verify(sessionService).storeOrUpdateSession(eq(session));
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
             inOrder.verify(auditService)
@@ -1058,7 +1058,7 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).save(session);
+            verify(sessionService).storeOrUpdateSession(session);
 
             verify(requestObjectAuthorizeValidator).validate(any());
 
@@ -1105,7 +1105,7 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).save(session);
+            verify(sessionService).storeOrUpdateSession(session);
 
             inOrder.verify(auditService)
                     .submitAuditEvent(
@@ -1256,7 +1256,7 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).save(session);
+            verify(sessionService).storeOrUpdateSession(session);
 
             verify(requestObjectAuthorizeValidator).validate(any());
 
@@ -1602,7 +1602,7 @@ class AuthorisationHandlerTest {
             when(configService.isBrowserSessionCookieEnabled()).thenReturn(true);
             Session sessionWithBrowserSessionId =
                     new Session(SESSION_ID).withBrowserSessionId(BROWSER_SESSION_ID);
-            when(sessionService.createSession()).thenReturn(sessionWithBrowserSessionId);
+            when(sessionService.generateSession()).thenReturn(sessionWithBrowserSessionId);
 
             Map<String, String> requestParams = buildRequestParams(null);
             APIGatewayProxyRequestEvent event = withRequestEvent(requestParams);
@@ -1746,8 +1746,8 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         setupExistingSessionAndCookieInHeader(null, null);
 
-                verify(sessionService).createSession();
-                verify(sessionService).save(sessionCaptor.capture());
+                verify(sessionService).generateSession();
+                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 assertEquals(
                         NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
                 assertEquals(
@@ -1763,8 +1763,8 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         setupExistingSessionAndCookieInHeader(null, BROWSER_SESSION_ID);
 
-                verify(sessionService).createSession();
-                verify(sessionService).save(sessionCaptor.capture());
+                verify(sessionService).generateSession();
+                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 assertEquals(
                         NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
                 assertEquals(
@@ -1782,8 +1782,8 @@ class AuthorisationHandlerTest {
                                 new Session(SESSION_ID).withBrowserSessionId(BROWSER_SESSION_ID),
                                 null);
 
-                verify(sessionService).createSession();
-                verify(sessionService).save(sessionCaptor.capture());
+                verify(sessionService).generateSession();
+                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 assertEquals(
                         NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
                 assertEquals(
@@ -1801,8 +1801,8 @@ class AuthorisationHandlerTest {
                                 new Session(SESSION_ID).withBrowserSessionId(null),
                                 BROWSER_SESSION_ID);
 
-                verify(sessionService, never()).createSession();
-                verify(sessionService).save(sessionCaptor.capture());
+                verify(sessionService, never()).generateSession();
+                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 assertNull(sessionCaptor.getValue().getBrowserSessionId());
                 assertEquals(
                         2, response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).size());
@@ -1824,8 +1824,8 @@ class AuthorisationHandlerTest {
                                 new Session(SESSION_ID).withBrowserSessionId(BROWSER_SESSION_ID),
                                 BROWSER_SESSION_ID);
 
-                verify(sessionService, never()).createSession();
-                verify(sessionService).save(sessionCaptor.capture());
+                verify(sessionService, never()).generateSession();
+                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 assertEquals(BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
                 assertEquals(
                         format(
@@ -1842,8 +1842,8 @@ class AuthorisationHandlerTest {
                                 new Session(SESSION_ID).withBrowserSessionId(BROWSER_SESSION_ID),
                                 DIFFERENT_BROWSER_SESSION_ID);
 
-                verify(sessionService).createSession();
-                verify(sessionService).save(sessionCaptor.capture());
+                verify(sessionService).generateSession();
+                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 assertEquals(
                         NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
                 assertEquals(
@@ -1859,7 +1859,7 @@ class AuthorisationHandlerTest {
                 when(configService.isSignOutOnBrowserCloseEnabled()).thenReturn(true);
                 when(sessionService.getSessionFromSessionCookie(any()))
                         .thenReturn(Optional.ofNullable(existingSession));
-                when(sessionService.createSession())
+                when(sessionService.generateSession())
                         .thenReturn(
                                 new Session(NEW_SESSION_ID)
                                         .withBrowserSessionId(NEW_BROWSER_SESSION_ID));

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -117,9 +117,10 @@ public class AuthCodeResponseGenerationService {
 
     public void saveSession(boolean docAppJourney, SessionService sessionService, Session session) {
         if (docAppJourney) {
-            sessionService.save(session.setNewAccount(EXISTING_DOC_APP_JOURNEY));
+            sessionService.storeOrUpdateSession(session.setNewAccount(EXISTING_DOC_APP_JOURNEY));
         } else {
-            sessionService.save(session.setAuthenticated(true).setNewAccount(EXISTING));
+            sessionService.storeOrUpdateSession(
+                    session.setAuthenticated(true).setNewAccount(EXISTING));
         }
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -114,7 +114,7 @@ public class LogoutService {
             clientSessionService.deleteStoredClientSession(clientSessionId);
         }
         LOG.info("Deleting Session");
-        sessionService.deleteSessionFromRedis(session.getSessionId());
+        sessionService.deleteStoredSession(session.getSessionId());
     }
 
     public APIGatewayProxyResponseEvent handleLogout(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -191,7 +191,7 @@ class LogoutServiceTest {
                         rpPairwiseId);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(sessionService).deleteStoredSession(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
@@ -223,7 +223,7 @@ class LogoutServiceTest {
                         rpPairwiseId);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(sessionService).deleteStoredSession(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
@@ -255,7 +255,7 @@ class LogoutServiceTest {
                         rpPairwiseId);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(sessionService).deleteStoredSession(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
@@ -288,7 +288,7 @@ class LogoutServiceTest {
                         rpPairwiseId);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(sessionService).deleteStoredSession(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
@@ -331,7 +331,7 @@ class LogoutServiceTest {
                         session, event, CLIENT_ID, intervention);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(sessionService).deleteStoredSession(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
@@ -360,7 +360,7 @@ class LogoutServiceTest {
                         session, event, CLIENT_ID, intervention);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(sessionService).deleteStoredSession(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
@@ -400,7 +400,7 @@ class LogoutServiceTest {
                 rpPairwiseId);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(sessionService).deleteStoredSession(session.getSessionId());
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
                         argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
@@ -468,7 +468,7 @@ class LogoutServiceTest {
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
         verify(clientSessionService).deleteStoredClientSession("client-session-id-2");
         verify(clientSessionService).deleteStoredClientSession("client-session-id-3");
-        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(sessionService).deleteStoredSession(session.getSessionId());
         verify(auditService)
                 .submitAuditEvent(
                         LOG_OUT_SUCCESS,
@@ -514,7 +514,7 @@ class LogoutServiceTest {
                         session, event, CLIENT_ID, REAUTH_FAILURE_URI);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteSessionFromRedis(session.getSessionId());
+        verify(sessionService).deleteStoredSession(session.getSessionId());
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
                         argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -42,7 +42,7 @@ public class SessionService {
                         configurationService.getRedisPassword()));
     }
 
-    public void save(Session session) {
+    public void storeOrUpdateSession(Session session) {
         try {
             redisConnectionService.saveWithExpiry(
                     session.getSessionId(),
@@ -53,12 +53,12 @@ public class SessionService {
         }
     }
 
-    public void updateSessionId(Session session) {
+    public void updateWithNewSessionId(Session session) {
         try {
             String oldSessionId = session.getSessionId();
             session.setSessionId(IdGenerator.generate());
             session.resetProcessingIdentityAttempts();
-            save(session);
+            storeOrUpdateSession(session);
             redisConnectionService.deleteValue(oldSessionId);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -81,7 +81,7 @@ public class SessionService {
                 .flatMap(
                         id -> {
                             try {
-                                return readSessionFromRedis(id);
+                                return getSession(id);
                             } catch (Exception e) {
                                 throw new RuntimeException(e);
                             }
@@ -91,7 +91,7 @@ public class SessionService {
     public Optional<Session> getSessionFromSessionCookie(Map<String, String> headers) {
         try {
             Optional<CookieHelper.SessionCookieIds> ids = cookieHelper.parseSessionCookie(headers);
-            return ids.flatMap(s -> readSessionFromRedis(s.getSessionId()));
+            return ids.flatMap(s -> getSession(s.getSessionId()));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -101,7 +101,7 @@ public class SessionService {
         redisConnectionService.deleteValue(sessionId);
     }
 
-    public Optional<Session> readSessionFromRedis(String sessionId) {
+    public Optional<Session> getSession(String sessionId) {
         String serializedSession = redisConnectionService.getValue(sessionId);
         return Optional.ofNullable(serializedSession)
                 .map(s -> OBJECT_MAPPER.readValueUnchecked(s, Session.class));

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
@@ -37,7 +37,7 @@ class SessionServiceTest {
 
         var session = new Session("session-id").addClientSession("client-session-id");
 
-        sessionService.save(session);
+        sessionService.storeOrUpdateSession(session);
 
         verify(redis, times(1))
                 .saveWithExpiry("session-id", objectMapper.writeValueAsString(session), 1234L);
@@ -136,8 +136,8 @@ class SessionServiceTest {
     void shouldUpdateSessionIdInRedisAndDeleteOldKey() {
         var session = new Session("session-id").addClientSession("client-session-id");
 
-        sessionService.save(session);
-        sessionService.updateSessionId(session);
+        sessionService.storeOrUpdateSession(session);
+        sessionService.updateWithNewSessionId(session);
 
         verify(redis, times(2)).saveWithExpiry(anyString(), anyString(), anyLong());
         verify(redis).deleteValue("session-id");
@@ -147,7 +147,7 @@ class SessionServiceTest {
     void shouldDeleteSessionIdFromRedis() {
         var session = new Session("session-id").addClientSession("client-session-id");
 
-        sessionService.save(session);
+        sessionService.storeOrUpdateSession(session);
         sessionService.deleteSessionFromRedis(session.getSessionId());
 
         verify(redis).deleteValue("session-id");


### PR DESCRIPTION
## What

- Modified SessionService to allow Auch and Orch Sessions to contain fields that the other does not.
- Renamed SessionService methods to remove ambiguity and be consistent with method names in ClientSessionService.
    - save -> storeOrUpdate
    - updateSessionId -> updateWithNewSessionId
    - createSession -> generateSession

Note: I've made a second PR that removes some unused session fields and adds an integration test for the above change. The reason for splitting this into two PRs is that the above change needs to be in production before it's safe to remove any fields as there could be a race condition between Auth and Orch releases.

## How to review

Code Review

## Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

Part 2: https://github.com/govuk-one-login/authentication-api/pull/5145