### PR TITLE
ATO-1084: bsid feature flag cleanup

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -429,8 +429,7 @@ public class AuthorisationHandler
 
         Optional<Session> sessionWithValidBrowserSessionId = session;
         boolean newAuthenticationRequired = false;
-        if (configurationService.isBrowserSessionCookieEnabled()
-                && browserSessionIdFromSession.isPresent()
+        if (browserSessionIdFromSession.isPresent()
                 && !Objects.equals(browserSessionIdFromSession, browserSessionIdFromCookie)) {
             sessionWithValidBrowserSessionId = Optional.empty();
             newAuthenticationRequired = true;
@@ -639,20 +638,12 @@ public class AuthorisationHandler
         attachOrchSessionIdToLogs(orchSession.getSessionId());
 
         user = user.withSessionId(session.getSessionId());
-        if (configurationService.isBrowserSessionCookieEnabled()) {
-            auditService.submitAuditEvent(
-                    OidcAuditableEvent.AUTHORISATION_INITIATED,
-                    authenticationRequest.getClientID().getValue(),
-                    user,
-                    pair("client-name", client.getClientName()),
-                    pair("new_authentication_required", newAuthenticationRequired));
-        } else {
-            auditService.submitAuditEvent(
-                    OidcAuditableEvent.AUTHORISATION_INITIATED,
-                    authenticationRequest.getClientID().getValue(),
-                    user,
-                    pair("client-name", client.getClientName()));
-        }
+        auditService.submitAuditEvent(
+                OidcAuditableEvent.AUTHORISATION_INITIATED,
+                authenticationRequest.getClientID().getValue(),
+                user,
+                pair("client-name", client.getClientName()),
+                pair("new_authentication_required", newAuthenticationRequired));
 
         clientSessionService.storeClientSession(clientSessionId, clientSession);
         orchSessionOptional.ifPresentOrElse(
@@ -949,8 +940,7 @@ public class AuthorisationHandler
                         configurationService.getSessionCookieAttributes(),
                         configurationService.getDomainName()));
 
-        if (configurationService.isBrowserSessionCookieEnabled()
-                && session.getBrowserSessionId() != null) {
+        if (session.getBrowserSessionId() != null) {
             cookies.add(
                     CookieHelper.buildCookieString(
                             CookieHelper.BROWSER_SESSION_COOKIE_NAME,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -430,7 +430,6 @@ public class AuthorisationHandler
         Optional<Session> sessionWithValidBrowserSessionId = session;
         boolean newAuthenticationRequired = false;
         if (configurationService.isBrowserSessionCookieEnabled()
-                && configurationService.isSignOutOnBrowserCloseEnabled()
                 && browserSessionIdFromSession.isPresent()
                 && !Objects.equals(browserSessionIdFromSession, browserSessionIdFromCookie)) {
             sessionWithValidBrowserSessionId = Optional.empty();
@@ -640,8 +639,7 @@ public class AuthorisationHandler
         attachOrchSessionIdToLogs(orchSession.getSessionId());
 
         user = user.withSessionId(session.getSessionId());
-        if (configurationService.isBrowserSessionCookieEnabled()
-                && configurationService.isSignOutOnBrowserCloseEnabled()) {
+        if (configurationService.isBrowserSessionCookieEnabled()) {
             auditService.submitAuditEvent(
                     OidcAuditableEvent.AUTHORISATION_INITIATED,
                     authenticationRequest.getClientID().getValue(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -256,7 +256,6 @@ class AuthorisationHandlerTest {
         when(configService.getPersistentCookieMaxAge()).thenReturn(34190000);
         when(configService.isIdentityEnabled()).thenReturn(true);
         when(configService.isBrowserSessionCookieEnabled()).thenReturn(true);
-        when(configService.isSignOutOnBrowserCloseEnabled()).thenReturn(true);
         when(authFrontend.baseURI()).thenReturn(FRONT_END_BASE_URI);
         when(authFrontend.errorURI()).thenReturn(FRONT_END_ERROR_URI);
         when(authFrontend.authorizeURI(Optional.empty(), Optional.empty()))

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -255,7 +255,6 @@ class AuthorisationHandlerTest {
         when(configService.getSessionCookieMaxAge()).thenReturn(3600);
         when(configService.getPersistentCookieMaxAge()).thenReturn(34190000);
         when(configService.isIdentityEnabled()).thenReturn(true);
-        when(configService.isBrowserSessionCookieEnabled()).thenReturn(true);
         when(authFrontend.baseURI()).thenReturn(FRONT_END_BASE_URI);
         when(authFrontend.errorURI()).thenReturn(FRONT_END_ERROR_URI);
         when(authFrontend.authorizeURI(Optional.empty(), Optional.empty()))

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -336,10 +336,5 @@ public class IntegrationTest {
         public Optional<String> getIPVCapacity() {
             return Optional.of("1");
         }
-
-        @Override
-        public boolean isBrowserSessionCookieEnabled() {
-            return true;
-        }
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -341,10 +341,5 @@ public class IntegrationTest {
         public boolean isBrowserSessionCookieEnabled() {
             return true;
         }
-
-        @Override
-        public boolean isSignOutOnBrowserCloseEnabled() {
-            return true;
-        }
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -204,10 +204,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("FETCH_RP_PUBLIC_KEY_FROM_JWKS_ENABLED");
     }
 
-    public boolean isBrowserSessionCookieEnabled() {
-        return getFlagOrFalse("IS_BROWSER_SESSION_COOKIE_ENABLED");
-    }
-
     public String getSpotQueueURI() {
         return System.getenv("SPOT_QUEUE_URL");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -208,10 +208,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("IS_BROWSER_SESSION_COOKIE_ENABLED");
     }
 
-    public boolean isSignOutOnBrowserCloseEnabled() {
-        return getFlagOrFalse("IS_SIGN_OUT_ON_BROWSER_CLOSE_ENABLED");
-    }
-
     public String getSpotQueueURI() {
         return System.getenv("SPOT_QUEUE_URL");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -46,9 +46,7 @@ public class SessionService {
 
     public Session generateSession() {
         Session session = new Session(IdGenerator.generate());
-        if (configurationService.isBrowserSessionCookieEnabled()) {
-            session.setBrowserSessionId(IdGenerator.generate());
-        }
+        session.setBrowserSessionId(IdGenerator.generate());
 
         return session;
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
@@ -37,7 +37,6 @@ class SessionServiceTest {
     @Test
     void shouldCreateSessionWithNewSessionIdAndBrowserSessionId() {
         try (MockedStatic<IdGenerator> idGenerator = mockStatic(IdGenerator.class)) {
-            when(configuration.isBrowserSessionCookieEnabled()).thenReturn(true);
             idGenerator.when(IdGenerator::generate).thenReturn("id-1", "id-2");
             Session session = sessionService.generateSession();
 

--- a/template.yaml
+++ b/template.yaml
@@ -74,14 +74,6 @@ Conditions:
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]
-  EnableSignOutOnBrowserClose:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -2228,10 +2220,6 @@ Resources:
             - false
           IS_BROWSER_SESSION_COOKIE_ENABLED: !If
             - EnableBrowserSessionCookie
-            - true
-            - false
-          IS_SIGN_OUT_ON_BROWSER_CLOSE_ENABLED: !If
-            - EnableSignOutOnBrowserClose
             - true
             - false
 

--- a/template.yaml
+++ b/template.yaml
@@ -66,14 +66,6 @@ Conditions:
       !Equals [integration, !Ref Environment],
     ]
   IsIntegration: !Equals [!Ref Environment, integration]
-  EnableBrowserSessionCookie:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -2216,10 +2208,6 @@ Resources:
           TXMA_AUDIT_ENCODED_ENABLED: true
           FETCH_RP_PUBLIC_KEY_FROM_JWKS_ENABLED: !If
             - EnableFetchJwks
-            - true
-            - false
-          IS_BROWSER_SESSION_COOKIE_ENABLED: !If
-            - EnableBrowserSessionCookie
             - true
             - false
 


### PR DESCRIPTION
## What
Both feature flags relating to browserSessionId have been turned on all the way to prod, and are working as expected, so we have no need for the feature flags anymore. This PR deletes both the overarching `isBrowserSessionCookieEnabled` and the `isSignOutOnBrowserCloseEnabled` flags.

## How to review
1. Code Review
2. Search codebase for any instance of these flags