### PR TITLE
AUT-3602: Emit reauth_failed audit event in VerifyCodeHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -514,12 +514,17 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
     private String getInternalCommonSubjectIdentifier(
             UserProfile userProfile, ClientRegistry client) {
-        var internalCommonSubjectIdentifier =
-                ClientSubjectHelper.getSubject(
-                        userProfile,
-                        client,
-                        authenticationService,
-                        configurationService.getInternalSectorUri());
-        return internalCommonSubjectIdentifier.getValue();
+        try {
+            var internalCommonSubjectIdentifier =
+                    ClientSubjectHelper.getSubject(
+                            userProfile,
+                            client,
+                            authenticationService,
+                            configurationService.getInternalSectorUri());
+            return internalCommonSubjectIdentifier.getValue();
+        } catch (RuntimeException e) {
+            LOG.info("Failed to derive Internal Common Subject Identifier. Defaulting to UNKNOWN.");
+            return AuditService.UNKNOWN;
+        }
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -210,12 +210,12 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
             sessionService.storeOrUpdateSession(session);
 
-            if (errorResponse.isPresent()) {
+            if (errorResponse.isPresent() && userProfile != null) {
                 handleInvalidVerificationCode(
                         codeRequest,
                         journeyType,
                         notificationType,
-                        userProfile,
+                        userProfile.getSubjectID(),
                         errorResponse.get(),
                         session,
                         auditContext);
@@ -251,16 +251,14 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             VerifyCodeRequest codeRequest,
             JourneyType journeyType,
             NotificationType notificationType,
-            UserProfile userProfile,
+            String subjectId,
             ErrorResponse errorResponse,
             Session session,
             AuditContext auditContext) {
-        if (journeyType == JourneyType.REAUTHENTICATION
-                && notificationType == MFA_SMS
-                && userProfile != null) {
+        if (journeyType == JourneyType.REAUTHENTICATION && notificationType == MFA_SMS) {
             if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
                 authenticationAttemptsService.createOrIncrementCount(
-                        userProfile.getSubjectID(),
+                        subjectId,
                         NowHelper.nowPlus(
                                         configurationService.getReauthEnterSMSCodeCountTTL(),
                                         ChronoUnit.SECONDS)

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -238,7 +238,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     userContext,
                     userProfile != null ? userProfile.getSubjectID() : null,
                     journeyType,
-                    auditContext);
+                    auditContext,
+                    client);
 
             return generateEmptySuccessApiGatewayResponse();
         } catch (ClientNotFoundException e) {
@@ -343,12 +344,13 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             UserContext userContext,
             String subjectId,
             JourneyType journeyType,
-            AuditContext auditContext) {
+            AuditContext auditContext,
+            ClientRegistry client) {
         var notificationType = codeRequest.notificationType();
         int loginFailureCount =
                 codeStorageService.getIncorrectMfaCodeAttemptsCount(session.getEmailAddress());
         var clientSession = userContext.getClientSession();
-        var clientId = userContext.getClient().get().getClientID();
+        var clientId = client.getClientID();
         var levelOfConfidence =
                 clientSession.getEffectiveVectorOfTrust().containsLevelOfConfidence()
                         ? clientSession.getEffectiveVectorOfTrust().getLevelOfConfidence()


### PR DESCRIPTION
## What

- Emits the AUTH_REAUTH_FAILED audit event from the VerifyCodeHandler when a user has exceeded the max number of authentication attempts for any count type.
- Also verified in tests that there are no interactions with the authentication attempts service when it is not turned on.

## How to review

1. Code Review


