### PR TITLE
ATO-922: add logging to verify if session email is null in DocApp

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -302,6 +302,11 @@ public class DocAppCallbackHandler
                                         "Successful", Boolean.toString(true)));
                 cloudwatchMetricsService.incrementCounter("DocAppCallback", dimensions);
 
+                // TODO: ATO-922: delete once verified that session has no email address in DocApp
+                // journey
+                LOG.info("is session email address null: {}", session.getEmailAddress() == null);
+                //
+
                 var authCode =
                         authorisationCodeService.generateAndSaveAuthorisationCode(
                                 clientSessionId, session.getEmailAddress(), clientSession);


### PR DESCRIPTION
## What
The email is added to the session in `CheckUserExistsHandler` in authentication, so in a doc app journey, this should be null. If it is, we can remove the use of email in the doc app journey.

## How to review
1. Code Review