### PR TITLE
BAU: Update commons-io to 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ subprojects {
                 "org.apache.httpcomponents:httpclient:4.5.14",
                 "org.apache.commons:commons-collections4:4.1",
                 "commons-net:commons-net:3.11.1",
-                "commons-io:commons-io:2.8.0",
+                "commons-io:commons-io:2.17.0",
                 "org.apache.commons:commons-lang3:3.17.0"
 
         bouncycastle "org.bouncycastle:bcpkix-jdk18on:1.78.1"


### PR DESCRIPTION
## What

To resolve the [Apache Commons IO: Possible denial of service attack on untrusted input to XmlStreamReader](https://github.com/govuk-one-login/authentication-api/security/dependabot/24) vulnerability.

## How to review

1. Code Review