### PR TITLE
Aut 3613/return reauth lock info from start handler

### DIFF
--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -10,6 +10,7 @@ module "frontend_api_start_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_authentication_attempt_read_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
@@ -26,16 +27,17 @@ module "start" {
   environment     = var.environment
 
   handler_environment_variables = {
-    TXMA_AUDIT_QUEUE_URL         = module.oidc_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT          = var.use_localstack ? var.localstack_endpoint : null
-    CUSTOM_DOC_APP_CLAIM_ENABLED = var.custom_doc_app_claim_enabled
-    DOC_APP_DOMAIN               = var.doc_app_domain
-    REDIS_KEY                    = local.redis_key
-    ENVIRONMENT                  = var.environment
-    DYNAMO_ENDPOINT              = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    HEADERS_CASE_INSENSITIVE     = var.use_localstack ? "true" : "false"
-    IDENTITY_ENABLED             = var.ipv_api_enabled
-    INTERNAl_SECTOR_URI          = var.internal_sector_uri
+    TXMA_AUDIT_QUEUE_URL                    = module.oidc_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT                     = var.use_localstack ? var.localstack_endpoint : null
+    CUSTOM_DOC_APP_CLAIM_ENABLED            = var.custom_doc_app_claim_enabled
+    DOC_APP_DOMAIN                          = var.doc_app_domain
+    REDIS_KEY                               = local.redis_key
+    ENVIRONMENT                             = var.environment
+    DYNAMO_ENDPOINT                         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    HEADERS_CASE_INSENSITIVE                = var.use_localstack ? "true" : "false"
+    IDENTITY_ENABLED                        = var.ipv_api_enabled
+    INTERNAl_SECTOR_URI                     = var.internal_sector_uri
+    AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED = var.authentication_attempts_service_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.StartHandler::handleRequest"
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
@@ -12,4 +12,5 @@ public record UserStartInfo(
         @SerializedName("cookieConsent") @Expose String cookieConsent,
         @SerializedName("gaCrossDomainTrackingId") @Expose String gaCrossDomainTrackingId,
         @SerializedName("docCheckingAppUser") @Expose boolean isDocCheckingAppUser,
-        @SerializedName("mfaMethodType") @Expose MFAMethodType mfaMethodType) {}
+        @SerializedName("mfaMethodType") @Expose MFAMethodType mfaMethodType,
+        @SerializedName("isBlockedForReauth") @Expose boolean isBlockedForReauth) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -122,9 +122,6 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                     .flatMap(
                             userProfile -> {
                                 if (hasEnteredIncorrectEmailTooManyTimes(userProfile)) {
-                                    if (configurationService.supportReauthSignoutEnabled()) {
-                                        clearCountOfFailedEmailEntryAttempts(userProfile);
-                                    }
                                     throw new AccountLockedException(
                                             "Account is locked due to too many failed attempts.",
                                             ErrorResponse.ERROR_1057);
@@ -199,9 +196,6 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
             String email, AuditContext auditContext) {
         var userProfile = authenticationService.getUserProfileByEmail(email);
         if (hasEnteredIncorrectEmailTooManyTimes(userProfile)) {
-            if (configurationService.supportReauthSignoutEnabled()) {
-                clearCountOfFailedEmailEntryAttempts(userProfile);
-            }
             throw new AccountLockedException(
                     "Account is locked due to too many failed attempts.", ErrorResponse.ERROR_1057);
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -152,6 +152,10 @@ public class StartHandler
                     "reauthenticateHeader: {} reauthenticate: {}",
                     reauthenticateHeader,
                     reauthenticate);
+            Optional<String> maybeInternalSubjectId =
+                    userContext.getUserProfile().map(UserProfile::getSubjectID);
+            Optional<String> maybeInternalCommonSubjectIdentifier =
+                    Optional.ofNullable(session.getInternalCommonSubjectIdentifier());
             var userStartInfo =
                     startService.buildUserStartInfo(
                             userContext,
@@ -177,19 +181,16 @@ public class StartHandler
 
             StartResponse startResponse = new StartResponse(userStartInfo, clientStartInfo);
 
-            String internalSubjectId = AuditService.UNKNOWN;
-            String internalCommonSubjectIdentifier = AuditService.UNKNOWN;
+            String internalSubjectIdForAuditEvent = AuditService.UNKNOWN;
+            String internalCommonSubjectIdentifierForAuditEvent = AuditService.UNKNOWN;
+
             if (userStartInfo.isAuthenticated()) {
                 LOG.info(
-                        "User is authenticated. Setting internalCommonSubjectId and internalSubjectId");
-                internalCommonSubjectIdentifier =
-                        Optional.ofNullable(session.getInternalCommonSubjectIdentifier())
-                                .orElse(AuditService.UNKNOWN);
-                internalSubjectId =
-                        userContext
-                                .getUserProfile()
-                                .map(UserProfile::getSubjectID)
-                                .orElse(AuditService.UNKNOWN);
+                        "User is authenticated. Setting internalCommonSubjectId and internalSubjectId for audit event");
+                internalCommonSubjectIdentifierForAuditEvent =
+                        maybeInternalCommonSubjectIdentifier.orElse(AuditService.UNKNOWN);
+                internalSubjectIdForAuditEvent =
+                        maybeInternalSubjectId.orElse(AuditService.UNKNOWN);
             }
 
             var txmaAuditHeader =
@@ -200,7 +201,7 @@ public class StartHandler
                             userContext.getClient().get().getClientID(),
                             clientSessionId,
                             session.getSessionId(),
-                            internalCommonSubjectIdentifier,
+                            internalCommonSubjectIdentifierForAuditEvent,
                             userContext
                                     .getUserProfile()
                                     .map(UserProfile::getEmail)
@@ -213,7 +214,7 @@ public class StartHandler
             auditService.submitAuditEvent(
                     FrontendAuditableEvent.AUTH_START_INFO_FOUND,
                     auditContext,
-                    pair("internalSubjectId", internalSubjectId));
+                    pair("internalSubjectId", internalSubjectIdForAuditEvent));
 
             return generateApiGatewayProxyResponse(200, startResponse);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -88,7 +88,8 @@ public class StartHandler
                         new DynamoClientService(configurationService),
                         new DynamoService(configurationService),
                         sessionService,
-                        reauthAttemptsHelper);
+                        reauthAttemptsHelper,
+                        configurationService);
         this.configurationService = configurationService;
     }
 
