### PR TITLE
ATO-979/c: Add verifiedMfaMethodType to Orch session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -35,6 +35,8 @@ import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
+import uk.gov.di.orchestration.shared.entity.MFAMethodType;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.ServiceType;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
@@ -46,6 +48,7 @@ import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationT
 import uk.gov.di.orchestration.sharedtest.extensions.AuthExternalApiStubExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
@@ -105,6 +108,9 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     public static final AccountInterventionsStubExtension accountInterventionApiStub =
             new AccountInterventionsStubExtension();
 
+    @RegisterExtension
+    public static final OrchSessionExtension orchSessionExtension = new OrchSessionExtension();
+
     protected static ConfigurationService configurationService;
 
     private static final String CLIENT_ID = "test-client-id";
@@ -155,6 +161,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertUserInfoStoredAndRedirectedToRp(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -254,6 +261,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToIpv(response, false);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     void accountInterventionSetup() throws Json.JsonException {
@@ -279,6 +287,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertUserInfoStoredAndRedirectedToRp(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -300,6 +309,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToBlockedPage(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -321,6 +331,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToSuspendedPage(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -342,6 +353,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToSuspendedPage(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -362,6 +374,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertUserInfoStoredAndRedirectedToRp(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -384,6 +397,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToSuspendedPage(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -407,6 +421,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertUserInfoStoredAndRedirectedToRp(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -430,6 +445,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertUserInfoStoredAndRedirectedToRp(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -489,6 +505,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertUserInfoStoredAndRedirectedToRp(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     void accountInterventionSetupWithIdentity() throws Json.JsonException {
@@ -515,6 +532,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToIpv(response, false);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -536,6 +554,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToBlockedPage(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -557,6 +576,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToIpv(response, false);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -579,6 +599,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToSuspendedPage(response);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -600,6 +621,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToIpv(response, true);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -626,6 +648,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToIpv(response, false);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -652,6 +675,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         constructQueryStringParameters());
 
         assertRedirectToIpv(response, true);
+        assertOrchSessionIsUpdatedWithUserInfoClaims();
     }
 
     @Test
@@ -776,6 +800,13 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
         assertThat(userInfoDbEntry.get().getUserInfo(), containsString("new_account"));
     }
 
+    private void assertOrchSessionIsUpdatedWithUserInfoClaims() {
+        Optional<OrchSessionItem> orchSession = orchSessionExtension.getSession(SESSION_ID);
+        assertTrue(orchSession.isPresent());
+        assertEquals(
+                MFAMethodType.AUTH_APP.getValue(), orchSession.get().getVerifiedMfaMethodType());
+    }
+
     private void setupClientReg(boolean identityVerificationSupported) {
         clientStore.registerClient(
                 CLIENT_ID,
@@ -835,6 +866,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                 ORCH_TO_AUTH_STATE,
                 SESSION_ID);
         setUpClientSession();
+        orchSessionExtension.addSession(new OrchSessionItem().withSessionId(SESSION_ID));
     }
 
     private Map<String, String> constructQueryStringParameters() {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthUserInfoClaims.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthUserInfoClaims.java
@@ -12,7 +12,8 @@ public enum AuthUserInfoClaims {
     EMAIL_VERIFIED("email_verified"),
     PHONE_NUMBER("phone_number"),
     PHONE_VERIFIED("phone_number_verified"),
-    SALT("salt");
+    SALT("salt"),
+    VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type");
 
     private final String value;
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -259,7 +259,14 @@ public class AuthenticationCallbackHandler
                             .orElseThrow(
                                     () ->
                                             new AuthenticationCallbackException(
-                                                    "Orchestration user session not found"));
+                                                    "Shared session not found in Redis"));
+            OrchSessionItem orchSession =
+                    orchSessionService
+                            .getSession(sessionCookiesIds.getSessionId())
+                            .orElseThrow(
+                                    () ->
+                                            new AuthenticationCallbackException(
+                                                    "Orchestration session not found in DynamoDB"));
 
             attachSessionIdToLogs(userSession);
             var clientSessionId = sessionCookiesIds.getClientSessionId();
@@ -344,14 +351,6 @@ public class AuthenticationCallbackHandler
                 LOG.info("Adding Authentication userinfo to dynamo");
                 userInfoStorageService.addAuthenticationUserInfoData(
                         userInfo.getSubject().getValue(), userInfo);
-
-                OrchSessionItem orchSession =
-                        orchSessionService
-                                .getSession(sessionCookiesIds.getSessionId())
-                                .orElseThrow(
-                                        () ->
-                                                new AuthenticationCallbackException(
-                                                        "Orchestration user session not found"));
                 addClaimsToOrchSession(orchSession, userInfo);
 
                 ClientRegistry client = clientService.getClient(clientId).orElseThrow();

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -58,6 +58,7 @@ import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
+import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
@@ -100,6 +101,7 @@ public class AuthenticationCallbackHandler
     private final AuthenticationAuthorizationService authorisationService;
     private final AuthenticationTokenService tokenService;
     private final SessionService sessionService;
+    private final OrchSessionService orchSessionService;
     private final ClientSessionService clientSessionService;
     private final AuditService auditService;
     private final AuthenticationUserInfoStorageService userInfoStorageService;
@@ -125,6 +127,7 @@ public class AuthenticationCallbackHandler
         this.tokenService =
                 new AuthenticationTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService);
+        this.orchSessionService = new OrchSessionService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.userInfoStorageService =
@@ -164,6 +167,7 @@ public class AuthenticationCallbackHandler
         this.tokenService =
                 new AuthenticationTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService, redisConnectionService);
+        this.orchSessionService = new OrchSessionService(configurationService);
         this.clientSessionService =
                 new ClientSessionService(configurationService, redisConnectionService);
         this.auditService = new AuditService(configurationService);
@@ -203,6 +207,7 @@ public class AuthenticationCallbackHandler
             AuthenticationAuthorizationService responseService,
             AuthenticationTokenService tokenService,
             SessionService sessionService,
+            OrchSessionService orchSessionService,
             ClientSessionService clientSessionService,
             AuditService auditService,
             AuthenticationUserInfoStorageService dynamoAuthUserInfoService,
@@ -218,6 +223,7 @@ public class AuthenticationCallbackHandler
         this.authorisationService = responseService;
         this.tokenService = tokenService;
         this.sessionService = sessionService;
+        this.orchSessionService = orchSessionService;
         this.clientSessionService = clientSessionService;
         this.auditService = auditService;
         this.userInfoStorageService = dynamoAuthUserInfoService;

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -19,6 +19,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
+import uk.gov.di.authentication.oidc.entity.AuthUserInfoClaims;
 import uk.gov.di.authentication.oidc.exceptions.AuthenticationCallbackValidationException;
 import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
 import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
@@ -139,6 +140,9 @@ class AuthenticationCallbackHandlerTest {
         when(USER_INFO.getBooleanClaim("new_account")).thenReturn(true);
         when(USER_INFO.getClaim("rp_client_id")).thenReturn(PAIRWISE_SUBJECT_ID.getValue());
         when(USER_INFO.getPhoneNumber()).thenReturn("1234");
+        when(USER_INFO.getClaim(
+                        AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(), String.class))
+                .thenReturn(MFAMethodType.AUTH_APP.getValue());
     }
 
     @BeforeEach
@@ -378,6 +382,26 @@ class AuthenticationCallbackHandlerTest {
                         OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED),
                 auditService);
         verifyNoInteractions(userInfoStorageService, cloudwatchMetricsService);
+    }
+
+    @Test
+    void shouldUpdateOrchSessionUsingClaimsFromUserInfoResponse()
+            throws UnsuccessfulCredentialResponseException {
+        usingValidSession();
+        usingValidClientSession();
+        usingValidClient();
+        var event = new APIGatewayProxyRequestEvent();
+        setValidHeadersAndQueryParameters(event);
+        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
+
+        handler.handleRequest(event, null);
+
+        var orchSessionCaptor = ArgumentCaptor.forClass(OrchSessionItem.class);
+        verify(orchSessionService, times(1)).updateSession(orchSessionCaptor.capture());
+        assertThat(
+                MFAMethodType.AUTH_APP.getValue(),
+                equalTo(orchSessionCaptor.getAllValues().get(0).getVerifiedMfaMethodType()));
     }
 
     @Nested
@@ -665,6 +689,8 @@ class AuthenticationCallbackHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
+        when(orchSessionService.getSession(SESSION_ID))
+                .thenReturn(Optional.of(new OrchSessionItem().withSessionId(SESSION_ID)));
     }
 
     private void usingValidClientSession() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -61,6 +61,7 @@ class AuthenticationCallbackHandlerTest {
             mock(AuthenticationAuthorizationService.class);
     private final AuthenticationTokenService tokenService = mock(AuthenticationTokenService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final AuthenticationUserInfoStorageService userInfoStorageService =
@@ -162,6 +163,7 @@ class AuthenticationCallbackHandlerTest {
                         authorizationService,
                         tokenService,
                         sessionService,
+                        orchSessionService,
                         clientSessionService,
                         auditService,
                         userInfoStorageService,

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthExternalApiStubExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthExternalApiStubExtension.java
@@ -1,6 +1,8 @@
 package uk.gov.di.orchestration.sharedtest.extensions;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import uk.gov.di.orchestration.shared.entity.MFAMethodType;
 import uk.gov.di.orchestration.sharedtest.httpstub.HttpStubExtension;
 
 import static java.lang.String.format;
@@ -29,16 +31,10 @@ public class AuthExternalApiStubExtension extends HttpStubExtension {
                                 + "}",
                         getHttpPort()));
 
-        String userInfoContent =
-                String.format(
-                        "{"
-                                + "\"sub\": \"%s\","
-                                + "\"new_account\": true,"
-                                + "\"verified_mfa_method_type\": \"AUTH_APP\""
-                                + "}",
-                        subjectId.getValue());
-
-        register("/userinfo", 200, "application/json", userInfoContent);
+        UserInfo userInfo = new UserInfo(subjectId);
+        userInfo.setClaim("new_account", true);
+        userInfo.setClaim("verified_mfa_method_type", MFAMethodType.AUTH_APP.getValue());
+        register("/userinfo", 200, "application/json", userInfo.toJSONString());
     }
 
     public void init(Subject subjectId, Long passwordResetTime) {
@@ -55,16 +51,10 @@ public class AuthExternalApiStubExtension extends HttpStubExtension {
                                 + "}",
                         getHttpPort()));
 
-        String userInfoContent =
-                String.format(
-                        "{"
-                                + "\"sub\": \"%s\","
-                                + "\"new_account\": true,"
-                                + "\"verified_mfa_method_type\": \"AUTH_APP\","
-                                + "\"password_reset_time\": %s"
-                                + "}",
-                        subjectId.getValue(), passwordResetTime.toString());
-
-        register("/userinfo", 200, "application/json", userInfoContent);
+        UserInfo userInfo = new UserInfo(subjectId);
+        userInfo.setClaim("new_account", true);
+        userInfo.setClaim("verified_mfa_method_type", MFAMethodType.AUTH_APP.getValue());
+        userInfo.setClaim("password_reset_time", passwordResetTime);
+        register("/userinfo", 200, "application/json", userInfo.toJSONString());
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthExternalApiStubExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthExternalApiStubExtension.java
@@ -31,7 +31,11 @@ public class AuthExternalApiStubExtension extends HttpStubExtension {
 
         String userInfoContent =
                 String.format(
-                        "{" + "\"sub\": \"%s\"," + "\"new_account\": true" + "}",
+                        "{"
+                                + "\"sub\": \"%s\","
+                                + "\"new_account\": true,"
+                                + "\"verified_mfa_method_type\": \"AUTH_APP\""
+                                + "}",
                         subjectId.getValue());
 
         register("/userinfo", 200, "application/json", userInfoContent);
@@ -56,6 +60,7 @@ public class AuthExternalApiStubExtension extends HttpStubExtension {
                         "{"
                                 + "\"sub\": \"%s\","
                                 + "\"new_account\": true,"
+                                + "\"verified_mfa_method_type\": \"AUTH_APP\","
                                 + "\"password_reset_time\": %s"
                                 + "}",
                         subjectId.getValue(), passwordResetTime.toString());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -8,9 +8,11 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 public class OrchSessionItem {
 
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
+    public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
 
     private String sessionId;
     private long timeToLive;
+    private String verifiedMfaMethodType;
 
     public OrchSessionItem() {}
 
@@ -40,6 +42,20 @@ public class OrchSessionItem {
 
     public OrchSessionItem withTimeToLive(long timeToLive) {
         this.timeToLive = timeToLive;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE)
+    public String getVerifiedMfaMethodType() {
+        return verifiedMfaMethodType;
+    }
+
+    public void setVerifiedMfaMethodType(String verifiedMfaMethodType) {
+        this.verifiedMfaMethodType = verifiedMfaMethodType;
+    }
+
+    public OrchSessionItem withVerifiedMfaMethodType(String verifiedMfaMethodType) {
+        this.verifiedMfaMethodType = verifiedMfaMethodType;
         return this;
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -1789,6 +1789,7 @@ Resources:
         - !Ref OrchToAuthSigningKmsAccessPolicy
         - !Ref IpvPublicEncryptionKeyAccessPolicy
         - !Ref AccountInterventionsServiceUriSecretAccessPolicy
+        - !Ref OrchSessionTableReadAndWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 


### PR DESCRIPTION
## What

This is the third part of splitting verifiedMfaMethodType session data. 

Now that Auth send the value in the userinfo response (https://github.com/govuk-one-login/authentication-api/pull/5301), and Orch have a dedicated session (https://github.com/govuk-one-login/authentication-api/pull/5326), this PR actually adds the value to the Orch session.

Once this is deployed, Auth and Orch will have access to verifiedMfaMethodType via their individual sessions, as well as the shared session (for now).

## Testing

Manually tested in dev and functions as intended: 
- When there is no existing session, verifiedMfaMethodType is added to the Orch session (with a value either AUTH_APP or SMS). 
- When there is an existing session, the value of verifiedMfaMethodType persists to the updated session (with a new session ID)
