### PR TITLE
AUT-2871: Code deploy for lambda to shift traffic canary blue green

### DIFF
--- a/ci/terraform/account-management/.terraform.lock.hcl
+++ b/ci/terraform/account-management/.terraform.lock.hcl
@@ -28,6 +28,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.1"
   constraints = "2.5.1"

--- a/ci/terraform/account-management/authdev1.tfvars
+++ b/ci/terraform/account-management/authdev1.tfvars
@@ -10,3 +10,5 @@ lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 
 openapi_spec_filename = "openapi_v2.yaml"
+
+code_deploy_notification = false

--- a/ci/terraform/account-management/authdev2.tfvars
+++ b/ci/terraform/account-management/authdev2.tfvars
@@ -10,3 +10,5 @@ lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 
 openapi_spec_filename = "openapi_v2.yaml"
+
+code_deploy_notification = false

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -72,4 +72,7 @@ module "codedeploy_authenticate" {
   lambda_version       = module.authenticate.lambda_version
   lambda_alias_name    = module.authenticate.lambda_alias_name
   lambda_alias_version = module.authenticate.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -63,3 +63,13 @@ module "authenticate" {
 
   depends_on = [module.account_management_api_authenticate_role]
 }
+
+module "codedeploy_authenticate" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "authenticate"
+  environment          = var.environment
+  lambda_function_name = module.authenticate.lambda_function_name
+  lambda_version       = module.authenticate.lambda_version
+  lambda_alias_name    = module.authenticate.lambda_alias_name
+  lambda_alias_version = module.authenticate.lambda_alias_version
+}

--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -69,6 +69,9 @@ resource "aws_lambda_alias" "authorizer_alias" {
   description      = "Alias pointing at active version of Lambda"
   function_name    = aws_lambda_function.authorizer.arn
   function_version = aws_lambda_function.authorizer.version
+  lifecycle {
+    ignore_changes = [function_version, routing_config]
+  }
 }
 
 
@@ -181,4 +184,14 @@ resource "aws_cloudwatch_metric_alarm" "lambda_authorizer_error_rate_cloudwatch_
     }
   }
   alarm_actions = [data.aws_sns_topic.slack_events.arn]
+}
+
+module "codedeploy_authorizer" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "authorizer"
+  environment          = var.environment
+  lambda_function_name = aws_lambda_function.authorizer.function_name
+  lambda_version       = aws_lambda_function.authorizer.version
+  lambda_alias_name    = aws_lambda_alias.authorizer_alias.name
+  lambda_alias_version = aws_lambda_alias.authorizer_alias.function_version
 }

--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -194,4 +194,7 @@ module "codedeploy_authorizer" {
   lambda_version       = aws_lambda_function.authorizer.version
   lambda_alias_name    = aws_lambda_alias.authorizer_alias.name
   lambda_alias_version = aws_lambda_alias.authorizer_alias.function_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/account-management/delete-account.tf
+++ b/ci/terraform/account-management/delete-account.tf
@@ -66,3 +66,13 @@ module "delete_account" {
 
   depends_on = [module.account_management_api_remove_account_role]
 }
+
+module "codedeploy_delete_account" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "delete-account"
+  environment          = var.environment
+  lambda_function_name = module.delete_account.lambda_function_name
+  lambda_version       = module.delete_account.lambda_version
+  lambda_alias_name    = module.delete_account.lambda_alias_name
+  lambda_alias_version = module.delete_account.lambda_alias_version
+}

--- a/ci/terraform/account-management/delete-account.tf
+++ b/ci/terraform/account-management/delete-account.tf
@@ -75,4 +75,7 @@ module "codedeploy_delete_account" {
   lambda_version       = module.delete_account.lambda_version
   lambda_alias_name    = module.delete_account.lambda_alias_name
   lambda_alias_version = module.delete_account.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/account-management/send-otp-notification.tf
+++ b/ci/terraform/account-management/send-otp-notification.tf
@@ -93,4 +93,7 @@ module "codedeploy_send_notification" {
   lambda_version       = module.send_otp_notification.lambda_version
   lambda_alias_name    = module.send_otp_notification.lambda_alias_name
   lambda_alias_version = module.send_otp_notification.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/account-management/send-otp-notification.tf
+++ b/ci/terraform/account-management/send-otp-notification.tf
@@ -84,3 +84,13 @@ module "send_otp_notification" {
     aws_elasticache_replication_group.account_management_sessions_store,
   ]
 }
+
+module "codedeploy_send_notification" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "send-otp-notification"
+  environment          = var.environment
+  lambda_function_name = module.send_otp_notification.lambda_function_name
+  lambda_version       = module.send_otp_notification.lambda_version
+  lambda_alias_name    = module.send_otp_notification.lambda_alias_name
+  lambda_alias_version = module.send_otp_notification.lambda_alias_version
+}

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -227,4 +227,18 @@ resource "aws_lambda_alias" "sqs_lambda_active" {
   description      = "Alias pointing at active version of Lambda"
   function_name    = aws_lambda_function.email_sqs_lambda.arn
   function_version = aws_lambda_function.email_sqs_lambda.version
+
+  lifecycle {
+    ignore_changes = [function_version, routing_config]
+  }
+}
+
+module "codedeploy_email_sqs_lambda" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "email-sqs-lambda"
+  environment          = var.environment
+  lambda_function_name = aws_lambda_function.email_sqs_lambda.function_name
+  lambda_version       = aws_lambda_function.email_sqs_lambda.version
+  lambda_alias_name    = aws_lambda_alias.sqs_lambda_active.name
+  lambda_alias_version = aws_lambda_alias.sqs_lambda_active.function_version
 }

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -241,4 +241,7 @@ module "codedeploy_email_sqs_lambda" {
   lambda_version       = aws_lambda_function.email_sqs_lambda.version
   lambda_alias_name    = aws_lambda_alias.sqs_lambda_active.name
   lambda_alias_version = aws_lambda_alias.sqs_lambda_active.function_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -79,4 +79,7 @@ module "codedeploy_update_email" {
   lambda_version       = module.update_email.lambda_version
   lambda_alias_name    = module.update_email.lambda_alias_name
   lambda_alias_version = module.update_email.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -70,3 +70,13 @@ module "update_email" {
 
   depends_on = [module.account_management_api_update_email_role]
 }
+
+module "codedeploy_update_email" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "update-email"
+  environment          = var.environment
+  lambda_function_name = module.update_email.lambda_function_name
+  lambda_version       = module.update_email.lambda_version
+  lambda_alias_name    = module.update_email.lambda_alias_name
+  lambda_alias_version = module.update_email.lambda_alias_version
+}

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -66,3 +66,13 @@ module "update_password" {
 
   depends_on = [module.account_management_api_update_password_role]
 }
+
+module "codedeploy_update_password" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "update-password"
+  environment          = var.environment
+  lambda_function_name = module.update_password.lambda_function_name
+  lambda_version       = module.update_password.lambda_version
+  lambda_alias_name    = module.update_password.lambda_alias_name
+  lambda_alias_version = module.update_password.lambda_alias_version
+}

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -75,4 +75,7 @@ module "codedeploy_update_password" {
   lambda_version       = module.update_password.lambda_version
   lambda_alias_name    = module.update_password.lambda_alias_name
   lambda_alias_version = module.update_password.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -75,4 +75,7 @@ module "codedeploy_update_phone_no" {
   lambda_version       = module.update_phone_number.lambda_version
   lambda_alias_name    = module.update_phone_number.lambda_alias_name
   lambda_alias_version = module.update_phone_number.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -66,3 +66,13 @@ module "update_phone_number" {
 
   depends_on = [module.account_management_api_update_phone_number_role]
 }
+
+module "codedeploy_update_phone_no" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "update-phone-number"
+  environment          = var.environment
+  lambda_function_name = module.update_phone_number.lambda_function_name
+  lambda_version       = module.update_phone_number.lambda_version
+  lambda_alias_name    = module.update_phone_number.lambda_alias_name
+  lambda_alias_version = module.update_phone_number.lambda_alias_version
+}

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -244,3 +244,15 @@ variable "openapi_spec_filename" {
   default     = "openapi.yaml"
   description = "The name of the OpenAPI spec file, located within this module."
 }
+
+variable "code_deploy_notification" {
+  description = "Enable Notification for Code deployment failure"
+  type        = bool
+  default     = true
+}
+
+variable "skip_canary" {
+  description = "Flag to skip canary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
+  type        = bool
+  default     = false
+}

--- a/ci/terraform/auth-external-api/.terraform.lock.hcl
+++ b/ci/terraform/auth-external-api/.terraform.lock.hcl
@@ -28,6 +28,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.1"
   constraints = "2.5.1"

--- a/ci/terraform/auth-external-api/authdev1.tfvars
+++ b/ci/terraform/auth-external-api/authdev1.tfvars
@@ -10,3 +10,5 @@ endpoint_memory_size   = 1536
 orch_client_id                       = "orchestrationAuth"
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENB3csRUIdoaTHNn079Jl7JpiXzxF0p2ZIddCErxtIhGMTTqtbQZJCPesSKUVE/DQbpIko3mLoisuFgmQfFouCw=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM0ZehmrdDd89uYEFMTakbS7JgwCGXK7CAYMcVvy1pP5yV4O2mnDjYmvjZpvio2ctgOPxDuBb38QP1HD9WAOR2w=="
+
+code_deploy_notification = false

--- a/ci/terraform/auth-external-api/authdev2.tfvars
+++ b/ci/terraform/auth-external-api/authdev2.tfvars
@@ -10,3 +10,5 @@ endpoint_memory_size   = 1536
 orch_client_id                       = "orchestrationAuth"
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/Yz722IDLN1mPqkPTihkwAkp/rUmBhnWynwAkE/YZlskX+N7VmwIjupla7O6hczlIOqkmPdQ1ayDqI8yY2QOiw=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwe8ey1GnTbH6E69EJFUkt4WQc1KltJwzOYNWUmK/+GxooRp+j9i9KWQ0WlV4gVI0iQkHY3ZKq+RWk94tSDHbyQ=="
+
+code_deploy_notification = false

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -74,3 +74,13 @@ module "auth_token" {
     aws_api_gateway_rest_api.di_auth_ext_api,
   ]
 }
