### PR TITLE
BAU: Attach journey id to Notify messages as a reference

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -141,13 +141,13 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                         request.getDestination(),
                         personalisation,
                         request.getNotificationType(),
-                        "");
+                        request.getClientSessionId());
             } else {
                 notificationService.sendText(
                         request.getDestination(),
                         personalisation,
                         request.getNotificationType(),
-                        "");
+                        request.getClientSessionId());
             }
             writeTestClientOtpToS3(
                     request.getNotificationType(), request.getCode(), request.getDestination());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -138,10 +138,16 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
 
             if (request.getNotificationType().isEmail()) {
                 notificationService.sendEmail(
-                        request.getDestination(), personalisation, request.getNotificationType());
+                        request.getDestination(),
+                        personalisation,
+                        request.getNotificationType(),
+                        "");
             } else {
                 notificationService.sendText(
-                        request.getDestination(), personalisation, request.getNotificationType());
+                        request.getDestination(),
+                        personalisation,
+                        request.getNotificationType(),
+                        "");
             }
             writeTestClientOtpToS3(
                     request.getNotificationType(), request.getCode(), request.getDestination());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -74,7 +74,12 @@ public class NotificationHandlerTest {
 
         NotifyRequest notifyRequest =
                 new NotifyRequest(
-                        CommonTestVariables.EMAIL, VERIFY_EMAIL, "654321", SupportedLanguage.EN);
+                        CommonTestVariables.EMAIL,
+                        VERIFY_EMAIL,
+                        "654321",
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
@@ -97,7 +102,9 @@ public class NotificationHandlerTest {
                 new NotifyRequest(
                         CommonTestVariables.EMAIL,
                         PASSWORD_RESET_CONFIRMATION,
-                        SupportedLanguage.EN);
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
@@ -122,7 +129,9 @@ public class NotificationHandlerTest {
                 new NotifyRequest(
                         CommonTestVariables.UK_MOBILE_NUMBER,
                         PASSWORD_RESET_CONFIRMATION_SMS,
-                        SupportedLanguage.EN);
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         var sqsEvent = generateSQSEvent(objectMapper.writeValueAsString(notifyRequest));
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
@@ -151,7 +160,9 @@ public class NotificationHandlerTest {
                 new NotifyRequest(
                         CommonTestVariables.EMAIL,
                         ACCOUNT_CREATED_CONFIRMATION,
-                        SupportedLanguage.EN);
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -177,7 +188,9 @@ public class NotificationHandlerTest {
                         CommonTestVariables.UK_MOBILE_NUMBER,
                         VERIFY_PHONE_NUMBER,
                         "654321",
-                        SupportedLanguage.EN);
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -197,7 +210,9 @@ public class NotificationHandlerTest {
                         CommonTestVariables.EMAIL,
                         TERMS_AND_CONDITIONS_BULK_EMAIL,
                         "",
-                        SupportedLanguage.EN);
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -225,7 +240,12 @@ public class NotificationHandlerTest {
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(
-                        CommonTestVariables.EMAIL, VERIFY_EMAIL, "654321", SupportedLanguage.EN);
+                        CommonTestVariables.EMAIL,
+                        VERIFY_EMAIL,
+                        "654321",
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
@@ -257,7 +277,9 @@ public class NotificationHandlerTest {
                         CommonTestVariables.UK_MOBILE_NUMBER,
                         VERIFY_PHONE_NUMBER,
                         "654321",
-                        SupportedLanguage.EN);
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -287,7 +309,12 @@ public class NotificationHandlerTest {
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(
-                        NOTIFY_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321", SupportedLanguage.EN);
+                        NOTIFY_PHONE_NUMBER,
+                        VERIFY_PHONE_NUMBER,
+                        "654321",
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -311,7 +338,9 @@ public class NotificationHandlerTest {
                         CommonTestVariables.UK_MOBILE_NUMBER,
                         MFA_SMS,
                         "654321",
-                        SupportedLanguage.EN);
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -328,7 +357,13 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessMfaMessageFromSQSQueueAndWriteToS3WhenTestClient()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(NOTIFY_PHONE_NUMBER, MFA_SMS, "654321", SupportedLanguage.EN);
+                new NotifyRequest(
+                        NOTIFY_PHONE_NUMBER,
+                        MFA_SMS,
+                        "654321",
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -352,7 +387,9 @@ public class NotificationHandlerTest {
                 new NotifyRequest(
                         CommonTestVariables.EMAIL,
                         ACCOUNT_CREATED_CONFIRMATION,
-                        SupportedLanguage.EN);
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
 
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
@@ -382,7 +419,9 @@ public class NotificationHandlerTest {
                         CommonTestVariables.EMAIL,
                         RESET_PASSWORD_WITH_CODE,
                         "654321",
-                        SupportedLanguage.EN);
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
@@ -407,7 +446,9 @@ public class NotificationHandlerTest {
                         CommonTestVariables.EMAIL,
                         VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
                         "654321",
-                        SupportedLanguage.EN);
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -47,7 +47,6 @@ import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildUR
 
 public class NotificationHandlerTest {
 
-    private static final String NOTIFY_PHONE_NUMBER = "01234567899";
     private static final String BUCKET_NAME = "test-s3-bucket";
     private static final String FRONTEND_BASE_URL = "https://localhost:8080/frontend";
     private static final String CONTACT_US_LINK_ROUTE = "contact-us";
@@ -61,7 +60,8 @@ public class NotificationHandlerTest {
 
     @BeforeEach
     void setUp() {
-        when(configService.getNotifyTestDestinations()).thenReturn(List.of(NOTIFY_PHONE_NUMBER));
+        when(configService.getNotifyTestDestinations())
+                .thenReturn(List.of(CommonTestVariables.UK_MOBILE_NUMBER));
         when(configService.getSmoketestBucketName()).thenReturn(BUCKET_NAME);
         when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
         when(configService.getContactUsLinkRoute()).thenReturn(CONTACT_US_LINK_ROUTE);
@@ -83,7 +83,7 @@ public class NotificationHandlerTest {
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
-        personalisation.put("email-address", notifyRequest.getDestination());
+        personalisation.put("email-address", CommonTestVariables.EMAIL);
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
@@ -182,7 +182,7 @@ public class NotificationHandlerTest {
 
         verify(notificationService)
                 .sendText(
-                        notifyRequest.getDestination(),
+                        CommonTestVariables.UK_MOBILE_NUMBER,
                         personalisation,
                         VERIFY_PHONE_NUMBER,
                         CommonTestVariables.CLIENT_SESSION_ID);
@@ -225,7 +225,7 @@ public class NotificationHandlerTest {
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
-        personalisation.put("email-address", notifyRequest.getDestination());
+        personalisation.put("email-address", CommonTestVariables.EMAIL);
         personalisation.put("contact-us-link", contactUsLinkUrl);
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
@@ -279,7 +279,7 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessPhoneMessageFromSQSQueueAndWriteToS3WhenTestClient()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                createRequest(NOTIFY_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
+                createRequest(CommonTestVariables.UK_MOBILE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -290,12 +290,15 @@ public class NotificationHandlerTest {
 
         verify(notificationService)
                 .sendText(
-                        notifyRequest.getDestination(),
+                        CommonTestVariables.UK_MOBILE_NUMBER,
                         personalisation,
                         VERIFY_PHONE_NUMBER,
                         CommonTestVariables.CLIENT_SESSION_ID);
         var putObjectRequest =
-                PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
+                PutObjectRequest.builder()
+                        .bucket(BUCKET_NAME)
+                        .key(CommonTestVariables.UK_MOBILE_NUMBER)
+                        .build();
         verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
     }
 
@@ -314,7 +317,7 @@ public class NotificationHandlerTest {
 
         verify(notificationService)
                 .sendText(
-                        notifyRequest.getDestination(),
+                        CommonTestVariables.UK_MOBILE_NUMBER,
                         personalisation,
                         MFA_SMS,
                         CommonTestVariables.CLIENT_SESSION_ID);
@@ -323,7 +326,8 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessMfaMessageFromSQSQueueAndWriteToS3WhenTestClient()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest = createRequest(NOTIFY_PHONE_NUMBER, MFA_SMS, "654321");
+        NotifyRequest notifyRequest =
+                createRequest(CommonTestVariables.UK_MOBILE_NUMBER, MFA_SMS, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -334,12 +338,15 @@ public class NotificationHandlerTest {
 
         verify(notificationService)
                 .sendText(
-                        notifyRequest.getDestination(),
+                        CommonTestVariables.UK_MOBILE_NUMBER,
                         personalisation,
                         MFA_SMS,
                         CommonTestVariables.CLIENT_SESSION_ID);
         var putObjectRequest =
-                PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
+                PutObjectRequest.builder()
+                        .bucket(BUCKET_NAME)
+                        .key(CommonTestVariables.UK_MOBILE_NUMBER)
+                        .build();
         verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
     }
 
@@ -361,12 +368,15 @@ public class NotificationHandlerTest {
 
         verify(notificationService)
                 .sendEmail(
-                        notifyRequest.getDestination(),
+                        CommonTestVariables.EMAIL,
                         personalisation,
                         ACCOUNT_CREATED_CONFIRMATION,
                         CommonTestVariables.CLIENT_SESSION_ID);
         var putObjectRequest =
-                PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
+                PutObjectRequest.builder()
+                        .bucket(BUCKET_NAME)
+                        .key(CommonTestVariables.UK_MOBILE_NUMBER)
+                        .build();
         verify(s3Client, times(0)).putObject(eq(putObjectRequest), any(RequestBody.class));
     }
 
@@ -383,7 +393,7 @@ public class NotificationHandlerTest {
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
-        personalisation.put("email-address", notifyRequest.getDestination());
+        personalisation.put("email-address", CommonTestVariables.EMAIL);
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
@@ -407,7 +417,7 @@ public class NotificationHandlerTest {
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
-        personalisation.put("email-address", notifyRequest.getDestination());
+        personalisation.put("email-address", CommonTestVariables.EMAIL);
 
         verify(notificationService)
                 .sendEmail(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -87,7 +87,7 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
-                .sendEmail(CommonTestVariables.EMAIL, personalisation, VERIFY_EMAIL);
+                .sendEmail(CommonTestVariables.EMAIL, personalisation, VERIFY_EMAIL, "");
     }
 
     @Test
@@ -108,7 +108,11 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
-                .sendEmail(CommonTestVariables.EMAIL, personalisation, PASSWORD_RESET_CONFIRMATION);
+                .sendEmail(
+                        CommonTestVariables.EMAIL,
+                        personalisation,
+                        PASSWORD_RESET_CONFIRMATION,
+                        "");
     }
 
     @Test
@@ -130,7 +134,8 @@ public class NotificationHandlerTest {
                 .sendText(
                         CommonTestVariables.UK_MOBILE_NUMBER,
                         personalisation,
-                        PASSWORD_RESET_CONFIRMATION_SMS);
+                        PASSWORD_RESET_CONFIRMATION_SMS,
+                        "");
     }
 
     @Test
@@ -158,7 +163,10 @@ public class NotificationHandlerTest {
 
         verify(notificationService)
                 .sendEmail(
-                        CommonTestVariables.EMAIL, personalisation, ACCOUNT_CREATED_CONFIRMATION);
+                        CommonTestVariables.EMAIL,
+                        personalisation,
+                        ACCOUNT_CREATED_CONFIRMATION,
+                        "");
     }
 
     @Test
@@ -179,7 +187,7 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, VERIFY_PHONE_NUMBER);
+                .sendText(notifyRequest.getDestination(), personalisation, VERIFY_PHONE_NUMBER, "");
     }
 
     @Test
@@ -228,7 +236,7 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
-                .sendEmail(CommonTestVariables.EMAIL, personalisation, VERIFY_EMAIL);
+                .sendEmail(CommonTestVariables.EMAIL, personalisation, VERIFY_EMAIL, "");
 
         RuntimeException exception =
                 assertThrows(
@@ -258,7 +266,10 @@ public class NotificationHandlerTest {
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
                 .sendText(
-                        CommonTestVariables.UK_MOBILE_NUMBER, personalisation, VERIFY_PHONE_NUMBER);
+                        CommonTestVariables.UK_MOBILE_NUMBER,
+                        personalisation,
+                        VERIFY_PHONE_NUMBER,
+                        "");
 
         RuntimeException exception =
                 assertThrows(
@@ -286,7 +297,7 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, VERIFY_PHONE_NUMBER);
+                .sendText(notifyRequest.getDestination(), personalisation, VERIFY_PHONE_NUMBER, "");
         var putObjectRequest =
                 PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
         verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
@@ -310,7 +321,7 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, MFA_SMS);
+                .sendText(notifyRequest.getDestination(), personalisation, MFA_SMS, "");
     }
 
     @Test
@@ -327,7 +338,7 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, MFA_SMS);
+                .sendText(notifyRequest.getDestination(), personalisation, MFA_SMS, "");
         var putObjectRequest =
                 PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
         verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
@@ -356,7 +367,8 @@ public class NotificationHandlerTest {
                 .sendEmail(
                         notifyRequest.getDestination(),
                         personalisation,
-                        ACCOUNT_CREATED_CONFIRMATION);
+                        ACCOUNT_CREATED_CONFIRMATION,
+                        "");
         var putObjectRequest =
                 PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
         verify(s3Client, times(0)).putObject(eq(putObjectRequest), any(RequestBody.class));
@@ -383,7 +395,8 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
-                .sendEmail(CommonTestVariables.EMAIL, personalisation, RESET_PASSWORD_WITH_CODE);
+                .sendEmail(
+                        CommonTestVariables.EMAIL, personalisation, RESET_PASSWORD_WITH_CODE, "");
     }
 
     @Test
@@ -408,7 +421,8 @@ public class NotificationHandlerTest {
                 .sendEmail(
                         CommonTestVariables.EMAIL,
                         personalisation,
-                        VERIFY_CHANGE_HOW_GET_SECURITY_CODES);
+                        VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
+                        "");
     }
 
     private String buildContactUsUrl() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -413,21 +413,16 @@ public class NotificationHandlerTest {
         return sqsEvent;
     }
 
-    private NotifyRequest createRequest(
-            String destination, NotificationType template, String code) {
-        return new NotifyRequest(
-                destination,
-                template,
-                code,
-                SupportedLanguage.EN,
-                CommonTestVariables.SESSION_ID,
-                CommonTestVariables.CLIENT_SESSION_ID);
-    }
-
     private SQSEvent notifyRequestEvent(String destination, NotificationType template, String code)
             throws Json.JsonException {
-        NotifyRequest notifyRequest = createRequest(destination, template, code);
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        return generateSQSEvent(notifyRequestString);
+        var notifyRequest =
+                new NotifyRequest(
+                        destination,
+                        template,
+                        code,
+                        SupportedLanguage.EN,
+                        CommonTestVariables.SESSION_ID,
+                        CommonTestVariables.CLIENT_SESSION_ID);
+        return generateSQSEvent(objectMapper.writeValueAsString(notifyRequest));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -73,10 +73,7 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessEmailMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
 
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.EMAIL, VERIFY_EMAIL, "654321");
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent = notifyRequestEvent(CommonTestVariables.EMAIL, VERIFY_EMAIL, "654321");
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
         handler.handleRequest(sqsEvent, context);
@@ -97,10 +94,8 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessResetPasswordConfirmationEmailFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.EMAIL, PASSWORD_RESET_CONFIRMATION, null);
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent =
+                notifyRequestEvent(CommonTestVariables.EMAIL, PASSWORD_RESET_CONFIRMATION, null);
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
         handler.handleRequest(sqsEvent, context);
@@ -119,12 +114,11 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessResetPasswordConfirmationSMSFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
-        var notifyRequest =
-                createRequest(
+        var sqsEvent =
+                notifyRequestEvent(
                         CommonTestVariables.UK_MOBILE_NUMBER,
                         PASSWORD_RESET_CONFIRMATION_SMS,
                         null);
-        var sqsEvent = generateSQSEvent(objectMapper.writeValueAsString(notifyRequest));
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
         handler.handleRequest(sqsEvent, context);
@@ -148,10 +142,8 @@ public class NotificationHandlerTest {
         when(configService.getAccountManagementURI()).thenReturn(baseUrl);
         when(configService.getGovUKAccountsURL()).thenReturn(govUKAccountsUrl);
 
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.EMAIL, ACCOUNT_CREATED_CONFIRMATION, null);
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent =
+                notifyRequestEvent(CommonTestVariables.EMAIL, ACCOUNT_CREATED_CONFIRMATION, null);
 
         handler.handleRequest(sqsEvent, context);
 
@@ -170,10 +162,9 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessPhoneMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.UK_MOBILE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent =
+                notifyRequestEvent(
+                        CommonTestVariables.UK_MOBILE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
 
         handler.handleRequest(sqsEvent, context);
 
@@ -190,10 +181,8 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldNotSendAnythingWhenATermsAndConditionsBulkEmail() throws Json.JsonException {
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.EMAIL, TERMS_AND_CONDITIONS_BULK_EMAIL, "");
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent =
+                notifyRequestEvent(CommonTestVariables.EMAIL, TERMS_AND_CONDITIONS_BULK_EMAIL, "");
 
         handler.handleRequest(sqsEvent, context);
 
@@ -217,10 +206,7 @@ public class NotificationHandlerTest {
     @Test
     void shouldThrowExceptionIfNotifyIsUnableToSendEmail()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.EMAIL, VERIFY_EMAIL, "654321");
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent = notifyRequestEvent(CommonTestVariables.EMAIL, VERIFY_EMAIL, "654321");
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
         Map<String, Object> personalisation = new HashMap<>();
@@ -249,10 +235,9 @@ public class NotificationHandlerTest {
     @Test
     void shouldThrowExceptionIfNotifyIsUnableToSendText()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.UK_MOBILE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent =
+                notifyRequestEvent(
+                        CommonTestVariables.UK_MOBILE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
@@ -278,10 +263,9 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessPhoneMessageFromSQSQueueAndWriteToS3WhenTestClient()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.UK_MOBILE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent =
+                notifyRequestEvent(
+                        CommonTestVariables.UK_MOBILE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
 
         handler.handleRequest(sqsEvent, context);
 
@@ -305,10 +289,8 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessMfaMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.UK_MOBILE_NUMBER, MFA_SMS, "654321");
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent =
+                notifyRequestEvent(CommonTestVariables.UK_MOBILE_NUMBER, MFA_SMS, "654321");
 
         handler.handleRequest(sqsEvent, context);
 
@@ -326,10 +308,8 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessMfaMessageFromSQSQueueAndWriteToS3WhenTestClient()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.UK_MOBILE_NUMBER, MFA_SMS, "654321");
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent =
+                notifyRequestEvent(CommonTestVariables.UK_MOBILE_NUMBER, MFA_SMS, "654321");
 
         handler.handleRequest(sqsEvent, context);
 
@@ -354,11 +334,8 @@ public class NotificationHandlerTest {
     void
             shouldSuccessfullyProcessAccountConfirmationRequestFromSQSQueueAndNotWriteOTPToS3WhenTestClient()
                     throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.EMAIL, ACCOUNT_CREATED_CONFIRMATION, null);
-
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent =
+                notifyRequestEvent(CommonTestVariables.EMAIL, ACCOUNT_CREATED_CONFIRMATION, null);
 
         handler.handleRequest(sqsEvent, context);
 
@@ -383,10 +360,8 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessPasswordResetWithCodeMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest =
-                createRequest(CommonTestVariables.EMAIL, RESET_PASSWORD_WITH_CODE, "654321");
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        SQSEvent sqsEvent =
+                notifyRequestEvent(CommonTestVariables.EMAIL, RESET_PASSWORD_WITH_CODE, "654321");
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
         handler.handleRequest(sqsEvent, context);
@@ -407,11 +382,9 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessVerifyChangeHowGetSecurityCodesMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest =
-                createRequest(
+        SQSEvent sqsEvent =
+                notifyRequestEvent(
                         CommonTestVariables.EMAIL, VERIFY_CHANGE_HOW_GET_SECURITY_CODES, "654321");
-        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
-        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
         handler.handleRequest(sqsEvent, context);
 
@@ -449,5 +422,12 @@ public class NotificationHandlerTest {
                 SupportedLanguage.EN,
                 CommonTestVariables.SESSION_ID,
                 CommonTestVariables.CLIENT_SESSION_ID);
+    }
+
+    private SQSEvent notifyRequestEvent(String destination, NotificationType template, String code)
+            throws Json.JsonException {
+        NotifyRequest notifyRequest = createRequest(destination, template, code);
+        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
+        return generateSQSEvent(notifyRequestString);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -73,13 +74,7 @@ public class NotificationHandlerTest {
             throws Json.JsonException, NotificationClientException {
 
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        CommonTestVariables.EMAIL,
-                        VERIFY_EMAIL,
-                        "654321",
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(CommonTestVariables.EMAIL, VERIFY_EMAIL, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
@@ -103,12 +98,7 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessResetPasswordConfirmationEmailFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        CommonTestVariables.EMAIL,
-                        PASSWORD_RESET_CONFIRMATION,
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(CommonTestVariables.EMAIL, PASSWORD_RESET_CONFIRMATION, null);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
@@ -130,12 +120,10 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessResetPasswordConfirmationSMSFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
         var notifyRequest =
-                new NotifyRequest(
+                createRequest(
                         CommonTestVariables.UK_MOBILE_NUMBER,
                         PASSWORD_RESET_CONFIRMATION_SMS,
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                        null);
         var sqsEvent = generateSQSEvent(objectMapper.writeValueAsString(notifyRequest));
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
 
@@ -161,12 +149,7 @@ public class NotificationHandlerTest {
         when(configService.getGovUKAccountsURL()).thenReturn(govUKAccountsUrl);
 
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        CommonTestVariables.EMAIL,
-                        ACCOUNT_CREATED_CONFIRMATION,
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(CommonTestVariables.EMAIL, ACCOUNT_CREATED_CONFIRMATION, null);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -188,13 +171,7 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessPhoneMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        CommonTestVariables.UK_MOBILE_NUMBER,
-                        VERIFY_PHONE_NUMBER,
-                        "654321",
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(CommonTestVariables.UK_MOBILE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -214,13 +191,7 @@ public class NotificationHandlerTest {
     @Test
     void shouldNotSendAnythingWhenATermsAndConditionsBulkEmail() throws Json.JsonException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        CommonTestVariables.EMAIL,
-                        TERMS_AND_CONDITIONS_BULK_EMAIL,
-                        "",
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(CommonTestVariables.EMAIL, TERMS_AND_CONDITIONS_BULK_EMAIL, "");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -247,13 +218,7 @@ public class NotificationHandlerTest {
     void shouldThrowExceptionIfNotifyIsUnableToSendEmail()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        CommonTestVariables.EMAIL,
-                        VERIFY_EMAIL,
-                        "654321",
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(CommonTestVariables.EMAIL, VERIFY_EMAIL, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
@@ -285,13 +250,7 @@ public class NotificationHandlerTest {
     void shouldThrowExceptionIfNotifyIsUnableToSendText()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        CommonTestVariables.UK_MOBILE_NUMBER,
-                        VERIFY_PHONE_NUMBER,
-                        "654321",
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(CommonTestVariables.UK_MOBILE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -320,13 +279,7 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessPhoneMessageFromSQSQueueAndWriteToS3WhenTestClient()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        NOTIFY_PHONE_NUMBER,
-                        VERIFY_PHONE_NUMBER,
-                        "654321",
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(NOTIFY_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -350,13 +303,7 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessMfaMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        CommonTestVariables.UK_MOBILE_NUMBER,
-                        MFA_SMS,
-                        "654321",
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(CommonTestVariables.UK_MOBILE_NUMBER, MFA_SMS, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -376,14 +323,7 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessMfaMessageFromSQSQueueAndWriteToS3WhenTestClient()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        NOTIFY_PHONE_NUMBER,
-                        MFA_SMS,
-                        "654321",
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+        NotifyRequest notifyRequest = createRequest(NOTIFY_PHONE_NUMBER, MFA_SMS, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -408,12 +348,7 @@ public class NotificationHandlerTest {
             shouldSuccessfullyProcessAccountConfirmationRequestFromSQSQueueAndNotWriteOTPToS3WhenTestClient()
                     throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        CommonTestVariables.EMAIL,
-                        ACCOUNT_CREATED_CONFIRMATION,
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(CommonTestVariables.EMAIL, ACCOUNT_CREATED_CONFIRMATION, null);
 
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
@@ -439,13 +374,7 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessPasswordResetWithCodeMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        CommonTestVariables.EMAIL,
-                        RESET_PASSWORD_WITH_CODE,
-                        "654321",
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(CommonTestVariables.EMAIL, RESET_PASSWORD_WITH_CODE, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl = "https://localhost:8080/frontend/" + CONTACT_US_LINK_ROUTE;
@@ -469,13 +398,8 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessVerifyChangeHowGetSecurityCodesMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        CommonTestVariables.EMAIL,
-                        VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
-                        "654321",
-                        SupportedLanguage.EN,
-                        CommonTestVariables.SESSION_ID,
-                        CommonTestVariables.CLIENT_SESSION_ID);
+                createRequest(
+                        CommonTestVariables.EMAIL, VERIFY_CHANGE_HOW_GET_SECURITY_CODES, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -504,5 +428,16 @@ public class NotificationHandlerTest {
         SQSEvent sqsEvent = new SQSEvent();
         sqsEvent.setRecords(singletonList(sqsMessage));
         return sqsEvent;
+    }
+
+    private NotifyRequest createRequest(
+            String destination, NotificationType template, String code) {
+        return new NotifyRequest(
+                destination,
+                template,
+                code,
+                SupportedLanguage.EN,
+                CommonTestVariables.SESSION_ID,
+                CommonTestVariables.CLIENT_SESSION_ID);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -92,7 +92,11 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
-                .sendEmail(CommonTestVariables.EMAIL, personalisation, VERIFY_EMAIL, "");
+                .sendEmail(
+                        CommonTestVariables.EMAIL,
+                        personalisation,
+                        VERIFY_EMAIL,
+                        CommonTestVariables.CLIENT_SESSION_ID);
     }
 
     @Test
@@ -119,7 +123,7 @@ public class NotificationHandlerTest {
                         CommonTestVariables.EMAIL,
                         personalisation,
                         PASSWORD_RESET_CONFIRMATION,
-                        "");
+                        CommonTestVariables.CLIENT_SESSION_ID);
     }
 
     @Test
@@ -144,7 +148,7 @@ public class NotificationHandlerTest {
                         CommonTestVariables.UK_MOBILE_NUMBER,
                         personalisation,
                         PASSWORD_RESET_CONFIRMATION_SMS,
-                        "");
+                        CommonTestVariables.CLIENT_SESSION_ID);
     }
 
     @Test
@@ -177,7 +181,7 @@ public class NotificationHandlerTest {
                         CommonTestVariables.EMAIL,
                         personalisation,
                         ACCOUNT_CREATED_CONFIRMATION,
-                        "");
+                        CommonTestVariables.CLIENT_SESSION_ID);
     }
 
     @Test
@@ -200,7 +204,11 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, VERIFY_PHONE_NUMBER, "");
+                .sendText(
+                        notifyRequest.getDestination(),
+                        personalisation,
+                        VERIFY_PHONE_NUMBER,
+                        CommonTestVariables.CLIENT_SESSION_ID);
     }
 
     @Test
@@ -256,7 +264,11 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
-                .sendEmail(CommonTestVariables.EMAIL, personalisation, VERIFY_EMAIL, "");
+                .sendEmail(
+                        CommonTestVariables.EMAIL,
+                        personalisation,
+                        VERIFY_EMAIL,
+                        CommonTestVariables.CLIENT_SESSION_ID);
 
         RuntimeException exception =
                 assertThrows(
@@ -291,7 +303,7 @@ public class NotificationHandlerTest {
                         CommonTestVariables.UK_MOBILE_NUMBER,
                         personalisation,
                         VERIFY_PHONE_NUMBER,
-                        "");
+                        CommonTestVariables.CLIENT_SESSION_ID);
 
         RuntimeException exception =
                 assertThrows(
@@ -324,7 +336,11 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, VERIFY_PHONE_NUMBER, "");
+                .sendText(
+                        notifyRequest.getDestination(),
+                        personalisation,
+                        VERIFY_PHONE_NUMBER,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         var putObjectRequest =
                 PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
         verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
@@ -350,7 +366,11 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, MFA_SMS, "");
+                .sendText(
+                        notifyRequest.getDestination(),
+                        personalisation,
+                        MFA_SMS,
+                        CommonTestVariables.CLIENT_SESSION_ID);
     }
 
     @Test
@@ -373,7 +393,11 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, MFA_SMS, "");
+                .sendText(
+                        notifyRequest.getDestination(),
+                        personalisation,
+                        MFA_SMS,
+                        CommonTestVariables.CLIENT_SESSION_ID);
         var putObjectRequest =
                 PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
         verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
@@ -405,7 +429,7 @@ public class NotificationHandlerTest {
                         notifyRequest.getDestination(),
                         personalisation,
                         ACCOUNT_CREATED_CONFIRMATION,
-                        "");
+                        CommonTestVariables.CLIENT_SESSION_ID);
         var putObjectRequest =
                 PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
         verify(s3Client, times(0)).putObject(eq(putObjectRequest), any(RequestBody.class));
@@ -435,7 +459,10 @@ public class NotificationHandlerTest {
 
         verify(notificationService)
                 .sendEmail(
-                        CommonTestVariables.EMAIL, personalisation, RESET_PASSWORD_WITH_CODE, "");
+                        CommonTestVariables.EMAIL,
+                        personalisation,
+                        RESET_PASSWORD_WITH_CODE,
+                        CommonTestVariables.CLIENT_SESSION_ID);
     }
 
     @Test
@@ -463,7 +490,7 @@ public class NotificationHandlerTest {
                         CommonTestVariables.EMAIL,
                         personalisation,
                         VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
-                        "");
+                        CommonTestVariables.CLIENT_SESSION_ID);
     }
 
     private String buildContactUsUrl() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.service.notify.NotificationClientException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Collections.emptyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static uk.gov.di.authentication.frontendapi.services.NotificationServiceTest.FakeNotificationType.FAKE_EMAIL;
@@ -39,7 +40,7 @@ class NotificationServiceTest {
         emailPersonalisation.put("validation-code", "some-code");
         emailPersonalisation.put("email-address", TEST_EMAIL);
 
-        notificationService.sendEmail(TEST_EMAIL, emailPersonalisation, FAKE_EMAIL);
+        notificationService.sendEmail(TEST_EMAIL, emailPersonalisation, FAKE_EMAIL, "");
 
         verify(notificationClient).sendEmail("FAKE_EMAIL", TEST_EMAIL, emailPersonalisation, "");
     }
@@ -49,10 +50,33 @@ class NotificationServiceTest {
         Map<String, Object> phonePersonalisation = new HashMap<>();
         phonePersonalisation.put("validation-code", "some-code");
         notificationService.sendText(
-                CommonTestVariables.UK_MOBILE_NUMBER, phonePersonalisation, FAKE_SMS);
+                CommonTestVariables.UK_MOBILE_NUMBER, phonePersonalisation, FAKE_SMS, "");
 
         verify(notificationClient)
                 .sendSms(
                         "FAKE_SMS", CommonTestVariables.UK_MOBILE_NUMBER, phonePersonalisation, "");
+    }
+
+    @Test
+    void shouldAttachReferenceToEmail() throws NotificationClientException {
+        notificationService.sendEmail(
+                CommonTestVariables.EMAIL, emptyMap(), FAKE_EMAIL, "some-reference-id");
+
+        verify(notificationClient)
+                .sendEmail(
+                        "FAKE_EMAIL", CommonTestVariables.EMAIL, emptyMap(), "some-reference-id");
+    }
+
+    @Test
+    void shouldAttachReferenceToText() throws NotificationClientException {
+        notificationService.sendText(
+                CommonTestVariables.UK_MOBILE_NUMBER, emptyMap(), FAKE_SMS, "some-reference-id");
+
+        verify(notificationClient)
+                .sendSms(
+                        "FAKE_SMS",
+                        CommonTestVariables.UK_MOBILE_NUMBER,
+                        emptyMap(),
+                        "some-reference-id");
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
@@ -21,16 +21,20 @@ public class NotificationService {
         this.configurationService = configurationService;
     }
 
-    public void sendEmail(String email, Map<String, Object> personalisation, TemplateAware type)
+    public void sendEmail(
+            String email, Map<String, Object> personalisation, TemplateAware type, String reference)
             throws NotificationClientException {
         notifyClient.sendEmail(
-                type.getTemplateId(configurationService), email, personalisation, "");
+                type.getTemplateId(configurationService), email, personalisation, reference);
     }
 
     public void sendText(
-            String phoneNumber, Map<String, Object> personalisation, TemplateAware type)
+            String phoneNumber,
+            Map<String, Object> personalisation,
+            TemplateAware type,
+            String reference)
             throws NotificationClientException {
         notifyClient.sendSms(
-                type.getTemplateId(configurationService), phoneNumber, personalisation, "");
+                type.getTemplateId(configurationService), phoneNumber, personalisation, reference);
     }
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
@@ -190,7 +190,7 @@ public class BulkUserEmailSenderScheduledEventHandler
     private boolean sendNotifyEmail(String email) throws NotificationClientException {
         if (configurationService.isBulkUserEmailEmailSendingEnabled()) {
             LOG.info("Bulk user email sending email.");
-            notificationService.sendEmail(email, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
+            notificationService.sendEmail(email, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL, "");
             return true;
         } else {
             LOG.info("Bulk user email email sending not enabled.");

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
@@ -147,7 +147,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
 
         verify(notificationService, times(1))
-                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL, "");
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.EMAIL_SENT);
         verify(auditService)
@@ -183,7 +183,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
 
         verify(notificationService, times(0))
-                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL, "");
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.EMAIL_SENT);
         verify(auditService, never())
@@ -224,7 +224,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
 
         verify(notificationService, times(0))
-                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL, "");
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.TERMS_ACCEPTED_RECENTLY);
         verify(auditService, never())
@@ -267,7 +267,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
                     ClientSubjectHelper.calculatePairwiseIdentifier(
                             TEST_SUBJECT_IDS[j], "test.account.gov.uk", SALT);
             verify(notificationService, times(1))
-                    .sendEmail(TEST_EMAILS[j], Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
+                    .sendEmail(TEST_EMAILS[j], Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL, "");
             verify(bulkEmailUsersService, times(1))
                     .updateUserStatus(TEST_SUBJECT_IDS[j], BulkEmailStatus.EMAIL_SENT);
             verify(auditService)
@@ -299,7 +299,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
 
         verify(notificationService, times(0))
-                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL, "");
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.ACCOUNT_NOT_FOUND);
         verifyNoInteractions(auditService);
@@ -315,7 +315,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
                 .thenReturn(Optional.of(new UserProfile().withEmail(EMAIL)));
         doThrow(NotificationClientException.class)
                 .when(notificationService)
-                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL, "");
         when(bulkEmailUsersService.updateUserStatus(
                         SUBJECT_ID, BulkEmailStatus.ERROR_SENDING_EMAIL))
                 .thenReturn(
@@ -327,7 +327,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
 
         verify(notificationService, times(1))
-                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL, "");
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.ERROR_SENDING_EMAIL);
         verifyNoInteractions(auditService);
@@ -364,7 +364,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         verify(bulkEmailUsersService, never())
                 .getNSubjectIdsByStatus(anyInt(), eq(BulkEmailStatus.PENDING));
         verify(notificationService, times(1))
-                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL, "");
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.EMAIL_SENT);
     }
@@ -402,7 +402,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
 
         verify(bulkEmailUsersService, never()).getNSubjectIdsByStatus(anyInt(), any());
         verify(notificationService, times(1))
-                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL);
+                .sendEmail(EMAIL, Map.of(), TERMS_AND_CONDITIONS_BULK_EMAIL, "");
         verify(bulkEmailUsersService, times(1))
                 .updateUserStatus(SUBJECT_ID, BulkEmailStatus.RETRY_EMAIL_SENT);
     }


### PR DESCRIPTION
The Notify API allows users to attach a [`reference`](https://docs.notifications.service.gov.uk/java.html#reference-required) to each API call.

We currently default this to an empty string but we can attach a journey id to it so that we are able to link delivery receipts to individual journeys.

This will help us diagnose when users are having issues such as SMS not being delivered.

This PR also adds some refactoring of the NotificationServiceTest.
