### PR TITLE
ATO-965: add browserSessionId to fresh session creation

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -74,7 +74,9 @@ public class StartService {
         if (session.isAuthenticated() && userProfile.isEmpty()) {
             LOG.info(
                     "Session is authenticated but user profile is empty. Creating new session with existing sessionID");
-            session = new Session(session.getSessionId());
+            session =
+                    new Session(session.getSessionId())
+                            .withBrowserSessionId(session.getBrowserSessionId());
             session.addClientSession(clientSessionId);
             sessionService.storeOrUpdateSession(session);
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -122,6 +122,7 @@ class StartServiceTest {
         SESSION.setNewAccount(Session.AccountState.EXISTING);
         SESSION.setVerifiedMfaMethodType(MFAMethodType.AUTH_APP);
         SESSION.setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
+        SESSION.setBrowserSessionId("some-browser-session-id");
         var session = startService.validateSession(SESSION, currentClientSessionId);
 
         assertFalse(session.isAuthenticated());
@@ -130,6 +131,7 @@ class StartServiceTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         assertTrue(session.getClientSessions().contains("some-client-session-id"));
         assertFalse(session.getClientSessions().contains("previous-session-client-session-id"));
+        assertThat(session.getBrowserSessionId(), equalTo("some-browser-session-id"));
         verify(sessionService).storeOrUpdateSession(session);
     }
 
@@ -148,6 +150,7 @@ class StartServiceTest {
         SESSION.setNewAccount(Session.AccountState.EXISTING);
         SESSION.setVerifiedMfaMethodType(MFAMethodType.AUTH_APP);
         SESSION.setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
+        SESSION.setBrowserSessionId("some-browser-session-id");
         var session = startService.validateSession(SESSION, currentClientSessionId);
 
         assertTrue(session.isAuthenticated());
@@ -155,6 +158,7 @@ class StartServiceTest {
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         assertThat(session.isNewAccount(), equalTo(Session.AccountState.EXISTING));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
+        assertThat(session.getBrowserSessionId(), equalTo("some-browser-session-id"));
         assertTrue(session.getClientSessions().contains("some-client-session-id"));
         assertTrue(session.getClientSessions().contains("previous-session-client-session-id"));
         verifyNoInteractions(sessionService);


### PR DESCRIPTION
## What
Adds `.withBrowserSessionId(session.getBrowserSessionId())` to the session refresh in the `validateSession` function. This was causing sessions to be overwritten without a bsid, and the log "Session has no browser session id" to be seen, despite those sessions previously having browser session ids.

## How to review

1. Code Review