+
+module "codedeploy_auth_token" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "auth-token"
+  environment          = var.environment
+  lambda_function_name = module.auth_token.lambda_function_name
+  lambda_version       = module.auth_token.lambda_version
+  lambda_alias_name    = module.auth_token.lambda_alias_name
+  lambda_alias_version = module.auth_token.lambda_alias_version
+}

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -83,4 +83,7 @@ module "codedeploy_auth_token" {
   lambda_version       = module.auth_token.lambda_version
   lambda_alias_name    = module.auth_token.lambda_alias_name
   lambda_alias_version = module.auth_token.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -79,4 +79,7 @@ module "codedeploy_auth_userinfo" {
   lambda_version       = module.auth_userinfo.lambda_version
   lambda_alias_name    = module.auth_userinfo.lambda_alias_name
   lambda_alias_version = module.auth_userinfo.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -70,3 +70,13 @@ module "auth_userinfo" {
     aws_api_gateway_rest_api.di_auth_ext_api,
   ]
 }
+
+module "codedeploy_auth_userinfo" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "auth-userinfo"
+  environment          = var.environment
+  lambda_function_name = module.auth_userinfo.lambda_function_name
+  lambda_version       = module.auth_userinfo.lambda_version
+  lambda_alias_name    = module.auth_userinfo.lambda_alias_name
+  lambda_alias_version = module.auth_userinfo.lambda_alias_version
+}

--- a/ci/terraform/auth-external-api/variables.tf
+++ b/ci/terraform/auth-external-api/variables.tf
@@ -130,3 +130,15 @@ locals {
     scaling_trigger = var.scaling_trigger
   }
 }
+
+variable "code_deploy_notification" {
+  description = "Enable Notification for Code deployment failure"
+  type        = bool
+  default     = true
+}
+
+variable "skip_canary" {
+  description = "Flag to skip canary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
+  type        = bool
+  default     = false
+}

--- a/ci/terraform/delivery-receipts/.terraform.lock.hcl
+++ b/ci/terraform/delivery-receipts/.terraform.lock.hcl
@@ -28,6 +28,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.1"
   constraints = "2.5.1"

--- a/ci/terraform/delivery-receipts/authdev1.tfvars
+++ b/ci/terraform/delivery-receipts/authdev1.tfvars
@@ -8,3 +8,5 @@ notify_template_map = {
   CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION_TEMPLATE_ID = "d253a170-8144-4471-b339-c35965c9298a"
   TERMS_AND_CONDITIONS_BULK_EMAIL_TEMPLATE_ID            = "067548f2-420d-4da9-923f-ec9a941706cf"
 }
+
+code_deploy_notification = false

--- a/ci/terraform/delivery-receipts/authdev2.tfvars
+++ b/ci/terraform/delivery-receipts/authdev2.tfvars
@@ -8,3 +8,5 @@ notify_template_map = {
   CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION_TEMPLATE_ID = "d253a170-8144-4471-b339-c35965c9298a"
   TERMS_AND_CONDITIONS_BULK_EMAIL_TEMPLATE_ID            = "067548f2-420d-4da9-923f-ec9a941706cf"
 }
+
+code_deploy_notification = false

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -55,3 +55,13 @@ module "notify_callback" {
     aws_api_gateway_rest_api.di_authentication_delivery_receipts_api,
   ]
 }
+
+module "codedeploy_notify_callback" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "notify-callback"
+  environment          = var.environment
+  lambda_function_name = module.notify_callback.lambda_function_name
+  lambda_version       = module.notify_callback.lambda_version
+  lambda_alias_name    = module.notify_callback.lambda_alias_name
+  lambda_alias_version = module.notify_callback.lambda_alias_version
+}

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -64,4 +64,7 @@ module "codedeploy_notify_callback" {
   lambda_version       = module.notify_callback.lambda_version
   lambda_alias_name    = module.notify_callback.lambda_alias_name
   lambda_alias_version = module.notify_callback.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/delivery-receipts/variables.tf
+++ b/ci/terraform/delivery-receipts/variables.tf
@@ -106,3 +106,15 @@ variable "notify_template_map" {
     REPORT_SUSPICIOUS_ACTIVITY_EMAIL_TEMPLATE_ID           = "2b3170b5-159e-457f-a282-f30f6006dc32"
   }
 }
+
+variable "code_deploy_notification" {
+  description = "Enable Notification for Code deployment failure"
+  type        = bool
+  default     = true
+}
+
+variable "skip_canary" {
+  description = "Flag to skip canary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
+  type        = bool
+  default     = false
+}

--- a/ci/terraform/interventions-api-stub/.terraform.lock.hcl
+++ b/ci/terraform/interventions-api-stub/.terraform.lock.hcl
@@ -28,6 +28,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.1"
   constraints = "2.5.1"

--- a/ci/terraform/interventions-api-stub/authdev1.tfvars
+++ b/ci/terraform/interventions-api-stub/authdev1.tfvars
@@ -1,2 +1,4 @@
 environment         = "authdev1"
 shared_state_bucket = "di-auth-development-tfstate"
+
+code_deploy_notification = false

--- a/ci/terraform/interventions-api-stub/authdev2.tfvars
+++ b/ci/terraform/interventions-api-stub/authdev2.tfvars
@@ -1,2 +1,4 @@
 environment         = "authdev2"
 shared_state_bucket = "di-auth-development-tfstate"
+
+code_deploy_notification = false

--- a/ci/terraform/interventions-api-stub/lambda.tf
+++ b/ci/terraform/interventions-api-stub/lambda.tf
@@ -44,3 +44,13 @@ module "account_interventions_stub_lambda" {
   slack_event_topic_arn                  = data.aws_sns_topic.slack_events.arn
   dynatrace_secret                       = local.dynatrace_secret
 }
+
+module "codedeploy_account_interventions_stub_lambda" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "account-interventions-stub"
+  environment          = var.environment
+  lambda_function_name = module.account_interventions_stub_lambda.lambda_function_name
+  lambda_version       = module.account_interventions_stub_lambda.lambda_version
+  lambda_alias_name    = module.account_interventions_stub_lambda.lambda_alias_name
+  lambda_alias_version = module.account_interventions_stub_lambda.lambda_alias_version
+}

