### PR TITLE
BAU: Constrain commons-io to minimum 2.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,6 +145,10 @@ subprojects {
                 add(conf.name, 'com.google.protobuf:protobuf-java:[3.25.5,)') {
                     because 'CVE-2024-7254 is fixed in 3.25.5 and above'
                 }
+
+                add(conf.name, 'commons-io:commons-io:[2.14.0,)') {
+                    because 'CVE-2024-47554 is fixed in 2.14.0 and above'
+                }
             }
         }
 


### PR DESCRIPTION
## What

`notifications-java-client` currently uses 2.8.0 which has the issue [Apache Commons IO: Possible denial of service attack on untrusted input to XmlStreamReader ](https://github.com/advisories/GHSA-78wr-2p64-hpwj).

Here we ensure that the minimum `commons-io` version we use is patched while we await a bump release of `notifications-java-client`.


## How to review

1. Code Review

## Related PRs

- https://github.com/govuk-one-login/authentication-api/pull/5353
- https://github.com/alphagov/notifications-java-client/pull/247
