### PR TITLE
AUT-3602: Emit reauth_failed audit event in verifyMfaCodeHandler when user has too many pre-existing authentication attempts for any count

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -492,12 +492,17 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
     private String getInternalCommonSubjectIdentifier(
             UserProfile userProfile, ClientRegistry client) {
-        var internalCommonSubjectIdentifier =
-                ClientSubjectHelper.getSubject(
-                        userProfile,
-                        client,
-                        authenticationService,
-                        configurationService.getInternalSectorUri());
-        return internalCommonSubjectIdentifier.getValue();
+        try {
+            var internalCommonSubjectIdentifier =
+                    ClientSubjectHelper.getSubject(
+                            userProfile,
+                            client,
+                            authenticationService,
+                            configurationService.getInternalSectorUri());
+            return internalCommonSubjectIdentifier.getValue();
+        } catch (RuntimeException e) {
+            LOG.info("Failed to derive Internal Common Subject Identifier. Defaulting to UNKNOWN.");
+            return AuditService.UNKNOWN;
+        }
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -6,11 +6,14 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.helpers.SessionHelper;
 import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessor;
 import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessorFactory;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
@@ -20,6 +23,7 @@ import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.ReauthAuthenticationAttemptsHelper;
@@ -147,6 +151,15 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         Optional<UserProfile> userProfileMaybe = userContext.getUserProfile();
         UserProfile userProfile = userProfileMaybe.orElse(null);
 
+        var auditContext =
+                auditContextFromUserContext(
+                        userContext,
+                        userContext.getSession().getInternalCommonSubjectIdentifier(),
+                        userContext.getSession().getEmailAddress(),
+                        IpAddressHelper.extractIpAddress(input),
+                        AuditService.UNKNOWN,
+                        extractPersistentIdFromHeaders(input.getHeaders()));
+
         LOG.info("Invoking verify MFA code handler");
 
         if (isInvalidCodeRequestType(codeRequest, journeyType))
@@ -155,7 +168,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         if (userProfileMissingForReauthenticationJourney(userProfile, journeyType))
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1049);
 
-        if (errorCountsExceededForReauthentication(journeyType, userProfile))
+        if (checkErrorCountsForReauthAndEmitFailedAuditEventIfBlocked(
+                journeyType, userProfile, auditContext, userContext))
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1057);
 
         try {
@@ -184,8 +198,11 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         return userProfile == null && journeyType == JourneyType.REAUTHENTICATION;
     }
 
-    private boolean errorCountsExceededForReauthentication(
-            JourneyType journeyType, UserProfile userProfile) {
+    private boolean checkErrorCountsForReauthAndEmitFailedAuditEventIfBlocked(
+            JourneyType journeyType,
+            UserProfile userProfile,
+            AuditContext auditContext,
+            UserContext userContext) {
         if (configurationService.isAuthenticationAttemptsServiceEnabled()
                 && JourneyType.REAUTHENTICATION.equals(journeyType)
                 && userProfile != null) {
@@ -195,7 +212,18 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             var countTypesWhereLimitExceeded =
                     ReauthAuthenticationAttemptsHelper.countTypesWhereUserIsBlockedForReauth(
                             counts, configurationService);
-            if (!countTypesWhereLimitExceeded.isEmpty()) {
+
+            ClientRegistry client = userContext.getClient().orElse(null);
+            if (!countTypesWhereLimitExceeded.isEmpty() && client != null) {
+                String rpPairwiseId = getInternalCommonSubjectIdentifier(userProfile, client);
+                auditService.submitAuditEvent(
+                        FrontendAuditableEvent.AUTH_REAUTH_FAILED,
+                        auditContext,
+                        ReauthMetadataBuilder.builder(rpPairwiseId)
+                                .withAllIncorrectAttemptCounts(counts)
+                                .withFailureReason(countTypesWhereLimitExceeded)
+                                .build());
+
                 LOG.info(
                         "Re-authentication locked due to {} counts exceeded.",
                         countTypesWhereLimitExceeded);
@@ -460,5 +488,16 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 };
         return Stream.concat(basicMetadataPairs.stream(), additionalPairs.stream())
                 .toArray(AuditService.MetadataPair[]::new);
+    }
+
+    private String getInternalCommonSubjectIdentifier(
+            UserProfile userProfile, ClientRegistry client) {
+        var internalCommonSubjectIdentifier =
+                ClientSubjectHelper.getSubject(
+                        userProfile,
+                        client,
+                        authenticationService,
+                        configurationService.getInternalSectorUri());
+        return internalCommonSubjectIdentifier.getValue();
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -549,6 +549,7 @@ class VerifyMfaCodeHandlerTest {
         if (journeyType != REAUTHENTICATION) {
             verify(codeStorageService)
                     .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, 900L);
+            verifyNoInteractions(authenticationAttemptsService);
         }
         verify(codeStorageService)
                 .deleteIncorrectMfaCodeAttemptsCount(EMAIL, MFAMethodType.AUTH_APP);
@@ -590,6 +591,7 @@ class VerifyMfaCodeHandlerTest {
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
         verifyNoInteractions(cloudwatchMetricsService);
+        verifyNoInteractions(authenticationAttemptsService);
         assertAuditEventSubmittedWithMetadata(
                 FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
                 pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
@@ -628,6 +630,7 @@ class VerifyMfaCodeHandlerTest {
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
         verifyNoInteractions(cloudwatchMetricsService);
+        verifyNoInteractions(authenticationAttemptsService);
         assertAuditEventSubmittedWithMetadata(
                 FrontendAuditableEvent.AUTH_INVALID_CODE_SENT,
                 pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),


### PR DESCRIPTION
## What

Emit reauth_failed audit event in verifyMfaCodeHandler when user has too many pre-existing authentication attempts for any count.

Also tested that we return the correct error in the case that a user has pre-existing auth attempt counts of any kind, and that there are no interactions with the authentication attempts service when it is not turned on.

## How to review

1. Code Review