--- a/ci/terraform/interventions-api-stub/lambda.tf
+++ b/ci/terraform/interventions-api-stub/lambda.tf
@@ -53,4 +53,7 @@ module "codedeploy_account_interventions_stub_lambda" {
   lambda_version       = module.account_interventions_stub_lambda.lambda_version
   lambda_alias_name    = module.account_interventions_stub_lambda.lambda_alias_name
   lambda_alias_version = module.account_interventions_stub_lambda.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/interventions-api-stub/variables.tf
+++ b/ci/terraform/interventions-api-stub/variables.tf
@@ -78,3 +78,15 @@ locals {
     scaling_trigger = var.scaling_trigger
   }
 }
+
+variable "code_deploy_notification" {
+  description = "Enable Notification for Code deployment failure"
+  type        = bool
+  default     = true
+}
+
+variable "skip_canary" {
+  description = "Flag to skip canary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
+  type        = bool
+  default     = false
+}

--- a/ci/terraform/modules/codedeploy/codedeploy.tf
+++ b/ci/terraform/modules/codedeploy/codedeploy.tf
@@ -1,0 +1,96 @@
+# ----------------------------------------------------------
+# CodeDeploy resources
+# ----------------------------------------------------------
+
+resource "aws_codedeploy_app" "auth" {
+  compute_platform = "Lambda"
+  name             = replace("${var.environment}-${var.endpoint_name}", ".", "")
+}
+
+resource "aws_codedeploy_deployment_group" "auth" {
+  app_name              = aws_codedeploy_app.auth.name
+  deployment_group_name = "authDeploymentGroup"
+  service_role_arn      = aws_iam_role.codedeploy_deployment_group_auth.arn
+
+  deployment_config_name = "CodeDeployDefault.LambdaLinear10PercentEvery1Minute"
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = var.auto_rollback_events
+  }
+
+}
+
+# ----------------------------------------------------------
+# Trigger of deployment
+# ----------------------------------------------------------
+
+resource "null_resource" "run_codedeploy" {
+
+  triggers = {
+    lambda_version = var.lambda_version
+  }
+
+  provisioner "local-exec" {
+
+    interpreter = var.interpreter
+    command     = <<EOT
+#!/bin/bash
+if [ '${var.lambda_version}' == '${var.lambda_alias_version}' ]; then
+  echo "Skipping deployment because target version (${var.lambda_version}) is already the current version"
+  exit 0
+fi
+ID=$(${var.aws_cli_command} deploy create-deployment \
+    --application-name ${aws_codedeploy_app.auth.name}  \
+    --deployment-group-name ${aws_codedeploy_deployment_group.auth.deployment_group_name}  \
+    --revision "{\"revisionType\":\"AppSpecContent\",\"appSpecContent\":{\"content\":\"{\\\"version\\\":0,\\\"Resources\\\":[{\\\"${var.lambda_function_name}\\\":{\\\"Type\\\":\\\"AWS::Lambda::Function\\\",\\\"Properties\\\":{\\\"Name\\\":\\\"${var.lambda_function_name}\\\",\\\"Alias\\\":\\\"${var.lambda_alias_name}\\\",\\\"CurrentVersion\\\":\\\"${var.lambda_alias_version}\\\",\\\"TargetVersion\\\":\\\"${var.lambda_version}\\\"}}}]}\"}}" \
+    --output text \
+    --query '[deploymentId]')
+STATUS=$(${var.aws_cli_command} deploy get-deployment \
+    --deployment-id $ID \
+    --output text \
+    --query '[deploymentInfo.status]')
+while [[ $STATUS == "Created" || $STATUS == "InProgress" || $STATUS == "Pending" || $STATUS == "Queued" || $STATUS == "Ready" ]]; do
+    echo "Status: $STATUS..."
+    STATUS=$(${var.aws_cli_command} deploy get-deployment \
+        --deployment-id $ID \
+        --output text \
+        --query '[deploymentInfo.status]')
+    SLEEP_TIME=$((( $RANDOM % 5 ) + ${var.get_deployment_sleep_timer}))
+    echo "Sleeping for: $SLEEP_TIME Seconds"
+    sleep $SLEEP_TIME
+done
+${var.aws_cli_command} deploy get-deployment --deployment-id $ID
+if [[ $STATUS == "Succeeded" ]]; then
+    echo "Deployment succeeded."
+else
+    echo "Deployment failed!"
+    exit 1
+fi
+EOT
+  }
+
+}
+
+# ----------------------------------------------------------
+# notify deployment Failure
+# ----------------------------------------------------------
+
+data "aws_cloudformation_export" "notifications" {
+  name = "${var.environment}-notifications-BuildNotificationTopicArn"
+}
+resource "aws_codestarnotifications_notification_rule" "auth" {
+  detail_type    = "BASIC"
+  event_type_ids = ["codedeploy-application-deployment-failed"]
+
+  name     = replace("${var.environment}-${var.endpoint_name}-notify", ".", "")
+  resource = aws_codedeploy_app.auth.arn
+
+  target {
+    address = data.aws_cloudformation_export.notifications.value
+  }
+}

--- a/ci/terraform/modules/codedeploy/codedeploy.tf
+++ b/ci/terraform/modules/codedeploy/codedeploy.tf
@@ -81,12 +81,12 @@ EOT
 # ----------------------------------------------------------
 
 data "aws_cloudformation_export" "notifications" {
-  count = var.code_deploy_notification ? 0 : 1
+  count = var.code_deploy_notification ? 1 : 0
   name  = "${var.environment}-notifications-BuildNotificationTopicArn"
 }
 
 resource "aws_codestarnotifications_notification_rule" "auth" {
-  count          = var.code_deploy_notification ? 0 : 1
+  count          = var.code_deploy_notification ? 1 : 0
   detail_type    = "BASIC"
   event_type_ids = ["codedeploy-application-deployment-failed"]
 

--- a/ci/terraform/modules/codedeploy/codedeploy.tf
+++ b/ci/terraform/modules/codedeploy/codedeploy.tf
@@ -77,7 +77,7 @@ EOT
 }
 
 # ----------------------------------------------------------
