### PR TITLE
Aut 3601/emit basic auth reauth success event

### DIFF
--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -31,12 +31,13 @@ module "orch_auth_code" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    ENVIRONMENT          = var.environment
-    TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
-    REDIS_KEY            = local.redis_key
+    DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT                    = var.environment
+    TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
+    INTERNAl_SECTOR_URI            = var.internal_sector_uri
+    REDIS_KEY                      = local.redis_key
+    SUPPORT_REAUTH_SIGNOUT_ENABLED = var.support_reauth_signout_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler::handleRequest"
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -57,7 +57,8 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     AUTH_REVERIFY_SUCCESSFUL_TOKEN_RECEIVED,
     AUTH_REVERIFY_UNSUCCESSFUL_TOKEN_RECEIVED,
     AUTH_REVERIFY_SUCCESSFUL_VERIFICATION_INFO_RECEIVED,
-    AUTH_REAUTH_FAILED;
+    AUTH_REAUTH_FAILED,
+    AUTH_REAUTH_SUCCESS;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
@@ -12,4 +12,5 @@ public record AuthCodeRequest(
         @SerializedName("claims") @Expose List<String> claims,
         @SerializedName("rp-sector-uri") @Expose @Required String sectorIdentifier,
         @SerializedName("is-new-account") @Expose @Required boolean isNewAccount,
-        @SerializedName("password-reset-time") @Expose Long passwordResetTime) {}
+        @SerializedName("password-reset-time") @Expose Long passwordResetTime,
+        @SerializedName("is-reauth-journey") @Expose Boolean isReauthJourney) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
@@ -5,94 +5,11 @@ import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.validation.Required;
 
 import java.util.List;
-import java.util.Optional;
 
-public class AuthCodeRequest {
-
-    @SerializedName("redirect-uri")
-    @Expose
-    @Required
-    private String redirectUri;
-
-    @SerializedName("state")
-    @Expose
-    @Required
-    private String state;
-
-    @SerializedName("claims")
-    @Expose
-    private List<String> claims;
-
-    @SerializedName("rp-sector-uri")
-    @Expose
-    @Required
-    private String sectorIdentifier;
-
-    @SerializedName("is-new-account")
-    @Expose
-    @Required
-    private boolean isNewAccount;
-
-    @SerializedName("password-reset-time")
-    @Expose
-    private Long passwordResetTime;
-
-    public AuthCodeRequest(
-            String redirectUri,
-            String state,
-            List<String> claims,
-            String sectorIdentifier,
-            boolean isNewAccount,
-            Optional<Long> passwordResetTime) {
-        this.redirectUri = redirectUri;
-        this.state = state;
-        this.claims = claims;
-        this.sectorIdentifier = sectorIdentifier;
-        this.isNewAccount = isNewAccount;
-        passwordResetTime.ifPresent(p -> this.passwordResetTime = p);
-    }
-
-    public String getRedirectUri() {
-        return redirectUri;
-    }
-
-    public void setRedirectUri(String redirectUri) {
-        this.redirectUri = redirectUri;
-    }
-
-    public String getState() {
-        return state;
-    }
-
-    public void setState(String state) {
-        this.state = state;
-    }
-
-    public List<String> getClaims() {
-        return claims;
-    }
-
-    public void setClaims(List<String> claims) {
-        this.claims = claims;
-    }
-
-    public String getSectorIdentifier() {
-        return sectorIdentifier;
-    }
-
-    public void setSectorIdentifier(String sectorIdentifier) {
-        this.sectorIdentifier = sectorIdentifier;
-    }
-
-    public boolean isNewAccount() {
-        return isNewAccount;
-    }
-
-    public Long getPasswordResetTime() {
-        return passwordResetTime;
-    }
-
-    public void setNewAccount(boolean newAccount) {
-        isNewAccount = newAccount;
-    }
-}
+public record AuthCodeRequest(
+        @SerializedName("redirect-uri") @Expose @Required String redirectUri,
+        @SerializedName("state") @Expose @Required String state,
+        @SerializedName("claims") @Expose List<String> claims,
+        @SerializedName("rp-sector-uri") @Expose @Required String sectorIdentifier,
+        @SerializedName("is-new-account") @Expose @Required boolean isNewAccount,
+        @SerializedName("password-reset-time") @Expose Long passwordResetTime) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -92,14 +92,14 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
             dynamoAuthCodeService.saveAuthCode(
                     userProfile.get().getSubjectID(),
                     authorisationCode.getValue(),
-                    authCodeRequest.getClaims(),
+                    authCodeRequest.claims(),
                     false,
-                    authCodeRequest.getSectorIdentifier(),
+                    authCodeRequest.sectorIdentifier(),
                     authCodeRequest.isNewAccount(),
-                    authCodeRequest.getPasswordResetTime());
+                    authCodeRequest.passwordResetTime());
 
-            var state = State.parse(authCodeRequest.getState());
-            var redirectUri = URI.create(authCodeRequest.getRedirectUri());
+            var state = State.parse(authCodeRequest.state());
+            var redirectUri = URI.create(authCodeRequest.redirectUri());
             var authorizationResponse =
                     new AuthorizationSuccessResponse(
                             redirectUri, authorisationCode, null, state, null);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -66,6 +66,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                         List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                         TEST_SECTOR_IDENTIFIER,
                         false,
+                        null,
                         null);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(200));
@@ -77,7 +78,13 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         setUpDynamo();
         var authRequest =
                 new AuthCodeRequest(
-                        TEST_REDIRECT_URI, TEST_STATE, null, TEST_SECTOR_IDENTIFIER, false, null);
+                        TEST_REDIRECT_URI,
+                        TEST_STATE,
+                        null,
+                        TEST_SECTOR_IDENTIFIER,
+                        false,
+                        null,
+                        null);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(200));
     }
@@ -92,6 +99,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                         List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                         TEST_SECTOR_IDENTIFIER,
                         false,
+                        null,
                         null);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
@@ -108,6 +116,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                         List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                         TEST_SECTOR_IDENTIFIER,
                         false,
+                        null,
                         null);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -66,7 +66,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                         List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                         TEST_SECTOR_IDENTIFIER,
                         false,
-                        Optional.empty());
+                        null);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(200));
     }
@@ -77,12 +77,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         setUpDynamo();
         var authRequest =
                 new AuthCodeRequest(
-                        TEST_REDIRECT_URI,
-                        TEST_STATE,
-                        null,
-                        TEST_SECTOR_IDENTIFIER,
-                        false,
-                        Optional.empty());
+                        TEST_REDIRECT_URI, TEST_STATE, null, TEST_SECTOR_IDENTIFIER, false, null);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(200));
     }
@@ -97,7 +92,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                         List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                         TEST_SECTOR_IDENTIFIER,
                         false,
-                        Optional.empty());
+                        null);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
@@ -113,7 +108,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                         List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                         TEST_SECTOR_IDENTIFIER,
                         false,
-                        Optional.empty());
+                        null);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));


### PR DESCRIPTION
## What

Emits the AUTH_REAUTH_SUCCESS event in the case of a reauth journey that has reached the point of the authentication auth handler, with metadata of the pairwise id.

Note that this PR does not contain all the extensions required by the event schema - adding the incorrect counts will be done in a subsequent PR, since we'd like to do this by way of the new session stored in dynamo.

## How to review

1. Code Review


## Related PRs

This event will not be emitted until [this PR](https://github.com/govuk-one-login/authentication-frontend/pull/2067) is also merged on the frontend that adds the necessary information to the auth code request to indicate the journey is a reauth journey. This PR is safe to merge first.
