### PR TITLE
ATO-1060: Add channel field to client registry which can be WEB or STRATEGIC_APP

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
@@ -92,6 +92,10 @@ public class ClientRegistrationRequest {
     @Expose
     private String idTokenSigningAlgorithm = ES256.getName();
 
+    @SerializedName("channel")
+    @Expose
+    private String channel;
+
     public ClientRegistrationRequest() {}
 
     public ClientRegistrationRequest(
@@ -110,7 +114,8 @@ public class ClientRegistrationRequest {
             boolean identityVerificationSupported,
             List<String> claims,
             String clientType,
-            String idTokenSigningAlgorithm) {
+            String idTokenSigningAlgorithm,
+            String channel) {
         this(
                 clientName,
                 redirectUris,
@@ -128,7 +133,8 @@ public class ClientRegistrationRequest {
                 claims,
                 clientType,
                 idTokenSigningAlgorithm,
-                null);
+                null,
+                channel);
     }
 
     public ClientRegistrationRequest(
@@ -148,7 +154,8 @@ public class ClientRegistrationRequest {
             List<String> claims,
             String clientType,
             String idTokenSigningAlgorithm,
-            List<String> clientLoCs) {
+            List<String> clientLoCs,
+            String channel) {
         this.clientName = clientName;
         this.redirectUris = redirectUris;
         this.contacts = contacts;
@@ -178,6 +185,7 @@ public class ClientRegistrationRequest {
         if (Objects.nonNull(clientLoCs)) {
             this.clientLoCs = clientLoCs;
         }
+        this.channel = channel;
     }
 
     public String getClientName() {
@@ -250,5 +258,9 @@ public class ClientRegistrationRequest {
 
     public String getIdTokenSigningAlgorithm() {
         return idTokenSigningAlgorithm;
+    }
+
+    public String getChannel() {
+        return channel;
     }
 }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
@@ -96,6 +96,11 @@ public class ClientRegistrationResponse {
     @Expose
     private String idTokenSigningAlgorithm;
 
+    @SerializedName("channel")
+    @Expose
+    @Required
+    private String channel;
+
     public ClientRegistrationResponse(
             String clientName,
             String clientId,
@@ -113,7 +118,8 @@ public class ClientRegistrationResponse {
             List<String> claims,
             String sectorIdentifierUri,
             String clientType,
-            String idTokenSigningAlgorithm) {
+            String idTokenSigningAlgorithm,
+            String channel) {
         this.clientName = clientName;
         this.clientId = clientId;
         this.redirectUris = redirectUris;
@@ -131,6 +137,7 @@ public class ClientRegistrationResponse {
         this.sectorIdentifierUri = sectorIdentifierUri;
         this.clientType = clientType;
         this.idTokenSigningAlgorithm = idTokenSigningAlgorithm;
+        this.channel = channel;
     }
 
     public ClientRegistrationResponse() {}

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -118,7 +118,8 @@ public class ClientRegistrationHandler
                     null,
                     ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
                     clientRegistrationRequest.getIdTokenSigningAlgorithm(),
-                    clientRegistrationRequest.getClientLoCs());
+                    clientRegistrationRequest.getClientLoCs(),
+                    clientRegistrationRequest.getChannel());
 
             var clientRegistrationResponse =
                     new ClientRegistrationResponse(
@@ -138,7 +139,8 @@ public class ClientRegistrationHandler
                             clientRegistrationRequest.getClaims(),
                             clientRegistrationRequest.getSectorIdentifierUri(),
                             clientRegistrationRequest.getClientType(),
-                            clientRegistrationRequest.getIdTokenSigningAlgorithm());
+                            clientRegistrationRequest.getIdTokenSigningAlgorithm(),
+                            clientRegistrationRequest.getChannel());
             LOG.info("Generating successful Client registration response");
             return generateApiGatewayProxyResponse(200, clientRegistrationResponse);
         } catch (JsonException e) {

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -122,7 +122,8 @@ public class UpdateClientConfigHandler
                             clientRegistry.getClaims(),
                             clientRegistry.getSectorIdentifierUri(),
                             clientRegistry.getClientType(),
-                            clientRegistry.getIdTokenSigningAlgorithm());
+                            clientRegistry.getIdTokenSigningAlgorithm(),
+                            clientRegistry.getChannel());
             LOG.info("Client updated");
             return generateApiGatewayProxyResponse(200, clientRegistrationResponse);
         } catch (JsonException | NullPointerException e) {

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -4,6 +4,7 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.client.RegistrationError;
 import com.nimbusds.openid.connect.sdk.SubjectType;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
+import uk.gov.di.orchestration.shared.entity.Channel;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
@@ -57,6 +58,8 @@ public class ClientConfigValidationService {
             new ErrorObject("invalid_client_metadata", "Invalid Accepted Levels of Confidence");
     public static final ErrorObject INVALID_ID_TOKEN_SIGNING_ALGORITHM =
             new ErrorObject("invalid_client_metadata", "Invalid ID Token Signing Algorithm");
+    public static final ErrorObject INVALID_CHANNEL =
+            new ErrorObject("invalid_client_metadata", "Invalid Channel");
 
     private static final Set<String> VALID_ID_TOKEN_SIGNING_ALGORITHMS =
             Stream.of(ES256.getName(), RS256.getName()).collect(Collectors.toSet());
@@ -128,6 +131,11 @@ public class ClientConfigValidationService {
                 .map(this::isValidIdTokenSigningAlgorithm)
                 .orElse(true)) {
             return Optional.of(INVALID_ID_TOKEN_SIGNING_ALGORITHM);
+        }
+        if (!Optional.ofNullable(registrationRequest.getChannel())
+                .map(this::isValidChannel)
+                .orElse(true)) {
+            return Optional.of(INVALID_CHANNEL);
         }
         return Optional.empty();
     }
@@ -279,5 +287,11 @@ public class ClientConfigValidationService {
 
     private boolean isValidIdTokenSigningAlgorithm(String idTokenSigningAlgorithm) {
         return VALID_ID_TOKEN_SIGNING_ALGORITHMS.contains(idTokenSigningAlgorithm);
+    }
+
+    private boolean isValidChannel(String channel) {
+        return Arrays.stream(Channel.values())
+                .map(Channel::getValue)
+                .anyMatch(pks -> pks.equals(channel));
     }
 }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
+import uk.gov.di.orchestration.shared.entity.Channel;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
@@ -97,7 +98,7 @@ class ClientRegistrationHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         event.setBody(
-                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"], \"public_key_source\": \"STATIC\",  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"back_channel_logout_uri\": \"http://localhost:8080/back-channel-logout-uri\", \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"pairwise\", \"id_token_signing_algorithm\": \"ES256\"}");
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"], \"public_key_source\": \"STATIC\",  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"back_channel_logout_uri\": \"http://localhost:8080/back-channel-logout-uri\", \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"pairwise\", \"id_token_signing_algorithm\": \"ES256\", \"channel\": \"WEB\"}");
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
         assertThat(result, hasStatus(200));
@@ -130,7 +131,8 @@ class ClientRegistrationHandlerTest {
                         null,
                         ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
                         "ES256",
-                        emptyList());
+                        emptyList(),
+                        Channel.WEB.getValue());
     }
 
     @Test
