### PR TITLE
ATO-967: new session on browser close using bsid

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1704,110 +1704,150 @@ class AuthorisationHandlerTest {
                             pair("description", expectedErrorObject.getDescription()));
         }
 
-        @Test
-        void shouldCreateNewSessionWithNewBSIDWhenNeitherSessionNorBSIDCookiePresent() {
-            ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
-            APIGatewayProxyResponseEvent response =
-                    setupExistingSessionAndCookieInHeader(null, null);
+        @Nested
+        class BrowserSessionId {
+            @Test
+            void shouldCreateNewSessionWithNewBSIDWhenNeitherSessionNorBSIDCookiePresent() {
+                ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
+                APIGatewayProxyResponseEvent response =
+                        setupExistingSessionAndCookieInHeader(null, null);
 
-            verify(sessionService).createSession();
-            verify(sessionService).save(sessionCaptor.capture());
-            assertEquals(NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
-            assertEquals(
-                    format(
-                            "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
-                            BROWSER_SESSION_ID_COOKIE_NAME, NEW_BROWSER_SESSION_ID),
-                    browserSessionIdCookieFromResponse(response));
-        }
+                verify(sessionService).createSession();
+                verify(sessionService).save(sessionCaptor.capture());
+                assertEquals(
+                        NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
+                assertEquals(
+                        format(
+                                "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                                BROWSER_SESSION_ID_COOKIE_NAME, NEW_BROWSER_SESSION_ID),
+                        browserSessionIdCookieFromResponse(response));
+            }
 
-        @Test
-        void shouldCreateNewSessionWithNewBSIDWhenNoSessionButCookieBSIDPresent() {
-            ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
-            APIGatewayProxyResponseEvent response =
-                    setupExistingSessionAndCookieInHeader(null, BROWSER_SESSION_ID);
+            @Test
+            void shouldCreateNewSessionWithNewBSIDWhenNoSessionButCookieBSIDPresent() {
+                ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
+                APIGatewayProxyResponseEvent response =
+                        setupExistingSessionAndCookieInHeader(null, BROWSER_SESSION_ID);
 
-            verify(sessionService).createSession();
-            verify(sessionService).save(sessionCaptor.capture());
-            assertEquals(NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
-            assertEquals(
-                    format(
-                            "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
-                            BROWSER_SESSION_ID_COOKIE_NAME, NEW_BROWSER_SESSION_ID),
-                    browserSessionIdCookieFromResponse(response));
-        }
+                verify(sessionService).createSession();
+                verify(sessionService).save(sessionCaptor.capture());
+                assertEquals(
+                        NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
+                assertEquals(
+                        format(
+                                "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                                BROWSER_SESSION_ID_COOKIE_NAME, NEW_BROWSER_SESSION_ID),
+                        browserSessionIdCookieFromResponse(response));
+            }
 
-        @Test
-        void shouldUseExistingSessionEvenWhenBSIDCookieAbsent() {
-            ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
-            APIGatewayProxyResponseEvent response =
-                    setupExistingSessionAndCookieInHeader(
-                            new Session(SESSION_ID).withBrowserSessionId(BROWSER_SESSION_ID), null);
+            @Test
+            void shouldCreateNewSessionWhenSessionHasBSIDButCookieDoesNot() {
+                ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
+                APIGatewayProxyResponseEvent response =
+                        setupExistingSessionAndCookieInHeader(
+                                new Session(SESSION_ID).withBrowserSessionId(BROWSER_SESSION_ID),
+                                null);
 
-            verify(sessionService, never()).createSession();
-            verify(sessionService).save(sessionCaptor.capture());
-            assertEquals(BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
-            assertEquals(
-                    format(
-                            "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
-                            BROWSER_SESSION_ID_COOKIE_NAME, BROWSER_SESSION_ID),
-                    browserSessionIdCookieFromResponse(response));
-        }
+                verify(sessionService).createSession();
+                verify(sessionService).save(sessionCaptor.capture());
+                assertEquals(
+                        NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
+                assertEquals(
+                        format(
+                                "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                                BROWSER_SESSION_ID_COOKIE_NAME, NEW_BROWSER_SESSION_ID),
+                        browserSessionIdCookieFromResponse(response));
+            }
 
-        @Test
-        void shouldUseExistingSessionWithNoBSIDEvenWhenBSIDCookiePresent() {
-            ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
-            APIGatewayProxyResponseEvent response =
-                    setupExistingSessionAndCookieInHeader(
-                            new Session(SESSION_ID).withBrowserSessionId(null), BROWSER_SESSION_ID);
+            @Test
+            void shouldUseExistingSessionWithNoBSIDEvenWhenBSIDCookiePresent() {
+                ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
+                APIGatewayProxyResponseEvent response =
+                        setupExistingSessionAndCookieInHeader(
+                                new Session(SESSION_ID).withBrowserSessionId(null),
+                                BROWSER_SESSION_ID);
 
-            verify(sessionService, never()).createSession();
-            verify(sessionService).save(sessionCaptor.capture());
-            assertNull(sessionCaptor.getValue().getBrowserSessionId());
-            assertEquals(2, response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).size());
-            assertTrue(
-                    response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).stream()
-                            .noneMatch(
-                                    it ->
-                                            it.startsWith(
-                                                    format(
-                                                            "%s=",
-                                                            BROWSER_SESSION_ID_COOKIE_NAME))));
-        }
+                verify(sessionService, never()).createSession();
+                verify(sessionService).save(sessionCaptor.capture());
+                assertNull(sessionCaptor.getValue().getBrowserSessionId());
+                assertEquals(
+                        2, response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).size());
+                assertTrue(
+                        response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).stream()
+                                .noneMatch(
+                                        it ->
+                                                it.startsWith(
+                                                        format(
+                                                                "%s=",
+                                                                BROWSER_SESSION_ID_COOKIE_NAME))));
+            }
 
-        @Test
-        void shouldUseExistingSessionWhenBSIDsMatch() {
-            ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
-            APIGatewayProxyResponseEvent response =
-                    setupExistingSessionAndCookieInHeader(
-                            new Session(SESSION_ID).withBrowserSessionId(BROWSER_SESSION_ID),
-                            BROWSER_SESSION_ID);
+            @Test
+            void shouldUseExistingSessionWhenBSIDsMatch() {
+                ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
+                APIGatewayProxyResponseEvent response =
+                        setupExistingSessionAndCookieInHeader(
+                                new Session(SESSION_ID).withBrowserSessionId(BROWSER_SESSION_ID),
+                                BROWSER_SESSION_ID);
 
-            verify(sessionService, never()).createSession();
-            verify(sessionService).save(sessionCaptor.capture());
-            assertEquals(BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
-            assertEquals(
-                    format(
-                            "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
-                            BROWSER_SESSION_ID_COOKIE_NAME, BROWSER_SESSION_ID),
-                    browserSessionIdCookieFromResponse(response));
-        }
+                verify(sessionService, never()).createSession();
+                verify(sessionService).save(sessionCaptor.capture());
+                assertEquals(BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
+                assertEquals(
+                        format(
+                                "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                                BROWSER_SESSION_ID_COOKIE_NAME, BROWSER_SESSION_ID),
+                        browserSessionIdCookieFromResponse(response));
+            }
 
-        @Test
-        void shouldUseExistingSessionEvenWhenBSIDDoNotMatch() {
-            ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
-            APIGatewayProxyResponseEvent response =
-                    setupExistingSessionAndCookieInHeader(
-                            new Session(SESSION_ID).withBrowserSessionId(BROWSER_SESSION_ID),
-                            DIFFERENT_BROWSER_SESSION_ID);
+            @Test
+            void shouldCreateNewSessionWhenSessionAndCookieBSIDDoNotMatch() {
+                ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
+                APIGatewayProxyResponseEvent response =
+                        setupExistingSessionAndCookieInHeader(
+                                new Session(SESSION_ID).withBrowserSessionId(BROWSER_SESSION_ID),
+                                DIFFERENT_BROWSER_SESSION_ID);
 
-            verify(sessionService, never()).createSession();
-            verify(sessionService).save(sessionCaptor.capture());
-            assertEquals(BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
-            assertEquals(
-                    format(
-                            "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
-                            BROWSER_SESSION_ID_COOKIE_NAME, BROWSER_SESSION_ID),
-                    browserSessionIdCookieFromResponse(response));
+                verify(sessionService).createSession();
+                verify(sessionService).save(sessionCaptor.capture());
+                assertEquals(
+                        NEW_BROWSER_SESSION_ID, sessionCaptor.getValue().getBrowserSessionId());
+                assertEquals(
+                        format(
+                                "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                                BROWSER_SESSION_ID_COOKIE_NAME, NEW_BROWSER_SESSION_ID),
+                        browserSessionIdCookieFromResponse(response));
+            }
+
+            private APIGatewayProxyResponseEvent setupExistingSessionAndCookieInHeader(
+                    Session existingSession, String browserSessionIdFromCookie) {
+                when(configService.isBrowserSessionCookieEnabled()).thenReturn(true);
+                when(configService.isSignOutOnBrowserCloseEnabled()).thenReturn(true);
+                when(sessionService.getSessionFromSessionCookie(any()))
+                        .thenReturn(Optional.ofNullable(existingSession));
+                when(sessionService.createSession())
+                        .thenReturn(
+                                new Session(NEW_SESSION_ID)
+                                        .withBrowserSessionId(NEW_BROWSER_SESSION_ID));
+
+                Map<String, String> requestParams = buildRequestParams(null);
+                APIGatewayProxyRequestEvent event = withRequestEvent(requestParams);
+                event.setRequestContext(
+                        new ProxyRequestContext()
+                                .withIdentity(
+                                        new RequestIdentity().withSourceIp("123.123.123.123")));
+                if (browserSessionIdFromCookie != null) {
+                    event.setHeaders(
+                            Map.of(
+                                    "Cookie",
+                                    format(
+                                            "%s=%s",
+                                            BROWSER_SESSION_ID_COOKIE_NAME,
+                                            browserSessionIdFromCookie)));
+                }
+
+                return makeHandlerRequest(event);
+            }
         }
     }
 
@@ -2368,30 +2408,9 @@ class AuthorisationHandlerTest {
         }
     }
 
-    private APIGatewayProxyResponseEvent setupExistingSessionAndCookieInHeader(
-            Session existingSession, String browserSessionIdFromCookie) {
-        when(configService.isBrowserSessionCookieEnabled()).thenReturn(true);
-        when(sessionService.getSessionFromSessionCookie(any()))
-                .thenReturn(Optional.ofNullable(existingSession));
-        when(sessionService.createSession())
-                .thenReturn(
-                        new Session(NEW_SESSION_ID).withBrowserSessionId(NEW_BROWSER_SESSION_ID));
-
-        Map<String, String> requestParams = buildRequestParams(null);
-        APIGatewayProxyRequestEvent event = withRequestEvent(requestParams);
-        event.setRequestContext(
-                new ProxyRequestContext()
-                        .withIdentity(new RequestIdentity().withSourceIp("123.123.123.123")));
-        if (browserSessionIdFromCookie != null) {
-            event.setHeaders(Map.of(BROWSER_SESSION_ID_COOKIE_NAME, browserSessionIdFromCookie));
-        }
-
-        return makeHandlerRequest(event);
-    }
-
     private String browserSessionIdCookieFromResponse(APIGatewayProxyResponseEvent response) {
         return response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).stream()
-                .filter(it -> it.startsWith(format("%s", BROWSER_SESSION_ID_COOKIE_NAME)))
+                .filter(it -> it.startsWith(format("%s=", BROWSER_SESSION_ID_COOKIE_NAME)))
                 .findAny()
                 .orElseThrow();
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -208,6 +208,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("IS_BROWSER_SESSION_COOKIE_ENABLED");
     }
 
+    public boolean isSignOutOnBrowserCloseEnabled() {
+        return getFlagOrFalse("IS_SIGN_OUT_ON_BROWSER_CLOSE_ENABLED");
+    }
+
     public String getSpotQueueURI() {
         return System.getenv("SPOT_QUEUE_URL");
     }

--- a/template.yaml
+++ b/template.yaml
@@ -72,6 +72,8 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
     ]
+  EnableSignOutOnBrowserClose:
+    !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]]
 
 Mappings:
   EnvironmentConfiguration:
@@ -2160,6 +2162,10 @@ Resources:
             - false
           IS_BROWSER_SESSION_COOKIE_ENABLED: !If
             - EnableBrowserSessionCookie
+            - true
+            - false
+          IS_SIGN_OUT_ON_BROWSER_CLOSE_ENABLED: !If
+            - EnableSignOutOnBrowserClose
             - true
             - false
 


### PR DESCRIPTION
## What
When a user makes an `/auth`, their bsid cookie must match the session id cookie, else the session is invalid. This means users are signed out on browser close. 

This feature is hidden behind a feature flag `isSignOutOnBrowserCloseEnabled`, which is different from the bsid cookie feature flag `isBrowserSessionCookieEnabled`, which will be rolled out ahead. `isSignOutOnBrowserCloseEnabled` is only turned on in dev and build (build so we can run the acceptance tests against it).

## How to review

Using the metrics logging of  https://github.com/govuk-one-login/authentication-api/pull/5104, I have tested that on browser close, the `bsid` cookie does not persist on the user machine. When I attempt to sign back in, my cookie and the session's `bsid` therefore do not match, and I have to sign back in as expected.
 
1. Code Review