@@ -108,7 +109,8 @@ public class StartHandler
                         new DynamoClientService(configurationService),
                         new DynamoService(configurationService),
                         sessionService,
-                        reauthAttemptsHelper);
+                        reauthAttemptsHelper,
+                        configurationService);
         this.configurationService = configurationService;
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -188,7 +188,8 @@ public class StartService {
                 cookieConsent,
                 gaTrackingId,
                 docCheckingAppUser,
-                mfaMethodType);
+                mfaMethodType,
+                false);
     }
 
     private boolean authApp(UserContext userContext) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -287,7 +287,6 @@ class CheckReAuthUserHandlerTest {
 
         verify(authenticationService, atLeastOnce())
                 .getUserProfileByEmailMaybe(EMAIL_USED_TO_SIGN_IN);
-        verify(codeStorageService, atLeastOnce()).getIncorrectEmailCount(any());
 
         verify(auditService)
                 .submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -183,7 +183,7 @@ class LoginHandlerReauthenticationRedisTest {
     @ParameterizedTest
     @EnumSource(MFAMethodType.class)
     void
-            shouldReturnErrorAndNotLockUserAccountOutAfterMaxNumberOfIncorrectPasswordsPresentedDuringReauthJourney(
+            shouldReturnErrorNotDeleteCountAndNotLockUserAccountOutAfterMaxNumberOfIncorrectPasswordsPresentedDuringReauthJourney(
                     MFAMethodType mfaMethodType) {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
@@ -208,7 +208,7 @@ class LoginHandlerReauthenticationRedisTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1028));
 
         verify(codeStorageService).getIncorrectPasswordCountReauthJourney(EMAIL);
-        verify(codeStorageService).deleteIncorrectPasswordCountReauthJourney(EMAIL);
+        verify(codeStorageService, never()).deleteIncorrectPasswordCountReauthJourney(EMAIL);
         verify(codeStorageService, never()).saveBlockedForEmail(any(), any(), anyLong());
 
         verify(auditService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -188,8 +188,9 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
 
     @ParameterizedTest
     @EnumSource(MFAMethodType.class)
-    void shouldReturnErrorAndNotLockUserAccountOutAfterMaxNumberOfIncorrectPasswordsPresented(
-            MFAMethodType mfaMethodType) {
+    void
+            shouldReturnErrorNotDeleteCountAndNotLockUserAccountOutAfterMaxNumberOfIncorrectPasswordsPresented(
+                    MFAMethodType mfaMethodType) {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
@@ -213,7 +214,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1028));
 
         verify(authenticationAttemptsService).getCount(any(), any(), any());
-        verify(authenticationAttemptsService).deleteCount(any(), any(), any());
+        verify(authenticationAttemptsService, never()).deleteCount(any(), any(), any());
 
         verify(auditService)
                 .submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -466,7 +466,7 @@ class LoginHandlerTest {
     @ParameterizedTest
     @EnumSource(MFAMethodType.class)
     void
-            shouldReturnErrorAndNotLockUserAccountOutAfterMaxNumberOfIncorrectPasswordsPresentedDuringReauthJourney(
+            shouldReturnErrorNotLockUserAccountAndRetainCountsOutAfterMaxNumberOfIncorrectPasswordsPresentedDuringReauthJourney(
                     MFAMethodType mfaMethodType) {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
@@ -489,7 +489,7 @@ class LoginHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1028));
 
         verify(codeStorageService).getIncorrectPasswordCountReauthJourney(EMAIL);
-        verify(codeStorageService).deleteIncorrectPasswordCountReauthJourney(EMAIL);
+        verify(codeStorageService, never()).deleteIncorrectPasswordCountReauthJourney(EMAIL);
         verify(codeStorageService, never()).saveBlockedForEmail(any(), any(), anyLong());
 
         verify(auditService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.frontendapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -57,7 +56,6 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -78,6 +76,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.DI_PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.ENCODED_DEVICE_DETAILS;
@@ -89,7 +88,6 @@ import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LE
 import static uk.gov.di.authentication.shared.entity.MFAMethodType.SMS;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
-import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -218,7 +216,7 @@ class LoginHandlerTest {
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
 
         // Act
         var result = handler.handleRequest(event, context);
@@ -270,7 +268,7 @@ class LoginHandlerTest {
         usingApplicableUserCredentialsWithLogin(SMS, true);
 
         var event =
-                eventWithHeadersAndBody(
+                apiRequestEventWithHeadersAndBody(
                         VALID_HEADERS_WITHOUT_AUDIT_ENCODED, validBodyWithEmailAndPassword);
 
         var result = handler.handleRequest(event, context);
@@ -295,7 +293,7 @@ class LoginHandlerTest {
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
@@ -318,7 +316,7 @@ class LoginHandlerTest {
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
@@ -353,7 +351,7 @@ class LoginHandlerTest {
 
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
@@ -380,7 +378,7 @@ class LoginHandlerTest {
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
         assertThat(result, hasStatus(200));
 
@@ -415,7 +413,7 @@ class LoginHandlerTest {
         usingValidSession();
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
@@ -442,7 +440,7 @@ class LoginHandlerTest {
         usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -483,7 +481,7 @@ class LoginHandlerTest {
         usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithReauthJourney);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithReauthJourney);
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -524,7 +522,7 @@ class LoginHandlerTest {
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -557,7 +555,7 @@ class LoginHandlerTest {
         usingValidSession();
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         handler.handleRequest(event, context);
 
         when(authenticationService.login(applicableUserCredentials, CommonTestVariables.PASSWORD))
@@ -583,7 +581,7 @@ class LoginHandlerTest {
         usingValidSession();
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         verify(auditService)
@@ -616,7 +614,7 @@ class LoginHandlerTest {
 
         var body = isReauthJourney ? validBodyWithReauthJourney : validBodyWithEmailAndPassword;
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, body);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
         handler.handleRequest(event, context);
 
         if (isReauthJourney && isReauthEnabled) {
@@ -643,7 +641,7 @@ class LoginHandlerTest {
         usingValidSession();
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(401));
@@ -655,7 +653,7 @@ class LoginHandlerTest {
     @Test
     void shouldReturn400IfAnyRequestParametersAreMissing() {
         var bodyWithoutEmail = format("{ \"password\": \"%s\"}", CommonTestVariables.PASSWORD);
-        var event = eventWithHeadersAndBody(VALID_HEADERS, bodyWithoutEmail);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, bodyWithoutEmail);
 
         usingValidSession();
         usingDefaultVectorOfTrust();
@@ -669,7 +667,7 @@ class LoginHandlerTest {
 
     @Test
     void shouldReturn400IfSessionIdIsInvalid() {
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
 
         when(sessionService.getSessionFromRequestHeaders(event.getHeaders()))
                 .thenReturn(Optional.empty());
@@ -689,7 +687,7 @@ class LoginHandlerTest {
         usingValidSession();
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         verify(auditService)
@@ -716,7 +714,7 @@ class LoginHandlerTest {
         usingApplicableUserCredentialsWithLogin(SMS, true);
         usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
@@ -746,7 +744,7 @@ class LoginHandlerTest {
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
 
         // Act
         var result = handler.handleRequest(event, context);
@@ -843,15 +841,6 @@ class LoginHandlerTest {
                                 new ClientRegistry()
                                         .withSmokeTest(true)
                                         .withClientID(CLIENT_ID.getValue())));
-    }
-
-    private APIGatewayProxyRequestEvent eventWithHeadersAndBody(
-            Map<String, String> headers, String body) {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setRequestContext(contextWithSourceIp(IP_ADDRESS));
-        event.setHeaders(headers);
-        event.setBody(body);
-        return event;
     }
 
     private void verifySessionIsSaved() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -154,7 +154,12 @@ class StartHandlerTest {
         when(startService.getCookieConsentValue(anyMap(), anyString()))
                 .thenReturn(cookieConsentValue);
         when(startService.buildUserStartInfo(
-                        userContext, cookieConsentValue, gaTrackingId, true, false))
+                        userContext,
+                        cookieConsentValue,
+                        gaTrackingId,
+                        true,
+                        false,
+                        Optional.empty()))
                 .thenReturn(userStartInfo);
         usingValidClientSession();
         usingValidSession();
@@ -201,7 +206,8 @@ class StartHandlerTest {
                                 false));
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
-        when(startService.buildUserStartInfo(userContext, null, null, true, false))
+        when(startService.buildUserStartInfo(
+                        userContext, null, null, true, false, Optional.empty()))
                 .thenReturn(userStartInfo);
         usingValidDocAppClientSession();
         usingValidSession();
@@ -242,7 +248,7 @@ class StartHandlerTest {
         when(startService.buildClientStartInfo(userContext)).thenReturn(getClientStartInfo());
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
-        when(startService.buildUserStartInfo(userContext, null, null, true, true))
+        when(startService.buildUserStartInfo(userContext, null, null, true, true, Optional.empty()))
                 .thenReturn(new UserStartInfo(false, false, false, null, null, false, null, false));
         usingValidSession();
         usingValidClientSession();
@@ -274,7 +280,7 @@ class StartHandlerTest {
         when(startService.buildClientStartInfo(userContext)).thenReturn(getClientStartInfo());
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
-        when(startService.buildUserStartInfo(userContext, null, null, true, true))
+        when(startService.buildUserStartInfo(userContext, null, null, true, true, Optional.empty()))
                 .thenReturn(new UserStartInfo(false, false, false, null, null, false, null, false));
         usingValidSession();
         usingValidClientSession();
@@ -303,7 +309,8 @@ class StartHandlerTest {
         when(startService.buildClientStartInfo(userContext)).thenReturn(getClientStartInfo());
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
-        when(startService.buildUserStartInfo(userContext, null, null, true, false))
+        when(startService.buildUserStartInfo(
+                        userContext, null, null, true, false, Optional.empty()))
                 .thenReturn(new UserStartInfo(false, false, true, null, null, false, null, false));
         usingValidSession();
         usingValidClientSession();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -187,7 +187,7 @@ class StartHandlerTest {
         when(userContext.getClientSession()).thenReturn(docAppClientSession);
         when(configurationService.getDocAppDomain()).thenReturn(URI.create("https://doc-app"));
         when(startService.validateSession(session, CLIENT_SESSION_ID)).thenReturn(session);
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, true, null);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, true, null, false);
         when(startService.buildUserContext(session, docAppClientSession)).thenReturn(userContext);
         when(startService.buildClientStartInfo(userContext))
                 .thenReturn(
@@ -243,7 +243,7 @@ class StartHandlerTest {
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
         when(startService.buildUserStartInfo(userContext, null, null, true, true))
-                .thenReturn(new UserStartInfo(false, false, false, null, null, false, null));
+                .thenReturn(new UserStartInfo(false, false, false, null, null, false, null, false));
         usingValidSession();
         usingValidClientSession();
 
@@ -275,7 +275,7 @@ class StartHandlerTest {
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
         when(startService.buildUserStartInfo(userContext, null, null, true, true))
-                .thenReturn(new UserStartInfo(false, false, false, null, null, false, null));
+                .thenReturn(new UserStartInfo(false, false, false, null, null, false, null, false));
         usingValidSession();
         usingValidClientSession();
 
@@ -304,7 +304,7 @@ class StartHandlerTest {
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
         when(startService.buildUserStartInfo(userContext, null, null, true, false))
-                .thenReturn(new UserStartInfo(false, false, true, null, null, false, null));
+                .thenReturn(new UserStartInfo(false, false, true, null, null, false, null, false));
         usingValidSession();
         usingValidClientSession();
 
@@ -460,6 +460,6 @@ class StartHandlerTest {
 
     private UserStartInfo getUserStartInfo(String cookieConsent, String gaCrossDomainTrackingId) {
         return new UserStartInfo(
-                false, false, true, cookieConsent, gaCrossDomainTrackingId, false, null);
+                false, false, true, cookieConsent, gaCrossDomainTrackingId, false, null, false);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -227,6 +227,7 @@ class StartServiceTest {
         assertThat(userStartInfo.gaCrossDomainTrackingId(), equalTo(gaTrackingId));
         assertThat(userStartInfo.isDocCheckingAppUser(), equalTo(false));
         assertThat(userStartInfo.isAuthenticated(), equalTo(isAuthenticated));
+        assertThat(userStartInfo.isBlockedForReauth(), equalTo(false));
     }
 
     private static Stream<Arguments> userStartIdentityInfo() {
@@ -266,11 +267,7 @@ class StartServiceTest {
                         false,
                         Optional.empty());
 
-        assertThat(userStartInfo.isUpliftRequired(), equalTo(false));
         assertThat(userStartInfo.isIdentityRequired(), equalTo(expectedIdentityRequiredValue));
-        assertThat(userStartInfo.cookieConsent(), equalTo("some-cookie-consent"));
-        assertThat(userStartInfo.gaCrossDomainTrackingId(), equalTo("some-ga-tracking-id"));
-        assertThat(userStartInfo.isDocCheckingAppUser(), equalTo(false));
     }
 
     @ParameterizedTest
@@ -358,11 +355,6 @@ class StartServiceTest {
                         false,
                         Optional.empty());
 
-        assertThat(userStartInfo.isUpliftRequired(), equalTo(false));
-        assertThat(userStartInfo.isIdentityRequired(), equalTo(false));
-        assertThat(userStartInfo.isAuthenticated(), equalTo(false));
-        assertThat(userStartInfo.cookieConsent(), equalTo("some-cookie-consent"));
-        assertThat(userStartInfo.gaCrossDomainTrackingId(), equalTo("some-ga-tracking-id"));
         assertThat(userStartInfo.isDocCheckingAppUser(), equalTo(true));
     }
 
@@ -483,8 +475,7 @@ class StartServiceTest {
     }
 
     @Test
-    void shouldCreateUserStartInfoWithAuthenticatedFalseWhenReauthenticationIsTrue()
-            throws NoSuchAlgorithmException, JOSEException {
+    void shouldCreateUserStartInfoWithAuthenticatedFalseWhenReauthenticationIsTrue() {
         when(dynamoService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(
                         Optional.of(
@@ -493,20 +484,9 @@ class StartServiceTest {
                                         .withSubjectID(new Subject().getValue())));
 
         SESSION.setAuthenticated(true);
-        var userContext =
-                buildUserContext(
-                        null,
-                        false,
-                        ClientType.WEB,
-                        generateSignedJWT(),
-                        true,
-                        true,
-                        Optional.empty(),
-                        Optional.empty(),
-                        false);
         var userStartInfo =
                 startService.buildUserStartInfo(
-                        userContext,
+                        basicUserContext,
                         "some-cookie-consent",
                         "some-ga-tracking-id",
                         true,
@@ -551,11 +531,6 @@ class StartServiceTest {
                         Optional.empty());
 
         assertThat(userStartInfo.isUpliftRequired(), equalTo(expectedUpliftRequiredValue));
-        assertThat(userStartInfo.isIdentityRequired(), equalTo(expectedIdentityRequiredValue));
-        assertThat(userStartInfo.cookieConsent(), equalTo("some-cookie-consent"));
-        assertThat(userStartInfo.gaCrossDomainTrackingId(), equalTo("some-ga-tracking-id"));
-        assertThat(userStartInfo.isDocCheckingAppUser(), equalTo(false));
-        assertThat(userStartInfo.mfaMethodType(), equalTo(expectedMfaMethodType));
     }
 
     @ParameterizedTest

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -120,7 +120,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 "cookieConsent":null,
                 "gaCrossDomainTrackingId":null,
                 "docCheckingAppUser":false,
-                "mfaMethodType":null}
+                "mfaMethodType":null,
+                "isBlockedForReauth":false}
                 """,
                         identityRequired, isAuthenticated);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelper.java
@@ -1,0 +1,40 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Map;
+
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_AUTH_APP_CODE;
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_SMS_CODE;
+
+public class ReauthAuthenticationAttemptsHelper {
+    private AuthenticationAttemptsService authenticationAttemptsService;
+    private ConfigurationService configurationService;
+    private static final JourneyType JOURNEY_TYPE = JourneyType.REAUTHENTICATION;
+
+    public ReauthAuthenticationAttemptsHelper(
+            ConfigurationService configurationService,
+            AuthenticationAttemptsService authenticationAttemptsService) {
+        this.configurationService = configurationService;
+        this.authenticationAttemptsService = authenticationAttemptsService;
+    }
+
+    public boolean isBlockedForReauth(String internalSubjectId) {
+        var reauthRelevantCountsToMaxRetries =
+                Map.ofEntries(
+                        Map.entry(ENTER_EMAIL, configurationService.getMaxEmailReAuthRetries()),
+                        Map.entry(ENTER_PASSWORD, configurationService.getMaxPasswordRetries()),
+                        Map.entry(ENTER_SMS_CODE, configurationService.getCodeMaxRetries()),
+                        Map.entry(ENTER_AUTH_APP_CODE, configurationService.getCodeMaxRetries()));
+        return reauthRelevantCountsToMaxRetries.entrySet().stream()
+                .anyMatch(
+                        entry ->
+                                authenticationAttemptsService.getCount(
+                                                internalSubjectId, JOURNEY_TYPE, entry.getKey())
+                                        >= entry.getValue());
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelperTest.java
@@ -1,0 +1,82 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.shared.entity.CountType;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ReauthAuthenticationAttemptsHelperTest {
+    private static final String SUBJECT_ID = new Subject().getValue();
+    private final AuthenticationAttemptsService authenticationAttemptsService =
+            mock(AuthenticationAttemptsService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final ReauthAuthenticationAttemptsHelper helper =
+            new ReauthAuthenticationAttemptsHelper(
+                    configurationService, authenticationAttemptsService);
+
+    private static Stream<Arguments> reauthRelevantCounts() {
+        return Stream.of(
+                Arguments.of(CountType.ENTER_EMAIL),
+                Arguments.of(CountType.ENTER_PASSWORD),
+                Arguments.of(CountType.ENTER_SMS_CODE),
+                Arguments.of(CountType.ENTER_AUTH_APP_CODE));
+    }
+
+    private void setupConfigurationServiceCountForCountType(
+            CountType countType, int retriesAllowed) {
+        switch (countType) {
+            case ENTER_EMAIL -> when(configurationService.getMaxEmailReAuthRetries())
+                    .thenReturn(retriesAllowed);
+            case ENTER_PASSWORD -> when(configurationService.getMaxPasswordRetries())
+                    .thenReturn(retriesAllowed);
+            case ENTER_AUTH_APP_CODE, ENTER_SMS_CODE, ENTER_EMAIL_CODE -> when(configurationService
+                            .getCodeMaxRetries())
+                    .thenReturn(retriesAllowed);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("reauthRelevantCounts")
+    void isBlockedForReauthReturnsTrueWhenAnyRelevantCountTypeExceedsTheThreshold(
+            CountType countThatExceedsMax) {
+        // Setup all counts to not exceed the max so we can isolate just the one that does exceed
+        // subsequently
+        Arrays.stream(CountType.values()).forEach(this::setupCountThatDoesNotExceedMax);
+
+        var retriesAllowed = 5;
+        setupConfigurationServiceCountForCountType(countThatExceedsMax, retriesAllowed);
+        when(authenticationAttemptsService.getCount(
+                        SUBJECT_ID, JourneyType.REAUTHENTICATION, countThatExceedsMax))
+                .thenReturn(retriesAllowed + 1);
+
+        assertTrue(helper.isBlockedForReauth(SUBJECT_ID));
+    }
+
+    @Test
+    void isBlockedForReauthReturnsTrueWhenNoCountExceedsTheThreshold() {
+        Arrays.stream(CountType.values()).forEach(this::setupCountThatDoesNotExceedMax);
+
+        assertFalse(helper.isBlockedForReauth(SUBJECT_ID));
+    }
+
+    private void setupCountThatDoesNotExceedMax(CountType count) {
+        var maxRetries = 4;
+        when(authenticationAttemptsService.getCount(
+                        SUBJECT_ID, JourneyType.REAUTHENTICATION, count))
+                .thenReturn(maxRetries - 1);
+        setupConfigurationServiceCountForCountType(count, maxRetries);
+    }
+}


### PR DESCRIPTION
## What

Returns reauth lock information from the start handler if the feature flag to use the new authentication attempts service is on.

Also removes the existing deletion of the counts, since we are going to retain these in order to return blocked information.

This is currently unused on the frontend, but a subsequent PR will respond on the frontend in the case of a reauth journey where someone is blocked.

## How to review

1. Code Review commit by commit

How I've tested this (you can choose to do the same or trust me):
1. Deploy to a test env, with the relevant reauth feature flags on
1. Open two different browsers. Log in in both
1. Start a reauth journey in one. Enter the wrong email or the wrong password to the point where you're logged out
1. Start a reauth journey in your other browser, just to the point where you hit the enter email page. You won't be blocked, but check the logs for the start handler and see that for this last call, isBlockedForReauth is true

Note! You need to do this all quite quickly to make sure sessions and ttls don't expire, worth getting it well set up in advance. 

1. Then check that for a journey with the feature flags off, nothing mad happens.

