### PR TITLE
Aut 3613: Increment incorrect email count up to 6 in reauth

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -208,14 +208,6 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
             uniqueUserIdentifier = rpPairwiseId;
         }
 
-        if (hasEnteredIncorrectEmailTooManyTimes(uniqueUserIdentifier)) {
-            throw new AccountLockedException(
-                    "Re-authentication is locked due to too many failed attempts.",
-                    ErrorResponse.ERROR_1057);
-        }
-
-        auditService.submitAuditEvent(AUTH_REAUTHENTICATION_INVALID, auditContext);
-
         authenticationAttemptsService.createOrIncrementCount(
                 uniqueUserIdentifier,
                 NowHelper.nowPlus(
@@ -225,6 +217,14 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                         .getEpochSecond(),
                 JourneyType.REAUTHENTICATION,
                 CountType.ENTER_EMAIL);
+
+        if (hasEnteredIncorrectEmailTooManyTimes(uniqueUserIdentifier)) {
+            throw new AccountLockedException(
+                    "Re-authentication is locked due to too many failed attempts.",
+                    ErrorResponse.ERROR_1057);
+        }
+
+        auditService.submitAuditEvent(AUTH_REAUTHENTICATION_INVALID, auditContext);
 
         return generateApiGatewayProxyErrorResponse(404, ERROR_1056);
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -158,17 +158,6 @@ class CheckReAuthUserHandlerTest {
 
         verify(authenticationService, atLeastOnce())
                 .getUserProfileByEmailMaybe(EMAIL_USED_TO_SIGN_IN);
-        verify(authenticationService, times(2)).getOrGenerateSalt(any(UserProfile.class));
-
-        verify(userContext).getClient();
-        verify(userContext, times(2)).getSession();
-        verify(userContext).getClientSessionId();
-        verify(userContext).getTxmaAuditEncoded();
-
-        verify(configurationService).getMaxEmailReAuthRetries();
-        verify(configurationService).getMaxPasswordRetries();
-        verify(configurationService).getInternalSectorUri();
-        verify(clientRegistry, times(4)).getRedirectUrls();
     }
 
     @Test
@@ -203,14 +192,6 @@ class CheckReAuthUserHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTHENTICATION_SUCCESSFUL,
                         testAuditContextWithoutAuditEncoded);
-
-        verify(userContext).getClient();
-        verify(userContext, times(2)).getSession();
-        verify(userContext).getClientSessionId();
-        verify(userContext).getTxmaAuditEncoded();
-
-        verify(configurationService).getMaxEmailReAuthRetries();
-        verify(configurationService).getMaxPasswordRetries();
     }
 
     @Test
@@ -239,12 +220,6 @@ class CheckReAuthUserHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTHENTICATION_INVALID,
                         testAuditContextWithAuditEncoded);
-
-        verify(userContext, atLeastOnce()).getSession();
-        verify(userContext).getClientSessionId();
-        verify(userContext).getTxmaAuditEncoded();
-
-        verify(configurationService).getMaxEmailReAuthRetries();
     }
 
     @Test
@@ -280,12 +255,6 @@ class CheckReAuthUserHandlerTest {
                         testAuditContextWithAuditEncoded,
                         AuditService.MetadataPair.pair(
                                 "number_of_attempts_user_allowed_to_login", 5));
-
-        verify(userContext, times(2)).getSession();
-        verify(userContext).getClientSessionId();
-        verify(userContext).getTxmaAuditEncoded();
-
-        verify(configurationService, times(2)).getMaxEmailReAuthRetries();
     }
 
     @Test
@@ -343,12 +312,6 @@ class CheckReAuthUserHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTHENTICATION_INVALID,
                         testAuditContextWithAuditEncoded);
-
-        verify(userContext, atLeastOnce()).getSession();
-        verify(userContext).getClientSessionId();
-        verify(userContext).getTxmaAuditEncoded();
-
-        verify(configurationService).getMaxEmailReAuthRetries();
     }
 
     private UserProfile generateUserProfile() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -245,7 +245,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public int getMaxEmailReAuthRetries() {
-        return Integer.parseInt(System.getenv().getOrDefault("EMAIL_MAX_RE_AUTH_RETRIES", "5"));
+        return Integer.parseInt(System.getenv().getOrDefault("EMAIL_MAX_RE_AUTH_RETRIES", "6"));
     }
 
     public boolean isCustomDocAppClaimEnabled() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -232,7 +232,7 @@ class ConfigurationServiceTest {
 
     @Test
     void getMaxEmailReAuthRetriesShouldDefault() {
-        assertEquals(5, configurationService.getMaxEmailReAuthRetries());
+        assertEquals(6, configurationService.getMaxEmailReAuthRetries());
     }
 
     @Test


### PR DESCRIPTION
## What

We want users to be logged out on the 6th attempt at an incorrect email in reauth. This is currently happening, but the count in the database is stopping at 5, which means that eventually the data we put into audit events will be confusing.

In this change, we increment the count of failed emails regardless of whether the current incorrect attempt logs someone out or not. We also set the configured value of max retries to 6, rather than 5. Together, these changes should not change the behaviour observed (a user should still be logged out on the 6th incorrect attempt), but should:

a) make the logic more consistent - currently max email attempts is configured to 5, but max passwords is configured to 6, but in both cases we only get locked out on th 6th incorrect attempt
b) make sure the value in the database is correct

## How to review

1. Code Review

