### PR TITLE
ATO-981: Set is new account at session start

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -18,13 +18,16 @@ class AuthSessionServiceIntegrationTest {
     protected static final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
 
     @Test
-    void shouldAddSessionWhenPreviousSessionIdNotGiven() {
+    void shouldAddNewSessionWithExpectedDefaultValuesWhenNoPreviousSessionIdProvided() {
         authSessionExtension.addSession(Optional.empty(), SESSION_ID);
 
         Optional<AuthSessionItem> retrievedSession = authSessionExtension.getSession(SESSION_ID);
 
         assertThat(retrievedSession.isPresent(), equalTo(true));
         assertThat(retrievedSession.get().getSessionId(), equalTo(SESSION_ID));
+        assertThat(
+                retrievedSession.get().getIsNewAccount(),
+                equalTo(AuthSessionItem.AccountState.UNKNOWN));
     }
 
     @Test
@@ -52,5 +55,8 @@ class AuthSessionServiceIntegrationTest {
         assertThat(retrievedPreviousSession.isPresent(), equalTo(false));
         assertThat(retrievedSession.isPresent(), equalTo(true));
         assertThat(retrievedSession.get().getSessionId(), equalTo(SESSION_ID));
+        assertThat(
+                retrievedSession.get().getIsNewAccount(),
+                equalTo(AuthSessionItem.AccountState.UNKNOWN));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -59,4 +59,35 @@ class AuthSessionServiceIntegrationTest {
                 retrievedSession.get().getIsNewAccount(),
                 equalTo(AuthSessionItem.AccountState.UNKNOWN));
     }
+
+    @Test
+    void shouldStoreAnUpdatedSession() {
+        authSessionExtension.addSession(Optional.empty(), SESSION_ID);
+        var session = authSessionExtension.getSession(SESSION_ID).get();
+        session.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
+        authSessionExtension.updateSession(session);
+        var updatedSession = authSessionExtension.getSession(SESSION_ID).get();
+        assertThat(
+                updatedSession.getIsNewAccount(), equalTo(AuthSessionItem.AccountState.EXISTING));
+    }
+
+    @Test
+    void shouldRetainAPreviousSessionsValuesWhenSessionIdIsUpdated() {
+        authSessionExtension.addSession(Optional.empty(), PREVIOUS_SESSION_ID);
+        var previousSession = authSessionExtension.getSession(PREVIOUS_SESSION_ID).get();
+        previousSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
+        authSessionExtension.updateSession(previousSession);
+        authSessionExtension.addSession(Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
+
+        Optional<AuthSessionItem> retrievedPreviousSession =
+                authSessionExtension.getSession(PREVIOUS_SESSION_ID);
+        Optional<AuthSessionItem> retrievedSession = authSessionExtension.getSession(SESSION_ID);
+
+        assertThat(retrievedPreviousSession.isPresent(), equalTo(false));
+        assertThat(retrievedSession.isPresent(), equalTo(true));
+        assertThat(retrievedSession.get().getSessionId(), equalTo(SESSION_ID));
+        assertThat(
+                retrievedSession.get().getIsNewAccount(),
+                equalTo(AuthSessionItem.AccountState.EXISTING));
+    }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -73,4 +73,8 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
     public void addSession(Optional<String> previousSessionId, String sessionId) {
         authSessionService.addOrUpdateSessionId(previousSessionId, sessionId);
     }
+
+    public void updateSession(AuthSessionItem sessionItem) {
+        authSessionService.updateSession(sessionItem);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -8,10 +8,18 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 public class AuthSessionItem {
 
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
+    public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "isNewAccount";
+
+    public enum AccountState {
+        NEW,
+        EXISTING,
+        EXISTING_DOC_APP_JOURNEY,
+        UNKNOWN
+    }
 
     private String sessionId;
-
     private long timeToLive;
+    private AccountState isNewAccount;
 
     public AuthSessionItem() {}
 
@@ -41,6 +49,20 @@ public class AuthSessionItem {
 
     public AuthSessionItem withTimeToLive(long timeToLive) {
         this.timeToLive = timeToLive;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_IS_NEW_ACCOUNT)
+    public AccountState getIsNewAccount() {
+        return this.isNewAccount;
+    }
+
+    public void setIsNewAccount(AccountState accountState) {
+        this.isNewAccount = accountState;
+    }
+
+    public AuthSessionItem withAccountState(AccountState accountState) {
+        this.isNewAccount = accountState;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -45,6 +45,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                 AuthSessionItem newItem =
                         new AuthSessionItem()
                                 .withSessionId(newSessionId)
+                                .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
                                 .withTimeToLive(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -2,6 +2,8 @@ package uk.gov.di.authentication.shared.services;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -17,6 +19,14 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
 
     public AuthSessionService(ConfigurationService configurationService) {
         super(AuthSessionItem.class, "auth-session", configurationService);
+        this.timeToLive = configurationService.getSessionExpiry();
+    }
+
+    public AuthSessionService(
+            DynamoDbClient dynamoDbClient,
+            DynamoDbTable<AuthSessionItem> dynamoDbTable,
+            ConfigurationService configurationService) {
+        super(dynamoDbTable, dynamoDbClient);
         this.timeToLive = configurationService.getSessionExpiry();
     }
 
@@ -74,5 +84,17 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
             LOG.info("Auth session item with expired TTL found. Session ID: {}", sessionId);
         }
         return validAuthSession;
+    }
+
+    public void updateSession(AuthSessionItem sessionItem) {
+        try {
+            update(sessionItem);
+        } catch (DynamoDbException e) {
+            LOG.error(
+                    "Error updating Auth session item with id {}, Error: {}",
+                    sessionItem.getSessionId(),
+                    e.getMessage());
+            throw e;
+        }
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -1,0 +1,81 @@
+package uk.gov.di.authentication.shared.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuthSessionServiceTest {
+    private final DynamoDbTable<AuthSessionItem> mockTable = mock(DynamoDbTable.class);
+    private final DynamoDbClient mockClient = mock(DynamoDbClient.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final String sessionId = "test-session-id";
+    private final Key sessionIdPartitionKey = Key.builder().partitionValue(sessionId).build();
+    private AuthSessionService authSessionService;
+
+    @BeforeEach
+    void testSetup() {
+        authSessionService = new AuthSessionService(mockClient, mockTable, configurationService);
+    }
+
+    @Test
+    void getSessionReturnsSessionWithValidTtl() {
+        withValidSession();
+        var session = authSessionService.getSession(sessionId);
+        assertThat(session.isPresent(), equalTo(true));
+    }
+
+    @Test
+    void getSessionReturnsEmptyOptionalWhenExpired() {
+        withExpiredSession();
+        var session = authSessionService.getSession(sessionId);
+        assertThat(session.isPresent(), equalTo(false));
+    }
+
+    @Test
+    void updateSessionThrowsAnyDynamoExceptions() {
+        withFailedUpdate();
+        var sessionToBeUpdated =
+                new AuthSessionItem()
+                        .withSessionId(sessionId)
+                        .withAccountState(AuthSessionItem.AccountState.EXISTING);
+        assertThrows(
+                DynamoDbException.class,
+                () -> authSessionService.updateSession(sessionToBeUpdated));
+    }
+
+    private void withValidSession() {
+        when(mockTable.getItem(sessionIdPartitionKey))
+                .thenReturn(
+                        new AuthSessionItem()
+                                .withSessionId(sessionId)
+                                .withTimeToLive(NowHelper.now().getTime()));
+    }
+
+    private void withExpiredSession() {
+        long septemberThe7th2002 = 1031405521;
+        when(mockTable.getItem(sessionIdPartitionKey))
+                .thenReturn(
+                        new AuthSessionItem()
+                                .withSessionId(sessionId)
+                                .withTimeToLive(septemberThe7th2002));
+    }
+
+    private void withFailedUpdate() {
+        doThrow(DynamoDbException.builder().message("Failed to update table").build())
+                .when(mockTable)
+                .updateItem(any(AuthSessionItem.class));
+    }
+}


### PR DESCRIPTION
## What: 
- Adds new attribute to session table, isNewAccount
- This is set with a default value of `UNKNOWN` when a session is created for the first time

## How to review
- Code review commit-by-commit
- Have tested in the following way
    - Deploy to a dev account (I did sandpit)
    -  Go to the RP stub and make it to the login page (you can go further but the only backend lambda which write to the  
        new session store is the start handler)
- Find your sessionId
- Have a look in the session table, you should see the value of `isNewAccount` set to unknown
- Come back again via the RP stub and observe the sessionId is updated and the isNewAccount state remains unknown
- Ran through a sign in journey because I'm paranoid 

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
