### PR TITLE
Aut 3530: check all reauth counts in reauth handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -122,16 +122,9 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                                 }
 
                                 if (hasEnteredIncorrectPasswordTooManyTimes(userProfile)) {
-                                    if (configurationService
-                                            .isAuthenticationAttemptsServiceEnabled()) {
-                                        throw new AccountLockedException(
-                                                "Reauth user has entered incorrect password too many times",
-                                                ErrorResponse.ERROR_1057);
-                                    } else {
-                                        throw new AccountLockedException(
-                                                "Account is locked due to too many failed incorrect password attempts.",
-                                                ErrorResponse.ERROR_1045);
-                                    }
+                                    throw new AccountLockedException(
+                                            "Reauth user has entered incorrect password too many times",
+                                            ErrorResponse.ERROR_1057);
                                 }
 
                                 return verifyReAuthentication(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.helpers.ReauthAuthenticationAttemptsHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
@@ -114,16 +115,22 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                     .getUserProfileByEmailMaybe(request.email())
                     .flatMap(
                             userProfile -> {
-                                if (hasEnteredIncorrectEmailTooManyTimes(
-                                        userProfile.getSubjectID())) {
+                                var countTypesToCounts =
+                                        authenticationAttemptsService.getCountsByJourney(
+                                                userProfile.getSubjectID(),
+                                                JourneyType.REAUTHENTICATION);
+
+                                var exceededCountTypes =
+                                        ReauthAuthenticationAttemptsHelper
+                                                .countTypesWhereUserIsBlockedForReauth(
+                                                        countTypesToCounts, configurationService);
+
+                                if (!exceededCountTypes.isEmpty()) {
+                                    LOG.info(
+                                            "Account is locked due to exceeded counts on count types {}",
+                                            exceededCountTypes);
                                     throw new AccountLockedException(
                                             "Account is locked due to too many failed attempts.",
-                                            ErrorResponse.ERROR_1057);
-                                }
-
-                                if (hasEnteredIncorrectPasswordTooManyTimes(userProfile)) {
-                                    throw new AccountLockedException(
-                                            "Reauth user has entered incorrect password too many times",
                                             ErrorResponse.ERROR_1057);
                                 }
 
@@ -230,16 +237,6 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                         subjectId, JourneyType.REAUTHENTICATION, CountType.ENTER_EMAIL);
 
         return incorrectEmailCount >= maxRetries;
-    }
-
-    private boolean hasEnteredIncorrectPasswordTooManyTimes(UserProfile userProfile) {
-        int incorrectPasswordCount;
-        incorrectPasswordCount =
-                authenticationAttemptsService.getCount(
-                        userProfile.getSubjectID(),
-                        JourneyType.REAUTHENTICATION,
-                        CountType.ENTER_PASSWORD);
-        return incorrectPasswordCount >= configurationService.getMaxPasswordRetries();
     }
 
     private void clearCountOfFailedEmailEntryAttempts(UserProfile userProfile) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -180,11 +180,15 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         auditContext = auditContext.withUserId(internalCommonSubjectIdentifier);
 
         if (isReauthJourneyWithFlagsEnabled(isReauthJourney)) {
+            var reauthCounts =
+                    authenticationAttemptsService.getCountsByJourney(
+                            userProfile.getSubjectID(), JourneyType.REAUTHENTICATION);
             var helper =
                     new ReauthAuthenticationAttemptsHelper(
                             configurationService, authenticationAttemptsService);
-            if (helper.isBlockedForReauth(userProfile.getSubjectID())) {
-                LOG.info("User has existing reauth block");
+            var exceedingCounts = helper.countTypesWhereUserIsBlockedForReauth(reauthCounts);
+            if (!exceedingCounts.isEmpty()) {
+                LOG.info("User has existing reauth block on counts {}", exceedingCounts);
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1057);
             }
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -183,9 +183,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             var reauthCounts =
                     authenticationAttemptsService.getCountsByJourney(
                             userProfile.getSubjectID(), JourneyType.REAUTHENTICATION);
-            var helper =
-                    new ReauthAuthenticationAttemptsHelper(
-                            configurationService, authenticationAttemptsService);
+            var helper = new ReauthAuthenticationAttemptsHelper(configurationService);
             var exceedingCounts = helper.countTypesWhereUserIsBlockedForReauth(reauthCounts);
             if (!exceedingCounts.isEmpty()) {
                 LOG.info("User has existing reauth block on counts {}", exceedingCounts);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -183,8 +183,9 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             var reauthCounts =
                     authenticationAttemptsService.getCountsByJourney(
                             userProfile.getSubjectID(), JourneyType.REAUTHENTICATION);
-            var helper = new ReauthAuthenticationAttemptsHelper(configurationService);
-            var exceedingCounts = helper.countTypesWhereUserIsBlockedForReauth(reauthCounts);
+            var exceedingCounts =
+                    ReauthAuthenticationAttemptsHelper.countTypesWhereUserIsBlockedForReauth(
+                            reauthCounts, configurationService);
             if (!exceedingCounts.isEmpty()) {
                 LOG.info("User has existing reauth block on counts {}", exceedingCounts);
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1057);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.DocAppSubjectIdHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
-import uk.gov.di.authentication.shared.helpers.ReauthAuthenticationAttemptsHelper;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
@@ -76,19 +75,16 @@ public class StartHandler
         this.clientSessionService = new ClientSessionService(configurationService);
         this.sessionService = new SessionService(configurationService);
         this.auditService = new AuditService(configurationService);
-        ReauthAuthenticationAttemptsHelper reauthAttemptsHelper = null;
+        AuthenticationAttemptsService authenticationAttemptsService = null;
         if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
-            reauthAttemptsHelper =
-                    new ReauthAuthenticationAttemptsHelper(
-                            configurationService,
-                            new AuthenticationAttemptsService(configurationService));
+            authenticationAttemptsService = new AuthenticationAttemptsService(configurationService);
         }
         this.startService =
                 new StartService(
                         new DynamoClientService(configurationService),
                         new DynamoService(configurationService),
                         sessionService,
-                        reauthAttemptsHelper,
+                        authenticationAttemptsService,
                         configurationService);
         this.configurationService = configurationService;
     }
@@ -97,19 +93,16 @@ public class StartHandler
         this.clientSessionService = new ClientSessionService(configurationService, redis);
         this.sessionService = new SessionService(configurationService, redis);
         this.auditService = new AuditService(configurationService);
-        ReauthAuthenticationAttemptsHelper reauthAttemptsHelper = null;
+        AuthenticationAttemptsService authenticationAttemptsService = null;
         if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
-            reauthAttemptsHelper =
-                    new ReauthAuthenticationAttemptsHelper(
-                            configurationService,
-                            new AuthenticationAttemptsService(configurationService));
+            authenticationAttemptsService = new AuthenticationAttemptsService(configurationService);
         }
         this.startService =
                 new StartService(
                         new DynamoClientService(configurationService),
                         new DynamoService(configurationService),
                         sessionService,
-                        reauthAttemptsHelper,
+                        authenticationAttemptsService,
                         configurationService);
         this.configurationService = configurationService;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -192,9 +192,9 @@ public class StartService {
                                             authenticationAttemptsService.getCountsByJourney(
                                                     subjectId, JourneyType.REAUTHENTICATION))
                             .orElse(Map.of());
-            var helper = new ReauthAuthenticationAttemptsHelper(configurationService);
             var blockedCountTypes =
-                    helper.countTypesWhereUserIsBlockedForReauth(reauthCountTypesToCounts);
+                    ReauthAuthenticationAttemptsHelper.countTypesWhereUserIsBlockedForReauth(
+                            reauthCountTypesToCounts, configurationService);
             isBlockedForReauth = !blockedCountTypes.isEmpty();
         }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -192,9 +192,7 @@ public class StartService {
                                             authenticationAttemptsService.getCountsByJourney(
                                                     subjectId, JourneyType.REAUTHENTICATION))
                             .orElse(Map.of());
