### PR TITLE
ATO-981 set is new account in userinfo

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -186,6 +186,8 @@ public class UserInfoHandler
                     accessToken.getValue());
         }
 
+        sessionService.storeOrUpdateSession(
+                userSession.setNewAccount(Session.AccountState.EXISTING));
         return generateApiGatewayProxyResponse(200, userInfo.toJSONString());
     }
 

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.util.Map;
 import java.util.Optional;
@@ -41,16 +42,19 @@ public class UserInfoHandler
     private final UserInfoService userInfoService;
     private final AccessTokenService accessTokenService;
     private final AuditService auditService;
+    private final SessionService sessionService;
 
     public UserInfoHandler(
             ConfigurationService configurationService,
             UserInfoService userInfoService,
             AccessTokenService accessTokenService,
-            AuditService auditService) {
+            AuditService auditService,
+            SessionService sessionService) {
         this.configurationService = configurationService;
         this.userInfoService = userInfoService;
         this.accessTokenService = accessTokenService;
         this.auditService = auditService;
+        this.sessionService = sessionService;
     }
 
     public UserInfoHandler() {
@@ -65,6 +69,7 @@ public class UserInfoHandler
                 new AccessTokenService(
                         configurationService, new CloudwatchMetricsService(configurationService));
         this.auditService = new AuditService(configurationService);
+        this.sessionService = new SessionService(configurationService);
     }
 
     @Override

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.services.AccessTokenService;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,7 @@ class UserInfoHandlerTest {
     private UserInfoService userInfoService;
     private AccessTokenService accessTokenService;
     private UserInfoHandler userInfoHandler;
+    private SessionService sessionService;
     private static final AccessTokenStore accessTokenStore = mock(AccessTokenStore.class);
     private static final Subject TEST_SUBJECT = new Subject();
     private static final UserInfo TEST_SUBJECT_USER_INFO = new UserInfo(TEST_SUBJECT);
@@ -53,11 +55,16 @@ class UserInfoHandlerTest {
         configurationService = mock(ConfigurationService.class);
         userInfoService = mock(UserInfoService.class);
         accessTokenService = mock(AccessTokenService.class);
+        sessionService = mock(SessionService.class);
         when(accessTokenService.getAccessTokenStore(any()))
                 .thenReturn(Optional.of(accessTokenStore));
         userInfoHandler =
                 new UserInfoHandler(
-                        configurationService, userInfoService, accessTokenService, auditService);
+                        configurationService,
+                        userInfoService,
+                        accessTokenService,
+                        auditService,
+                        sessionService);
 
         TEST_SUBJECT_USER_INFO.setEmailAddress("test@test.com");
         TEST_SUBJECT_USER_INFO.setPhoneNumber("0123456789");

--- a/ci/terraform/auth-external-api/shared.tf
+++ b/ci/terraform/auth-external-api/shared.tf
@@ -27,4 +27,6 @@ locals {
   access_token_store_signing_key_arn        = data.terraform_remote_state.shared.outputs.access_token_store_signing_key_arn
   user_credentials_encryption_policy_arn    = data.terraform_remote_state.shared.outputs.user_credentials_encryption_policy_arn
   user_profile_kms_key_arn                  = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
+  redis_ssm_parameter_policy                = data.terraform_remote_state.shared.outputs.redis_ssm_parameter_policy
+  redis_key                                 = "session"
 }

--- a/ci/terraform/auth-external-api/shared.tf
+++ b/ci/terraform/auth-external-api/shared.tf
@@ -16,17 +16,18 @@ data "terraform_remote_state" "shared" {
 
 
 locals {
-  authentication_vpc_arn                    = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
-  authentication_security_group_id          = data.terraform_remote_state.shared.outputs.authentication_security_group_id
-  authentication_private_subnet_ids         = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
-  audit_signing_key_arn                     = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
-  events_topic_encryption_key_arn           = data.terraform_remote_state.shared.outputs.events_topic_encryption_key_arn
-  lambda_code_signing_configuration_arn     = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
-  lambda_env_vars_encryption_kms_key_arn    = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
-  auth_code_store_signing_configuration_arn = data.terraform_remote_state.shared.outputs.auth_code_store_signing_configuration_arn
-  access_token_store_signing_key_arn        = data.terraform_remote_state.shared.outputs.access_token_store_signing_key_arn
-  user_credentials_encryption_policy_arn    = data.terraform_remote_state.shared.outputs.user_credentials_encryption_policy_arn
-  user_profile_kms_key_arn                  = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
-  redis_ssm_parameter_policy                = data.terraform_remote_state.shared.outputs.redis_ssm_parameter_policy
-  redis_key                                 = "session"
+  authentication_vpc_arn                      = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
+  authentication_security_group_id            = data.terraform_remote_state.shared.outputs.authentication_security_group_id
+  authentication_private_subnet_ids           = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
+  audit_signing_key_arn                       = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
+  events_topic_encryption_key_arn             = data.terraform_remote_state.shared.outputs.events_topic_encryption_key_arn
+  lambda_code_signing_configuration_arn       = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
+  lambda_env_vars_encryption_kms_key_arn      = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
+  auth_code_store_signing_configuration_arn   = data.terraform_remote_state.shared.outputs.auth_code_store_signing_configuration_arn
+  access_token_store_signing_key_arn          = data.terraform_remote_state.shared.outputs.access_token_store_signing_key_arn
+  user_credentials_encryption_policy_arn      = data.terraform_remote_state.shared.outputs.user_credentials_encryption_policy_arn
+  user_profile_kms_key_arn                    = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
+  redis_ssm_parameter_policy                  = data.terraform_remote_state.shared.outputs.redis_ssm_parameter_policy
+  authentication_oidc_redis_security_group_id = data.terraform_remote_state.shared.outputs.authentication_oidc_redis_security_group_id
+  redis_key                                   = "session"
 }

--- a/ci/terraform/auth-external-api/ssm.tf
+++ b/ci/terraform/auth-external-api/ssm.tf
@@ -1,0 +1,9 @@
+data "aws_iam_policy" "redis_parameter_policy" {
+  arn = local.redis_ssm_parameter_policy
+}
+
+resource "aws_iam_policy" "redis_parameter_policy" {
+  policy      = data.aws_iam_policy.redis_parameter_policy.policy
+  path        = "/${var.environment}/redis/${local.redis_key}/"
+  name_prefix = "parameter-store-policy"
+}

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -29,7 +29,8 @@ module "auth_userinfo" {
   handler_environment_variables = {
     ENVIRONMENT          = var.environment
     TXMA_AUDIT_QUEUE_URL = module.auth_ext_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT  = null
+    LOCALSTACK_ENDPOINT  = null,
+    REDIS_KEY            = local.redis_key
     DYNAMO_ENDPOINT      = null
     INTERNAl_SECTOR_URI  = var.internal_sector_uri
   }

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -51,6 +51,7 @@ module "auth_userinfo" {
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id
   ]
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.auth_userinfo_role.arn

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -12,7 +12,9 @@ module "auth_userinfo_role" {
     aws_iam_policy.dynamo_access_token_store_read_access_policy.arn,
     aws_iam_policy.dynamo_access_token_store_write_access_policy.arn,
     aws_iam_policy.access_token_store_signing_key_kms_policy.arn,
-    local.user_credentials_encryption_policy_arn
+    aws_iam_policy.redis_parameter_policy.arn,
+    local.user_credentials_encryption_policy_arn,
+    //ATO-981 Part 4: Setup access to new Auth Session Table
   ]
 }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -112,6 +112,9 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
         assertThat(
                 userInfoResponse.getClaim(OIDCScopeValue.EMAIL.getValue()),
                 equalTo(TEST_EMAIL_ADDRESS));
+        assertThat(
+                redis.getSession(TEST_SESSION_ID).isNewAccount(),
+                equalTo(Session.AccountState.EXISTING));
 
         assertNull(userInfoResponse.getClaim("legacy_subject_id"));
         assertNull(userInfoResponse.getClaim("public_subject_id"));
@@ -181,6 +184,9 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                                 .toHTTPResponse()
                                 .getHeaderMap()
                                 .get("WWW-Authenticate")));
