### PR TITLE
BAU: Standardise Auth session service exception handling

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -183,7 +183,6 @@ public class StartHandler
             StartRequest startRequest = objectMapper.readValue(input.getBody(), StartRequest.class);
             Optional<String> previousSessionId =
                     Optional.ofNullable(startRequest.previousSessionId());
-            LOG.info("previousSessionId: {}", previousSessionId);
             authSessionService.addOrUpdateSessionId(previousSessionId, session.getSessionId());
 
             var clientSessionId =

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -67,7 +67,7 @@ class AuthSessionServiceTest {
                         .withSessionId(SESSION_ID)
                         .withAccountState(AuthSessionItem.AccountState.EXISTING);
         assertThrows(
-                DynamoDbException.class,
+                AuthSessionException.class,
                 () -> authSessionService.updateSession(sessionToBeUpdated));
     }
 


### PR DESCRIPTION
## What

Ensure we log an error and re-throw AuthSessionException when any call to the Auth session DynamoDB table throws an exception.

Extract logic to a private method for maintainability.