-# notify deployment Failure
+# Notify codedeploy deployment Failure
 # ----------------------------------------------------------
 
 data "aws_cloudformation_export" "notifications" {

--- a/ci/terraform/modules/codedeploy/codedeploy.tf
+++ b/ci/terraform/modules/codedeploy/codedeploy.tf
@@ -12,7 +12,7 @@ resource "aws_codedeploy_deployment_group" "auth" {
   deployment_group_name = "authDeploymentGroup"
   service_role_arn      = aws_iam_role.codedeploy_deployment_group_auth.arn
 
-  deployment_config_name = var.disable_canary ? "CodeDeployDefault.LambdaLinear10PercentEvery1Minute" : "CodeDeployDefault.LambdaAllAtOnce"
+  deployment_config_name = var.skip_canary ? "CodeDeployDefault.LambdaAllAtOnce" : "CodeDeployDefault.LambdaLinear10PercentEvery1Minute"
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
     deployment_type   = "BLUE_GREEN"

--- a/ci/terraform/modules/codedeploy/iam.tf
+++ b/ci/terraform/modules/codedeploy/iam.tf
@@ -1,0 +1,23 @@
+resource "aws_iam_role" "codedeploy_deployment_group_auth" {
+  name_prefix = "authCodeDeployDeploymentGroupRole"
+
+  assume_role_policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Action" : "sts:AssumeRole",
+          "Principal" : {
+            "Service" : "codedeploy.amazonaws.com"
+          },
+          "Effect" : "Allow",
+        }
+      ]
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "codedeploy_deployment_group_auth" {
+  role       = aws_iam_role.codedeploy_deployment_group_auth.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+}

--- a/ci/terraform/modules/codedeploy/variables.tf
+++ b/ci/terraform/modules/codedeploy/variables.tf
@@ -57,3 +57,15 @@ variable "auto_rollback_events" {
   type        = list(string)
   default     = ["DEPLOYMENT_FAILURE"]
 }
+
+variable "code_deploy_notification" {
+  description = "Enable Notication for Code deployment failure"
+  type        = bool
+  default     = true
+}
+
+variable "disable_canary" {
+  description = "Flag to disable cannary via git commit  msg "
+  type        = bool
+  default     = true
+}

--- a/ci/terraform/modules/codedeploy/variables.tf
+++ b/ci/terraform/modules/codedeploy/variables.tf
@@ -65,7 +65,7 @@ variable "code_deploy_notification" {
 }
 
 variable "skip_canary" {
-  description = "Flag to skip cannary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
+  description = "Flag to skip canary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
   type        = bool
   default     = false
 }

--- a/ci/terraform/modules/codedeploy/variables.tf
+++ b/ci/terraform/modules/codedeploy/variables.tf
@@ -1,0 +1,59 @@
+variable "lambda_function_name" {
+  type = string
+}
+
+variable "lambda_version" {
+  type = string
+}
+
+variable "lambda_alias_name" {
+  description = "alias of lambda which will be deployed by CodeDeploy"
+  type        = string
+}
+
+variable "lambda_alias_version" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "endpoint_name" {
+  type = string
+}
+variable "aws_cli_command" {
+  description = "Command to run as AWS CLI. May include extra arguments like region and profile."
+  type        = string
+  default     = "aws"
+}
+
+variable "get_deployment_sleep_timer" {
+  description = "Adds additional sleep time to get-deployment command to avoid the service throttling"
+  type        = number
+  default     = 60
+}
+
+variable "force_deploy" {
+  description = "Force deployment every time (even when nothing changes)"
+  type        = bool
+  default     = false
+}
+
+variable "interpreter" {
+  description = "List of interpreter arguments used to execute deploy script, first arg is path"
+  type        = list(string)
+  default     = ["/bin/bash", "-c"]
+}
+
+variable "current_version" {
+  description = "Current version of Lambda function version to deploy (can't be $LATEST)"
+  type        = string
+  default     = ""
+}
+
+variable "auto_rollback_events" {
+  description = "List of event types that trigger a rollback. Supported types are DEPLOYMENT_FAILURE and DEPLOYMENT_STOP_ON_ALARM."
+  type        = list(string)
+  default     = ["DEPLOYMENT_FAILURE"]
+}

--- a/ci/terraform/modules/codedeploy/variables.tf
+++ b/ci/terraform/modules/codedeploy/variables.tf
@@ -64,8 +64,8 @@ variable "code_deploy_notification" {
   default     = true
 }
 
-variable "disable_canary" {
-  description = "Flag to disable cannary via git commit  msg "
+variable "skip_canary" {
+  description = "Flag to skip cannary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
   type        = bool
-  default     = true
+  default     = false
 }

--- a/ci/terraform/modules/endpoint-lambda/lambda.tf
+++ b/ci/terraform/modules/endpoint-lambda/lambda.tf
@@ -65,6 +65,9 @@ resource "aws_lambda_alias" "endpoint_lambda" {
   description      = "Alias pointing at active version of Lambda"
   function_name    = aws_lambda_function.endpoint_lambda.arn
   function_version = aws_lambda_function.endpoint_lambda.version
+  lifecycle {
+    ignore_changes = [function_version, routing_config]
+  }
 }
 
 resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrency_config" {

--- a/ci/terraform/modules/endpoint-lambda/outputs.tf
+++ b/ci/terraform/modules/endpoint-lambda/outputs.tf
@@ -12,3 +12,19 @@ output "integration_uri" {
 output "invoke_arn" {
   value = aws_lambda_alias.endpoint_lambda.invoke_arn
 }
+
+output "lambda_function_name" {
+  value = aws_lambda_function.endpoint_lambda.function_name
+}
+
+output "lambda_version" {
+  value = aws_lambda_function.endpoint_lambda.version
+}
+
+output "lambda_alias_name" {
+  value = aws_lambda_alias.endpoint_lambda.name
+}
+
+output "lambda_alias_version" {
+  value = aws_lambda_alias.endpoint_lambda.function_version
+}

--- a/ci/terraform/modules/endpoint-module-v2/outputs.tf
+++ b/ci/terraform/modules/endpoint-module-v2/outputs.tf
@@ -23,3 +23,21 @@ output "endpoint_lambda_alias" {
 output "invoke_arn" {
   value = module.endpoint_lambda.invoke_arn
 }
+
+#Below are required for code deploy
+
+output "lambda_function_name" {
+  value = module.endpoint_lambda.endpoint_lambda_function.function_name
+}
+
+output "lambda_version" {
+  value = module.endpoint_lambda.endpoint_lambda_function.version
+}
+
+output "lambda_alias_name" {
+  value = module.endpoint_lambda.endpoint_lambda_alias.name
+}
+
+output "lambda_alias_version" {
+  value = module.endpoint_lambda.endpoint_lambda_alias.function_version
+}

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -67,6 +67,9 @@ resource "aws_lambda_alias" "endpoint_lambda" {
   description      = "Alias pointing at active version of Lambda"
   function_name    = aws_lambda_function.endpoint_lambda.arn
   function_version = aws_lambda_function.endpoint_lambda.version
+  lifecycle {
+    ignore_changes = [function_version, routing_config]
+  }
 }
 
 resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrency_config" {

--- a/ci/terraform/modules/endpoint-module/outputs.tf
+++ b/ci/terraform/modules/endpoint-module/outputs.tf
@@ -9,3 +9,19 @@ output "integration_trigger_value" {
 output "method_trigger_value" {
   value = jsonencode(aws_api_gateway_method.endpoint_method)
 }
+
+output "lambda_function_name" {
+  value = aws_lambda_function.endpoint_lambda.function_name
+}
+
+output "lambda_version" {
+  value = aws_lambda_function.endpoint_lambda.version
+}
+
+output "lambda_alias_name" {
+  value = aws_lambda_alias.endpoint_lambda.name
+}
+
+output "lambda_alias_version" {
+  value = aws_lambda_alias.endpoint_lambda.function_version
+}

--- a/ci/terraform/oidc/.terraform.lock.hcl
+++ b/ci/terraform/oidc/.terraform.lock.hcl
@@ -28,6 +28,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.1"
   constraints = "2.5.1"

--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -76,3 +76,13 @@ module "account_interventions" {
 
   use_localstack = var.use_localstack
 }
+
+module "codedeploy_account_interventions" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "account-interventions"
+  environment          = var.environment
+  lambda_function_name = module.account_interventions[0].lambda_function_name
+  lambda_version       = module.account_interventions[0].lambda_version
+  lambda_alias_name    = module.account_interventions[0].lambda_alias_name
+  lambda_alias_version = module.account_interventions[0].lambda_alias_version
+}

--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -85,4 +85,7 @@ module "codedeploy_account_interventions" {
   lambda_version       = module.account_interventions[0].lambda_version
   lambda_alias_name    = module.account_interventions[0].lambda_alias_name
   lambda_alias_version = module.account_interventions[0].lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -78,4 +78,7 @@ module "codedeploy_account_recovery" {
   lambda_version       = module.account_recovery.lambda_version
   lambda_alias_name    = module.account_recovery.lambda_alias_name
   lambda_alias_version = module.account_recovery.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -69,3 +69,13 @@ module "account_recovery" {
 
   use_localstack = var.use_localstack
 }
+
+module "codedeploy_account_recovery" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "account-recovery"
+  environment          = var.environment
+  lambda_function_name = module.account_recovery.lambda_function_name
+  lambda_version       = module.account_recovery.lambda_version
+  lambda_alias_name    = module.account_recovery.lambda_alias_name
+  lambda_alias_version = module.account_recovery.lambda_alias_version
+}

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -76,4 +76,7 @@ module "codedeploy_auth_code" {
   lambda_version       = module.auth-code.lambda_version
   lambda_alias_name    = module.auth-code.lambda_alias_name
   lambda_alias_version = module.auth-code.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -67,3 +67,13 @@ module "auth-code" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_auth_code" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "auth-code"
+  environment          = var.environment
+  lambda_function_name = module.auth-code.lambda_function_name
+  lambda_version       = module.auth-code.lambda_version
+  lambda_alias_name    = module.auth-code.lambda_alias_name
+  lambda_alias_version = module.auth-code.lambda_alias_version
+}

--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -69,3 +69,5 @@ orch_redirect_uri = "https://oidc.authdev1.sandpit.account.gov.uk/orchestration-
 authorize_protected_subnet_enabled = true
 
 oidc_origin_domain_enabled = true
+
+code_deploy_notification = false

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -66,3 +66,5 @@ orch_redirect_uri                  = "https://oidc.authdev2.sandpit.account.gov.
 authorize_protected_subnet_enabled = true
 
 oidc_origin_domain_enabled = true
+
+code_deploy_notification = false

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -86,4 +86,7 @@ module "codedeploy_orch_auth_code" {
   lambda_version       = module.orch_auth_code.lambda_version
   lambda_alias_name    = module.orch_auth_code.lambda_alias_name
   lambda_alias_version = module.orch_auth_code.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -77,3 +77,13 @@ module "orch_auth_code" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_orch_auth_code" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "orch-auth-code"
+  environment          = var.environment
+  lambda_function_name = module.orch_auth_code.lambda_function_name
+  lambda_version       = module.orch_auth_code.lambda_version
+  lambda_alias_name    = module.orch_auth_code.lambda_alias_name
+  lambda_alias_version = module.orch_auth_code.lambda_alias_version
+}

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -98,4 +98,7 @@ module "codedeploy_authentication_callback" {
   lambda_version       = module.authentication_callback.lambda_version
   lambda_alias_name    = module.authentication_callback.lambda_alias_name
   lambda_alias_version = module.authentication_callback.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -89,3 +89,13 @@ module "authentication_callback" {
     aws_api_gateway_rest_api.di_authentication_api
   ]
 }
+
+module "codedeploy_authentication_callback" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "orchestration-redirect"
+  environment          = var.environment
+  lambda_function_name = module.authentication_callback.lambda_function_name
+  lambda_version       = module.authentication_callback.lambda_version
+  lambda_alias_name    = module.authentication_callback.lambda_alias_name
+  lambda_alias_version = module.authentication_callback.lambda_alias_version
+}

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -95,3 +95,13 @@ module "authorize" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_authorize" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "authorize"
+  environment          = var.environment
+  lambda_function_name = module.authorize.lambda_function_name
+  lambda_version       = module.authorize.lambda_version
+  lambda_alias_name    = module.authorize.lambda_alias_name
+  lambda_alias_version = module.authorize.lambda_alias_version
+}

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -104,4 +104,7 @@ module "codedeploy_authorize" {
   lambda_version       = module.authorize.lambda_version
   lambda_alias_name    = module.authorize.lambda_alias_name
   lambda_alias_version = module.authorize.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -76,3 +76,14 @@ module "check_email_fraud_block" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_check_email_fraud_block" {
+  count                = local.deploy_check_email_fraud_block_count
+  source               = "../modules/codedeploy"
+  endpoint_name        = "check-email-fraud-block"
+  environment          = var.environment
+  lambda_function_name = module.check_email_fraud_block[0].lambda_function_name
+  lambda_version       = module.check_email_fraud_block[0].lambda_version
+  lambda_alias_name    = module.check_email_fraud_block[0].lambda_alias_name
+  lambda_alias_version = module.check_email_fraud_block[0].lambda_alias_version
+}

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -86,4 +86,7 @@ module "codedeploy_check_email_fraud_block" {
   lambda_version       = module.check_email_fraud_block[0].lambda_version
   lambda_alias_name    = module.check_email_fraud_block[0].lambda_alias_name
   lambda_alias_version = module.check_email_fraud_block[0].lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -79,3 +79,14 @@ module "check_reauth_user" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_check_reauth_user" {
+  count                = local.deploy_reauth_user_count
+  source               = "../modules/codedeploy"
+  endpoint_name        = "check-reauth-user"
+  environment          = var.environment
+  lambda_function_name = module.check_reauth_user[0].lambda_function_name
+  lambda_version       = module.check_reauth_user[0].lambda_version
+  lambda_alias_name    = module.check_reauth_user[0].lambda_alias_name
+  lambda_alias_version = module.check_reauth_user[0].lambda_alias_version
+}

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -89,4 +89,7 @@ module "codedeploy_check_reauth_user" {
   lambda_version       = module.check_reauth_user[0].lambda_version
   lambda_alias_name    = module.check_reauth_user[0].lambda_alias_name
   lambda_alias_version = module.check_reauth_user[0].lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -78,3 +78,13 @@ module "doc-app-callback" {
     aws_api_gateway_rest_api.di_authentication_api,
   ]
 }
+
+module "codedeploy_doc_app_callback" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "doc-app-callback"
+  environment          = var.environment
+  lambda_function_name = module.doc-app-callback.lambda_function_name
+  lambda_version       = module.doc-app-callback.lambda_version
+  lambda_alias_name    = module.doc-app-callback.lambda_alias_name
+  lambda_alias_version = module.doc-app-callback.lambda_alias_version
+}

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -87,4 +87,7 @@ module "codedeploy_doc_app_callback" {
   lambda_version       = module.doc-app-callback.lambda_version
   lambda_alias_name    = module.doc-app-callback.lambda_alias_name
   lambda_alias_version = module.doc-app-callback.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -100,4 +100,7 @@ module "codedeploy_ipv_callback" {
   lambda_version       = module.ipv-callback.lambda_version
   lambda_alias_name    = module.ipv-callback.lambda_alias_name
   lambda_alias_version = module.ipv-callback.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -91,3 +91,13 @@ module "ipv-callback" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_ipv_callback" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "ipv-callback"
+  environment          = var.environment
+  lambda_function_name = module.ipv-callback.lambda_function_name
+  lambda_version       = module.ipv-callback.lambda_version
+  lambda_alias_name    = module.ipv-callback.lambda_alias_name
+  lambda_alias_version = module.ipv-callback.lambda_alias_version
+}

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -78,4 +78,7 @@ module "codedeploy_ipv_capacity" {
   lambda_version       = module.ipv-capacity.lambda_version
   lambda_alias_name    = module.ipv-capacity.lambda_alias_name
   lambda_alias_version = module.ipv-capacity.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -69,3 +69,13 @@ module "ipv-capacity" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_ipv_capacity" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "ipv-capacity"
+  environment          = var.environment
+  lambda_function_name = module.ipv-capacity.lambda_function_name
+  lambda_version       = module.ipv-capacity.lambda_version
+  lambda_alias_name    = module.ipv-capacity.lambda_alias_name
+  lambda_alias_version = module.ipv-capacity.lambda_alias_version
+}

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -66,4 +66,7 @@ module "codedeploy_jwks" {
   lambda_version       = module.jwks.lambda_version
   lambda_alias_name    = module.jwks.lambda_alias_name
   lambda_alias_version = module.jwks.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -57,3 +57,13 @@ module "jwks" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_jwks" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "jwks"
+  environment          = var.environment
+  lambda_function_name = module.jwks.lambda_function_name
+  lambda_version       = module.jwks.lambda_version
+  lambda_alias_name    = module.jwks.lambda_alias_name
+  lambda_alias_version = module.jwks.lambda_alias_version
+}

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -81,3 +81,13 @@ module "login" {
 
   use_localstack = var.use_localstack
 }
+
+module "codedeploy_login" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "login"
+  environment          = var.environment
+  lambda_function_name = module.login.lambda_function_name
+  lambda_version       = module.login.lambda_version
+  lambda_alias_name    = module.login.lambda_alias_name
+  lambda_alias_version = module.login.lambda_alias_version
+}

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -90,4 +90,7 @@ module "codedeploy_login" {
   lambda_version       = module.login.lambda_version
   lambda_alias_name    = module.login.lambda_alias_name
   lambda_alias_version = module.login.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -82,4 +82,7 @@ module "codedeploy_logout" {
   lambda_version       = module.logout.lambda_version
   lambda_alias_name    = module.logout.lambda_alias_name
   lambda_alias_version = module.logout.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -73,3 +73,13 @@ module "logout" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_logout" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "logout"
+  environment          = var.environment
+  lambda_function_name = module.logout.lambda_function_name
+  lambda_version       = module.logout.lambda_version
+  lambda_alias_name    = module.logout.lambda_alias_name
+  lambda_alias_version = module.logout.lambda_alias_version
+}

--- a/ci/terraform/oidc/mfa-reset-authorize.tf
+++ b/ci/terraform/oidc/mfa-reset-authorize.tf
@@ -73,3 +73,13 @@ module "mfa_reset_authorize" {
     aws_api_gateway_rest_api.di_authentication_frontend_api
   ]
 }
+
+module "codedeploy_mfa_reset_authorize" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "mfa-reset-authorize"
+  environment          = var.environment
+  lambda_function_name = module.mfa_reset_authorize.lambda_function_name
+  lambda_version       = module.mfa_reset_authorize.lambda_version
+  lambda_alias_name    = module.mfa_reset_authorize.lambda_alias_name
+  lambda_alias_version = module.mfa_reset_authorize.lambda_alias_version
+}

--- a/ci/terraform/oidc/mfa-reset-authorize.tf
+++ b/ci/terraform/oidc/mfa-reset-authorize.tf
@@ -82,4 +82,7 @@ module "codedeploy_mfa_reset_authorize" {
   lambda_version       = module.mfa_reset_authorize.lambda_version
   lambda_alias_name    = module.mfa_reset_authorize.lambda_alias_name
   lambda_alias_version = module.mfa_reset_authorize.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/mfa-reset-jar-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-jar-jwk.tf
@@ -63,4 +63,7 @@ module "codedeploy_mfa_reset_jar_signing_jwk" {
   lambda_version       = module.mfa_reset_jar_signing_jwk.lambda_version
   lambda_alias_name    = module.mfa_reset_jar_signing_jwk.lambda_alias_name
   lambda_alias_version = module.mfa_reset_jar_signing_jwk.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/mfa-reset-jar-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-jar-jwk.tf
@@ -54,3 +54,13 @@ module "mfa_reset_jar_signing_jwk" {
     aws_api_gateway_resource.auth_frontend_wellknown_resource,
   ]
 }
+
+module "codedeploy_mfa_reset_jar_signing_jwk" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "reverification-jwk.json"
+  environment          = var.environment
+  lambda_function_name = module.mfa_reset_jar_signing_jwk.lambda_function_name
+  lambda_version       = module.mfa_reset_jar_signing_jwk.lambda_version
+  lambda_alias_name    = module.mfa_reset_jar_signing_jwk.lambda_alias_name
+  lambda_alias_version = module.mfa_reset_jar_signing_jwk.lambda_alias_version
+}

--- a/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
@@ -64,4 +64,7 @@ module "codedeploy_mfa_reset_storage_token_jwk" {
   lambda_version       = module.mfa_reset_storage_token_jwk.lambda_version
   lambda_alias_name    = module.mfa_reset_storage_token_jwk.lambda_alias_name
   lambda_alias_version = module.mfa_reset_storage_token_jwk.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
@@ -55,3 +55,13 @@ module "mfa_reset_storage_token_jwk" {
     aws_api_gateway_resource.auth_frontend_wellknown_resource,
   ]
 }
+
+module "codedeploy_mfa_reset_storage_token_jwk" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "mfa-reset-jwk.json"
+  environment          = var.environment
+  lambda_function_name = module.mfa_reset_storage_token_jwk.lambda_function_name
+  lambda_version       = module.mfa_reset_storage_token_jwk.lambda_version
+  lambda_alias_name    = module.mfa_reset_storage_token_jwk.lambda_alias_name
+  lambda_alias_version = module.mfa_reset_storage_token_jwk.lambda_alias_version
+}

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -88,4 +88,7 @@ module "codedeploy_mfa" {
   lambda_version       = module.mfa.lambda_version
   lambda_alias_name    = module.mfa.lambda_alias_name
   lambda_alias_version = module.mfa.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -79,3 +79,13 @@ module "mfa" {
     aws_sqs_queue.email_queue,
   ]
 }
