### PR TITLE
Ato 981 set is new account in new orch session start

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -866,7 +866,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                 ORCH_TO_AUTH_STATE,
                 SESSION_ID);
         setUpClientSession();
-        orchSessionExtension.addSession(new OrchSessionItem().withSessionId(SESSION_ID));
+        orchSessionExtension.addSession(new OrchSessionItem(SESSION_ID));
     }
 
     private Map<String, String> constructQueryStringParameters() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchSessionServiceIntegrationTest.java
@@ -70,8 +70,7 @@ class OrchSessionServiceIntegrationTest {
 
     private void withPreviousExistingAccountSession() {
         orchSessionExtension.addSession(
-                new OrchSessionItem()
-                        .withSessionId(PREVIOUS_SESSION_ID)
+                new OrchSessionItem(PREVIOUS_SESSION_ID)
                         .withAccountState(OrchSessionItem.AccountState.EXISTING));
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -692,7 +692,7 @@ class AuthenticationCallbackHandlerTest {
     private void usingValidSession() {
         when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
         when(orchSessionService.getSession(SESSION_ID))
-                .thenReturn(Optional.of(new OrchSessionItem().withSessionId(SESSION_ID)));
+                .thenReturn(Optional.of(new OrchSessionItem(SESSION_ID)));
     }
 
     private void usingValidClientSession() {

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchSessionExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchSessionExtension.java
@@ -71,6 +71,11 @@ public class OrchSessionExtension extends DynamoExtension implements AfterEachCa
         orchSessionService.addSession(orchSession);
     }
 
+    public OrchSessionItem addOrUpdateSessionId(
+            Optional<String> previousSessionId, String newSessionId) {
+        return orchSessionService.addOrUpdateSessionId(previousSessionId, newSessionId);
+    }
+
     public Optional<OrchSessionItem> getSession(String sessionId) {
         return orchSessionService.getSession(sessionId);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -11,12 +11,21 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_EMAIL = "Email";
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
     public static final String ATTRIBUTE_RP_PAIRWISE_ID = "RpPairwiseId";
+    public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "IsNewAccount";
+
+    public enum AccountState {
+        NEW,
+        EXISTING,
+        EXISTING_DOC_APP_JOURNEY,
+        UNKNOWN
+    }
 
     private String sessionId;
     private long timeToLive;
     private String email;
     private String verifiedMfaMethodType;
     private String rpPairwiseId;
+    private AccountState isNewAccount;
 
     public OrchSessionItem() {}
 
@@ -92,6 +101,20 @@ public class OrchSessionItem {
 
     public OrchSessionItem withRpPairwiseId(String rpPairwiseId) {
         this.rpPairwiseId = rpPairwiseId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_IS_NEW_ACCOUNT)
+    public AccountState getIsNewAccount() {
+        return this.isNewAccount;
+    }
+
+    public void setIsNewAccount(AccountState accountState) {
+        this.isNewAccount = accountState;
+    }
+
+    public OrchSessionItem withAccountState(AccountState accountState) {
+        this.isNewAccount = accountState;
         return this;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -31,6 +31,7 @@ public class OrchSessionItem {
 
     public OrchSessionItem(String sessionId) {
         this.sessionId = sessionId;
+        this.isNewAccount = AccountState.UNKNOWN;
     }
 
     @DynamoDbPartitionKey

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
@@ -83,9 +83,7 @@ public class OrchSessionService extends BaseDynamoService<OrchSessionItem> {
                         newSessionId);
             } else {
                 newItem =
-                        new OrchSessionItem()
-                                .withSessionId(newSessionId)
-                                .withAccountState(OrchSessionItem.AccountState.UNKNOWN)
+                        new OrchSessionItem(newSessionId)
                                 .withTimeToLive(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
@@ -83,7 +83,9 @@ public class OrchSessionService extends BaseDynamoService<OrchSessionItem> {
                         newSessionId);
             } else {
                 newItem =
-                        new OrchSessionItem(newSessionId)
+                        new OrchSessionItem()
+                                .withSessionId(newSessionId)
+                                .withAccountState(OrchSessionItem.AccountState.UNKNOWN)
                                 .withTimeToLive(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()


### PR DESCRIPTION
## What
- Sets isNewAccount in the new Orch session to UNKNOWN at session start

## How to review
- Code review commit-by-commit 
- Deploy to a development environment 
    - Run through a jorney 
    - Check session now contains UNKNOWN in the isNewAccount field

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
