### PR TITLE
ATO-984: Include `previousSessionId` as claim in authorize request to Auth

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -1,0 +1,6 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public record StartRequest(@Expose @SerializedName("old-session-id") String oldSessionId) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -3,4 +3,5 @@ package uk.gov.di.authentication.frontendapi.entity;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public record StartRequest(@Expose @SerializedName("old-session-id") String oldSessionId) {}
+public record StartRequest(
+        @Expose @SerializedName("previous-session-id") String previousSessionId) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -182,8 +182,9 @@ public class StartHandler
                     Optional.ofNullable(session.getInternalCommonSubjectIdentifier());
 
             StartRequest startRequest = objectMapper.readValue(input.getBody(), StartRequest.class);
-            Optional<String> oldSessionId = Optional.ofNullable(startRequest.oldSessionId());
-            LOG.info("oldSessionId: {}", oldSessionId);
+            Optional<String> previousSessionId =
+                    Optional.ofNullable(startRequest.previousSessionId());
+            LOG.info("previousSessionId: {}", previousSessionId);
 
             var userStartInfo =
                     startService.buildUserStartInfo(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -53,6 +53,7 @@ public class StartHandler
     private static final Logger LOG = LogManager.getLogger(StartHandler.class);
 
     protected static final String REAUTHENTICATE_HEADER = "Reauthenticate";
+    protected static final String OLD_SESSION_ID_HEADER = "Old-Session-Id";
     private final ClientSessionService clientSessionService;
     private final SessionService sessionService;
     private final AuditService auditService;
@@ -176,6 +177,13 @@ public class StartHandler
                     userContext.getUserProfile().map(UserProfile::getSubjectID);
             Optional<String> maybeInternalCommonSubjectIdentifier =
                     Optional.ofNullable(session.getInternalCommonSubjectIdentifier());
+
+            var oldSessionId =
+                    getOptionalHeaderValueFromHeaders(
+                            input.getHeaders(),
+                            OLD_SESSION_ID_HEADER,
+                            configurationService.getHeadersCaseInsensitive());
+            LOG.info("oldSessionId: {}", oldSessionId);
             var userStartInfo =
                     startService.buildUserStartInfo(
                             userContext,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -66,6 +66,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final State STATE = new State();
     public static final String ENCODED_DEVICE_INFORMATION =
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
+    public static final String REQUEST_BODY =
+            "{\"old-session-id\":\"4waJ14KA9IyxKzY7bIGIA3hUDos\"}";
 
     @BeforeEach
     void setup() {
@@ -107,7 +109,10 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         registerClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR(), ClientType.WEB);
 
         var response =
-                makeRequest(Optional.empty(), standardHeadersWithSessionId(sessionId), Map.of());
+                makeRequest(
+                        Optional.of(REQUEST_BODY),
+                        standardHeadersWithSessionId(sessionId),
+                        Map.of());
         assertThat(response, hasStatus(200));
 
         var user =
@@ -172,7 +177,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var headers = standardHeadersWithSessionId(sessionId);
         headers.put("Reauthenticate", "true");
 
-        var response = makeRequest(Optional.empty(), headers, Map.of());
+        var response = makeRequest(Optional.of(REQUEST_BODY), headers, Map.of());
         assertThat(response, hasStatus(200));
 
         StartResponse startResponse =
@@ -220,7 +225,10 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         registerClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR(), ClientType.WEB);
 
         var response =
-                makeRequest(Optional.empty(), standardHeadersWithSessionId(sessionId), Map.of());
+                makeRequest(
+                        Optional.of(REQUEST_BODY),
+                        standardHeadersWithSessionId(sessionId),
+                        Map.of());
         assertThat(response, hasStatus(200));
 
         StartResponse startResponse =
@@ -268,7 +276,10 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         registerClient(keyPair, ClientType.APP);
 
         var response =
-                makeRequest(Optional.empty(), standardHeadersWithSessionId(sessionId), Map.of());
+                makeRequest(
+                        Optional.of(REQUEST_BODY),
+                        standardHeadersWithSessionId(sessionId),
+                        Map.of());
         assertThat(response, hasStatus(200));
 
         var startResponse = objectMapper.readValue(response.getBody(), StartResponse.class);
@@ -306,7 +317,10 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         registerClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR(), ClientType.WEB);
 
         var response =
-                makeRequest(Optional.empty(), standardHeadersWithSessionId(sessionId), Map.of());
+                makeRequest(
+                        Optional.of(REQUEST_BODY),
+                        standardHeadersWithSessionId(sessionId),
+                        Map.of());
 
         assertThat(response, hasStatus(200));
         assertThat(redis.getSession(sessionId).isAuthenticated(), equalTo(false));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -67,7 +67,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     public static final String ENCODED_DEVICE_INFORMATION =
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
     public static final String REQUEST_BODY =