+
+module "codedeploy_mfa" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "mfa"
+  environment          = var.environment
+  lambda_function_name = module.mfa.lambda_function_name
+  lambda_version       = module.mfa.lambda_version
+  lambda_alias_name    = module.mfa.lambda_alias_name
+  lambda_alias_version = module.mfa.lambda_alias_version
+}

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -81,3 +81,13 @@ module "processing-identity" {
 
   use_localstack = var.use_localstack
 }
+
+module "codedeploy_processing_identity" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "processing-identity"
+  environment          = var.environment
+  lambda_function_name = module.processing-identity.lambda_function_name
+  lambda_version       = module.processing-identity.lambda_version
+  lambda_alias_name    = module.processing-identity.lambda_alias_name
+  lambda_alias_version = module.processing-identity.lambda_alias_version
+}

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -90,4 +90,7 @@ module "codedeploy_processing_identity" {
   lambda_version       = module.processing-identity.lambda_version
   lambda_alias_name    = module.processing-identity.lambda_alias_name
   lambda_alias_version = module.processing-identity.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -72,4 +72,7 @@ module "codedeploy_register" {
   lambda_version       = module.register[0].lambda_version
   lambda_alias_name    = module.register[0].lambda_alias_name
   lambda_alias_version = module.register[0].lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -63,3 +63,13 @@ module "register" {
     aws_api_gateway_resource.register_resource,
   ]
 }
+
+module "codedeploy_register" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "register"
+  environment          = var.environment
+  lambda_function_name = module.register[0].lambda_function_name
+  lambda_version       = module.register[0].lambda_version
+  lambda_alias_name    = module.register[0].lambda_alias_name
+  lambda_alias_version = module.register[0].lambda_alias_version
+}

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -87,4 +87,7 @@ module "codedeploy_reset_password_request" {
   lambda_version       = module.reset-password-request.lambda_version
   lambda_alias_name    = module.reset-password-request.lambda_alias_name
   lambda_alias_version = module.reset-password-request.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -78,3 +78,13 @@ module "reset-password-request" {
     aws_sqs_queue.email_queue,
   ]
 }
