### PR TITLE
BAU: Use sonar instead of sonarqube

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -376,4 +376,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew testCodeCoverageReport sonarqube -x test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck
+        run: ./gradlew testCodeCoverageReport sonar -x test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck

--- a/.github/workflows/sonar-analysis-on-merge.yml
+++ b/.github/workflows/sonar-analysis-on-merge.yml
@@ -29,4 +29,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew --no-daemon test testCodeCoverageReport sonarqube -x spotlessApply spotlessCheck
+        run: ./gradlew --no-daemon test testCodeCoverageReport sonar -x spotlessApply spotlessCheck

--- a/build.gradle
+++ b/build.gradle
@@ -407,7 +407,7 @@ task utilsTerraform (type: Terraform) {
 
 String jacocoBuildReportPath = "reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"
 
-sonarqube {
+sonar {
     properties {
         property "sonar.projectKey", "govuk-one-login_authentication-api"
         property "sonar.organization", "govuk-one-login"


### PR DESCRIPTION
## What

PR to use 'sonar' instead of 'sonarqube' in pre merge checks. Sonarqube has been deprecated and it was complaining when pre-merge checks were running.

## How to review

1. Code Review