### PR TITLE
ATO-984 (3/5): Add previousSessionId claim to authorize request to Authentication

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -481,10 +481,10 @@ public class AuthorisationHandler
             updateAttachedSessionIdToLogs(session.getSessionId());
             LOG.info("Created session");
         } else {
-            var oldSessionId = session.getSessionId();
+            var previousSessionId = session.getSessionId();
             sessionService.updateSessionId(session);
             updateAttachedSessionIdToLogs(session.getSessionId());
-            LOG.info("Updated session id from {} - new", oldSessionId);
+            LOG.info("Updated session id from {} - new", previousSessionId);
         }
 
         Subject subjectId =
@@ -567,14 +567,15 @@ public class AuthorisationHandler
         var session = existingSession.orElseGet(sessionService::createSession);
         attachSessionIdToLogs(session);
 
+        Optional<String> previousSessionId = existingSession.map(Session::getSessionId);
         if (existingSession.isEmpty()) {
             updateAttachedSessionIdToLogs(session.getSessionId());
             LOG.info("Created session");
         } else {
-            var oldSessionId = session.getSessionId();
+            previousSessionId = Optional.of(session.getSessionId());
             sessionService.updateSessionId(session);
             updateAttachedSessionIdToLogs(session.getSessionId());
-            LOG.info("Updated session id from {} - new", oldSessionId);
+            LOG.info("Updated session id from {} - new", previousSessionId);
         }
 
         user = user.withSessionId(session.getSessionId());
@@ -600,7 +601,8 @@ public class AuthorisationHandler
                 client,
                 reauthRequested,
                 vtrList,
-                user);
+                user,
+                previousSessionId);
     }
 
     private APIGatewayProxyResponseEvent generateAuthRedirect(
@@ -611,7 +613,8 @@ public class AuthorisationHandler
             ClientRegistry client,
             boolean reauthRequested,
             List<VectorOfTrust> vtrList,
-            TxmaAuditUser user) {
+            TxmaAuditUser user,
+            Optional<String> previousSessionId) {
         LOG.info("Redirecting");
 
         Optional<Prompt.Type> prompt =
@@ -682,6 +685,7 @@ public class AuthorisationHandler
                         .claim("client_id", configurationService.getOrchestrationClientId())
                         .claim("redirect_uri", configurationService.getOrchestrationRedirectURI())
                         .claim("reauthenticate", reauthenticateClaim);
+        previousSessionId.ifPresent(id -> claimsBuilder.claim("previous_session_id", id));
 
         var claimsSetRequest =
                 constructAdditionalAuthenticationClaims(client, authenticationRequest);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1420,6 +1420,27 @@ class AuthorisationHandlerTest {
         }
 
         @Test
+        void shouldAddPreviousSessionIdClaimIfThereIsAnExistingSession() throws ParseException {
+            when(sessionService.getSessionFromSessionCookie(any()))
+                    .thenReturn(Optional.of(new Session(SESSION_ID)));
+
+            var requestParams =
+                    buildRequestParams(
+                            Map.of("scope", "openid profile phone", "vtr", "[\"Cl.Cm.P2\"]"));
+
+            APIGatewayProxyRequestEvent event = withRequestEvent(requestParams);
+            event.setRequestContext(
+                    new ProxyRequestContext()
+                            .withIdentity(new RequestIdentity().withSourceIp("123.123.123.123")));
+            makeHandlerRequest(event);
+
+            ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
+            verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
+            assertThat(
+                    argument.getValue().getStringClaim("previous_session_id"), equalTo(SESSION_ID));
+        }
+
+        @Test
         void shouldAddPublicSubjectIdClaimIfAmScopePresent() throws ParseException {
             Map<String, String> requestParams = buildRequestParams(Map.of("scope", "openid am"));
             APIGatewayProxyRequestEvent event = withRequestEvent(requestParams);


### PR DESCRIPTION
## What

Include `previousSessionId` as a claim in authorize request to Authentication. If there is no `previousSessionId`, no claim is added.

## Why?

This is required in order to break session dependencies between Authentication and Orchestration. When Auth has its own session store, the hash key for the session will be `sessionId`. When `sessionId` gets updated, the record will need to be recreated, and in order to do this, Auth need to map the previous session ID to the new one (which will be extracted from the gs cookie).

## Testing

Has been deployed to sandpit / dev along with the changes below. On first journey `previousSessionId` is `null` in StartHandler. On second journey it is the previous value of `sessionId`.

## Related PRs

ATO-984 incremental deployment:
1. https://github.com/govuk-one-login/authentication-api/pull/5171
2. https://github.com/govuk-one-login/authentication-frontend/pull/2006
3. https://github.com/govuk-one-login/authentication-api/pull/5172
4. https://github.com/govuk-one-login/authentication-api/pull/5174
5. TODO