+
+module "codedeploy_reset_password_request" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "reset-password-request"
+  environment          = var.environment
+  lambda_function_name = module.reset-password-request.lambda_function_name
+  lambda_version       = module.reset-password-request.lambda_version
+  lambda_alias_name    = module.reset-password-request.lambda_alias_name
+  lambda_alias_version = module.reset-password-request.lambda_alias_version
+}

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -90,4 +90,7 @@ module "codedeploy_reset_password" {
   lambda_version       = module.reset_password.lambda_version
   lambda_alias_name    = module.reset_password.lambda_alias_name
   lambda_alias_version = module.reset_password.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -81,3 +81,13 @@ module "reset_password" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_reset_password" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "reset-password"
+  environment          = var.environment
+  lambda_function_name = module.reset_password.lambda_function_name
+  lambda_version       = module.reset_password.lambda_version
+  lambda_alias_name    = module.reset_password.lambda_alias_name
+  lambda_alias_version = module.reset_password.lambda_alias_version
+}

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -80,4 +80,7 @@ module "codedeploy_reverification_result" {
   lambda_version       = module.reverification_result.lambda_version
   lambda_alias_name    = module.reverification_result.lambda_alias_name
   lambda_alias_version = module.reverification_result.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -71,3 +71,13 @@ module "reverification_result" {
     aws_api_gateway_rest_api.di_authentication_frontend_api
   ]
 }
+
+module "codedeploy_reverification_result" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "reverification-result"
+  environment          = var.environment
+  lambda_function_name = module.reverification_result.lambda_function_name
+  lambda_version       = module.reverification_result.lambda_version
+  lambda_alias_name    = module.reverification_result.lambda_alias_name
+  lambda_alias_version = module.reverification_result.lambda_alias_version
+}

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -93,4 +93,7 @@ module "codedeploy_send_notification" {
   lambda_version       = module.send_notification.lambda_version
   lambda_alias_name    = module.send_notification.lambda_alias_name
   lambda_alias_version = module.send_notification.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -84,3 +84,13 @@ module "send_notification" {
     aws_sqs_queue.email_queue,
   ]
 }
