### PR TITLE
BAU: Fix NullPointerException in incrementCloudwatchCounter

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenService.java
@@ -32,6 +32,7 @@ public class AccessTokenService extends BaseDynamoService<AccessTokenStore> {
     public AccessTokenService(ConfigurationService configurationService) {
         super(AccessTokenStore.class, "access-token-store", configurationService);
         this.timeToExist = configurationService.getAccessTokenExpiry();
+        this.configurationService = configurationService;
     }
 
     public AccessTokenService(


### PR DESCRIPTION
## What

Fix NullPointerException in incrementCloudwatchCounter

'configurationService' is not being set in the 'AccessTokenService' constructor. 
Removes 'Unable to increment access token service cloudwatch counter' from the logs and allows the counter to be set.

https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?q=search%20index%3D%22gds_di_production%22%20source%3D%22*%3A%2Faws%2F*%2Fproduction-*%22%20%20%20%20%22Unable%20to%20increment%20access%20token%20service%20cloudwatch%20counter%22&earliest=1727967000&latest=1727967300&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&sid=1727972385.369674

## How to review

1. Code Review
1. Deploy to a test environment, run a journey and check that the error is missing from the logs.
