### PR TITLE
ATO-965: add bsid integration tests

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -267,7 +267,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var persistentCookie =
                 getHttpCookieFromMultiValueResponseHeaders(
                         response.getMultiValueHeaders(), "di-persistent-session-id");
-        assertThat(persistentCookie.isPresent(), equalTo(true));
+        assertTrue(persistentCookie.isPresent());
         assertThat(persistentCookie.get().getValue(), containsString(PERSISTENT_SESSION_ID));
         assertTrue(
                 isValidPersistentSessionCookieWithDoubleDashedTimestamp(
@@ -311,14 +311,14 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var persistentCookie =
                 getHttpCookieFromMultiValueResponseHeaders(
                         response.getMultiValueHeaders(), "di-persistent-session-id");
-        assertThat(persistentCookie.isPresent(), equalTo(true));
+        assertTrue(persistentCookie.isPresent());
         assertThat(persistentCookie.get().getValue(), containsString(PERSISTENT_SESSION_ID));
         assertTrue(
                 isValidPersistentSessionCookieWithDoubleDashedTimestamp(
                         persistentCookie.get().getValue()));
         var languageCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "lng");
-        assertThat(languageCookie.isPresent(), equalTo(true));
+        assertTrue(languageCookie.isPresent());
         assertThat(languageCookie.get().getValue(), equalTo("en"));
 
         assertTxmaAuditEventsReceived(
@@ -404,11 +404,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
         assertOnSessionCookie(sessionCookie);
-        assertThat(
+        assertTrue(
                 getHttpCookieFromMultiValueResponseHeaders(
                                 response.getMultiValueHeaders(), "di-persistent-session-id")
-                        .isPresent(),
-                equalTo(true));
+                        .isPresent());
 
         Optional<HttpCookie> browserSessionIdCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "bsid");
@@ -445,11 +444,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
         assertOnSessionCookie(sessionCookie);
-        assertThat(
+        assertTrue(
                 getHttpCookieFromMultiValueResponseHeaders(
                                 response.getMultiValueHeaders(), "di-persistent-session-id")
-                        .isPresent(),
-                equalTo(true));
+                        .isPresent());
 
         Optional<HttpCookie> browserSessionIdCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "bsid");
@@ -491,11 +489,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         System.out.println(response.getMultiValueHeaders());
 
-        assertThat(
+        assertTrue(
                 getHttpCookieFromMultiValueResponseHeaders(
                                 response.getMultiValueHeaders(), "di-persistent-session-id")
-                        .isPresent(),
-                equalTo(true));
+                        .isPresent());
 
         var sessionCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
@@ -542,11 +539,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
         assertOnSessionCookie(sessionCookie, previousSessionId);
-        assertThat(
+        assertTrue(
                 getHttpCookieFromMultiValueResponseHeaders(
                                 response.getMultiValueHeaders(), "di-persistent-session-id")
-                        .isPresent(),
-                equalTo(true));
+                        .isPresent());
         Optional<HttpCookie> browserSessionIdCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "bsid");
         assertTrue(browserSessionIdCookie.isPresent());
@@ -585,11 +581,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
         assertOnSessionCookie(sessionCookie, previousSessionId);
-        assertThat(
+        assertTrue(
                 getHttpCookieFromMultiValueResponseHeaders(
                                 response.getMultiValueHeaders(), "di-persistent-session-id")
-                        .isPresent(),
-                equalTo(true));
+                        .isPresent());
 
         Optional<HttpCookie> browserSessionIdCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "bsid");
@@ -683,11 +678,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
         assertOnSessionCookie(sessionCookie, previousSessionId);
-        assertThat(
+        assertTrue(
                 getHttpCookieFromMultiValueResponseHeaders(
                                 response.getMultiValueHeaders(), "di-persistent-session-id")
-                        .isPresent(),
-                equalTo(true));
+                        .isPresent());
 
         Optional<HttpCookie> browserSessionIdCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "bsid");
@@ -731,11 +725,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
         assertOnSessionCookie(sessionCookie, previousSessionId);
