### PR TITLE
BAU: Remove unneeded pinned child dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,14 +62,6 @@ subprojects {
     buildscript {
         dependencies {
             constraints {
-                classpath('com.google.guava:guava:[32.0.0-jre,)') {
-                    because 'CVE-2020-8908 is fixed in 32.0.0-jre and above'
-                }
-
-                classpath('org.apache.commons:commons-compress:[1.26.0,)') {
-                    because 'CVE-2024-26308 is fixed in 1.26.0 and above'
-                }
-
                 classpath('io.netty:netty-codec-http:[4.1.108.Final,)') {
                     because 'CVE-2024-29025 is fixed in io.netty:netty-codec-http:4.1.108.Final and higher'
                 }
@@ -133,20 +125,7 @@ subprojects {
     //
     dependencies {
         constraints {
-            implementation('org.apache.logging.log4j:log4j-api:2.23.1')
-            testRuntimeOnly('org.apache.logging.log4j:log4j-api:2.23.1')
-            implementation('org.apache.logging.log4j:log4j-core:2.23.1')
-            testRuntimeOnly('org.apache.logging.log4j:log4j-core:2.23.1')
-
             configurations.configureEach { conf ->
-                add(conf.name, 'com.google.guava:guava:[32.0.0-jre,)') {
-                    because 'CVE-2020-8908 is fixed in 32.0.0-jre and above'
-                }
-
-                add(conf.name, 'org.apache.commons:commons-compress:[1.26.0,)') {
-                    because 'CVE-2024-26308 is fixed in 1.26.0 and above'
-                }
-
                 add(conf.name, 'io.netty:netty-codec-http:[4.1.108.Final,)') {
                     because 'CVE-2024-29025 is fixed in io.netty:netty-codec-http:4.1.108.Final and higher'
                 }


### PR DESCRIPTION
## What

Since these child dependency versions were pinned, parent dependencies that used them have been updated to include the updated child dependencies.

They were pinned in the first place because they address vulnerabilities that were fixed in the child, but not the parent.

Removing the pinned versions when no longer needed improves maintainability.

## How to review

1. Code Review
2. See the "Dependency review for pull requests / dependency-review" PR check is successful

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.
