### PR TITLE
AUT-3529: Added SMS code reauth attempt count

### DIFF
--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -54,6 +54,7 @@ otp_code_ttl_duration                     = 600
 email_acct_creation_otp_code_ttl_duration = 600
 reauth_enter_email_count_ttl              = 120
 reauth_enter_password_count_ttl           = 120
+reauth_enter_sms_code_count_ttl           = 120
 
 orch_client_id  = "orchestrationAuth"
 orch_account_id = "816047645251"

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -53,6 +53,7 @@ otp_code_ttl_duration                     = 600
 email_acct_creation_otp_code_ttl_duration = 600
 reauth_enter_email_count_ttl              = 120
 reauth_enter_password_count_ttl           = 120
+reauth_enter_sms_code_count_ttl           = 120
 
 
 orch_client_id  = "orchestrationAuth"

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -45,3 +45,4 @@ orch_trustmark_enabled               = true
 
 reauth_enter_email_count_ttl    = 300
 reauth_enter_password_count_ttl = 300
+reauth_enter_sms_code_count_ttl = 300

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -223,6 +223,11 @@ variable "reauth_enter_password_count_ttl" {
   default = 3600
 }
 
+variable "reauth_enter_sms_code_count_ttl" {
+  type    = number
+  default = 3600
+}
+
 variable "support_account_creation_count_ttl" {
   default     = false
   type        = bool

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -13,6 +13,9 @@ module "frontend_api_verify_code_role" {
     aws_iam_policy.dynamo_account_modifiers_write_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.dynamo_authentication_attempt_write_policy.arn,
+    aws_iam_policy.dynamo_authentication_attempt_read_policy.arn,
+    aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
@@ -46,6 +49,8 @@ module "verify_code" {
     EMAIL_ACCOUNT_CREATION_LOCKOUT_COUNT_TTL = var.account_creation_lockout_count_ttl
     SUPPORT_ACCOUNT_CREATION_COUNT_TTL       = var.support_account_creation_count_ttl
     SUPPORT_REAUTH_SIGNOUT_ENABLED           = var.support_reauth_signout_enabled
+    REAUTH_ENTER_SMS_CODE_COUNT_TTL          = var.reauth_enter_sms_code_count_ttl
+    AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED  = var.authentication_attempts_service_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest"
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -92,6 +92,11 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 System.getenv().getOrDefault("REAUTH_ENTER_PASSWORD_COUNT_TTL", "3600"));
     }
 
+    public long getReauthEnterSMSCodeCountTTL() {
+        return Long.parseLong(
+                System.getenv().getOrDefault("REAUTH_ENTER_SMS_CODE_COUNT_TTL", "3600"));
+    }
+
     public boolean supportAccountCreationTTL() {
         return System.getenv()
                 .getOrDefault("SUPPORT_ACCOUNT_CREATION_COUNT_TTL", String.valueOf(false))


### PR DESCRIPTION
## What

This PR implements the create or increment count logic into the verify code handler, incrementing the count for
ENTER_SMS_CODE in the authentication attempts table for a reauth journey when a user fails to enter the correct SMS MFA. If there is a count for a user having failed to enter the right sms mfa code and they then succeed, the count will be deleted.

A PR will follow implementing the corresponding logic for the auth app MFA in the verifyMfaCodeHandler.

## How to review

1. Code Review
2.  Deploy changes to authdev1
3.  Go through reauth journey successfully up to entering SMS MFA
4. Enter an incorrect MFA and see the count in the authdev1-authentication-attempt table
5. Enter the correct MFA code and see that the count clears