-        assertThat(
+        assertTrue(
                 getHttpCookieFromMultiValueResponseHeaders(
                                 response.getMultiValueHeaders(), "di-persistent-session-id")
-                        .isPresent(),
-                equalTo(true));
+                        .isPresent());
 
         Optional<HttpCookie> browserSessionIdCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "bsid");
@@ -782,11 +775,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
         assertOnSessionCookie(sessionCookie, previousSessionId);
-        assertThat(
+        assertTrue(
                 getHttpCookieFromMultiValueResponseHeaders(
                                 response.getMultiValueHeaders(), "di-persistent-session-id")
-                        .isPresent(),
-                equalTo(true));
+                        .isPresent());
 
         Optional<HttpCookie> browserSessionIdCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "bsid");
@@ -844,10 +836,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var languageCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "lng");
         if (uiLocales.contains("en")) {
-            assertThat(languageCookie.isPresent(), equalTo(true));
+            assertTrue(languageCookie.isPresent());
             assertThat(languageCookie.get().getValue(), equalTo("en"));
         } else if (uiLocales.contains("cy")) {
-            assertThat(languageCookie.isPresent(), equalTo(true));
+            assertTrue(languageCookie.isPresent());
             assertThat(languageCookie.get().getValue(), equalTo("cy"));
         } else {
             assertThat(languageCookie.isPresent(), equalTo(false));
@@ -1139,7 +1131,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     private void assertOnSessionCookie(Optional<HttpCookie> sessionCookie) {
-        assertThat(sessionCookie.isPresent(), equalTo(true));
+        assertTrue(sessionCookie.isPresent());
         var sessionId = sessionCookie.get().getValue().split("\\.")[0];
         assertTrue(orchSessionExtension.getSession(sessionId).isPresent());
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -346,10 +346,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(
                 redirectUri,
                 startsWith(TEST_CONFIGURATION_SERVICE.getAuthFrontendBaseURL().toString()));
-        assertThat(
-                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
-                        .isPresent(),
-                equalTo(true));
         var sessionCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
         assertOnSessionCookie(sessionCookie);
@@ -842,10 +838,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Optional.of("GET"));
         assertThat(response, hasStatus(302));
         assertThat(getLocationResponseHeader(response), startsWith(AUTHORIZE_URI.toString()));
-        assertThat(
-                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
-                        .isPresent(),
-                equalTo(true));
         var sessionCookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
         assertOnSessionCookie(sessionCookie);

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -19,6 +19,7 @@ import java.net.HttpCookie;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -217,6 +218,15 @@ public class IntegrationTest {
     protected Map<String, String> constructHeaders(Optional<HttpCookie> cookie) {
         final Map<String, String> headers = new HashMap<>();
         cookie.ifPresent(c -> headers.put("Cookie", c.toString()));
+        headers.put("txma-audit-encoded", TXMA_ENCODED_HEADER_VALUE);
+        return headers;
+    }
+
+    protected Map<String, String> constructHeaders(HttpCookie[] cookies) {
+        final Map<String, String> headers = new HashMap<>();
+        String cookiesString =
+                String.join("; ", Arrays.stream(cookies).map(HttpCookie::toString).toList());
+        headers.put("Cookie", cookiesString);
         headers.put("txma-audit-encoded", TXMA_ENCODED_HEADER_VALUE);
         return headers;
     }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -326,5 +326,15 @@ public class IntegrationTest {
         public Optional<String> getIPVCapacity() {
             return Optional.of("1");
         }
+
+        @Override
+        public boolean isBrowserSessionCookieEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean isSignOutOnBrowserCloseEnabled() {
+            return true;
+        }
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -146,6 +146,14 @@ public class RedisExtension
                 session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
     }
 
+    public void addBrowserSesssionIdToSession(String sessionId, String browserSessionId)
+            throws Json.JsonException {
+        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
+        session.setBrowserSessionId(browserSessionId);
+        redis.saveWithExpiry(
+                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+    }
+
     public void setSessionCredentialTrustLevel(
             String sessionId, CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);


### PR DESCRIPTION
## What
- Turns on the bsid feature in integration tests
- Updates current tests accordingly
- Adds new test for the new route bsid introduces: valid "gs" cookie, but invalid "bsid" cookie

## How to review

1. Code Review