### PR TITLE
AUT-3602: Add reauth_failed audit event in login handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
@@ -5,6 +5,7 @@ import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.services.AuditService;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
@@ -66,5 +67,15 @@ public class ReauthMetadataBuilder {
             metadataPairs.add(failureReason);
         }
         return metadataPairs.toArray(AuditService.MetadataPair[]::new);
+    }
+
+    public static ReauthFailureReasons getReauthFailureReason(List<CountType> exceededCountTypes) {
+        CountType exceededType = exceededCountTypes.get(0);
+        return switch (exceededType) {
+            case ENTER_EMAIL -> ReauthFailureReasons.INCORRECT_EMAIL;
+            case ENTER_PASSWORD -> ReauthFailureReasons.INCORRECT_PASSWORD;
+            case ENTER_AUTH_APP_CODE, ENTER_SMS_CODE -> ReauthFailureReasons.INCORRECT_OTP;
+            default -> null;
+        };
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
@@ -18,7 +18,7 @@ public class ReauthMetadataBuilder {
     private AuditService.MetadataPair failureReason;
 
     private ReauthMetadataBuilder(String rpPairwiseId) {
-        this.rpPairwiseIdPair = pair("rp_pairwise_id", rpPairwiseId);
+        this.rpPairwiseIdPair = pair("rpPairwiseId", rpPairwiseId);
     }
 
     public static ReauthMetadataBuilder builder(String rpPairwiseId) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
@@ -49,6 +49,18 @@ public class ReauthMetadataBuilder {
         return this;
     }
 
+    public ReauthMetadataBuilder withFailureReason(List<CountType> exceededCountTypes) {
+        CountType exceededType = exceededCountTypes.get(0);
+        ReauthFailureReasons reauthFailureReason =
+                switch (exceededType) {
+                    case ENTER_EMAIL -> ReauthFailureReasons.INCORRECT_EMAIL;
+                    case ENTER_PASSWORD -> ReauthFailureReasons.INCORRECT_PASSWORD;
+                    case ENTER_AUTH_APP_CODE, ENTER_SMS_CODE -> ReauthFailureReasons.INCORRECT_OTP;
+                    default -> null;
+                };
+        return withFailureReason(reauthFailureReason);
+    }
+
     public AuditService.MetadataPair[] build() {
         var metadataPairs = new ArrayList<AuditService.MetadataPair>();
         if (rpPairwiseIdPair != null) {
@@ -67,15 +79,5 @@ public class ReauthMetadataBuilder {
             metadataPairs.add(failureReason);
         }
         return metadataPairs.toArray(AuditService.MetadataPair[]::new);
-    }
-
-    public static ReauthFailureReasons getReauthFailureReason(List<CountType> exceededCountTypes) {
-        CountType exceededType = exceededCountTypes.get(0);
-        return switch (exceededType) {
-            case ENTER_EMAIL -> ReauthFailureReasons.INCORRECT_EMAIL;
-            case ENTER_PASSWORD -> ReauthFailureReasons.INCORRECT_PASSWORD;
-            case ENTER_AUTH_APP_CODE, ENTER_SMS_CODE -> ReauthFailureReasons.INCORRECT_OTP;
-            default -> null;
-        };
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -34,7 +34,6 @@ import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
@@ -142,26 +141,14 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                                     LOG.info(
                                             "Account is locked due to exceeded counts on count types {}",
                                             exceededCountTypes);
-
-                                    ReauthFailureReasons reauthFailureReason =
-                                            getReauthFailureReason(exceededCountTypes);
-
-                                    AuditService.MetadataPair[] metadataPairs =
-                                            ReauthMetadataBuilder.builder(request.rpPairwiseId())
-                                                    .withAllIncorrectAttemptCounts(
-                                                            authenticationAttemptsService
-                                                                    .getCountsByJourney(
-                                                                            userProfile
-                                                                                    .getSubjectID(),
-                                                                            JourneyType
-                                                                                    .REAUTHENTICATION))
-                                                    .withFailureReason(reauthFailureReason)
-                                                    .build();
-
                                     auditService.submitAuditEvent(
                                             FrontendAuditableEvent.AUTH_REAUTH_FAILED,
                                             updatedAuditContext,
-                                            metadataPairs);
+                                            ReauthMetadataBuilder.builder(request.rpPairwiseId())
+                                                    .withAllIncorrectAttemptCounts(
+                                                            countTypesToCounts)
+                                                    .withFailureReason(exceededCountTypes)
+                                                    .build());
 
                                     throw new AccountLockedException(
                                             "Account is locked due to too many failed attempts.",
@@ -200,16 +187,6 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
             LOG.error("Account is locked due to too many failed attempts.");
             return generateApiGatewayProxyErrorResponse(400, e.getErrorResponse());
         }
-    }
-
-    private static ReauthFailureReasons getReauthFailureReason(List<CountType> exceededCountTypes) {
-        CountType exceededType = exceededCountTypes.get(0);
-        return switch (exceededType) {
-            case ENTER_EMAIL -> ReauthFailureReasons.INCORRECT_EMAIL;
-            case ENTER_PASSWORD -> ReauthFailureReasons.INCORRECT_PASSWORD;
-            case ENTER_AUTH_APP_CODE, ENTER_SMS_CODE -> ReauthFailureReasons.INCORRECT_OTP;
-            default -> null;
-        };
     }
 
     private Optional<String> verifyReAuthentication(
@@ -308,16 +285,15 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                 metadataPairsForIncorrectEmail.toArray(new AuditService.MetadataPair[0]));
 
         if (hasEnteredIncorrectEmailTooManyTimes(updatedCount)) {
-            AuditService.MetadataPair[] metadataPairs =
+            auditService.submitAuditEvent(
+                    FrontendAuditableEvent.AUTH_REAUTH_FAILED,
+                    auditContext,
                     ReauthMetadataBuilder.builder(rpPairwiseId)
                             .withAllIncorrectAttemptCounts(
                                     authenticationAttemptsService.getCountsByJourney(
                                             uniqueUserIdentifier, JourneyType.REAUTHENTICATION))
                             .withFailureReason(ReauthFailureReasons.INCORRECT_EMAIL)
-                            .build();
-
-            auditService.submitAuditEvent(
-                    FrontendAuditableEvent.AUTH_REAUTH_FAILED, auditContext, metadataPairs);
+                            .build());
 
             auditService.submitAuditEvent(
                     AUTH_REAUTH_INCORRECT_EMAIL_LIMIT_BREACHED,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -11,6 +11,8 @@ import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.LoginRequest;
 import uk.gov.di.authentication.frontendapi.entity.LoginResponse;
 import uk.gov.di.authentication.frontendapi.entity.PasswordResetType;
+import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
+import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.services.UserMigrationService;
 import uk.gov.di.authentication.shared.conditions.TermsAndConditionsHelper;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
@@ -218,7 +220,12 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
         if (!credentialsAreValid(request, userProfile)) {
             return handleInvalidCredentials(
-                    request, incorrectPasswordCount, auditContext, userProfile, isReauthJourney);
+                    request,
+                    incorrectPasswordCount,
+                    auditContext,
+                    userProfile,
+                    isReauthJourney,
+                    userContext);
         }
 
         return handleValidCredentials(
@@ -309,7 +316,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             int incorrectPasswordCount,
             AuditContext auditContext,
             UserProfile userProfile,
-            boolean isReauthJourney) {
+            boolean isReauthJourney,
+            UserContext userContext) {
         var updatedIncorrectPasswordCount = incorrectPasswordCount + 1;
 
         incrementCountOfFailedAttemptsToProvidePassword(userProfile, isReauthJourney);
@@ -322,6 +330,28 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                 pair(ATTEMPT_NO_FAILED_AT, configurationService.getMaxPasswordRetries()));
 
         if (updatedIncorrectPasswordCount >= configurationService.getMaxPasswordRetries()) {
+            if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
+                var client = userContext.getClient().orElseThrow();
+                var calculatedPairwiseId =
+                        ClientSubjectHelper.getSubject(
+                                        userProfile,
+                                        client,
+                                        authenticationService,
+                                        configurationService.getInternalSectorUri())
+                                .getValue();
+                AuditService.MetadataPair[] metadataPairs =
+                        ReauthMetadataBuilder.builder(calculatedPairwiseId)
+                                .withAllIncorrectAttemptCounts(
+                                        authenticationAttemptsService.getCountsByJourney(
+                                                userProfile.getSubjectID(),
+                                                JourneyType.REAUTHENTICATION))
+                                .withFailureReason(ReauthFailureReasons.INCORRECT_PASSWORD)
+                                .build();
+
+                auditService.submitAuditEvent(
+                        FrontendAuditableEvent.AUTH_REAUTH_FAILED, auditContext, metadataPairs);
+            }
+
             if (isJourneyWhereBlockingApplies(isReauthJourney)) {
                 blockUser(
                         userProfile.getSubjectID(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -349,7 +349,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                 pair(ATTEMPT_NO_FAILED_AT, configurationService.getMaxPasswordRetries()));
 
         if (updatedIncorrectPasswordCount >= configurationService.getMaxPasswordRetries()) {
-            if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
+            if (isReauthJourneyWithFlagsEnabled(isReauthJourney)) {
                 var calculatedPairwiseId = calculatePairwiseId(userContext, userProfile);
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTH_FAILED,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -234,7 +234,7 @@ class CheckReAuthUserHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTH_FAILED,
                         testAuditContextWithAuditEncoded,
-                        AuditService.MetadataPair.pair("rp_pairwise_id", TEST_RP_PAIRWISE_ID),
+                        AuditService.MetadataPair.pair("rpPairwiseId", TEST_RP_PAIRWISE_ID),
                         AuditService.MetadataPair.pair("incorrect_email_attempt_count", 6),
                         AuditService.MetadataPair.pair("incorrect_password_attempt_count", 0),
                         AuditService.MetadataPair.pair("incorrect_otp_code_attempt_count", 0),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -248,7 +248,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                             FrontendAuditableEvent.AUTH_REAUTH_FAILED,
                             auditContextWithAllUserInfo.withTxmaAuditEncoded(
                                     Optional.of(ENCODED_DEVICE_DETAILS)),
-                            pair("rp_pairwise_id", TEST_RP_PAIRWISE_ID),
+                            pair("rpPairwiseId", TEST_RP_PAIRWISE_ID),
                             pair("incorrect_email_attempt_count", 0),
                             pair("incorrect_password_attempt_count", 6),
                             pair("incorrect_otp_code_attempt_count", 0),
@@ -347,7 +347,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                             FrontendAuditableEvent.AUTH_REAUTH_FAILED,
                             auditContextWithAllUserInfo.withTxmaAuditEncoded(
                                     Optional.of(ENCODED_DEVICE_DETAILS)),
-                            pair("rp_pairwise_id", TEST_RP_PAIRWISE_ID),
+                            pair("rpPairwiseId", TEST_RP_PAIRWISE_ID),
                             pair("incorrect_email_attempt_count", expectedEmailAttemptCount),
                             pair("incorrect_password_attempt_count", expectedPasswordAttemptCount),
                             pair("incorrect_otp_code_attempt_count", expectedOtpAttemptCount),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -19,7 +19,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.frontendapi.services.UserMigrationService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
@@ -27,6 +30,7 @@ import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -68,6 +72,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.longThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -103,6 +108,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     .setMfaMethod(AUTH_APP_MFA_METHOD);
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String CLIENT_NAME = "client-name";
+    private static final String TEST_RP_PAIRWISE_ID = "test-rp-pairwise-id";
     private static final Subject INTERNAL_SUBJECT_ID = new Subject();
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final MFAMethod AUTH_APP_MFA_METHOD =
@@ -112,6 +118,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     .withEnabled(true);
     private static final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
     private final Context context = mock(Context.class);
+    private final Subject subject = mock(Subject.class);
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT_ID.getValue(), "test.account.gov.uk", SALT);
@@ -198,42 +205,68 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
     void
             shouldReturnErrorNotDeleteCountAndNotLockUserAccountOutAfterMaxNumberOfIncorrectPasswordsPresented(
                     MFAMethodType mfaMethodType) {
-        UserProfile userProfile = generateUserProfile(null);
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                .thenReturn(Optional.of(userProfile));
-        when(clientSession.getAuthRequestParams()).thenReturn(generateAuthRequest().toParameters());
+        try (MockedStatic<ClientSubjectHelper> clientSubjectHelperMockedStatic =
+                Mockito.mockStatic(ClientSubjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
+            UserProfile userProfile = generateUserProfile(null);
+            when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                    .thenReturn(Optional.of(userProfile));
+            clientSubjectHelperMockedStatic
+                    .when(() -> ClientSubjectHelper.getSubject(any(), any(), any(), any()))
+                    .thenReturn(subject);
+            when(subject.getValue()).thenReturn(TEST_RP_PAIRWISE_ID);
+            when(clientSession.getAuthRequestParams())
+                    .thenReturn(generateAuthRequest().toParameters());
 
-        when(authenticationAttemptsService.getCount(any(), any(), any()))
-                .thenReturn(MAX_ALLOWED_RETRIES - 1);
+            when(authenticationAttemptsService.getCount(
+                            any(), eq(REAUTHENTICATION), eq(ENTER_PASSWORD)))
+                    .thenReturn(MAX_ALLOWED_RETRIES - 1);
+            when(authenticationAttemptsService.getCountsByJourney(
+                            any(String.class), eq(JourneyType.REAUTHENTICATION)))
+                    .thenReturn(Map.of(CountType.ENTER_PASSWORD, MAX_ALLOWED_RETRIES - 1))
+                    .thenReturn(Map.of(ENTER_PASSWORD, MAX_ALLOWED_RETRIES));
 
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
+            when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
 
-        usingValidSession();
-        usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
-        usingDefaultVectorOfTrust();
+            usingValidSession();
+            usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
+            usingDefaultVectorOfTrust();
 
-        var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithReauthJourney);
+            var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithReauthJourney);
 
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+            APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1028));
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.ERROR_1028));
 
-        verify(authenticationAttemptsService, never()).deleteCount(any(), any(), any());
+            verify(authenticationAttemptsService, never()).deleteCount(any(), any(), any());
 
-        verify(auditService)
-                .submitAuditEvent(
-                        AUTH_INVALID_CREDENTIALS,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
-                        pair("internalSubjectId", userProfile.getSubjectID()),
-                        pair(
-                                "incorrectPasswordCount",
-                                configurationService.getMaxPasswordRetries()),
-                        pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
+            verify(auditService, times(1))
+                    .submitAuditEvent(
+                            FrontendAuditableEvent.AUTH_REAUTH_FAILED,
+                            auditContextWithAllUserInfo.withTxmaAuditEncoded(
+                                    Optional.of(ENCODED_DEVICE_DETAILS)),
+                            pair("rp_pairwise_id", TEST_RP_PAIRWISE_ID),
+                            pair("incorrect_email_attempt_count", 0),
+                            pair("incorrect_password_attempt_count", 6),
+                            pair("incorrect_otp_code_attempt_count", 0),
+                            pair("failure-reason", "incorrect_password"));
 
-        verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_INVALID_CREDENTIALS,
+                            auditContextWithAllUserInfo.withTxmaAuditEncoded(
+                                    Optional.of(ENCODED_DEVICE_DETAILS)),
+                            pair("internalSubjectId", userProfile.getSubjectID()),
+                            pair(
+                                    "incorrectPasswordCount",
+                                    configurationService.getMaxPasswordRetries()),
+                            pair(
+                                    "attemptNoFailedAt",
+                                    configurationService.getMaxPasswordRetries()));
+
+            verifyNoInteractions(cloudwatchMetricsService);
+            verify(sessionService, never()).storeOrUpdateSession(any());
+        }
     }
 
     private static Stream<Arguments> reauthCountTypes() {
@@ -323,6 +356,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
+        when(clientSession.getAuthRequestParams()).thenReturn(generateAuthRequest().toParameters());
         usingApplicableUserCredentialsWithLogin(SMS, false);
 
         when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);


### PR DESCRIPTION
## What

If the authentication attempts service is turned on, the reauth_failed audit event will
send in the event that a user has failed to reauthenticate successfully and has been
locked out of their account. This happens both in the case that a user has just been
locked out, or they have already been locked out and have failed to reauthenticate.


## How to review

1. Code Review