### PR TITLE
BAU: Add journey IDs to callback log lines

### DIFF
--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -8,6 +8,7 @@ import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.deliveryreceiptsapi.entity.NotifyDeliveryReceipt;
 import uk.gov.di.authentication.shared.entity.DeliveryReceiptsNotificationType;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -35,6 +36,7 @@ public class NotifyCallbackHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String JOURNEY_ID = "journeyId";
     private final ConfigurationService configurationService;
     private DynamoService dynamoService = null;
 
@@ -86,6 +88,8 @@ public class NotifyCallbackHandler
         NotifyDeliveryReceipt deliveryReceipt;
         try {
             deliveryReceipt = objectMapper.readValue(input.getBody(), NotifyDeliveryReceipt.class);
+            ThreadContext.remove(JOURNEY_ID);
+            ThreadContext.put(JOURNEY_ID, deliveryReceipt.reference());
             if (deliveryReceipt.notificationType().equals("sms")) {
                 LOG.info("Sms delivery receipt received");
                 var countryCode = getCountryCodeFromNumber(deliveryReceipt.to());
@@ -124,8 +128,10 @@ public class NotifyCallbackHandler
             }
         } catch (JsonException e) {
             LOG.error("Unable to parse Notify Delivery Receipt");
+            ThreadContext.remove(JOURNEY_ID);
             throw new RuntimeException("Unable to parse Notify Delivery Receipt");
         }
+        ThreadContext.remove(JOURNEY_ID);
         return generateEmptySuccessApiGatewayResponse();
     }
 

--- a/delivery-receipts-api/src/main/resources/log4j2.xml
+++ b/delivery-receipts-api/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
     <Appenders>
         <Lambda name="Lambda">
             <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
-                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+                <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:journeyId:-unknown}"/>
             </JsonLayout>
         </Lambda>
     </Appenders>

--- a/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
+++ b/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
@@ -367,6 +367,23 @@ class NotifyCallbackHandlerTest {
     }
 
     @Test
+    void shouldErrorIfPayloadFailsToParse() {
+        var malformedBodyPayload =
+                new APIGatewayProxyRequestEvent()
+                        .withHeaders(Map.of("Authorization", "Bearer " + BEARER_TOKEN))
+                        .withBody("not-a-valid-delivery-receipt");
+
+        var exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> handler.handleRequest(malformedBodyPayload, context),
+                        "Expected to throw exception");
+
+        verifyNoInteractions(cloudwatchMetricsService);
+        assertThat(exception.getMessage(), equalTo("Unable to parse Notify Delivery Receipt"));
+    }
+
+    @Test
     void shouldParsePayloadWithExpectedNullValues() {
         assertDoesNotThrow(
                 () -> {


### PR DESCRIPTION
This follows from #5206 by using the reference ID in the log lines so we can match up deliveries with One Login journeys.