+
+module "codedeploy_send_notification" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "send-notification"
+  environment          = var.environment
+  lambda_function_name = module.send_notification.lambda_function_name
+  lambda_version       = module.send_notification.lambda_version
+  lambda_alias_name    = module.send_notification.lambda_alias_name
+  lambda_alias_version = module.send_notification.lambda_alias_version
+}

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -76,3 +76,13 @@ module "signup" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_signup" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "signup"
+  environment          = var.environment
+  lambda_function_name = module.signup.lambda_function_name
+  lambda_version       = module.signup.lambda_version
+  lambda_alias_name    = module.signup.lambda_alias_name
+  lambda_alias_version = module.signup.lambda_alias_version
+}

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -85,4 +85,7 @@ module "codedeploy_signup" {
   lambda_version       = module.signup.lambda_version
   lambda_alias_name    = module.signup.lambda_alias_name
   lambda_alias_version = module.signup.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -80,3 +80,13 @@ module "start" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_start" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "start"
+  environment          = var.environment
+  lambda_function_name = module.start.lambda_function_name
+  lambda_version       = module.start.lambda_version
+  lambda_alias_name    = module.start.lambda_alias_name
+  lambda_alias_version = module.start.lambda_alias_version
+}

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -89,4 +89,7 @@ module "codedeploy_start" {
   lambda_version       = module.start.lambda_version
   lambda_alias_name    = module.start.lambda_alias_name
   lambda_alias_version = module.start.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/storage-token-jwk.tf
+++ b/ci/terraform/oidc/storage-token-jwk.tf
@@ -54,3 +54,13 @@ module "storage_token_jwk" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_storage_token_jwk" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "storage-token-jwk.json"
+  environment          = var.environment
+  lambda_function_name = module.storage_token_jwk.lambda_function_name
+  lambda_version       = module.storage_token_jwk.lambda_version
+  lambda_alias_name    = module.storage_token_jwk.lambda_alias_name
+  lambda_alias_version = module.storage_token_jwk.lambda_alias_version
+}

--- a/ci/terraform/oidc/storage-token-jwk.tf
+++ b/ci/terraform/oidc/storage-token-jwk.tf
@@ -63,4 +63,7 @@ module "codedeploy_storage_token_jwk" {
   lambda_version       = module.storage_token_jwk.lambda_version
   lambda_alias_name    = module.storage_token_jwk.lambda_alias_name
   lambda_alias_version = module.storage_token_jwk.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -51,3 +51,13 @@ module "trustmarks" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_trustmarks" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "trustmarks"
+  environment          = var.environment
+  lambda_function_name = module.trustmarks.lambda_function_name
+  lambda_version       = module.trustmarks.lambda_version
+  lambda_alias_name    = module.trustmarks.lambda_alias_name
+  lambda_alias_version = module.trustmarks.lambda_alias_version
+}

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -60,4 +60,7 @@ module "codedeploy_trustmarks" {
   lambda_version       = module.trustmarks.lambda_version
   lambda_alias_name    = module.trustmarks.lambda_alias_name
   lambda_alias_version = module.trustmarks.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -71,3 +71,13 @@ module "update" {
     aws_api_gateway_resource.register_resource,
   ]
 }
+
+module "codedeploy_update_client_info" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "update-client-info"
+  environment          = var.environment
+  lambda_function_name = module.update[0].lambda_function_name
+  lambda_version       = module.update[0].lambda_version
+  lambda_alias_name    = module.update[0].lambda_alias_name
+  lambda_alias_version = module.update[0].lambda_alias_version
+}

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -80,4 +80,7 @@ module "codedeploy_update_client_info" {
   lambda_version       = module.update[0].lambda_version
   lambda_alias_name    = module.update[0].lambda_alias_name
   lambda_alias_version = module.update[0].lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -74,3 +74,13 @@ module "update_profile" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_update_profile" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "update-profile"
+  environment          = var.environment
+  lambda_function_name = module.update_profile.lambda_function_name
+  lambda_version       = module.update_profile.lambda_version
+  lambda_alias_name    = module.update_profile.lambda_alias_name
+  lambda_alias_version = module.update_profile.lambda_alias_version
+}

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -83,4 +83,7 @@ module "codedeploy_update_profile" {
   lambda_version       = module.update_profile.lambda_version
   lambda_alias_name    = module.update_profile.lambda_alias_name
   lambda_alias_version = module.update_profile.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -82,4 +82,7 @@ module "codedeploy_userexists" {
   lambda_version       = module.userexists.lambda_version
   lambda_alias_name    = module.userexists.lambda_alias_name
   lambda_alias_version = module.userexists.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -73,3 +73,13 @@ module "userexists" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_userexists" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "userexists"
+  environment          = var.environment
+  lambda_function_name = module.userexists.lambda_function_name
+  lambda_version       = module.userexists.lambda_version
+  lambda_alias_name    = module.userexists.lambda_alias_name
+  lambda_alias_version = module.userexists.lambda_alias_version
+}

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -75,3 +75,13 @@ module "userinfo" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+module "codedeploy_userinfo" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "userinfo"
+  environment          = var.environment
+  lambda_function_name = module.userinfo.lambda_function_name
+  lambda_version       = module.userinfo.lambda_version
+  lambda_alias_name    = module.userinfo.lambda_alias_name
+  lambda_alias_version = module.userinfo.lambda_alias_version
+}

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -84,4 +84,7 @@ module "codedeploy_userinfo" {
   lambda_version       = module.userinfo.lambda_version
   lambda_alias_name    = module.userinfo.lambda_alias_name
   lambda_alias_version = module.userinfo.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -745,3 +745,15 @@ locals {
     scaling_trigger = var.scaling_trigger
   }
 }
+
+variable "code_deploy_notification" {
+  description = "Enable Notification for Code deployment failure"
+  type        = bool
+  default     = true
+}
+
+variable "skip_canary" {
+  description = "Flag to skip canary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
+  type        = bool
+  default     = false
+}

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -93,3 +93,14 @@ module "verify_code" {
     aws_sqs_queue.email_queue,
   ]
 }
+
+
+module "codedeploy_verify_code" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "verify-code"
+  environment          = var.environment
+  lambda_function_name = module.verify_code.lambda_function_name
+  lambda_version       = module.verify_code.lambda_version
+  lambda_alias_name    = module.verify_code.lambda_alias_name
+  lambda_alias_version = module.verify_code.lambda_alias_version
+}

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -103,4 +103,7 @@ module "codedeploy_verify_code" {
   lambda_version       = module.verify_code.lambda_version
   lambda_alias_name    = module.verify_code.lambda_alias_name
   lambda_alias_version = module.verify_code.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -99,4 +99,7 @@ module "codedeploy_verify_mfa_code" {
   lambda_version       = module.verify_mfa_code.lambda_version
   lambda_alias_name    = module.verify_mfa_code.lambda_alias_name
   lambda_alias_version = module.verify_mfa_code.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -90,3 +90,13 @@ module "verify_mfa_code" {
     aws_api_gateway_rest_api.di_authentication_frontend_api,
   ]
 }
+
+module "codedeploy_verify_mfa_code" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "verify-mfa-code"
+  environment          = var.environment
+  lambda_function_name = module.verify_mfa_code.lambda_function_name
+  lambda_version       = module.verify_mfa_code.lambda_version
+  lambda_alias_name    = module.verify_mfa_code.lambda_alias_name
+  lambda_alias_version = module.verify_mfa_code.lambda_alias_version
+}

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -61,4 +61,7 @@ module "codedeploy_openid_configuration_discovery" {
   lambda_version       = module.openid_configuration_discovery.lambda_version
   lambda_alias_name    = module.openid_configuration_discovery.lambda_alias_name
   lambda_alias_version = module.openid_configuration_discovery.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -52,3 +52,13 @@ module "openid_configuration_discovery" {
 
   ]
 }
+
+module "codedeploy_openid_configuration_discovery" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "openid-configuration"
+  environment          = var.environment
+  lambda_function_name = module.openid_configuration_discovery.lambda_function_name
+  lambda_version       = module.openid_configuration_discovery.lambda_version
+  lambda_alias_name    = module.openid_configuration_discovery.lambda_alias_name
+  lambda_alias_version = module.openid_configuration_discovery.lambda_alias_version
+}

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -196,3 +196,9 @@ variable "auth_new_frontend_account_id" {
   description = "Account id of the auth new frontend"
   default     = ""
 }