@@ -143,7 +145,7 @@ class ClientRegistrationHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         event.setBody(
-                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"], \"public_key_source\": \"STATIC\", \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"pairwise\", \"id_token_signing_algorithm\": \"ES256\"}");
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"], \"public_key_source\": \"STATIC\", \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"pairwise\", \"id_token_signing_algorithm\": \"ES256\", \"channel\": \"WEB\"}");
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
         assertThat(result, hasStatus(200));
@@ -169,7 +171,8 @@ class ClientRegistrationHandlerTest {
                         null,
                         ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
                         "ES256",
-                        emptyList());
+                        emptyList(),
+                        Channel.WEB.getValue());
     }
 
     @Test
@@ -182,7 +185,7 @@ class ClientRegistrationHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         event.setBody(
-                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"], \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"back_channel_logout_uri\": \"http://localhost:8080/back-channel-logout-uri\", \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"pairwise\", \"id_token_signing_algorithm\": \"ES256\"}");
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"], \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"back_channel_logout_uri\": \"http://localhost:8080/back-channel-logout-uri\", \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"pairwise\", \"id_token_signing_algorithm\": \"ES256\", \"channel\": \"WEB\"}");
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
         assertThat(result, hasStatus(200));
@@ -208,7 +211,8 @@ class ClientRegistrationHandlerTest {
                         null,
                         ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
                         "ES256",
-                        emptyList());
+                        emptyList(),
+                        Channel.WEB.getValue());
     }
 
     @Test
