### PR TITLE
ATO-984 (1/5): Configure /start to have GET and POST methods

### DIFF
--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -23,7 +23,7 @@ module "start" {
 
   endpoint_name   = "start"
   path_part       = "start"
-  endpoint_method = ["GET"]
+  endpoint_method = ["GET", "POST"]
   environment     = var.environment
 
   handler_environment_variables = {


### PR DESCRIPTION
## What

- Orchestration will need to pass more information to Auth via API as part of splitting the shared session. Using POST means information can be passed in the body instead of headers.
- In order to safely switch from the auth frontend sending GET to sending POST, /start needs to accept both for a while. This is a temporary measure and will eventually be set to just POST.

This has been tested in dev / sandpit. 

## Related PRs

ATO-984 incremental deployment:
1. https://github.com/govuk-one-login/authentication-api/pull/5171
2. https://github.com/govuk-one-login/authentication-frontend/pull/2006
3. https://github.com/govuk-one-login/authentication-api/pull/5172
4. https://github.com/govuk-one-login/authentication-api/pull/5174
5. Make /start only POST (PR todo)
