### PR TITLE
Ato 981 set is new account from auth user info response

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -80,7 +80,6 @@ import static uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent.A
 import static uk.gov.di.orchestration.shared.conditions.DocAppUserHelper.isDocCheckingAppUserWithSubjectId;
 import static uk.gov.di.orchestration.shared.conditions.IdentityHelper.identityRequired;
 import static uk.gov.di.orchestration.shared.domain.RequestHeaders.SESSION_ID_HEADER;
-import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.orchestration.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
 import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
@@ -354,6 +353,8 @@ public class AuthenticationCallbackHandler
 
                 Boolean newAccount = userInfo.getBooleanClaim("new_account");
                 AccountState accountState = newAccount ? AccountState.NEW : AccountState.EXISTING;
+
+                sessionService.storeOrUpdateSession(userSession.setNewAccount(accountState));
                 var docAppJourney = isDocCheckingAppUserWithSubjectId(clientSession);
                 Map<String, String> dimensions =
                         buildDimensions(
@@ -470,8 +471,7 @@ public class AuthenticationCallbackHandler
                         new AuthenticationSuccessResponse(
                                 clientRedirectURI, authCode, null, null, state, null, responseMode);
 
-                sessionService.storeOrUpdateSession(
-                        userSession.setAuthenticated(true).setNewAccount(EXISTING));
+                sessionService.storeOrUpdateSession(userSession.setAuthenticated(true));
 
                 cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
                 cloudwatchMetricsService.incrementSignInByClient(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -196,11 +196,14 @@ class AuthenticationCallbackHandlerTest {
         assertThat(
                 redirectLocation,
                 equalTo(REDIRECT_URI + "?code=" + AUTH_CODE_RP_TO_ORCH + "&state=" + RP_STATE));
-        var savedSession = ArgumentCaptor.forClass(Session.class);
         verifyUserInfoRequest();
-        verify(sessionService).storeOrUpdateSession(savedSession.capture());
-        assertTrue(savedSession.getValue().isAuthenticated());
-        assertEquals(savedSession.getValue().isNewAccount(), Session.AccountState.EXISTING);
+
+        var sessionSaveCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionService, times(2)).storeOrUpdateSession(sessionSaveCaptor.capture());
+        assertThat(
+                Session.AccountState.NEW,
+                equalTo(sessionSaveCaptor.getAllValues().get(0).isNewAccount()));
+        assertTrue(sessionSaveCaptor.getAllValues().get(1).isAuthenticated());
 
         verify(cloudwatchMetricsService).incrementCounter(eq("AuthenticationCallback"), any());
         verify(cloudwatchMetricsService).incrementCounter(eq("SignIn"), any());


### PR DESCRIPTION
## What:
- This sets isNewAccount in the authentication callback handler using the UserInfo response from auth, regardless of whether this is an auth or identity journey. This is needed because when a user is returned from the identity journey (IPV callback handler) we need to emit metrics on this session field, and we can no longer rely on auth setting it.
- 
## How to review
- Code review commit-by-commit 
Deploy to a dev environment 
   - Run through a journey, check all is fine 
   
## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