-            var helper =
-                    new ReauthAuthenticationAttemptsHelper(
-                            configurationService, authenticationAttemptsService);
+            var helper = new ReauthAuthenticationAttemptsHelper(configurationService);
             var blockedCountTypes =
                     helper.countTypesWhereUserIsBlockedForReauth(reauthCountTypesToCounts);
             isBlockedForReauth = !blockedCountTypes.isEmpty();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -252,8 +252,8 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
         when(clientSession.getAuthRequestParams()).thenReturn(generateAuthRequest().toParameters());
 
         setupConfigurationServiceCountForCountType(countType, MAX_ALLOWED_RETRIES);
-        when(authenticationAttemptsService.getCount(any(), eq(REAUTHENTICATION), eq(countType)))
-                .thenReturn(MAX_ALLOWED_RETRIES);
+        when(authenticationAttemptsService.getCountsByJourney(any(), eq(REAUTHENTICATION)))
+                .thenReturn(Map.of(countType, MAX_ALLOWED_RETRIES));
 
         if (countType != ENTER_PASSWORD) {
             when(authenticationAttemptsService.getCount(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelper.java
@@ -12,14 +12,12 @@ import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_SMS_CODE;
 
 public class ReauthAuthenticationAttemptsHelper {
-    private ConfigurationService configurationService;
 
-    public ReauthAuthenticationAttemptsHelper(ConfigurationService configurationService) {
-        this.configurationService = configurationService;
-    }
+    private ReauthAuthenticationAttemptsHelper() {}
 
-    public List<CountType> countTypesWhereUserIsBlockedForReauth(
-            Map<CountType, Integer> retrievedCountTypesToCounts) {
+    public static List<CountType> countTypesWhereUserIsBlockedForReauth(
+            Map<CountType, Integer> retrievedCountTypesToCounts,
+            ConfigurationService configurationService) {
         var reauthRelevantCountsToMaxRetries =
                 Map.ofEntries(
                         Map.entry(ENTER_EMAIL, configurationService.getMaxEmailReAuthRetries()),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelper.java
@@ -1,8 +1,6 @@
 package uk.gov.di.authentication.shared.helpers;
 
 import uk.gov.di.authentication.shared.entity.CountType;
-import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.List;
@@ -14,29 +12,22 @@ import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_SMS_CODE;
 
 public class ReauthAuthenticationAttemptsHelper {
-    private AuthenticationAttemptsService authenticationAttemptsService;
     private ConfigurationService configurationService;
-    private static final JourneyType JOURNEY_TYPE = JourneyType.REAUTHENTICATION;
 
-    public ReauthAuthenticationAttemptsHelper(
-            ConfigurationService configurationService,
-            AuthenticationAttemptsService authenticationAttemptsService) {
+    public ReauthAuthenticationAttemptsHelper(ConfigurationService configurationService) {
         this.configurationService = configurationService;
-        this.authenticationAttemptsService = authenticationAttemptsService;
-    }
-
-    public boolean isBlockedForReauth(String internalSubjectId) {
-        return reauthRelevantCountsToMaxRetries().entrySet().stream()
-                .anyMatch(
-                        entry ->
-                                authenticationAttemptsService.getCount(
-                                                internalSubjectId, JOURNEY_TYPE, entry.getKey())
-                                        >= entry.getValue());
     }
 
     public List<CountType> countTypesWhereUserIsBlockedForReauth(
             Map<CountType, Integer> retrievedCountTypesToCounts) {
-        return reauthRelevantCountsToMaxRetries().entrySet().stream()
+        var reauthRelevantCountsToMaxRetries =
+                Map.ofEntries(
+                        Map.entry(ENTER_EMAIL, configurationService.getMaxEmailReAuthRetries()),
+                        Map.entry(ENTER_PASSWORD, configurationService.getMaxPasswordRetries()),
+                        Map.entry(ENTER_SMS_CODE, configurationService.getCodeMaxRetries()),
+                        Map.entry(ENTER_AUTH_APP_CODE, configurationService.getCodeMaxRetries()));
+
+        return reauthRelevantCountsToMaxRetries.entrySet().stream()
                 .filter(
                         entry -> {
                             var countType = entry.getKey();
@@ -46,13 +37,5 @@ public class ReauthAuthenticationAttemptsHelper {
                         })
                 .map(Map.Entry::getKey)
                 .toList();
-    }
-
-    private Map<CountType, Integer> reauthRelevantCountsToMaxRetries() {
-        return Map.ofEntries(
-                Map.entry(ENTER_EMAIL, configurationService.getMaxEmailReAuthRetries()),
-                Map.entry(ENTER_PASSWORD, configurationService.getMaxPasswordRetries()),
-                Map.entry(ENTER_SMS_CODE, configurationService.getCodeMaxRetries()),
-                Map.entry(ENTER_AUTH_APP_CODE, configurationService.getCodeMaxRetries()));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationAttemptsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationAttemptsService.java
@@ -5,6 +5,9 @@ import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Optional;
 
 public class AuthenticationAttemptsService extends BaseDynamoService<AuthenticationAttempts> {
@@ -46,6 +49,20 @@ public class AuthenticationAttemptsService extends BaseDynamoService<Authenticat
             return 0;
         }
         return authenticationAttemptRecord.get().getCount();
+    }
+
+    public Map<CountType, Integer> getCountsByJourney(
+            String internalSubjectId, JourneyType journeyType) {
+        Map<CountType, Integer> results = new EnumMap<>(CountType.class);
+        Arrays.stream(CountType.values())
+                .forEach(
+                        countType -> {
+                            var count = getCount(internalSubjectId, journeyType, countType);
+                            if (count > 0) {
+                                results.put(countType, count);
+                            }
+                        });
+        return results;
     }
 
     public void deleteCount(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelperTest.java
@@ -13,8 +13,6 @@ import static org.mockito.Mockito.when;
 
 class ReauthAuthenticationAttemptsHelperTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private final ReauthAuthenticationAttemptsHelper helper =
-            new ReauthAuthenticationAttemptsHelper(configurationService);
 
     @Test
     void countTypesThatExceedMaxShouldReturnTheCountTypesThatHaveExceededTheirMaximums() {
@@ -36,7 +34,8 @@ class ReauthAuthenticationAttemptsHelperTest {
         var expectedReauthCountsExceeded =
                 List.of(CountType.ENTER_EMAIL, CountType.ENTER_AUTH_APP_CODE);
         var actualReauthCountsExceeded =
-                helper.countTypesWhereUserIsBlockedForReauth(retrievedCountTypesToCounts);
+                ReauthAuthenticationAttemptsHelper.countTypesWhereUserIsBlockedForReauth(
+                        retrievedCountTypesToCounts, configurationService);
 
         assertTrue(
                 expectedReauthCountsExceeded.containsAll(actualReauthCountsExceeded)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelperTest.java
@@ -1,86 +1,20 @@
 package uk.gov.di.authentication.shared.helpers;
 
-import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.CountType;
-import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class ReauthAuthenticationAttemptsHelperTest {
-    private static final String SUBJECT_ID = new Subject().getValue();
-    private final AuthenticationAttemptsService authenticationAttemptsService =
-            mock(AuthenticationAttemptsService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ReauthAuthenticationAttemptsHelper helper =
-            new ReauthAuthenticationAttemptsHelper(
-                    configurationService, authenticationAttemptsService);
-
-    private static Stream<Arguments> reauthRelevantCounts() {
-        return Stream.of(
-                Arguments.of(CountType.ENTER_EMAIL),
-                Arguments.of(CountType.ENTER_PASSWORD),
-                Arguments.of(CountType.ENTER_SMS_CODE),
-                Arguments.of(CountType.ENTER_AUTH_APP_CODE));
-    }
-
-    private void setupConfigurationServiceCountForCountType(
-            CountType countType, int retriesAllowed) {
-        switch (countType) {
-            case ENTER_EMAIL -> when(configurationService.getMaxEmailReAuthRetries())
-                    .thenReturn(retriesAllowed);
-            case ENTER_PASSWORD -> when(configurationService.getMaxPasswordRetries())
-                    .thenReturn(retriesAllowed);
-            case ENTER_AUTH_APP_CODE, ENTER_SMS_CODE, ENTER_EMAIL_CODE -> when(configurationService
-                            .getCodeMaxRetries())
-                    .thenReturn(retriesAllowed);
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("reauthRelevantCounts")
-    void isBlockedForReauthReturnsTrueWhenAnyRelevantCountTypeExceedsTheThreshold(
-            CountType countThatExceedsMax) {
-        // Setup all counts to not exceed the max so we can isolate just the one that does exceed
-        // subsequently
-        Arrays.stream(CountType.values()).forEach(this::setupCountThatDoesNotExceedMax);
-
-        var retriesAllowed = 5;
-        setupConfigurationServiceCountForCountType(countThatExceedsMax, retriesAllowed);
-        when(authenticationAttemptsService.getCount(
-                        SUBJECT_ID, JourneyType.REAUTHENTICATION, countThatExceedsMax))
-                .thenReturn(retriesAllowed + 1);
-
-        assertTrue(helper.isBlockedForReauth(SUBJECT_ID));
-    }
-
-    @Test
-    void isBlockedForReauthReturnsTrueWhenNoCountExceedsTheThreshold() {
-        Arrays.stream(CountType.values()).forEach(this::setupCountThatDoesNotExceedMax);
-
-        assertFalse(helper.isBlockedForReauth(SUBJECT_ID));
-    }
-
-    private void setupCountThatDoesNotExceedMax(CountType count) {
-        var maxRetries = 4;
-        when(authenticationAttemptsService.getCount(
-                        SUBJECT_ID, JourneyType.REAUTHENTICATION, count))
-                .thenReturn(maxRetries - 1);
-        setupConfigurationServiceCountForCountType(count, maxRetries);
-    }
+            new ReauthAuthenticationAttemptsHelper(configurationService);
 
     @Test
     void countTypesThatExceedMaxShouldReturnTheCountTypesThatHaveExceededTheirMaximums() {


### PR DESCRIPTION
## What

Contains a refactor to the way we retrieve and check reauth counts, in order to:

* Make our code more flexible - this way, the calling code can decide what to do in the case of different exceeded counts, and later on it'll make life easier when we want to populate audit events with all counts.
* Make helpers contain static methods

Then, it updates the check reauth user handler to ensure that we're checking all reauth counts, and log a user out in the case of any that exceed the configured maximum.

## How to review

1. Code Review commit by commit
