### PR TITLE
ATO-1076: Rename Orch session table (back to original name)

### DIFF
--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchSessionExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchSessionExtension.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 public class OrchSessionExtension extends DynamoExtension implements AfterEachCallback {
 
-    public static final String TABLE_NAME = "local-Orch-Session";
+    public static final String TABLE_NAME = "local-OrchSession";
     public static final String SESSION_ID_FIELD = "SessionId";
     private OrchSessionService orchSessionService;
     private final ConfigurationService configurationService;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
@@ -22,7 +22,7 @@ public class OrchSessionService extends BaseDynamoService<OrchSessionItem> {
     private final long timeToLive;
 
     public OrchSessionService(ConfigurationService configurationService) {
-        super(OrchSessionItem.class, "Orch-Session", configurationService, true);
+        super(OrchSessionItem.class, "OrchSession", configurationService, true);
         this.timeToLive = configurationService.getSessionExpiry();
         this.cookieHelper = new CookieHelper();
     }

--- a/template.yaml
+++ b/template.yaml
@@ -416,7 +416,7 @@ Resources:
   OrchSessionTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-Orch-Session
+      TableName: !Sub ${Environment}-OrchSession
       AttributeDefinitions:
         - AttributeName: SessionId
           AttributeType: S


### PR DESCRIPTION
Previously the Orch session table had to be renamed (from OrchSession to Orch-Session) as the primary key needed updating, which means the table needed to be recreated with a new name. Now the table is deployed, the old table name can be used again, which fits the Orchestration table naming style.

PR which did original renaming: https://github.com/govuk-one-login/authentication-api/pull/5349