### PR TITLE
ATO-922: set email in orch session

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -61,6 +61,7 @@ class AuthenticationCallbackHandlerTest {
             mock(AuthenticationAuthorizationService.class);
     private final AuthenticationTokenService tokenService = mock(AuthenticationTokenService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final AuthenticationUserInfoStorageService userInfoStorageService =
@@ -162,6 +163,7 @@ class AuthenticationCallbackHandlerTest {
                         authorizationService,
                         tokenService,
                         sessionService,
+                        orchSessionService,
                         clientSessionService,
                         auditService,
                         userInfoStorageService,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -10,6 +10,7 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
 
     private String sessionId;
+    private String email;
     private long timeToLive;
 
     public OrchSessionItem() {}
@@ -26,6 +27,20 @@ public class OrchSessionItem {
 
     public OrchSessionItem withSessionId(String sessionId) {
         this.sessionId = sessionId;
+        return this;
+    }
+
+    @DynamoDbAttribute("email")
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public OrchSessionItem withEmail(String email) {
+        this.email = email;
         return this;
     }
 


### PR DESCRIPTION
## What
- Adds the email property to the orch session (needed for client registry lookups)
- Sets the email property in the Authentication Callback Handler to the email in the user info response

## How to review
1. Code Review