@@ -282,7 +286,8 @@ class ClientRegistrationHandlerTest {
                                 + "\"service_type\": \"%s\", "
                                 + "\"sector_identifier_uri\": \"%s\", "
                                 + "\"subject_type\": \"%s\", "
-                                + "\"client_type\": \"%s\" }",
+                                + "\"client_type\": \"%s\", "
+                                + "\"channel\": \"WEB\"}",
                         CLIENT_NAME, MANDATORY, SECTOR_IDENTIFIER, SUBJECT_TYPE, clientType));
         var result = makeHandlerRequest(event);
 

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
+import uk.gov.di.orchestration.shared.entity.Channel;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
@@ -57,7 +58,8 @@ class ClientConfigValidationServiceTest {
                         emptyList(),
                         null,
                         null,
-                        null),
+                        null,
+                        Channel.WEB.getValue()),
                 Arguments.of(
                         null,
                         null,
@@ -68,7 +70,8 @@ class ClientConfigValidationServiceTest {
                         null,
                         null,
                         null,
-                        null),
+                        null,
+                        Channel.STRATEGIC_APP.getValue()),
                 Arguments.of(
                         singletonList("http://localhost/post-redirect-logout"),
                         "http://back-channel.com",
@@ -78,7 +81,8 @@ class ClientConfigValidationServiceTest {
                         List.of(ValidClaims.ADDRESS.getValue()),
                         String.valueOf(MANDATORY),
                         ClientType.WEB.getValue(),
-                        ES256.getName()),
+                        ES256.getName(),
+                        null),
                 Arguments.of(
                         List.of(
                                 "http://localhost/post-redirect-logout",
@@ -93,7 +97,8 @@ class ClientConfigValidationServiceTest {
                                 ValidClaims.PASSPORT.getValue()),
                         String.valueOf(OPTIONAL),
                         ClientType.APP.getValue(),
-                        RS256.getName()));
+                        RS256.getName(),
+                        Channel.WEB.getValue()));
     }
 
     @ParameterizedTest
@@ -107,7 +112,8 @@ class ClientConfigValidationServiceTest {
             List<String> claims,
             String serviceType,
             String clientType,
-            String idTokenSigningAlgorithm) {
+            String idTokenSigningAlgorithm,
+            String channel) {
         Optional<ErrorObject> errorResponse =
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
@@ -123,7 +129,8 @@ class ClientConfigValidationServiceTest {
                                 "public",
                                 claims,
                                 clientType,
-                                idTokenSigningAlgorithm));
+                                idTokenSigningAlgorithm,
+                                channel));
         assertThat(errorResponse, equalTo(Optional.empty()));
     }
 
@@ -144,7 +151,8 @@ class ClientConfigValidationServiceTest {
                                 "public",
                                 emptyList(),
                                 ClientType.WEB.getValue(),
-                                ES256.getName()));
+                                ES256.getName(),
+                                Channel.WEB.getValue()));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_POST_LOGOUT_URI)));
     }
 
@@ -165,7 +173,8 @@ class ClientConfigValidationServiceTest {
                                 "public",
                                 emptyList(),
                                 ClientType.WEB.getValue(),
-                                ES256.getName()));
+                                ES256.getName(),
+                                Channel.WEB.getValue()));
         assertThat(errorResponse, equalTo(Optional.of(RegistrationError.INVALID_REDIRECT_URI)));
     }
 
@@ -186,7 +195,8 @@ class ClientConfigValidationServiceTest {
                                 "public",
                                 emptyList(),
                                 ClientType.WEB.getValue(),
-                                ES256.getName()));
+                                ES256.getName(),
+                                Channel.WEB.getValue()));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_PUBLIC_KEY)));
     }
 
@@ -207,7 +217,8 @@ class ClientConfigValidationServiceTest {
                                 "public",
                                 emptyList(),
                                 ClientType.WEB.getValue(),
-                                ES256.getName()));
+                                ES256.getName(),
+                                Channel.WEB.getValue()));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_PUBLIC_KEY)));
     }
 
@@ -228,7 +239,8 @@ class ClientConfigValidationServiceTest {
                                 "public",
                                 emptyList(),
                                 ClientType.WEB.getValue(),
-                                ES256.getName()));
+                                ES256.getName(),
+                                Channel.WEB.getValue()));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_JWKS_URI)));
     }
 
@@ -249,7 +261,8 @@ class ClientConfigValidationServiceTest {
                                 "public",
                                 emptyList(),
                                 ClientType.WEB.getValue(),
-                                ES256.getName()));
+                                ES256.getName(),
+                                Channel.WEB.getValue()));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_SCOPE)));
     }
 
@@ -270,7 +283,8 @@ class ClientConfigValidationServiceTest {
                                 "public",
                                 emptyList(),
                                 ClientType.WEB.getValue(),
-                                ES256.getName()));
+                                ES256.getName(),
+                                Channel.WEB.getValue()));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_SCOPE)));
     }
 
