### PR TITLE
AUT-3613: Return different error response for password retries exceed…

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -128,9 +128,16 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                                 }
 
                                 if (hasEnteredIncorrectPasswordTooManyTimes(userProfile)) {
-                                    throw new AccountLockedException(
-                                            "Account is locked due to too many failed incorrect password attempts.",
-                                            ErrorResponse.ERROR_1045);
+                                    if (configurationService
+                                            .isAuthenticationAttemptsServiceEnabled()) {
+                                        throw new AccountLockedException(
+                                                "Reauth user has entered incorrect password too many times",
+                                                ErrorResponse.ERROR_1057);
+                                    } else {
+                                        throw new AccountLockedException(
+                                                "Account is locked due to too many failed incorrect password attempts.",
+                                                ErrorResponse.ERROR_1045);
+                                    }
                                 }
 
                                 return verifyReAuthentication(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -342,18 +342,9 @@ class CheckReAuthUserHandlerTest {
                         userContext);
 
         assertEquals(400, result.getStatusCode());
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1045));
-
-        verify(authenticationService, atLeastOnce())
-                .getUserProfileByEmailMaybe(EMAIL_USED_TO_SIGN_IN);
-        verify(clientRegistry, times(2)).getRedirectUrls();
-
-        verify(userContext, times(2)).getSession();
-        verify(userContext).getClientSessionId();
-        verify(userContext).getTxmaAuditEncoded();
-
-        verify(configurationService).getMaxEmailReAuthRetries();
-        verify(configurationService, times(2)).getMaxPasswordRetries();
+        var expectedErrorResponse =
+                supportAuthenticationAttempts ? ErrorResponse.ERROR_1057 : ErrorResponse.ERROR_1045;
+        assertThat(result, hasJsonBody(expectedErrorResponse));
     }
 
     @ParameterizedTest

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReauthUserHandlerAuthenticationAttemptsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReauthUserHandlerAuthenticationAttemptsIntegrationTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.frontendapi.entity.CheckReauthUserRequest;
 import uk.gov.di.authentication.frontendapi.lambda.CheckReAuthUserHandler;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CountType;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -23,7 +24,6 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
-import uk.gov.di.orchestration.shared.entity.ErrorResponse;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 
 import java.net.URI;
@@ -180,7 +180,7 @@ public class CheckReauthUserHandlerAuthenticationAttemptsIntegrationTest
     }
 
     @Test
-    void shouldReturn400WhenUserHasBeenBlockedForMaxPasswordRetries() {
+    void shouldReturn400WhenUserHasExceededMaxPasswordRetries() {
         userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
         registerClient("https://randomSectorIDuRI.COM");
 
@@ -208,7 +208,7 @@ public class CheckReauthUserHandlerAuthenticationAttemptsIntegrationTest
                         Map.of("principalId", expectedPairwiseId));
 
         assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1045));
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1057));
     }
 
     private ClientSession createClientSession() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -68,10 +68,11 @@ public enum ErrorResponse {
     ERROR_1054(1054, "Account Interventions API Gateway Timeout"),
     ERROR_1055(1055, "Account Interventions API Unexpected Error"),
     ERROR_1056(1056, "User not found or no match"),
-    ERROR_1057(1057, "User entered invalid email too many times"),
+    ERROR_1057(1057, "User entered invalid reauth sign in details too many times"),
     ERROR_1058(1058, "IPV TokenResponse was not successful"),
     ERROR_1059(1059, "Error getting reverification result"),
     ERROR_1060(1060, "Failed to generate MFA Reset Authorize JAR for IPV");
+
     private int code;
 
     private String message;


### PR DESCRIPTION
…ed in reauth

In the new world, we want to log someone out rather than lock someone out when they've exceeded the max retries for reauth credential entry. Returning the existing code will mean that we treat this as a log out on the frontend. I've repurposed the error description with the view that we can return this error code for all reauth incorrect credential entries and treat these as non lock outs.

Also got rid of unnecessary mock checks in unit test

