### PR TITLE
ATO-1072: Create Orch session dynamo table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -3764,6 +3764,54 @@ Resources:
 
   #region Policies
 
+  OrchSessionTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowOrchSessionTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt OrchSessionTable.Arn
+          - Sid: AllowOrchSessionTableDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: !GetAtt OrchSessionTableEncryptionKey.Arn
+
+  OrchSessionTableWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowOrchSessionTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+            Resource: !GetAtt OrchSessionTable.Arn
+          - Sid: AllowOrchSessionTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+            Resource: !GetAtt OrchSessionTableEncryptionKey.Arn
+
+  OrchSessionTableDeleteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowOrchSessionTableDeleteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DeleteItem
+            Resource: !GetAtt OrchSessionTable.Arn
+
   IdentityCredentialsTableReadAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -382,6 +382,63 @@ Resources:
               ArnLike:
                 kms:EncryptionContext:aws:logs:arn: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
 
+  #region Orchestration Session DynamoDB Table
+
+  OrchSessionTableEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS encryption key for Orch session DynamoDB table
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Sid: AllowDynamodbAccessToEncryptionKey
+            Effect: Allow
+            Principal:
+              Service: dynamodb.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+
+  OrchSessionTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${Environment}-OrchSession
+      AttributeDefinitions:
+        - AttributeName: sessionId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: sessionId
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEEnabled: true
+        KMSMasterKeyId: !GetAtt OrchSessionTableEncryptionKey.Arn
+        SSEType: KMS
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - Key: Name
+          Value: OrchSessionTable
+
+  #endregion
+
   #region RP Public Key DynamoDB Table
 
   RpPublicKeyTableEncryptionKey:


### PR DESCRIPTION
## What

This table will be used to store Orchestration session data once we have migrated from the existing shared redis store. DynamoDB is more scalable than redis and will allow us to do proper Orchestration performance / scaling testing.

This PR is very similar to https://github.com/govuk-one-login/authentication-api/pull/5125 which set up the equivalent Auth session table.

Note that point in time recovery is currently enabled, but we may disable in future based on the outcome of [ATO-1073](https://govukverify.atlassian.net/browse/ATO-1073).

## Testing

Deployed to Orch dev and the table is created successfully.

[ATO-1073]: https://govukverify.atlassian.net/browse/ATO-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