@@ -291,7 +305,8 @@ class ClientConfigValidationServiceTest {
                                 "public",
                                 List.of("name", "email"),
                                 ClientType.WEB.getValue(),
-                                ES256.getName()));
+                                ES256.getName(),
+                                Channel.WEB.getValue()));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_CLAIM)));
     }
 
@@ -312,7 +327,8 @@ class ClientConfigValidationServiceTest {
                                 "public",
                                 emptyList(),
                                 "Mobile",
-                                ES256.getName()));
+                                ES256.getName(),
+                                Channel.WEB.getValue()));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_CLIENT_TYPE)));
     }
 
@@ -336,7 +352,8 @@ class ClientConfigValidationServiceTest {
                         emptyList(),
                         ClientType.WEB.getValue(),
                         ES256.getName(),
-                        List.of("Unsupported_LoC"));
+                        List.of("Unsupported_LoC"),
+                        Channel.WEB.getValue());
 
         Optional<ErrorObject> errorResponse =
                 validationService.validateClientRegistrationConfig(regReq);
@@ -365,7 +382,8 @@ class ClientConfigValidationServiceTest {
                         emptyList(),
                         ClientType.WEB.getValue(),
                         invalidIdTokenSource,
-                        List.of("Unsupported_LoC"));
+                        List.of("Unsupported_LoC"),
+                        Channel.WEB.getValue());
 
         Optional<ErrorObject> errorResponse =
                 validationService.validateClientRegistrationConfig(regReq);
@@ -391,7 +409,8 @@ class ClientConfigValidationServiceTest {
                                 subjectType,
                                 emptyList(),
                                 ClientType.WEB.getValue(),
-                                ES256.getName()));
+                                ES256.getName(),
+                                Channel.WEB.getValue()));
         assertThat(errorResponse, equalTo(expectedResult));
     }
 
@@ -648,7 +667,8 @@ class ClientConfigValidationServiceTest {
             String subjectType,
             List<String> claims,
             String clientType,
-            String idTokenSigningAlgorithm) {
+            String idTokenSigningAlgorithm,
+            String channel) {
         return new ClientRegistrationRequest(
                 "The test client",
                 redirectUri,
@@ -665,7 +685,8 @@ class ClientConfigValidationServiceTest {
                 false,
                 claims,
                 clientType,
-                idTokenSigningAlgorithm);
+                idTokenSigningAlgorithm,
+                channel);
     }
 
     private UpdateClientConfigRequest generateClientUpdateRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler;
+import uk.gov.di.orchestration.shared.entity.Channel;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
@@ -87,7 +88,8 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
                         false,
                         claims,
                         ClientType.WEB.getValue(),
-                        JWSAlgorithm.ES256.getName());
+                        JWSAlgorithm.ES256.getName(),
+                        Channel.WEB.getValue());
 
         var response = makeRequest(Optional.of(clientRequest), Map.of(), Map.of());
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/contract/ClientRegistryProviderTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/contract/ClientRegistryProviderTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeAll;
 import uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler;
 import uk.gov.di.authentication.clientregistry.lambda.UpdateClientConfigHandler;
 import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService;
+import uk.gov.di.orchestration.shared.entity.Channel;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
@@ -38,6 +39,7 @@ public class ClientRegistryProviderTest extends PactProviderTest {
     private static final String TOKEN_AUTH_METHOD = "private_key_jwt";
     private static final String ID_TOKEN_SIGNING_ALGORITHM = JWSAlgorithm.ES256.getName();
     private static final List<String> CLIENT_LOCS = List.of();
+    private static final String CHANNEL = Channel.WEB.getValue();
 
     private DynamoClientService clientService;
 
@@ -88,6 +90,7 @@ public class ClientRegistryProviderTest extends PactProviderTest {
                 CLIENT_SECRET,
                 TOKEN_AUTH_METHOD,
                 ID_TOKEN_SIGNING_ALGORITHM,
-                CLIENT_LOCS);
+                CLIENT_LOCS,
+                CHANNEL);
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
@@ -11,6 +11,7 @@ import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.orchestration.shared.entity.Channel;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
@@ -159,7 +160,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 null,
                 ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
                 null,
-                emptyList());
+                emptyList(),
+                Channel.WEB.getValue());
     }
 
     public void registerClient(
@@ -199,7 +201,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 null,
                 ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
                 null,
-                clientLoCs);
+                clientLoCs,
+                Channel.WEB.getValue());
     }
 
     public void registerClient(
@@ -240,7 +243,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 clientSecret,
                 clientAuthMethod,
                 isTokenSigningAlgorithm,
-                emptyList());
+                emptyList(),
+                Channel.WEB.getValue());
     }
 
     public void registerClient(
@@ -279,7 +283,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 null,
                 ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
                 isTokenSigningAlgorithm,
-                emptyList());
+                emptyList(),
+                Channel.WEB.getValue());
     }
 
     public boolean clientExists(String clientID) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Channel.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Channel.java