-            "{\"old-session-id\":\"4waJ14KA9IyxKzY7bIGIA3hUDos\"}";
+            "{\"previous-session-id\":\"4waJ14KA9IyxKzY7bIGIA3hUDos\"}";
 
     @BeforeEach
     void setup() {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -481,10 +481,10 @@ public class AuthorisationHandler
             updateAttachedSessionIdToLogs(session.getSessionId());
             LOG.info("Created session");
         } else {
-            var oldSessionId = session.getSessionId();
+            var previousSessionId = session.getSessionId();
             sessionService.updateSessionId(session);
             updateAttachedSessionIdToLogs(session.getSessionId());
-            LOG.info("Updated session id from {} - new", oldSessionId);
+            LOG.info("Updated session id from {} - new", previousSessionId);
         }
 
         Subject subjectId =
@@ -567,15 +567,15 @@ public class AuthorisationHandler
         var session = existingSession.orElseGet(sessionService::createSession);
         attachSessionIdToLogs(session);
 
-        Optional<String> oldSessionId = existingSession.map(Session::getSessionId);
+        Optional<String> previousSessionId = existingSession.map(Session::getSessionId);
         if (existingSession.isEmpty()) {
             updateAttachedSessionIdToLogs(session.getSessionId());
             LOG.info("Created session");
         } else {
-            oldSessionId = Optional.of(session.getSessionId());
+            previousSessionId = Optional.of(session.getSessionId());
             sessionService.updateSessionId(session);
             updateAttachedSessionIdToLogs(session.getSessionId());
-            LOG.info("Updated session id from {} - new", oldSessionId);
+            LOG.info("Updated session id from {} - new", previousSessionId);
         }
 
         user = user.withSessionId(session.getSessionId());
@@ -602,7 +602,7 @@ public class AuthorisationHandler
                 reauthRequested,
                 vtrList,
                 user,
-                oldSessionId);
+                previousSessionId);
     }
 
     private APIGatewayProxyResponseEvent generateAuthRedirect(
@@ -614,7 +614,7 @@ public class AuthorisationHandler
             boolean reauthRequested,
             List<VectorOfTrust> vtrList,
             TxmaAuditUser user,
-            Optional<String> oldSessionId) {
+            Optional<String> previousSessionId) {
         LOG.info("Redirecting");
 
         Optional<Prompt.Type> prompt =
@@ -685,7 +685,7 @@ public class AuthorisationHandler
                         .claim("client_id", configurationService.getOrchestrationClientId())
                         .claim("redirect_uri", configurationService.getOrchestrationRedirectURI())
                         .claim("reauthenticate", reauthenticateClaim);
-        oldSessionId.ifPresent(id -> claimsBuilder.claim("old_session_id", id));
+        previousSessionId.ifPresent(id -> claimsBuilder.claim("previous_session_id", id));
 
         var claimsSetRequest =
                 constructAdditionalAuthenticationClaims(client, authenticationRequest);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1420,7 +1420,7 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldAddOldSessionIdClaimIfThereIsAnExistingSession() throws ParseException {
+        void shouldAddPreviousSessionIdClaimIfThereIsAnExistingSession() throws ParseException {
             when(sessionService.getSessionFromSessionCookie(any()))
                     .thenReturn(Optional.of(new Session(SESSION_ID)));
 
@@ -1436,7 +1436,8 @@ class AuthorisationHandlerTest {
 
             ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
-            assertThat(argument.getValue().getStringClaim("old_session_id"), equalTo(SESSION_ID));
+            assertThat(
+                    argument.getValue().getStringClaim("previous_session_id"), equalTo(SESSION_ID));
         }
 
         @Test


### PR DESCRIPTION
Note this PR will be closed in favour of incremental deployments:
1. https://github.com/govuk-one-login/authentication-api/pull/5171
2. https://github.com/govuk-one-login/authentication-frontend/pull/2006
3. https://github.com/govuk-one-login/authentication-api/pull/5172
4. https://github.com/govuk-one-login/authentication-api/pull/5174
5. TODO

## What

1. Include `previousSessionId` as a claim in authorize request to Authentication.
- If there is no `previousSessionId`, no claim is added.

2. Extract `previousSessionId` from authorize request in Authentication code

- This value will be used to get the record from the Auth session store which needs to be updated with a new `sessionId` hash key.

## Why?

This is required in order to break session dependencies between Authentication and Orchestration. When Auth has its own session store, the hash key for the session will be `sessionId`. When `sessionId` gets updated, the record will need to be recreated, and in order to do this, Auth need to map the previous session ID to the new one (which will be extracted from the gs cookie).

## Testing

Has been deployed to sandpit / dev along with the frontend change below. On first journey `previousSessionId` is `null` in StartHandler. On second journey it is the previous value of `sessionId`.

## Related PRs

- Auth frontend change to pass `previousSessionId` between AuthorisationHandler and StartHandler: https://github.com/govuk-one-login/authentication-frontend/pull/2006

- Table for Auth session store: https://github.com/govuk-one-login/authentication-api/pull/5125