### PR TITLE
BAU: Add timestamps to bookend email check logs

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -212,20 +212,25 @@ public class SendOtpNotificationHandler
                                             .getAuthorizer()
                                             .getOrDefault("principalId", AuditService.UNKNOWN)
                                             .toString();
+                            UUID requestReference = UUID.randomUUID();
+                            long timeOfInitialRequest = NowHelper.now().toInstant().toEpochMilli();
                             pendingEmailCheckSqsClient.send(
                                     objectMapper.writeValueAsString(
                                             new PendingEmailCheckRequest(
                                                     userId,
-                                                    UUID.randomUUID(),
+                                                    requestReference,
                                                     email,
                                                     sessionId,
                                                     clientSessionId,
                                                     persistentSessionId,
                                                     IpAddressHelper.extractIpAddress(input),
                                                     JourneyType.ACCOUNT_MANAGEMENT,
-                                                    NowHelper.now().toInstant().toEpochMilli(),
+                                                    timeOfInitialRequest,
                                                     isTestUserRequest)));
-                            LOG.info("Email address check requested");
+                            LOG.info(
+                                    "Email address check requested for {} at {}",
+                                    requestReference,
+                                    timeOfInitialRequest);
                         } else {
                             LOG.info(
                                     "Skipped request for new email address check. Result already cached");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -317,20 +317,25 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                 String persistentSessionId =
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
 
+                UUID requestReference = UUID.randomUUID();
+                long timeOfInitialRequest = NowHelper.now().toInstant().toEpochMilli();
                 pendingEmailCheckSqsClient.send(
                         objectMapper.writeValueAsString(
                                 new PendingEmailCheckRequest(
                                         AuditService.UNKNOWN,
-                                        UUID.randomUUID(),
+                                        requestReference,
                                         destination,
                                         sessionId,
                                         clientSessionId,
                                         persistentSessionId,
                                         IpAddressHelper.extractIpAddress(input),
                                         JourneyType.REGISTRATION,
-                                        NowHelper.now().toInstant().toEpochMilli(),
+                                        timeOfInitialRequest,
                                         testClientWithAllowedEmail)));
-                LOG.info("Email address check requested");
+                LOG.info(
+                        "Email address check requested for {} at {}",
+                        requestReference,
+                        timeOfInitialRequest);
             } else {
                 LOG.info("Skipped request for new email address check. Result already cached");
             }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/EmailCheckResultWriterHandler.java
@@ -63,10 +63,15 @@ public class EmailCheckResultWriterHandler implements RequestHandler<SQSEvent, V
                         emailCheckResult.timeToExist(),
                         emailCheckResult.requestReference());
 
+                long currentTime = now().getTime();
+                long timeOfInitialRequest = emailCheckResult.timeOfInitialRequest();
+                long duration = currentTime - timeOfInitialRequest;
                 LOG.info(
-                        "Message for email check reference {} written to database",
-                        emailCheckResult.requestReference());
-                var duration = now().getTime() - emailCheckResult.timeOfInitialRequest();
+                        "Message for email check reference {} written to database. Started at {}, now {} for duration {}",
+                        emailCheckResult.requestReference(),
+                        timeOfInitialRequest,
+                        currentTime,
+                        duration);
 
                 cloudwatchMetricsService.logEmailCheckDuration(duration);
             } catch (JsonException e) {


### PR DESCRIPTION
## What

Adding timestamps to our existing logs for the start and end of the async email check process to help diagnose a potential issue on the `EmailCheckDuration` metric.

We're currently seeing 10 unaccounted for seconds in the async journey. After some analysis we're leaning to an issue with the `EmailCheckDuration` metric rather than those 10 seconds actually existing.

Adding these will allow a comparison with the value of the start and end times as recorded in the metric vs when the time the logs are recorded.

Once we're satisfied with the data gathered here in our logs this could be reverted.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.