@@ -1,0 +1,16 @@
+package uk.gov.di.orchestration.shared.entity;
+
+public enum Channel {
+    WEB("WEB"),
+    STRATEGIC_APP("STRATEGIC_APP");
+
+    private final String value;
+
+    Channel(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
@@ -43,6 +43,7 @@ public class ClientRegistry {
     private String idTokenSigningAlgorithm = "ES256";
     private boolean smokeTest = false;
     private List<String> clientLoCs = new ArrayList<>();
+    private String channel;
 
     private static final Set<String> RS256_MAPPINGS =
             Set.of(JWSAlgorithm.RS256.getName(), "RSA256");
@@ -469,6 +470,20 @@ public class ClientRegistry {
 
     public ClientRegistry withPermitMissingNonce(boolean permitMissingNonce) {
         this.permitMissingNonce = permitMissingNonce;
+        return this;
+    }
+
+    @DynamoDbAttribute("Channel")
+    public String getChannel() {
+        return Optional.ofNullable(channel).orElseGet(Channel.WEB::getValue);
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public ClientRegistry withChannel(String channel) {
+        this.channel = channel;
         return this;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
@@ -79,6 +79,10 @@ public class UpdateClientConfigRequest {
     @Expose
     private Boolean identityVerificationSupported;
 
+    @SerializedName("channel")
+    @Expose
+    private String channel;
+
     public UpdateClientConfigRequest() {}
 
     public String getClientId() {
@@ -151,6 +155,10 @@ public class UpdateClientConfigRequest {
 
     public Boolean getidentityVerificationSupported() {
         return identityVerificationSupported;
+    }
+
+    public String getChannel() {
+        return channel;
     }
 
     public UpdateClientConfigRequest setClientId(String clientId) {
@@ -241,6 +249,11 @@ public class UpdateClientConfigRequest {
     public UpdateClientConfigRequest setIdentityVerificationSupported(
             Boolean identityVerificationSupported) {
         this.identityVerificationSupported = identityVerificationSupported;
+        return this;
+    }
+
+    public UpdateClientConfigRequest setChannel(String channel) {
+        this.channel = channel;
         return this;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientService.java
@@ -32,7 +32,8 @@ public interface ClientService {
             String clientSecret,
             String tokenAuthMethod,
             String idTokenSigningAlgorithm,
-            List<String> clientLoCs);
+            List<String> clientLoCs,
+            String channel);
 
     Optional<ClientRegistry> getClient(String clientId);
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
@@ -78,7 +78,8 @@ public class DynamoClientService implements ClientService {
             String clientSecret,
             String tokenAuthMethod,
             String idTokenSigningAlgorithm,
-            List<String> clientLoCs) {
+            List<String> clientLoCs,
+            String channel) {
         var clientRegistry =
                 new ClientRegistry()
                         .withClientID(clientID)
@@ -100,7 +101,8 @@ public class DynamoClientService implements ClientService {
                         .withIdentityVerificationSupported(identityVerificationSupported)
                         .withIdTokenSigningAlgorithm(idTokenSigningAlgorithm)
                         .withTokenAuthMethod(tokenAuthMethod)
-                        .withActive(true);
+                        .withActive(true)
+                        .withChannel(channel);
         if (Objects.nonNull(clientSecret)) {
             clientRegistry.withClientSecret(Argon2EncoderHelper.argon2Hash(clientSecret));
         }
@@ -143,6 +145,7 @@ public class DynamoClientService implements ClientService {
                 .ifPresent(clientRegistry::withIdTokenSigningAlgorithm);
         Optional.ofNullable(updateRequest.getidentityVerificationSupported())
                 .ifPresent(clientRegistry::withIdentityVerificationSupported);
+        Optional.ofNullable(updateRequest.getChannel()).ifPresent(clientRegistry::withChannel);
         dynamoClientRegistryTable.putItem(clientRegistry);
         return clientRegistry;
     }


### PR DESCRIPTION
## What

Add `channel` field to client registry. The possible values are "WEB" (default) and "STRATEGIC_APP".

The handlers to register / update a client in the client registry have also been updated.

`channel` will be passed to Authentication via the authorize request. "STRATEGIC_APP" is a request for mobile view.

## Testing

Once this is deployed to integration, I'll test adding a new client and check it sets the value of `channel` to "WEB".