### PR TITLE
AUT-3529: Added Auth App reauth attempt count

### DIFF
--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -54,6 +54,7 @@ otp_code_ttl_duration                     = 600
 email_acct_creation_otp_code_ttl_duration = 600
 reauth_enter_email_count_ttl              = 120
 reauth_enter_password_count_ttl           = 120
+reauth_enter_auth_app_code_count_ttl      = 120
 reauth_enter_sms_code_count_ttl           = 120
 
 orch_client_id  = "orchestrationAuth"

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -54,6 +54,7 @@ email_acct_creation_otp_code_ttl_duration = 600
 reauth_enter_email_count_ttl              = 120
 reauth_enter_password_count_ttl           = 120
 reauth_enter_sms_code_count_ttl           = 120
+reauth_enter_auth_app_code_count_ttl      = 120
 
 
 orch_client_id  = "orchestrationAuth"

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -43,6 +43,7 @@ orch_userinfo_enabled                = true
 orch_storage_token_jwk_enabled       = true
 orch_trustmark_enabled               = true
 
-reauth_enter_email_count_ttl    = 300
-reauth_enter_password_count_ttl = 300
-reauth_enter_sms_code_count_ttl = 300
+reauth_enter_email_count_ttl         = 300
+reauth_enter_password_count_ttl      = 300
+reauth_enter_sms_code_count_ttl      = 300
+reauth_enter_auth_app_code_count_ttl = 300

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -223,6 +223,11 @@ variable "reauth_enter_password_count_ttl" {
   default = 3600
 }
 
+variable "reauth_enter_auth_app_code_count_ttl" {
+  type    = number
+  default = 3600
+}
+
 variable "reauth_enter_sms_code_count_ttl" {
   type    = number
   default = 3600

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -11,6 +11,9 @@ module "frontend_api_verify_mfa_code_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
     aws_iam_policy.dynamo_account_modifiers_write_access_policy.arn,
+    aws_iam_policy.dynamo_authentication_attempt_write_policy.arn,
+    aws_iam_policy.dynamo_authentication_attempt_read_policy.arn,
+    aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
@@ -30,24 +33,26 @@ module "verify_mfa_code" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT                         = var.environment
-    LOCKOUT_DURATION                    = var.lockout_duration
-    LOCKOUT_COUNT_TTL                   = var.lockout_count_ttl
-    TXMA_AUDIT_QUEUE_URL                = module.oidc_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT                 = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY                           = local.redis_key
-    DYNAMO_ENDPOINT                     = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TERMS_CONDITIONS_VERSION            = var.terms_and_conditions
-    TEST_CLIENT_VERIFY_EMAIL_OTP        = var.test_client_verify_email_otp
-    TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP = var.test_client_verify_phone_number_otp
-    TEST_CLIENTS_ENABLED                = var.test_clients_enabled
-    INTERNAl_SECTOR_URI                 = var.internal_sector_uri
-    EXPERIAN_PHONE_CHECKER_QUEUE_URL    = local.experian_phone_check_sqs_queue_id
-    PHONE_CHECKER_WITH_RETRY            = var.phone_checker_with_retry
-    CODE_MAX_RETRIES_INCREASED          = var.code_max_retries_increased
-    REDUCED_LOCKOUT_DURATION            = var.reduced_lockout_duration
-    SQS_ENDPOINT                        = var.use_localstack ? "http://localhost:45678/" : null
-    SUPPORT_REAUTH_SIGNOUT_ENABLED      = var.support_reauth_signout_enabled
+    ENVIRONMENT                             = var.environment
+    LOCKOUT_DURATION                        = var.lockout_duration
+    LOCKOUT_COUNT_TTL                       = var.lockout_count_ttl
+    TXMA_AUDIT_QUEUE_URL                    = module.oidc_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT                     = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                               = local.redis_key
+    DYNAMO_ENDPOINT                         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TERMS_CONDITIONS_VERSION                = var.terms_and_conditions
+    TEST_CLIENT_VERIFY_EMAIL_OTP            = var.test_client_verify_email_otp
+    TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP     = var.test_client_verify_phone_number_otp
+    TEST_CLIENTS_ENABLED                    = var.test_clients_enabled
+    INTERNAl_SECTOR_URI                     = var.internal_sector_uri
+    EXPERIAN_PHONE_CHECKER_QUEUE_URL        = local.experian_phone_check_sqs_queue_id
+    PHONE_CHECKER_WITH_RETRY                = var.phone_checker_with_retry
+    CODE_MAX_RETRIES_INCREASED              = var.code_max_retries_increased
+    REDUCED_LOCKOUT_DURATION                = var.reduced_lockout_duration
+    SQS_ENDPOINT                            = var.use_localstack ? "http://localhost:45678/" : null
+    SUPPORT_REAUTH_SIGNOUT_ENABLED          = var.support_reauth_signout_enabled
+    AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED = var.authentication_attempts_service_enabled
+    REAUTH_ENTER_AUTH_APP_CODE_COUNT_TTL    = var.reauth_enter_auth_app_code_count_ttl
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler::handleRequest"
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -701,9 +701,7 @@ class VerifyCodeHandlerTest {
 
         verify(authenticationAttemptsService, times(1))
                 .deleteCount(
-                        expectedCommonSubject,
-                        JourneyType.REAUTHENTICATION,
-                        CountType.ENTER_SMS_CODE);
+                        TEST_SUBJECT_ID, JourneyType.REAUTHENTICATION, CountType.ENTER_SMS_CODE);
         assertThat(result, hasStatus(204));
     }
 
@@ -721,7 +719,7 @@ class VerifyCodeHandlerTest {
 
         verify(authenticationAttemptsService, times(1))
                 .createOrIncrementCount(
-                        expectedCommonSubject,
+                        TEST_SUBJECT_ID,
                         4070908800L,
                         JourneyType.REAUTHENTICATION,
                         CountType.ENTER_SMS_CODE);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -92,6 +92,11 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 System.getenv().getOrDefault("REAUTH_ENTER_PASSWORD_COUNT_TTL", "3600"));
     }
 
+    public long getReauthEnterAuthAppCodeCountTTL() {
+        return Long.parseLong(
+                System.getenv().getOrDefault("REAUTH_ENTER_AUTH_APP_CODE_COUNT_TTL", "3600"));
+    }
+
     public long getReauthEnterSMSCodeCountTTL() {
         return Long.parseLong(
                 System.getenv().getOrDefault("REAUTH_ENTER_SMS_CODE_COUNT_TTL", "3600"));


### PR DESCRIPTION
## What

Implemented the create or increment count logic into the verify mfa code handler, incrementing the count for ENTER_AUTH_APP_CODE in the authentication attempts table for a reauth journey when a journey with MFAMethodType.AUTH_APP fails. If there is a count for a user having failed to enter the right auth app mfa code and they then succeed, the count will be deleted.

This PR follows the related PR implementing the equivalent logic into the VerifyCodeHandler. This PR has also fixed an issue with the VerifyCodeHandler using the internal subject ID instead of the subject ID when interacting with the authentication attempts table.

Following this PR we will look to improve the robustness of the lambdas by implementing error handling, such as in the case of receiving a reauth request when reauth journeys are not enabled.

## How to review

1. Code Review
2. Deploy changes to authdev1
3. Go through reauth journey successfully up to entering AUTH APP mfa
4. Enter an incorrect MFA and see the count in the authdev1-authentication-attempt table
5. Enter the correct MFA code and see that the count clears

## Related PRs
https://github.com/govuk-one-login/authentication-api/pull/5156
