### PR TITLE
ATO-995: Canary deployments cleanup

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -25,7 +25,6 @@ Parameters:
   LambdaDeploymentPreference:
     Type: String
     Description: Specifies the configuration to enable gradual Lambda deployments
-    Default: AllAtOnce
 
 Conditions:
   UsePermissionsBoundary: !Not [!Equals [none, !Ref PermissionsBoundary]]

--- a/template.yaml
+++ b/template.yaml
@@ -101,7 +101,6 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/8bc4e01c-466b-4663-9c60-c29d5e9f2fcf
       defaultProvisionedConcurrency: 0
       aisUriSecretId: 6b29b810-e509-4354-9d75-934d0f154d07
-      canaryDeploymentEnabled: true
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "6of9f4amvg"
@@ -133,7 +132,6 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/5fdfad8b-ca31-4afc-a948-59fd498c0f3c
       defaultProvisionedConcurrency: 1
       aisUriSecretId: fd6ef1f1-7d31-40ca-978d-2180199141d8
-      canaryDeploymentEnabled: true
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "1rvwudxmbk"
@@ -165,7 +163,6 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:758531536632:key/3d990d7b-0042-4115-8263-e6b472d84cc2
       defaultProvisionedConcurrency: 3
       aisUriSecretId: daea90b7-b7a9-45b1-98fb-7d9ce8da5a72
-      canaryDeploymentEnabled: true
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "k2skqhxed6"
@@ -197,7 +194,6 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/e34095ae-a65b-4609-99b3-9c1f407eff73
       defaultProvisionedConcurrency: 1
       aisUriSecretId: ""
-      canaryDeploymentEnabled: true
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       authApiId: "s4gj268zy6"
@@ -229,7 +225,6 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:172348255554:key/0e5c92f4-26a1-442d-a57b-87db810a40d1
       defaultProvisionedConcurrency: 3
       aisUriSecretId: ""
-      canaryDeploymentEnabled: true
   ProvisionedConcurrency:
     staging:
       TrustmarkFunction: 1
@@ -239,12 +234,6 @@ Mappings:
 Globals:
   Function:
     DeploymentPreference:
-      Enabled:
-        !FindInMap [
-          EnvironmentConfiguration,
-          !Ref Environment,
-          canaryDeploymentEnabled,
-        ]
       Type: !Ref LambdaDeploymentPreference
       Role: !GetAtt CodeDeployServiceRole.Arn
     Environment:


### PR DESCRIPTION
## What

Canary deployments are now enabled in all envs, so:
- Remove default value of `LambdaDeploymentPreference` so that this value is controlled by the pipeline parameter `LambdaCanaryDeployment`.
- Remove redundant `canaryDeploymentEnabled` feature flag.

This will be checked in build before promotion to higher envs.


