### PR TITLE
AUT-3613: Return different error response for password retries exceed…

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -128,9 +128,16 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                                 }
 
                                 if (hasEnteredIncorrectPasswordTooManyTimes(userProfile)) {
-                                    throw new AccountLockedException(
-                                            "Account is locked due to too many failed incorrect password attempts.",
-                                            ErrorResponse.ERROR_1045);
+                                    if (configurationService
+                                            .isAuthenticationAttemptsServiceEnabled()) {
+                                        throw new AccountLockedException(
+                                                "Reauth user has entered incorrect password too many times",
+                                                ErrorResponse.ERROR_1061);
+                                    } else {
+                                        throw new AccountLockedException(
+                                                "Account is locked due to too many failed incorrect password attempts.",
+                                                ErrorResponse.ERROR_1045);
+                                    }
                                 }
 
                                 return verifyReAuthentication(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReauthUserHandlerAuthenticationAttemptsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReauthUserHandlerAuthenticationAttemptsIntegrationTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.frontendapi.entity.CheckReauthUserRequest;
 import uk.gov.di.authentication.frontendapi.lambda.CheckReAuthUserHandler;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CountType;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -23,7 +24,6 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
-import uk.gov.di.orchestration.shared.entity.ErrorResponse;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 
 import java.net.URI;
@@ -180,7 +180,7 @@ public class CheckReauthUserHandlerAuthenticationAttemptsIntegrationTest
     }
 
     @Test
-    void shouldReturn400WhenUserHasBeenBlockedForMaxPasswordRetries() {
+    void shouldReturn400WhenUserHasExceededMaxPasswordRetries() {
         userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
         registerClient("https://randomSectorIDuRI.COM");
 
@@ -208,7 +208,7 @@ public class CheckReauthUserHandlerAuthenticationAttemptsIntegrationTest
                         Map.of("principalId", expectedPairwiseId));
 
         assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1045));
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1061));
     }
 
     private ClientSession createClientSession() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -71,7 +71,9 @@ public enum ErrorResponse {
     ERROR_1057(1057, "User entered invalid email too many times"),
     ERROR_1058(1058, "IPV TokenResponse was not successful"),
     ERROR_1059(1059, "Error getting reverification result"),
-    ERROR_1060(1060, "Failed to generate MFA Reset Authorize JAR for IPV");
+    ERROR_1060(1060, "Failed to generate MFA Reset Authorize JAR for IPV"),
+    ERROR_1061(1061, "User entered invalid password for reauth too many times");
+
     private int code;
 
     private String message;


### PR DESCRIPTION
…ed in reauth

This will allow us to differentiate between a case where we want to lock someone out because their max retries have been exceeded vs log someone out (in the case of a reauth journey).

## What

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
