### PR TITLE
Revert "Revert "AUT-3529: Delete email & password counts on authentication""

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -274,6 +274,17 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
         boolean termsAndConditionsAccepted = isTermsAndConditionsAccepted(userContext, userProfile);
 
+        if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
+            authenticationAttemptsService.deleteCount(
+                    userProfile.getSubjectID(),
+                    JourneyType.REAUTHENTICATION,
+                    CountType.ENTER_EMAIL);
+            authenticationAttemptsService.deleteCount(
+                    userProfile.getSubjectID(),
+                    JourneyType.REAUTHENTICATION,
+                    CountType.ENTER_PASSWORD);
+        }
+
         try {
             return generateApiGatewayProxyResponse(
                     200,


### PR DESCRIPTION
This PR adds logic that deletes email and password authentication attempt accounts when a user
goes through the normal sign in journey. Previously, authenticating in this way would not effect
counts when they should have been being reset.

The original PR was reverted to rule it out as a cause for pipeline flakiness. Since it has been ruled out as a cause we are going to merge again