### PR TITLE
ATO-981: Remove auth setter from shared session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -54,7 +54,6 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.frontendapi.helpers.FrontendApiPhoneNumberHelper.redactPhoneNumber;
 import static uk.gov.di.authentication.frontendapi.services.UserMigrationService.userHasBeenPartlyMigrated;
 import static uk.gov.di.authentication.shared.conditions.MfaHelper.getUserMFADetail;
-import static uk.gov.di.authentication.shared.entity.Session.AccountState.EXISTING;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.JOURNEY_TYPE;
@@ -292,7 +291,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         sessionService.storeOrUpdateSession(
                 userContext
                         .getSession()
-                        .setNewAccount(EXISTING)
                         .setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier));
 
         authSessionService.updateSession(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -34,7 +34,6 @@ import java.util.Optional;
 
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_CREATE_ACCOUNT_EMAIL_ALREADY_EXISTS;
-import static uk.gov.di.authentication.shared.entity.Session.AccountState.NEW;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
@@ -181,7 +180,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                     userContext
                             .getSession()
                             .setEmailAddress(request.getEmail())
-                            .setNewAccount(NEW)
                             .setInternalCommonSubjectIdentifier(
                                     internalCommonSubjectIdentifier.getValue()));
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -903,9 +903,7 @@ class LoginHandlerTest {
                         argThat(
                                 t ->
                                         t.getInternalCommonSubjectIdentifier()
-                                                        .equals(expectedCommonSubject)
-                                                && t.isNewAccount()
-                                                        == Session.AccountState.EXISTING));
+                                                .equals(expectedCommonSubject)));
     }
 
     private void verifyAuthSessionIsSaved() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -191,8 +191,9 @@ class SignUpHandlerTest {
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("rpPairwiseId", expectedRpPairwiseId));
 
-        verify(sessionService)
-                .storeOrUpdateSession(argThat(s -> s.isNewAccount() == Session.AccountState.NEW));
+        verify(authSessionService)
+                .updateSession(
+                        argThat(s -> s.getIsNewAccount() == AuthSessionItem.AccountState.NEW));
         verify(sessionService, atLeastOnce())
                 .storeOrUpdateSession(
                         argThat(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -255,14 +255,6 @@ public class RedisExtension
         codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email);
     }
 
-    public void setIsNewAccount(String sessionId, Session.AccountState accountState)
-            throws Json.JsonException {
-        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.setNewAccount(accountState);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
-    }
-
     public void addToRedis(String key, String value, Long expiry) {
         redis.saveWithExpiry(key, value, expiry);
     }


### PR DESCRIPTION
## What
- We've now moved the [getters](https://github.com/govuk-one-login/authentication-api/pull/5303) and the [setters](https://github.com/govuk-one-login/authentication-api/pull/5280) for `isNewAccount` to the new session store. This means Auth no longer need to set this value in the shared redis session. This PR removes the redundant setting of these values.
- I've left reading the redis session in the `UserInfo` handler as we may need to set values in the shared session as an interim step when transitioning (like we did [here](https://github.com/govuk-one-login/authentication-api/pull/5219))
- There is some [future work to clean up the session class](https://govukverify.atlassian.net/jira/software/c/projects/ATO/boards/390?selectedIssue=ATO-982) so will clean that up as part of this 


## How to review:
- Code review commit by commit 
- Deploy to a development environment
    - Ran through a journey as a sanity check

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs
Needs  PR merged first  first https://github.com/govuk-one-login/authentication-api/pull/5330