### PR TITLE
Bau/refactor check reauth users to not lookup so much

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
@@ -15,6 +15,8 @@ public class ReauthMetadataBuilder {
     private AuditService.MetadataPair incorrectEmailAttemptCountPair;
     private AuditService.MetadataPair incorrectPasswordAttemptCount;
     private AuditService.MetadataPair incorrectOtpAttemptCount;
+    private AuditService.MetadataPair restrictedUserSuppliedEmailPair;
+    private AuditService.MetadataPair restrictedUserIdForUserSuppliedEmailPair;
     private AuditService.MetadataPair failureReason;
 
     private ReauthMetadataBuilder(String rpPairwiseId) {
@@ -27,10 +29,7 @@ public class ReauthMetadataBuilder {
 
     public ReauthMetadataBuilder withAllIncorrectAttemptCounts(
             Map<CountType, Integer> countsByJourney) {
-        this.incorrectEmailAttemptCountPair =
-                pair(
-                        "incorrect_email_attempt_count",
-                        countsByJourney.getOrDefault(CountType.ENTER_EMAIL, 0));
+        withIncorrectEmailAttemptCount(countsByJourney.getOrDefault(CountType.ENTER_EMAIL, 0));
         this.incorrectPasswordAttemptCount =
                 pair(
                         "incorrect_password_attempt_count",
@@ -40,6 +39,22 @@ public class ReauthMetadataBuilder {
                         "incorrect_otp_code_attempt_count",
                         (countsByJourney.getOrDefault(CountType.ENTER_SMS_CODE, 0))
                                 + (countsByJourney.getOrDefault(CountType.ENTER_AUTH_APP_CODE, 0)));
+        return this;
+    }
+
+    public ReauthMetadataBuilder withIncorrectEmailAttemptCount(int count) {
+        this.incorrectEmailAttemptCountPair = pair("incorrect_email_attempt_count", count);
+        return this;
+    }
+
+    public ReauthMetadataBuilder withRestrictedUserSuppliedEmail(String userSuppliedEmail) {
+        this.restrictedUserSuppliedEmailPair = pair("user_supplied_email", userSuppliedEmail, true);
+        return this;
+    }
+
+    public ReauthMetadataBuilder withRestrictedUserIdForUserSuppliedEmail(String userId) {
+        this.restrictedUserIdForUserSuppliedEmailPair =
+                pair("user_id_for_user_supplied_email", userId, true);
         return this;
     }
 
@@ -77,6 +92,12 @@ public class ReauthMetadataBuilder {
         }
         if (failureReason != null) {
             metadataPairs.add(failureReason);
+        }
+        if (restrictedUserSuppliedEmailPair != null) {
+            metadataPairs.add(restrictedUserSuppliedEmailPair);
+        }
+        if (restrictedUserIdForUserSuppliedEmailPair != null) {
+            metadataPairs.add(restrictedUserIdForUserSuppliedEmailPair);
         }
         return metadataPairs.toArray(AuditService.MetadataPair[]::new);
     }


### PR DESCRIPTION
## What

Previously, we were making multiple duplicate calls to look up counts from the database for reauth:

1. an initial call when the user has an account, to check if we should immediately log them out due to exceeded counts
2. a call when emitting the success audit event result, to populate the extensions
3. another when the user submits an incorrect code
4. another when the user submits an incorrect code and breaches the max retries exceeded limit

In this PR, we just do this lookup once - either at the beginning for a user who exists, or when emitting the failed event for a user who does not exist. In the case of an incorrect code, we increment both the database value and either the value in memory. 

This limits the number of database calls made.

## How to review

1. Code Review