+        assertThat(
+                redis.getSession(TEST_SESSION_ID).isNewAccount(),
+                equalTo(Session.AccountState.NEW));
     }
 
     @Test
@@ -215,6 +221,9 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                 equalTo(Session.AccountState.NEW));
 
         assertTrue(accessTokenStoreExtension.getAccessToken(accessTokenAsString).get().isUsed());
+        assertThat(
+                redis.getSession(TEST_SESSION_ID).isNewAccount(),
+                equalTo(Session.AccountState.NEW));
     }
 
     @Test
@@ -243,6 +252,9 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                                 .toHTTPResponse()
                                 .getHeaderMap()
                                 .get("WWW-Authenticate")));
+        assertThat(
+                redis.getSession(TEST_SESSION_ID).isNewAccount(),
+                equalTo(Session.AccountState.NEW));
     }
 
     private UserProfile addTokenToDynamoAndCreateAssociatedUser(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -258,6 +258,14 @@ public class RedisExtension
         codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email);
     }
 
+    public void setIsNewAccount(String sessionId, Session.AccountState accountState)
+            throws Json.JsonException {
+        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
+        session.setNewAccount(accountState);
+        redis.saveWithExpiry(
+                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+    }
+
     public void addToRedis(String key, String value, Long expiry) {
         redis.saveWithExpiry(key, value, expiry);
     }


### PR DESCRIPTION
## What
- We're now setting the value of `isNewAccount` in the Auth userInfo lambda. This is a pre-requisite to splitting this value from the shared session store as currently Auth rely on Orchestration to update this in `AuthenticationCallBack` handler and `IPVCallBack` handler. We're setting it here as Auth need to start independently setting this value, and this point is closest to the end of the handoff between Auth and Orch, and closest to when it would be set by Orch.
- Soon we will co-set this value in the new Auth session store, before eventually migrating to the auth only store.

## How to review

For example:
- Code review commit-by-commit 
- Deployed to sandpit and ran through a journey, confirmed that the session is updated in the userinfo handler



## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
