### PR TITLE
ATO-981: Send sessionId to Auth `/userinfo` endpoint 

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 
 import static uk.gov.di.authentication.external.domain.AuthExternalApiAuditableEvent.AUTH_USERINFO_SENT_TO_ORCHESTRATION;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.AUTHORIZATION_HEADER;
+import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getOptionalHeaderValueFromHeaders;
@@ -83,6 +84,15 @@ public class UserInfoHandler
         ThreadContext.clearMap();
         LOG.info("Request received to the UserInfoHandler");
         Map<String, String> headers = input.getHeaders();
+
+        String sessionId =
+                getOptionalHeaderValueFromHeaders(
+                                input.getHeaders(),
+                                SESSION_ID_HEADER,
+                                configurationService.getHeadersCaseInsensitive())
+                        .orElse("Not present");
+
+        LOG.info("Session-Id : {} in userinfo request", sessionId);
 
         Optional<String> authorisationHeader =
                 getOptionalHeaderValueFromHeaders(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -79,6 +79,7 @@ import static java.util.Objects.nonNull;
 import static uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED;
 import static uk.gov.di.orchestration.shared.conditions.DocAppUserHelper.isDocCheckingAppUserWithSubjectId;
 import static uk.gov.di.orchestration.shared.conditions.IdentityHelper.identityRequired;
+import static uk.gov.di.orchestration.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.orchestration.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
@@ -318,15 +319,15 @@ public class AuthenticationCallbackHandler
                         buildURI(
                                 configurationService.getAuthenticationBackendURI().toString(),
                                 "userinfo");
-
+                var sessionId = userSession.getSessionId();
                 HTTPRequest authorizationRequest = new HTTPRequest(GET, userInfoURI);
+                authorizationRequest.setHeader(SESSION_ID_HEADER, sessionId);
                 authorizationRequest.setAuthorization(
                         tokenResponse
                                 .toSuccessResponse()
                                 .getTokens()
                                 .getAccessToken()
                                 .toAuthorizationHeader());
-
                 UserInfo userInfo = tokenService.sendUserInfoDataRequest(authorizationRequest);
 
                 auditService.submitAuditEvent(


### PR DESCRIPTION
## What
- Sends the session id in the headers of the `/userinfo` request from orchestration to auth
- Adds some logging to log this sessionId if present in the headers of the request
<!-- Describe what you have changed and why -->

## How to review
- Code review commit-by-commit 
- Tested by sequentially deploying in Orch dev, running through a journey and then deploying auth sandpit and running through again, all went fine!
## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
