### PR TITLE
Aut 2257: Fix index out of bounds exception

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -28,6 +28,7 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DynamoServiceIntegrationTest {
 
@@ -445,6 +446,21 @@ class DynamoServiceIntegrationTest {
         assertThat(
                 dynamoService.getOptionalUserProfileFromSubject("5555").get().getEmail(),
                 equalTo("email5"));
+    }
+
+    @Test
+    void shouldRetrieveUserProfileFromSubject() {
+        userStore.signUp("email1", "password-1", new Subject("1111"));
+
+        assertThat(dynamoService.getUserProfileFromSubject("1111").getEmail(), equalTo("email1"));
+    }
+
+    @Test
+    void shouldThrowErrorIfNoUserProfileExists() {
+        assertThrows(
+                RuntimeException.class,
+                () -> dynamoService.getUserProfileFromSubject("NonExistentUser"),
+                "No userCredentials found with query search");
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -522,15 +522,7 @@ public class DynamoService implements AuthenticationService {
 
     @Override
     public UserProfile getUserProfileFromSubject(String subject) {
-        QueryConditional q =
-                QueryConditional.keyEqualTo(Key.builder().partitionValue(subject).build());
-        DynamoDbIndex<UserProfile> subjectIDIndex = dynamoUserProfileTable.index("SubjectIDIndex");
-        QueryEnhancedRequest queryEnhancedRequest =
-                QueryEnhancedRequest.builder().consistentRead(false).queryConditional(q).build();
-        Optional<UserProfile> userProfile =
-                subjectIDIndex.query(queryEnhancedRequest).stream()
-                        .findFirst()
-                        .flatMap(page -> page.items().stream().findFirst());
+        Optional<UserProfile> userProfile = getOptionalUserProfileFromSubject(subject);
         if (userProfile.isEmpty()) {
             throw new RuntimeException("No userCredentials found with query search");
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -529,9 +529,8 @@ public class DynamoService implements AuthenticationService {
                 QueryEnhancedRequest.builder().consistentRead(false).queryConditional(q).build();
         Optional<UserProfile> userProfile =
                 subjectIDIndex.query(queryEnhancedRequest).stream()
-                        .limit(1)
-                        .map(t -> t.items().get(0))
-                        .findFirst();
+                        .findFirst()
+                        .flatMap(page -> page.items().stream().findFirst());
         if (userProfile.isEmpty()) {
             throw new RuntimeException("No userCredentials found with query search");
         }
@@ -558,9 +557,8 @@ public class DynamoService implements AuthenticationService {
                 QueryEnhancedRequest.builder().consistentRead(false).queryConditional(q).build();
         Optional<UserProfile> userProfile =
                 subjectIDIndex.query(queryEnhancedRequest).stream()
-                        .limit(1)
-                        .map(t -> t.items().get(0))
-                        .findFirst();
+                        .findFirst()
+                        .flatMap(page -> page.items().stream().findFirst());
         if (userProfile.isEmpty()) {
             throw new RuntimeException("No userCredentials found with query search");
         }


### PR DESCRIPTION
## What

We've very occassionally been hitting errors `java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0` as a result of a .get(0) in our dynamo service, when a user profile is not found for a subject id.

This fixes this code by not assuming that the list we're calling .get(0) on has any items. This will mean that we get a more descriptive error (no user profile found) rather than this exception. It won't stop us throwing exceptions in this case.

Note that I attempted to reproduce this in tests but didn't manage to since I think the situation that produces this is very edge case-y (backed up by the very occassionnal nature of these errors).

## How to review

1. Code Review
