### PR TITLE
Aut 3530/check reauth counts mfa

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -151,7 +151,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             AuditService.UNKNOWN,
                             extractPersistentIdFromHeaders(input.getHeaders()));
 
-            if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
+            if (journeyType == JourneyType.REAUTHENTICATION
+                    && configurationService.isAuthenticationAttemptsServiceEnabled()) {
                 var countsByJourney =
                         authenticationAttemptsService.getCountsByJourney(
                                 userContext.getUserProfile().get().getSubjectID(),
@@ -162,6 +163,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                                 countsByJourney, configurationService);
 
                 if (!countTypesWhereBlocked.isEmpty()) {
+                    LOG.info(
+                            "Re-authentication locked due to {} counts exceeded.",
+                            countTypesWhereBlocked);
                     return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1057);
                 }
             }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -40,6 +40,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
@@ -303,8 +304,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     true);
 
             if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
-                clearReauthAttemptCountsForSuccessfullyReauthenticatedUser(
-                        userProfile.getSubjectID());
+                clearReauthErrorCountsForSuccessfullyAuthenticatedUser(userProfile.getSubjectID());
             }
         }
 
@@ -316,9 +316,12 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 FrontendAuditableEvent.AUTH_CODE_VERIFIED, auditContext, metadataPairArray);
     }
 
-    void clearReauthAttemptCountsForSuccessfullyReauthenticatedUser(String subjectId) {
-        authenticationAttemptsService.deleteCount(
-                subjectId, JourneyType.REAUTHENTICATION, CountType.ENTER_SMS_CODE);
+    void clearReauthErrorCountsForSuccessfullyAuthenticatedUser(String subjectId) {
+        Arrays.stream(CountType.values())
+                .forEach(
+                        countType ->
+                                authenticationAttemptsService.deleteCount(
+                                        subjectId, JourneyType.REAUTHENTICATION, countType));
     }
 
     private AuditService.MetadataPair[] metadataPairs(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.ReauthAuthenticationAttemptsHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
@@ -148,6 +149,24 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     codeRequest.getMfaMethodType(),
                     codeRequest.getJourneyType());
             return generateApiGatewayProxyErrorResponse(400, ERROR_1002);
+        }
+
+        if (configurationService.isAuthenticationAttemptsServiceEnabled()
+                && JourneyType.REAUTHENTICATION.equals(codeRequest.getJourneyType())) {
+            var counts =
+                    authenticationAttemptsService.getCountsByJourney(
+                            userContext.getUserProfile().get().getSubjectID(),
+                            JourneyType.REAUTHENTICATION);
+            var countTypesWhereLimitExceeded =
+                    ReauthAuthenticationAttemptsHelper.countTypesWhereUserIsBlockedForReauth(
+                            counts, configurationService);
+
+            if (!countTypesWhereLimitExceeded.isEmpty()) {
+                LOG.info(
+                        "Re-authentication locked due to {} counts exceeded.",
+                        countTypesWhereLimitExceeded);
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1057);
+            }
         }
 
         LOG.info("Invoking verify MFA code handler");

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -364,12 +364,17 @@ class VerifyCodeHandlerTest {
         when(configurationService.getTestClientVerifyEmailOTP())
                 .thenReturn(Optional.of(TEST_CLIENT_CODE));
         when(codeStorageService.getOtpCode(email, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
+
+        when(authenticationService.getUserProfileFromEmail(email))
+                .thenReturn(Optional.of(userProfile));
+
         testSession.setEmailAddress(email);
         testSession.setInternalCommonSubjectIdentifier(expectedCommonSubject);
         String body =
                 format(
                         "{ \"code\": \"%s\", \"notificationType\": \"%s\"  }",
                         TEST_CLIENT_CODE, VERIFY_EMAIL);
+
         var result = makeCallWithCode(body, Optional.of(testSession), TEST_CLIENT_ID);
 
         assertThat(result, hasStatus(204));
@@ -400,6 +405,10 @@ class VerifyCodeHandlerTest {
         when(configurationService.getTestClientVerifyEmailOTP())
                 .thenReturn(Optional.of(TEST_CLIENT_CODE));
         when(codeStorageService.getOtpCode(email, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
+
+        when(authenticationService.getUserProfileFromEmail(email))
+                .thenReturn(Optional.of(userProfile));
+
         testSession.setEmailAddress(email);
         testSession.setInternalCommonSubjectIdentifier(expectedCommonSubject);
         String body =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -673,6 +673,19 @@ class VerifyCodeHandlerTest {
     }
 
     @Test
+    void shouldAllowInteractiveSignInWhenMaxReauthAttemptsReachedAndJourneyIsNotReauthentciation() {
+        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
+        when(configurationService.getMaxEmailReAuthRetries()).thenReturn(5);
+        when(authenticationAttemptsService.getCountsByJourney(any(), any()))
+                .thenReturn(Map.of(CountType.ENTER_EMAIL, 6));
+        when(codeStorageService.getOtpCode(EMAIL, MFA_SMS)).thenReturn(Optional.of(CODE));
+
+        var result = makeCallWithCode(CODE, MFA_SMS.toString(), JourneyType.SIGN_IN);
+
+        assertThat(result, hasStatus(204));
+    }
+
+    @Test
     void shouldReturnMaxReauthAttemptsReachedAndReturn400WhenMaxReauthAttemptsExceeded() {
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
         when(configurationService.getMaxEmailReAuthRetries()).thenReturn(5);
@@ -680,8 +693,7 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Map.of(CountType.ENTER_EMAIL, 6));
         when(codeStorageService.getOtpCode(EMAIL, MFA_SMS)).thenReturn(Optional.of(CODE));
 
-        var result =
-                makeCallWithCode(INVALID_CODE, MFA_SMS.toString(), JourneyType.REAUTHENTICATION);
+        var result = makeCallWithCode(CODE, MFA_SMS.toString(), JourneyType.REAUTHENTICATION);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1057));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -10,6 +10,7 @@ import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
@@ -24,6 +25,7 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
 import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.net.URI;
@@ -60,6 +62,10 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
     private static final Subject SUBJECT = new Subject();
     private static final String INTERNAl_SECTOR_HOST = "test.account.gov.uk";
 
+    @RegisterExtension
+    protected static final AuthenticationAttemptsStoreExtension authCodeExtension =
+            new AuthenticationAttemptsStoreExtension();
+
     @BeforeEach
     void setup() {
         handler =
@@ -67,6 +73,10 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         REAUTH_SIGNOUT_AND_TXMA_ENABLED_CONFIGUARION_SERVICE,
                         redisConnectionService);
         txmaAuditQueue.clear();
+        var password = "password-1";
+        userStore.signUp(EMAIL_ADDRESS, password);
+        userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");
+        userStore.setPhoneNumberAndVerificationStatus(EMAIL_ADDRESS, "01234567890", true, true);
     }
 
     private static Stream<NotificationType> emailNotificationTypes() {


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

When the User enters a MFA code in a re-authentication journey we should check that they are not locked out re-authenticating by checking their error counts.

We also check if a UserProfile is available and error out if not.

## How to review

1. Code Review
 
<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
