### PR TITLE
ATO-979/b: Add verifiedMfaType to userinfo response

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/entity/AuthUserInfoClaims.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/entity/AuthUserInfoClaims.java
@@ -12,7 +12,8 @@ public enum AuthUserInfoClaims {
     EMAIL_VERIFIED("email_verified"),
     PHONE_NUMBER("phone_number"),
     PHONE_VERIFIED("phone_number_verified"),
-    SALT("salt");
+    SALT("salt"),
+    VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type");
 
     private final String value;
 

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -165,7 +165,7 @@ public class UserInfoHandler
                 throw new AccessTokenException(
                         "Invalid bearer token", BearerTokenError.INVALID_TOKEN);
             }
-            userInfo = userInfoService.populateUserInfo(accessTokenStore);
+            userInfo = userInfoService.populateUserInfo(accessTokenStore, authSession);
         } catch (AccessTokenException e) {
             LOG.warn(
                     "AccessTokenException: {}. Sending back UserInfoErrorResponse", e.getMessage());

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -90,7 +90,9 @@ public class UserInfoService {
     }
 
     private void addClaimsFromSession(AuthSessionItem authSession, UserInfo userInfo) {
-        userInfo.setClaim("verified_mfa_method_type", authSession.getVerifiedMfaMethodType());
+        userInfo.setClaim(
+                AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
+                authSession.getVerifiedMfaMethodType());
     }
 
     private static String bytesToBase64(ByteBuffer byteBuffer) {

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
 import uk.gov.di.authentication.external.entity.AuthUserInfoClaims;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -39,7 +40,15 @@ public class UserInfoService {
                         authenticationService);
 
         var userInfo = new UserInfo(internalPairwiseId);
+        addClaimsFromToken(accessTokenInfo, internalSubjectId, userProfile, userInfo);
+        return userInfo;
+    }
 
+    private void addClaimsFromToken(
+            AccessTokenStore accessTokenInfo,
+            String internalSubjectId,
+            UserProfile userProfile,
+            UserInfo userInfo) {
         var rpPairwiseId =
                 ClientSubjectHelper.calculatePairwiseIdentifier(
                         internalSubjectId,
@@ -75,7 +84,6 @@ public class UserInfoService {
             String base64StringFromSalt = bytesToBase64(userProfile.getSalt());
             userInfo.setClaim("salt", base64StringFromSalt);
         }
-        return userInfo;
     }
 
     private static String bytesToBase64(ByteBuffer byteBuffer) {

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkBytes;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -60,6 +61,7 @@ public class UserInfoServiceTest {
                     .withPhoneNumber(TEST_PHONE)
                     .withPhoneNumberVerified(TEST_PHONE_VERIFIED)
                     .withSalt(TEST_SALT);
+    private static final AuthSessionItem authSession = new AuthSessionItem();
 
     @BeforeEach
     public void setUp() {
@@ -85,7 +87,7 @@ public class UserInfoServiceTest {
             String expectedPhoneNumber,
             Boolean expectedPhoneNumberVerified,
             String expectedSalt) {
-        UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore);
+        UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore, authSession);
 
         assertEquals(TEST_INTERNAL_PAIRWISE_ID, actual.getSubject().getValue());
         assertEquals(TEST_RP_PAIRWISE_ID, actual.getClaim("rp_pairwise_id"));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.external.domain.AuthExternalApiAuditableEvent;
 import uk.gov.di.authentication.external.lambda.UserInfoHandler;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -128,6 +129,9 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
         assertNull(userInfoResponse.getPhoneNumber());
         assertNull(userInfoResponse.getPhoneNumberVerified());
         assertNull(userInfoResponse.getClaim("salt"));
+        assertThat(
+                userInfoResponse.getClaim("verified_mfa_method_type"),
+                equalTo(MFAMethodType.AUTH_APP.getValue()));
 
         assertTrue(accessTokenStoreExtension.getAccessToken(accessTokenAsString).get().isUsed());
         assertTxmaAuditEventsSubmittedWithMatchingNames(
@@ -334,6 +338,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                 authSessionExtension
                         .getSession(TEST_SESSION_ID)
                         .get()
-                        .withAccountState(AuthSessionItem.AccountState.NEW));
+                        .withAccountState(AuthSessionItem.AccountState.NEW)
+                        .withVerifiedMfaMethodType(MFAMethodType.AUTH_APP.getValue()));
     }
 }


### PR DESCRIPTION
## What

Before, claims were set on the userinfo response using data from the access token only. 

Now, as part of splitting the shared session, some Auth session data needs to be sent to Orch. The way we are doing this is by including session data as claims in the userinfo response.

This PR sets up a method (`addClaimsFromSession`) to add additional claims to the userinfo response from the Auth session. For now only `"verified_mfa_method_type"` claim is added, but more will follow in future as more of the shared session gets split.
