### PR TITLE
ATO-1006: Remove Unused Fields From Session Classes (2/2)

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -64,9 +64,7 @@ public class StartService {
         if (session.isAuthenticated() && userProfile.isEmpty()) {
             LOG.info(
                     "Session is authenticated but user profile is empty. Creating new session with existing sessionID");
-            session =
-                    new Session(session.getSessionId())
-                            .withBrowserSessionId(session.getBrowserSessionId());
+            session = new Session(session.getSessionId());
             session.addClientSession(clientSessionId);
             sessionService.storeOrUpdateSession(session);
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -115,7 +115,6 @@ class StartServiceTest {
         SESSION.setNewAccount(Session.AccountState.EXISTING);
         SESSION.setVerifiedMfaMethodType(MFAMethodType.AUTH_APP);
         SESSION.setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
-        SESSION.setBrowserSessionId("some-browser-session-id");
         var session = startService.validateSession(SESSION, currentClientSessionId);
 
         assertFalse(session.isAuthenticated());
@@ -124,7 +123,6 @@ class StartServiceTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         assertTrue(session.getClientSessions().contains("some-client-session-id"));
         assertFalse(session.getClientSessions().contains("previous-session-client-session-id"));
-        assertThat(session.getBrowserSessionId(), equalTo("some-browser-session-id"));
         verify(sessionService).storeOrUpdateSession(session);
     }
 
@@ -143,7 +141,6 @@ class StartServiceTest {
         SESSION.setNewAccount(Session.AccountState.EXISTING);
         SESSION.setVerifiedMfaMethodType(MFAMethodType.AUTH_APP);
         SESSION.setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
-        SESSION.setBrowserSessionId("some-browser-session-id");
         var session = startService.validateSession(SESSION, currentClientSessionId);
 
         assertTrue(session.isAuthenticated());
@@ -151,7 +148,6 @@ class StartServiceTest {
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         assertThat(session.isNewAccount(), equalTo(Session.AccountState.EXISTING));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
-        assertThat(session.getBrowserSessionId(), equalTo("some-browser-session-id"));
         assertTrue(session.getClientSessions().contains("some-client-session-id"));
         assertTrue(session.getClientSessions().contains("previous-session-client-session-id"));
         verifyNoInteractions(sessionService);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -30,10 +30,7 @@ public class Session {
 
     @Expose private int retryCount;
 
-    @Expose private int passwordResetCount;
-
     @Expose private Map<CodeRequestType, Integer> codeRequestCountMap;
-    @Expose private Map<CountType, Integer> preservedReauthCountsForAudit;
 
     @Expose private CredentialTrustLevel currentCredentialStrength;
 
@@ -96,20 +93,6 @@ public class Session {
 
     public Session setEmailAddress(String emailAddress) {
         this.emailAddress = emailAddress;
-        return this;
-    }
-
-    public int getPasswordResetCount() {
-        return passwordResetCount;
-    }
-
-    public Session incrementPasswordResetCount() {
-        this.passwordResetCount = passwordResetCount + 1;
-        return this;
-    }
-
-    public Session resetPasswordResetCount() {
-        this.passwordResetCount = 0;
         return this;
     }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -126,14 +126,6 @@ public class RedisExtension
                 session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
     }
 
-    public void incrementInitialProcessingIdentityAttemptsInSession(String sessionId)
-            throws Json.JsonException {
-        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.incrementProcessingIdentityAttempts();
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
-    }
-
     public void incrementPasswordCount(String email) {
         codeStorageService.increaseIncorrectPasswordCount(email);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -22,8 +22,6 @@ public class Session {
 
     @Expose private String sessionId;
 
-    @Expose private String browserSessionId;
-
     @Expose private List<String> clientSessions;
 
     @Expose private String emailAddress;
@@ -42,8 +40,6 @@ public class Session {
 
     @Expose private boolean authenticated;
 
-    @Expose private int processingIdentityAttempts;
-
     @Expose private MFAMethodType verifiedMfaMethodType;
 
     @Expose private String internalCommonSubjectIdentifier;
@@ -52,26 +48,12 @@ public class Session {
         this.sessionId = sessionId;
         this.clientSessions = new ArrayList<>();
         this.isNewAccount = AccountState.UNKNOWN;
-        this.processingIdentityAttempts = 0;
         this.codeRequestCountMap = new HashMap<>();
         initializeCodeRequestMap();
     }
 
     public String getSessionId() {
         return sessionId;
-    }
-
-    public String getBrowserSessionId() {
-        return browserSessionId;
-    }
-
-    public void setBrowserSessionId(String browserSessionId) {
-        this.browserSessionId = browserSessionId;
-    }
-
-    public Session withBrowserSessionId(String browserSessionId) {
-        this.browserSessionId = browserSessionId;
-        return this;
     }
 
     public Session setSessionId(String sessionId) {
@@ -183,19 +165,6 @@ public class Session {
     public Session setAuthenticated(boolean authenticated) {
         this.authenticated = authenticated;
         return this;
-    }
-
-    public int getProcessingIdentityAttempts() {
-        return processingIdentityAttempts;
-    }
-
-    public void resetProcessingIdentityAttempts() {
-        this.processingIdentityAttempts = 0;
-    }
-
-    public int incrementProcessingIdentityAttempts() {
-        this.processingIdentityAttempts += 1;
-        return processingIdentityAttempts;
     }
 
     public MFAMethodType getVerifiedMfaMethodType() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -4,7 +4,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
-import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.InputSanitiser;
 import uk.gov.di.authentication.shared.helpers.JsonUpdateHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -57,18 +56,6 @@ public class SessionService {
 
             redisConnectionService.saveWithExpiry(
                     session.getSessionId(), newSession, configurationService.getSessionExpiry());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void updateWithNewSessionId(Session session) {
-        try {
-            String oldSessionId = session.getSessionId();
-            session.setSessionId(IdGenerator.generate());
-            session.resetProcessingIdentityAttempts();
-            storeOrUpdateSession(session, oldSessionId);
-            redisConnectionService.deleteValue(oldSessionId);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
@@ -16,8 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -130,17 +128,6 @@ class SessionServiceTest {
                                         CookieHelper.REQUEST_COOKIE_HEADER, "gs=session-id.456;")));
 
         assertFalse(session.isPresent());
-    }
-
-    @Test
-    void shouldUpdateSessionIdInRedisAndDeleteOldKey() {
-        var session = new Session("session-id").addClientSession("client-session-id");
-
-        sessionService.storeOrUpdateSession(session);
-        sessionService.updateWithNewSessionId(session);
-
-        verify(redis, times(2)).saveWithExpiry(anyString(), anyString(), anyLong());
-        verify(redis).deleteValue("session-id");
     }
 
     @Test


### PR DESCRIPTION
## What

- Removed unused field _browserSessionId_ from Auth Session Class
- Removed unused field _processingIdentityAttempts_ from Auth Session Class
- Removed unused field _passwordResetCount_ from Orch Session Class
- Removed unused method _updateWithNewSessionId_ (formerly named _updateSessionId_) from Auth SessionService
- Replaced AuthOrchSerializationServicesIntegrationTest with SessionServiceIntegrationTest - The former tested only serialisation / deserialisation between Auth and Orch without simulating Redis.

Note: This is the second of two PRs and will require a rebase once the first goes in.

## How to review

Code Review

## Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

Part 1: https://github.com/govuk-one-login/authentication-api/pull/5133