### PR TITLE
ATO-1076: Temporarily change Orch session table name

### DIFF
--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchSessionExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchSessionExtension.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 public class OrchSessionExtension extends DynamoExtension implements AfterEachCallback {
 
-    public static final String TABLE_NAME = "local-OrchSession";
+    public static final String TABLE_NAME = "local-Orch-Session";
     public static final String SESSION_ID_FIELD = "SessionId";
     private OrchSessionService orchSessionService;
     private final ConfigurationService configurationService;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
@@ -22,7 +22,7 @@ public class OrchSessionService extends BaseDynamoService<OrchSessionItem> {
     private final long timeToLive;
 
     public OrchSessionService(ConfigurationService configurationService) {
-        super(OrchSessionItem.class, "OrchSession", configurationService, true);
+        super(OrchSessionItem.class, "Orch-Session", configurationService, true);
         this.timeToLive = configurationService.getSessionExpiry();
         this.cookieHelper = new CookieHelper();
     }

--- a/template.yaml
+++ b/template.yaml
@@ -416,7 +416,7 @@ Resources:
   OrchSessionTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-OrchSession
+      TableName: !Sub ${Environment}-Orch-Session
       AttributeDefinitions:
         - AttributeName: SessionId
           AttributeType: S


### PR DESCRIPTION
Failing to deploy: 
`"CloudFormation cannot update a stack when a custom-named resource requires replacing. Rename <env>-OrchSession and update the stack again"`

A subsequent PR will change the table name back to <env>-OrchSession