+
+variable "skip_canary" {
+  description = "Flag to skip canary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
+  type        = bool
+  default     = false
+}

--- a/ci/terraform/test-services/.terraform.lock.hcl
+++ b/ci/terraform/test-services/.terraform.lock.hcl
@@ -28,6 +28,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.1"
   constraints = "2.5.1"

--- a/ci/terraform/test-services/authdev1.tfvars
+++ b/ci/terraform/test-services/authdev1.tfvars
@@ -5,3 +5,5 @@ synthetics_users = "any.user@digital.cabinet-office.gov.uk"
 
 logging_endpoint_enabled = false
 logging_endpoint_arns    = []
+
+code_deploy_notification = false

--- a/ci/terraform/test-services/authdev2.tfvars
+++ b/ci/terraform/test-services/authdev2.tfvars
@@ -5,3 +5,5 @@ synthetics_users = "any.user@digital.cabinet-office.gov.uk"
 
 logging_endpoint_enabled = false
 logging_endpoint_arns    = []
+
+code_deploy_notification = false

--- a/ci/terraform/test-services/delete-synthetics-user.tf
+++ b/ci/terraform/test-services/delete-synthetics-user.tf
@@ -66,4 +66,7 @@ module "codedeploy_synthetics_user" {
   lambda_version       = module.delete-synthetics-user.lambda_version
   lambda_alias_name    = module.delete-synthetics-user.lambda_alias_name
   lambda_alias_version = module.delete-synthetics-user.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/test-services/delete-synthetics-user.tf
+++ b/ci/terraform/test-services/delete-synthetics-user.tf
@@ -57,3 +57,13 @@ module "delete-synthetics-user" {
     aws_api_gateway_rest_api.di_authentication_test_services_api,
   ]
 }
+
+module "codedeploy_synthetics_user" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "synthetics-user"
+  environment          = var.environment
+  lambda_function_name = module.delete-synthetics-user.lambda_function_name
+  lambda_version       = module.delete-synthetics-user.lambda_version
+  lambda_alias_name    = module.delete-synthetics-user.lambda_alias_name
+  lambda_alias_version = module.delete-synthetics-user.lambda_alias_version
+}

--- a/ci/terraform/test-services/variables.tf
+++ b/ci/terraform/test-services/variables.tf
@@ -97,3 +97,15 @@ variable "txma_account_id" {
   default = ""
   type    = string
 }
+
+variable "code_deploy_notification" {
+  description = "Enable Notification for Code deployment failure"
+  type        = bool
+  default     = true
+}
+
+variable "skip_canary" {
+  description = "Flag to skip canary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
+  type        = bool
+  default     = false
+}

--- a/ci/terraform/ticf-cri-stub/.terraform.lock.hcl
+++ b/ci/terraform/ticf-cri-stub/.terraform.lock.hcl
@@ -28,6 +28,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.1"
   constraints = "2.5.1"

--- a/ci/terraform/ticf-cri-stub/authdev1.tfvars
+++ b/ci/terraform/ticf-cri-stub/authdev1.tfvars
@@ -1,2 +1,4 @@
 environment         = "authdev1"
 shared_state_bucket = "di-auth-development-tfstate"
+
+code_deploy_notification = false

--- a/ci/terraform/ticf-cri-stub/authdev2.tfvars
+++ b/ci/terraform/ticf-cri-stub/authdev2.tfvars
@@ -1,2 +1,4 @@
 environment         = "authdev2"
 shared_state_bucket = "di-auth-development-tfstate"
+
+code_deploy_notification = false

--- a/ci/terraform/ticf-cri-stub/lambda.tf
+++ b/ci/terraform/ticf-cri-stub/lambda.tf
@@ -44,3 +44,13 @@ module "ticf_cri_stub_lambda" {
   slack_event_topic_arn                  = data.aws_sns_topic.slack_events.arn
   dynatrace_secret                       = local.dynatrace_secret
 }
+
+module "codedeploy_ticf_cri_stub_" {
+  source               = "../modules/codedeploy"
+  endpoint_name        = "ticf-cri-stub"
+  environment          = var.environment
+  lambda_function_name = module.ticf_cri_stub_lambda.lambda_function_name
+  lambda_version       = module.ticf_cri_stub_lambda.lambda_version
+  lambda_alias_name    = module.ticf_cri_stub_lambda.lambda_alias_name
+  lambda_alias_version = module.ticf_cri_stub_lambda.lambda_alias_version
+}

--- a/ci/terraform/ticf-cri-stub/lambda.tf
+++ b/ci/terraform/ticf-cri-stub/lambda.tf
@@ -53,4 +53,7 @@ module "codedeploy_ticf_cri_stub_" {
   lambda_version       = module.ticf_cri_stub_lambda.lambda_version
   lambda_alias_name    = module.ticf_cri_stub_lambda.lambda_alias_name
   lambda_alias_version = module.ticf_cri_stub_lambda.lambda_alias_version
+
+  skip_canary              = var.skip_canary
+  code_deploy_notification = var.code_deploy_notification
 }

--- a/ci/terraform/ticf-cri-stub/variables.tf
+++ b/ci/terraform/ticf-cri-stub/variables.tf
@@ -72,3 +72,15 @@ locals {
     scaling_trigger = var.scaling_trigger
   }
 }
+
+variable "code_deploy_notification" {
+  description = "Enable Notification for Code deployment failure"
+  type        = bool
+  default     = true
+}
+
+variable "skip_canary" {
+  description = "Flag to skip canary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
+  type        = bool
+  default     = false
+}

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -190,3 +190,9 @@ variable "support_email_check_enabled" {
   type        = bool
   description = "Feature flag which toggles the Experian email check on and off"
 }
+
+variable "skip_canary" {
+  description = "Flag to skip canary if [skip canary] or [canary skip], or [no canary] string is included in git merge commit message"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## What
AUT-2870 & AUT-2871 
Code Deploy to shift lambda traffic  Post new version of Lambda Deployment 

## Why 

Observation during Performance testing have shown that when lambda is running in concurrency to process request & we have a new version of lambda getting deployed same time  the Traffic switch to new lambda is done instantly which cause lambda Throttling as old version is processing existing request before the concurrency is released back & new version scale up to Process new request .

To mitigate this situation we are having a Blue green deployment  with Linear shifting the Traffic by 10% every 1 minute hopefully this will help processing the new request on new Version  & existing request on old version Gracefully without throttling 

What will this solution do :
1) It will Shift Alias traffic to new version in linear way Blue/Green
2) It will Auto rollback in case of Lambda Deployment Failure  in init phase or other Failure to previous version
3) In case of Manual roll back we can always re deploy the Previous Version on Lambda using click ops Single click operation.
4) It has an Escape Hatch  to skip canary deployments  in case we need to push your changes without waiting to shift Traffic 

**This PR also include the trust initiative related to have a Blue/green deployment in pipeline** 


**_`**Below Both version throttling  when instance traffic switch is done**`_** 
<img width="904" alt="image" src="https://github.com/govuk-one-login/authentication-api/assets/144677445/bec35c78-7e20-4c95-923e-79dc248e29f7">

**_`**Provisioned Currency getting reseted on new version**`_** 

<img width="1078" alt="image" src="https://github.com/govuk-one-login/authentication-api/assets/144677445/cdedf190-abe6-41ba-870e-963742e6b9cd">


**_`**Code Deploy traffic Shift**`_**

![image](https://github.com/govuk-one-login/authentication-api/assets/144677445/e335f73f-4070-4e6d-9351-70b00999bff9)


**_`**Weight in Lambda Version**`_**

<img width="1435" alt="image" src="https://github.com/govuk-one-login/authentication-api/assets/144677445/bb70077b-d0a8-4827-a4f7-5c1f8860438d">

**_`**Code Deploy App View**`_** 
<img width="1435" alt="image" src="https://github.com/govuk-one-login/authentication-api/assets/144677445/da293929-0184-4296-a2ed-93fd7b193c93">

**_`**Deployment**`_** 

<img width="1405" alt="image" src="https://github.com/govuk-one-login/authentication-api/assets/144677445/71dac33f-f270-46f5-bcfc-19039ca7f98b">

