### PR TITLE
ATO-1064: add audit log for bsid sign out

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -429,6 +429,11 @@ public class AuthorisationHandler
                 && browserSessionIdFromSession.isPresent()
                 && !Objects.equals(browserSessionIdFromSession, browserSessionIdFromCookie)) {
             sessionWithValidBrowserSessionId = Optional.empty();
+            auditService.submitAuditEvent(
+                    OidcAuditableEvent.AUTHORISATION_INITIATED,
+                    authRequest.getClientID().getValue(),
+                    user,
+                    pair("new_authentication_required", true));
         } else {
             sessionWithValidBrowserSessionId = session;
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -412,8 +412,6 @@ public class AuthorisationHandler
                     user);
         }
 
-        Optional<Session> sessionWithValidBrowserSessionId;
-
         Optional<String> browserSessionIdFromSession = session.map(Session::getBrowserSessionId);
         Optional<String> browserSessionIdFromCookie =
                 CookieHelper.parseBrowserSessionCookie(input.getHeaders());
@@ -424,6 +422,7 @@ public class AuthorisationHandler
         }
         //
 
+        Optional<Session> sessionWithValidBrowserSessionId = session;
         if (configurationService.isBrowserSessionCookieEnabled()
                 && configurationService.isSignOutOnBrowserCloseEnabled()
                 && browserSessionIdFromSession.isPresent()
@@ -434,8 +433,6 @@ public class AuthorisationHandler
                     authRequest.getClientID().getValue(),
                     user,
                     pair("new_authentication_required", true));
-        } else {
-            sessionWithValidBrowserSessionId = session;
         }
 
         return handleAuthJourney(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1791,6 +1791,12 @@ class AuthorisationHandlerTest {
                                 "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
                                 BROWSER_SESSION_ID_COOKIE_NAME, NEW_BROWSER_SESSION_ID),
                         browserSessionIdCookieFromResponse(response));
+                inOrder.verify(auditService)
+                        .submitAuditEvent(
+                                OidcAuditableEvent.AUTHORISATION_INITIATED,
+                                CLIENT_ID.getValue(),
+                                BASE_AUDIT_USER,
+                                pair("new_authentication_required", true));
             }
 
             @Test
@@ -1851,6 +1857,12 @@ class AuthorisationHandlerTest {
                                 "%s=%s; Domain=oidc.auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
                                 BROWSER_SESSION_ID_COOKIE_NAME, NEW_BROWSER_SESSION_ID),
                         browserSessionIdCookieFromResponse(response));
+                inOrder.verify(auditService)
+                        .submitAuditEvent(
+                                OidcAuditableEvent.AUTHORISATION_INITIATED,
+                                CLIENT_ID.getValue(),
+                                BASE_AUDIT_USER,
+                                pair("new_authentication_required", true));
             }
 
             private APIGatewayProxyResponseEvent setupExistingSessionAndCookieInHeader(


### PR DESCRIPTION
## What
Adds audit log for a user needing to authenticate as a result of having an invalid "bsid". This is only logged if the "bsid" is the _only_ reason for a new authentication journey, so not logged if both "gs" and "bsid" are missing, for example. This means only the journeys affected by this change will be logged.

Original ticket to make a decision on this auditting: https://govukverify.atlassian.net/browse/ATO-969
Event catalogue update: https://github.com/govuk-one-login/event-catalogue/pull/234
Slack discussions: https://gds.slack.com/archives/C021FD820N6/p1724763497125069 and https://gds.slack.com/archives/C05811D4JMR/p1724766923917489

## How to review

1. Code Review