### PR TITLE
ATO-984 (5/5): Remove GET method from Start lambda

### DIFF
--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -23,7 +23,7 @@ module "start" {
 
   endpoint_name   = "start"
   path_part       = "start"
-  endpoint_method = ["GET", "POST"]
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {


### PR DESCRIPTION
## What

Remove GET method from Start lambda

GET is no longer in use. Authentication frontend is now POSTing to /start (see 2/5 below) so that session information can be transferred from Orchestration to Authentication in the request body.

Tested in sandpit and functioning as intended.

## Related PRs

ATO-984 incremental deployment:
1. https://github.com/govuk-one-login/authentication-api/pull/5171
2. https://github.com/govuk-one-login/authentication-frontend/pull/2006
3. https://github.com/govuk-one-login/authentication-api/pull/5172
4. https://github.com/govuk-one-login/authentication-api/pull/5174
5. https://github.com/govuk-one-login/authentication-api/pull/5215
