### PR TITLE
AUT-3529: Delete email & password counts on authentication

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -274,6 +274,17 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
         boolean termsAndConditionsAccepted = isTermsAndConditionsAccepted(userContext, userProfile);
 
+        if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
+            authenticationAttemptsService.deleteCount(
+                    userProfile.getSubjectID(),
+                    JourneyType.REAUTHENTICATION,
+                    CountType.ENTER_EMAIL);
+            authenticationAttemptsService.deleteCount(
+                    userProfile.getSubjectID(),
+                    JourneyType.REAUTHENTICATION,
+                    CountType.ENTER_PASSWORD);
+        }
+
         try {
             return generateApiGatewayProxyResponse(
                     200,


### PR DESCRIPTION
## What

This PR adds logic that deletes email and password authentication attempt counts when a user goes through the normal sign in journey. Previously, authenticating in this way would not effect counts when they should have been being reset.

The ticket states there was an issue with users being able to use silent logins to reset their email and password counts without re-authenticating, however when testing this was not a problem and counts were not being reset.

## How to review

For silent log in (to check the issue outlined in the ticket is not there, no code changes in this PR associated with silent login):

1. Go through sign in journey with isAuthenticationAttemptsServiceEnabled == true
2. Go through re-authentication journey up to enter password screen
3. Enter wrong password X number of times and check the count in dynamodb == X
4. In new tab, go to stub again getting taken to logged in page
5. Check that the count still == X

For deleting the account on successful authentication (related to changes in this PR):

1. Code review 
2. Sign in with isAuthenticationAttemptsServiceEnabled == true
3. Enter wrong password X number of times and check the count in dynamodb == X
4. In new incognito tab, sign in again
5. See that count has been deleted in dynamodb
