### PR TITLE
ATO-979/a: Set verifiedMfaMethodType in Auth session

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -700,6 +700,38 @@ data "aws_iam_policy_document" "dynamo_auth_session_read_policy_document" {
   }
 }
 
+// This is required because we've reached the managed polices per role quota limit (20)
+// Ticket raised to requst quota increase (ATO-1056)
+data "aws_iam_policy_document" "dynamo_auth_session_read_write_policy_document" {
+  statement {
+    sid    = "AllowReadAndWrite"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchWriteItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+    ]
+    resources = [
+      data.aws_dynamodb_table.auth_session_table.arn,
+      "${data.aws_dynamodb_table.auth_session_table.arn}/index/*",
+    ]
+  }
+
+  statement {
+    sid    = "AllowEncryptionAndDecryption"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+      "kms:Decrypt",
+    ]
+    resources = [local.auth_session_table_encryption_key_arn]
+  }
+}
+
 resource "aws_iam_policy" "dynamo_client_registry_write_access_policy" {
   name_prefix = "dynamo-client-registry-write-policy"
   path        = "/${var.environment}/oidc-default/"
@@ -906,6 +938,16 @@ resource "aws_iam_policy" "dynamo_auth_session_read_policy" {
   description = "IAM policy for managing read permissions to the auth session table"
 
   policy = data.aws_iam_policy_document.dynamo_auth_session_read_policy_document.json
+}
+
+// This is required because we've reached the managed polices per role quota limit (20)
+// Ticket raised to requst quota increase (ATO-1056)
+resource "aws_iam_policy" "dynamo_auth_session_read_write_policy" {
+  name_prefix = "dynamo-auth-session-read-write-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing read and write permissions to the auth session table"
+
+  policy = data.aws_iam_policy_document.dynamo_auth_session_read_write_policy_document.json
 }
 
 resource "aws_iam_policy" "dynamo_auth_session_delete_policy" {

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -16,6 +16,8 @@ module "frontend_api_verify_code_role" {
     aws_iam_policy.dynamo_authentication_attempt_write_policy.arn,
     aws_iam_policy.dynamo_authentication_attempt_read_policy.arn,
     aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
+    aws_iam_policy.dynamo_auth_session_write_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -16,6 +16,7 @@ module "frontend_api_verify_mfa_code_role" {
     aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.dynamo_auth_session_read_write_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -146,7 +146,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             LOG.info("Processing request");
 
             var session = userContext.getSession();
-            Optional<String> authSessionId = authSessionService.getSessionIdFromRequestHeaders(input.getHeaders());
+            Optional<String> authSessionId =
+                    authSessionService.getSessionIdFromRequestHeaders(input.getHeaders());
             if (authSessionId.isEmpty()) {
                 LOG.warn("Auth session ID cannot be found");
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
@@ -225,6 +226,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
             processSuccessfulCodeRequest(
                     session,
+                    authSessionId.get(),
                     codeRequest,
                     userContext,
                     userProfileMaybe.isPresent() ? userProfileMaybe.get().getSubjectID() : null,
@@ -317,6 +319,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
     private void processSuccessfulCodeRequest(
             Session session,
+            String authSessionId,
             VerifyCodeRequest codeRequest,
             UserContext userContext,
             String subjectId,
@@ -339,6 +342,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     false);
             sessionService.storeOrUpdateSession(
                     session.setVerifiedMfaMethodType(MFAMethodType.SMS));
+            authSessionService.setVerifiedMfaMethodType(authSessionId, MFAMethodType.SMS);
             clearAccountRecoveryBlockIfPresent(session, auditContext);
             cloudwatchMetricsService.incrementAuthenticationSuccess(
                     session.isNewAccount(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.helpers.ReauthAuthenticationAttemptsHelpe
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -53,6 +54,7 @@ import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHA
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachAuthSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.TestClientHelper.isTestClientWithAllowedEmail;
@@ -69,6 +71,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final DynamoAccountModifiersService accountModifiersService;
     private final AuthenticationAttemptsService authenticationAttemptsService;
+    private final AuthSessionService authSessionService;
 
     protected VerifyCodeHandler(
             ConfigurationService configurationService,
@@ -80,7 +83,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             AuditService auditService,
             CloudwatchMetricsService cloudwatchMetricsService,
             DynamoAccountModifiersService accountModifiersService,
-            AuthenticationAttemptsService authenticationAttemptsService) {
+            AuthenticationAttemptsService authenticationAttemptsService,
+            AuthSessionService authSessionService) {
         super(
                 VerifyCodeRequest.class,
                 configurationService,
@@ -93,6 +97,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.accountModifiersService = accountModifiersService;
         this.authenticationAttemptsService = authenticationAttemptsService;
+        this.authSessionService = authSessionService;
     }
 
     public VerifyCodeHandler() {
@@ -107,6 +112,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.accountModifiersService = new DynamoAccountModifiersService(configurationService);
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
+        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     public VerifyCodeHandler(
@@ -118,6 +124,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.accountModifiersService = new DynamoAccountModifiersService(configurationService);
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
+        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     @Override
@@ -139,6 +146,13 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             LOG.info("Processing request");
 
             var session = userContext.getSession();
+            Optional<String> authSessionId = authSessionService.getSessionIdFromRequestHeaders(input.getHeaders());
+            if (authSessionId.isEmpty()) {
+                LOG.warn("Auth session ID cannot be found");
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
+            } else {
+                attachAuthSessionIdToLogs(authSessionId.get());
+            }
             var notificationType = codeRequest.notificationType();
             var journeyType = getJourneyType(codeRequest, notificationType);
             var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -176,7 +176,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
         try {
             String subjectID = userProfileMaybe.map(UserProfile::getSubjectID).orElse(null);
-            return verifyCode(input, codeRequest, userContext, journeyType, subjectID);
+            return verifyCode(
+                    input, codeRequest, userContext, journeyType, subjectID, authSessionId.get());
         } catch (Exception e) {
             LOG.error("Unexpected exception thrown");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
@@ -226,7 +227,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             VerifyMfaCodeRequest codeRequest,
             UserContext userContext,
             JourneyType journeyType,
-            String subjectId) {
+            String subjectId,
+            String authSessionId) {
 
         var mfaCodeProcessor =
                 mfaCodeProcessorFactory
@@ -291,6 +293,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                                                     CredentialTrustLevel.MEDIUM_LEVEL)
                                             .setVerifiedMfaMethodType(
                                                     codeRequest.getMfaMethodType()));
+
+                            authSessionService.setVerifiedMfaMethodType(
+                                    authSessionId, codeRequest.getMfaMethodType());
 
                             var clientId =
                                     userContext.getClient().isPresent()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -36,6 +36,7 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -133,6 +134,7 @@ class VerifyCodeHandlerTest {
             mock(DynamoAccountModifiersService.class);
     private final AuthenticationAttemptsService authenticationAttemptsService =
             mock(AuthenticationAttemptsService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
 
     private final ClientRegistry clientRegistry =
             new ClientRegistry()
@@ -196,7 +198,8 @@ class VerifyCodeHandlerTest {
                         auditService,
                         cloudwatchMetricsService,
                         accountModifiersService,
-                        authenticationAttemptsService);
+                        authenticationAttemptsService,
+                        authSessionService);
 
         when(authenticationService.getUserProfileFromEmail(EMAIL))
                 .thenReturn(Optional.of(userProfile));
@@ -212,6 +215,8 @@ class VerifyCodeHandlerTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(MAX_RETRIES);
         when(configurationService.getMaxEmailReAuthRetries()).thenReturn(MAX_RETRIES);
         when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
+        when(authSessionService.getSessionIdFromRequestHeaders(any()))
+                .thenReturn(Optional.of(SESSION_ID));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -43,6 +43,7 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -137,6 +138,7 @@ class VerifyMfaCodeHandlerTest {
             mock(CloudwatchMetricsService.class);
     private final AuthenticationAttemptsService authenticationAttemptsService =
             mock(AuthenticationAttemptsService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =
@@ -173,6 +175,8 @@ class VerifyMfaCodeHandlerTest {
         when(configurationService.getMaxEmailReAuthRetries()).thenReturn(MAX_RETRIES);
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(clientSession));
+        when(authSessionService.getSessionIdFromRequestHeaders(any()))
+                .thenReturn(Optional.of(SESSION_ID));
 
         handler =
                 new VerifyMfaCodeHandler(
@@ -185,7 +189,8 @@ class VerifyMfaCodeHandlerTest {
                         auditService,
                         mfaCodeProcessorFactory,
                         cloudwatchMetricsService,
-                        authenticationAttemptsService);
+                        authenticationAttemptsService,
+                        authSessionService);
     }
 
     @AfterEach

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -29,6 +29,7 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
 import uk.gov.di.authentication.sharedtest.helper.AuthAppStub;
 
@@ -92,6 +93,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     protected static final AuthenticationAttemptsStoreExtension authCodeExtension =
             new AuthenticationAttemptsStoreExtension();
 
+    @RegisterExtension
+    protected static final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
+
     @BeforeEach
     void beforeEachSetup() throws Json.JsonException {
         handler =
@@ -102,6 +106,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         txmaAuditQueue.clear();
 
         this.sessionId = redis.createSession();
+        authSessionExtension.addSession(Optional.empty(), this.sessionId);
         redis.addInternalCommonSubjectIdToSession(this.sessionId, internalCommonSubjectId);
         setUpTest(sessionId, withScope());
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -16,6 +16,7 @@ public class AuthSessionItem {
         EXISTING_DOC_APP_JOURNEY,
         UNKNOWN
     }
+
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
 
     private String sessionId;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -16,8 +16,10 @@ public class AuthSessionItem {
         EXISTING_DOC_APP_JOURNEY,
         UNKNOWN
     }
+    public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
 
     private String sessionId;
+    private String verifiedMfaMethodType;
     private long timeToLive;
     private AccountState isNewAccount;
 
@@ -35,6 +37,20 @@ public class AuthSessionItem {
 
     public AuthSessionItem withSessionId(String sessionId) {
         this.sessionId = sessionId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE)
+    public String getVerifiedMfaMethodType() {
+        return verifiedMfaMethodType;
+    }
+
+    public void setVerifiedMfaMethodType(String verifiedMfaMethodType) {
+        this.verifiedMfaMethodType = verifiedMfaMethodType;
+    }
+
+    public AuthSessionItem withVerifiedMfaMethodType(String verifiedMfaMethodType) {
+        this.verifiedMfaMethodType = verifiedMfaMethodType;
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/AuthSessionException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/AuthSessionException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class AuthSessionException extends RuntimeException {
+
+    public AuthSessionException(String message) {
+        super(message);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -1,9 +1,11 @@
 package uk.gov.di.authentication.shared.helpers;
 
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.Session;
 
 import static uk.gov.di.authentication.shared.helpers.InputSanitiser.sanitiseBase64;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.AUTH_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.SESSION_ID;
 
 public class LogLineHelper {
@@ -12,6 +14,7 @@ public class LogLineHelper {
 
     public enum LogFieldName {
         SESSION_ID("sessionId", true),
+        AUTH_SESSION_ID("authSessionId", true),
         CLIENT_SESSION_ID("clientSessionId", true),
         GOVUK_SIGNIN_JOURNEY_ID("govukSigninJourneyId", true),
         PERSISTENT_SESSION_ID("persistentSessionId", true),
@@ -54,6 +57,14 @@ public class LogLineHelper {
 
     public static void attachSessionIdToLogs(String sessionId) {
         attachLogFieldToLogs(SESSION_ID, sessionId);
+    }
+
+    public static void attachAuthSessionIdToLogs(AuthSessionItem authSession) {
+        attachLogFieldToLogs(AUTH_SESSION_ID, authSession.getSessionId());
+    }
+
+    public static void attachAuthSessionIdToLogs(String sessionId) {
+        attachLogFieldToLogs(AUTH_SESSION_ID, sessionId);
     }
 
     public static void updateAttachedSessionIdToLogs(String sessionId) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -48,7 +48,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                         configurationService.getHeadersCaseInsensitive());
 
         if (sessionId.isEmpty()) {
-            LOG.warn("Value not found for Client-Session-Id header");
+            LOG.warn("Value not found for Session-Id header");
         }
         return sessionId;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -127,7 +127,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
             if (item.isPresent()) {
                 AuthSessionItem updatedItem =
                         item.get().withVerifiedMfaMethodType(mfaMethodType.getValue());
-                update(updatedItem);
+                updateSession(updatedItem);
                 LOG.info("verifiedMfaMethodType updated in Auth session table.");
             } else {
                 LOG.error("No Auth session item found with provided sessionId");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -82,7 +82,7 @@ public class SessionService {
                         configurationService.getHeadersCaseInsensitive());
 
         if (sessionId.isEmpty()) {
-            LOG.warn("Value not found for Client-Session-Id header");
+            LOG.warn("Value not found for Session-Id header");
         }
 
         return sessionId


### PR DESCRIPTION
## Background
In order to break the shared session dependency between Auth and Orch, session data are being moved to an Auth owned Auth session table.

There are three parts to breaking the `verifiedMfaMethodType` dependency, this PR is part a:
- ATO-979/a: VerifyCode & VerifyMfaCode: Set in Auth session
- ATO-979/b: UserInfoHandler: Get from Auth session and include in userinfo response
- ATO-979/c: AuthenticationCallbackHandler: Take from userinfo response and set in Orch session

## What

This PR sets `verifiedMfaMethodType` in the Auth session, in the VerifyCode and VerifyMfaCode lambdas.

Note that we exceeded the quote of 20 policies per role, so as a workaround the read and write policies have been combined. Ticket to track requesting a quota increase: https://govukverify.atlassian.net/browse/ATO-1056
