### PR TITLE
AUT-3800: Add values required by acceptance tests into SSM

### DIFF
--- a/ci/terraform/account-management/acceptance-test-values.tf
+++ b/ci/terraform/account-management/acceptance-test-values.tf
@@ -1,0 +1,22 @@
+resource "aws_ssm_parameter" "at_internal_am_api" {
+  name  = "/acceptance-tests/${var.environment}/INTERNAL_AM_API"
+  type  = "String"
+  value = "https://${local.account_management_api_fqdn}/"
+}
+
+import {
+  to = aws_ssm_parameter.at_internal_am_api
+  id = "/acceptance-tests/${var.environment}/INTERNAL_AM_API"
+}
+
+resource "aws_ssm_parameter" "at_email_verify_code" {
+  name  = "/acceptance-tests/${var.environment}/EMAIL_VERIFY_CODE"
+  type  = "String"
+  value = var.test_client_verify_email_otp
+}
+
+resource "aws_ssm_parameter" "at_phone_verify_code" {
+  name  = "/acceptance-tests/${var.environment}/PHONE_VERIFY_CODE"
+  type  = "String"
+  value = var.test_client_verify_phone_number_otp
+}

--- a/ci/terraform/shared/acceptance-test-values.tf
+++ b/ci/terraform/shared/acceptance-test-values.tf
@@ -1,0 +1,47 @@
+resource "aws_ssm_parameter" "at_terms_and_conditions_version" {
+  name  = "/acceptance-tests/${var.environment}/TERMS_AND_CONDITIONS_VERSION"
+  type  = "String"
+  value = var.terms_and_conditions
+}
+
+resource "aws_ssm_parameter" "at_email_address_format" {
+  name  = "/acceptance-tests/${var.environment}/EMAIL_ADDRESS_FORMAT"
+  type  = "String"
+  value = local.acceptance_test_rp_client_emails.pattern
+}
+
+resource "aws_ssm_parameter" "at_sector_host" {
+  name  = "/acceptance-tests/${var.environment}/SECTOR_HOST"
+  type  = "String"
+  value = "identity.${local.service_domain}"
+}
+import {
+  to = aws_ssm_parameter.at_sector_host
+  id = "/acceptance-tests/${var.environment}/SECTOR_HOST"
+}
+
+resource "aws_ssm_parameter" "at_rp_url" {
+  name  = "/acceptance-tests/${var.environment}/RP_URL"
+  type  = "String"
+  value = var.orch_stub_deployed ? "https://orchstub.signin.${local.service_domain}/" : "${var.stub_rp_clients[index(var.stub_rp_clients.*.at_client, true)].sector_identifier_uri}/?relyingParty=${random_string.stub_relying_party_client_id[var.stub_rp_clients[index(var.stub_rp_clients.*.at_client, true)].client_name].result}"
+}
+import {
+  to = aws_ssm_parameter.at_rp_url
+  id = "/acceptance-tests/${var.environment}/RP_URL"
+}
+
+resource "aws_ssm_parameter" "at_rp_type" {
+  name  = "/acceptance-tests/${var.environment}/STUB_RP_TYPE"
+  type  = "String"
+  value = var.orch_stub_deployed ? "ORCHESTRATION" : "LEGACY"
+}
+
+resource "aws_ssm_parameter" "at_doc_app_url" {
+  name  = "/acceptance-tests/${var.environment}/DOC_APP_URL"
+  type  = "String"
+  value = var.stub_rp_clients[index(var.stub_rp_clients.*.client_name, "relying-party-stub-${var.environment}-app")].sector_identifier_uri
+}
+import {
+  to = aws_ssm_parameter.at_doc_app_url
+  id = "/acceptance-tests/${var.environment}/DOC_APP_URL"
+}

--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -6,9 +6,11 @@ password_pepper     = "fake-pepper"
 enable_api_gateway_execution_request_tracing = true
 di_tools_signing_profile_version_arn         = "arn:aws:signer:eu-west-2:706615647326:/signing-profiles/di_auth_lambda_signing_20220214175605677200000001/ZPqg7ZUgCP"
 
+orch_stub_deployed = false
 stub_rp_clients = [
   {
     client_name           = "di-auth-stub-relying-party-authdev1"
+    at_client             = true # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://rp-dev.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-dev.build.stubs.account.gov.uk/oidc/authorization-code/callback",
@@ -25,6 +27,32 @@ stub_rp_clients = [
       "phone",
       "wallet-subject-id",
       "am"
+    ]
+    one_login_service = false
+    service_type      = "MANDATORY"
+  },
+  {
+    // this client may or may not work. It's needed for the SSM parameter generation though, so this could be classed as a dummy entry.
+    client_name           = "relying-party-stub-authdev1-app"
+    at_client             = false # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
+    sector_identifier_uri = "https://doc-app-rp-dev.build.stubs.account.gov.uk"
+    callback_urls = [
+      "https://doc-app-rp-dev.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+      "http://localhost:8080/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://doc-app-rp-dev.build.stubs.account.gov.uk/signed-out",
+      "http://localhost:8080/signed-out",
+    ]
+    test_client                     = "1"
+    identity_verification_supported = "1"
+    client_type                     = "app"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+      "wallet-subject-id",
+      "doc-checking-app"
     ]
     one_login_service = false
     service_type      = "MANDATORY"

--- a/ci/terraform/shared/authdev2.tfvars
+++ b/ci/terraform/shared/authdev2.tfvars
@@ -6,9 +6,11 @@ password_pepper     = "fake-pepper"
 enable_api_gateway_execution_request_tracing = true
 di_tools_signing_profile_version_arn         = "arn:aws:signer:eu-west-2:706615647326:/signing-profiles/di_auth_lambda_signing_20220214175605677200000001/ZPqg7ZUgCP"
 
+orch_stub_deployed = false
 stub_rp_clients = [
   {
     client_name           = "di-auth-stub-relying-party-authdev2"
+    at_client             = true # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://rp-dev.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-dev.build.stubs.account.gov.uk/oidc/authorization-code/callback",
@@ -24,6 +26,32 @@ stub_rp_clients = [
       "email",
       "phone",
       "wallet-subject-id",
+    ]
+    one_login_service = false
+    service_type      = "MANDATORY"
+  },
+  {
+    // this client may or may not work. It's needed for the SSM parameter generation though, so this could be classed as a dummy entry.
+    client_name           = "relying-party-stub-authdev2-app"
+    at_client             = false # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
+    sector_identifier_uri = "https://doc-app-rp-dev.build.stubs.account.gov.uk"
+    callback_urls = [
+      "https://doc-app-rp-dev.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+      "http://localhost:8080/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://doc-app-rp-dev.build.stubs.account.gov.uk/signed-out",
+      "http://localhost:8080/signed-out",
+    ]
+    test_client                     = "1"
+    identity_verification_supported = "1"
+    client_type                     = "app"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+      "wallet-subject-id",
+      "doc-checking-app"
     ]
     one_login_service = false
     service_type      = "MANDATORY"

--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -1,6 +1,7 @@
 stub_rp_clients = [
   {
     client_name           = "relying-party-stub-build"
+    at_client             = false # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://rp-build.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-build.build.stubs.account.gov.uk/oidc/authorization-code/callback",
@@ -25,6 +26,7 @@ stub_rp_clients = [
   },
   {
     client_name           = "relying-party-stub-build-app"
+    at_client             = false # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://doc-app-rp-build.build.stubs.account.gov.uk"
     callback_urls = [
       "https://doc-app-rp-build.build.stubs.account.gov.uk/oidc/authorization-code/callback",
@@ -46,6 +48,7 @@ stub_rp_clients = [
   },
   {
     client_name           = "relying-party-stub-build-acceptance-test"
+    at_client             = true # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://acceptance-test-rp-build.build.stubs.account.gov.uk"
     callback_urls = [
       "https://acceptance-test-rp-build.build.stubs.account.gov.uk/oidc/authorization-code/callback",
@@ -70,6 +73,7 @@ stub_rp_clients = [
   },
   {
     client_name           = "relying-party-micro-stub-build-acceptance-test"
+    at_client             = false # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://acceptance-test-rp-micro-stub-build.build.stubs.account.gov.uk"
     callback_urls = [
       "http://localhost:3031/callback",
@@ -95,6 +99,7 @@ stub_rp_clients = [
   {
     # New client for Secure pipeline Migration
     client_name           = "relying-party-stub-build-sp"
+    at_client             = false # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://rp-build-sp.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-build-sp.build.stubs.account.gov.uk/oidc/authorization-code/callback",

--- a/ci/terraform/shared/dev-stub-clients.tfvars
+++ b/ci/terraform/shared/dev-stub-clients.tfvars
@@ -1,6 +1,7 @@
 stub_rp_clients = [
   {
     client_name           = "relying-party-stub-dev"
+    at_client             = true # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://rp-dev.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-dev.build.stubs.account.gov.uk/oidc/authorization-code/callback",
@@ -25,6 +26,7 @@ stub_rp_clients = [
   },
   {
     client_name           = "relying-party-stub-dev-app"
+    at_client             = false # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://doc-app-rp-dev.build.stubs.account.gov.uk"
     callback_urls = [
       "https://doc-app-rp-dev.build.stubs.account.gov.uk/oidc/authorization-code/callback",

--- a/ci/terraform/shared/dns.tf
+++ b/ci/terraform/shared/dns.tf
@@ -1,0 +1,6 @@
+locals {
+  prod           = var.environment == "production" ? "account.gov.uk" : ""
+  sandpitdevs    = var.environment == "authdev1" || var.environment == "authdev2" ? "${var.environment}.sandpit.account.gov.uk" : ""
+  otherenv       = var.environment != "production" && var.environment != "authdev1" && var.environment != "authdev2" ? "${var.environment}.account.gov.uk" : ""
+  service_domain = coalesce(local.prod, local.sandpitdevs, local.otherenv)
+}

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -1,6 +1,7 @@
 stub_rp_clients = [
   {
     client_name           = "relying-party-stub-integration"
+    at_client             = true # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://rp-integration.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-integration.build.stubs.account.gov.uk/oidc/authorization-code/callback",
@@ -22,6 +23,7 @@ stub_rp_clients = [
   },
   {
     client_name           = "relying-party-stub-integration-app"
+    at_client             = false # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://doc-app-rp-integration.build.stubs.account.gov.uk"
     callback_urls = [
       "https://doc-app-rp-integration.build.stubs.account.gov.uk/oidc/authorization-code/callback",

--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -1,6 +1,7 @@
 stub_rp_clients = [
   {
     client_name           = "relying-party-stub-production"
+    at_client             = true # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://rp.stubs.account.gov.uk"
     callback_urls = [
       "https://rp.stubs.account.gov.uk/oidc/authorization-code/callback",
@@ -22,6 +23,7 @@ stub_rp_clients = [
   },
   {
     client_name           = "relying-party-stub-production-app"
+    at_client             = false # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://doc-app-rp.stubs.account.gov.uk"
     callback_urls = [
       "https://doc-app-rp.stubs.account.gov.uk/oidc/authorization-code/callback",

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -6,9 +6,11 @@ password_pepper     = "fake-pepper"
 enable_api_gateway_execution_request_tracing = true
 di_tools_signing_profile_version_arn         = "arn:aws:signer:eu-west-2:706615647326:/signing-profiles/di_auth_lambda_signing_20220214175605677200000001/ZPqg7ZUgCP"
 
+orch_stub_deployed = false
 stub_rp_clients = [
   {
     client_name           = "relying-party-stub-sandpit"
+    at_client             = true
     sector_identifier_uri = "https://rp-dev.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-dev.build.stubs.account.gov.uk/oidc/authorization-code/callback",
@@ -30,6 +32,7 @@ stub_rp_clients = [
   },
   {
     client_name           = "relying-party-stub-sandpit-app"
+    at_client             = false
     sector_identifier_uri = "https://doc-app-rp-dev.build.stubs.account.gov.uk"
     callback_urls = [
       "https://doc-app-rp-dev.build.stubs.account.gov.uk/oidc/authorization-code/callback",

--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -1,6 +1,7 @@
 stub_rp_clients = [
   {
     client_name           = "relying-party-stub-staging"
+    at_client             = false # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://rp-staging.build.stubs.account.gov.uk"
     callback_urls = [
       "https://rp-staging.build.stubs.account.gov.uk/oidc/authorization-code/callback",
@@ -23,6 +24,7 @@ stub_rp_clients = [
   },
   {
     client_name           = "relying-party-stub-staging-app"
+    at_client             = false # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://doc-app-rp-staging.build.stubs.account.gov.uk"
     callback_urls = [
       "https://doc-app-rp-staging.build.stubs.account.gov.uk/oidc/authorization-code/callback",
@@ -42,6 +44,7 @@ stub_rp_clients = [
   },
   {
     client_name           = "relying-party-stub-staging-perf-test"
+    at_client             = true # This client is the one used for acceptance tests. there should be exactly one of these marked as true.
     sector_identifier_uri = "https://perf-test-rp-staging.build.stubs.account.gov.uk"
     callback_urls = [
       "https://perf-test-rp-staging.build.stubs.account.gov.uk/oidc/authorization-code/callback",

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -15,6 +15,13 @@ resource "random_string" "stub_relying_party_client_id" {
   length  = 32
 }
 
+locals {
+  acceptance_test_rp_client_emails = {
+    pattern = "test-user+${var.environment}-$${instantiationMillis}-$${counter}@test.null.local" # '$${' = literal '${' (escaped)
+    regex   = "^test-user\\+${var.environment}-\\d+-\\d+@test\\.null\\.local$"
+  }
+}
+
 resource "aws_dynamodb_table_item" "stub_relying_party_client" {
   for_each = { for client in var.stub_rp_clients : client.client_name => client }
 
@@ -101,7 +108,7 @@ resource "aws_dynamodb_table_item" "stub_relying_party_client" {
       N = each.value.test_client
     }
     TestClientEmailAllowlist = {
-      L = [for email in split(",", var.test_client_email_allowlist) : {
+      L = [for email in concat(split(",", var.test_client_email_allowlist), [local.acceptance_test_rp_client_emails.regex]) : {
         S = email
       }]
     }

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -89,8 +89,22 @@ variable "logging_endpoint_arns" {
 
 variable "stub_rp_clients" {
   default     = []
-  type        = list(object({ client_name : string, sector_identifier_uri : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, one_login_service : bool, service_type : string }))
+  type        = list(object({ client_name : string, at_client : bool, sector_identifier_uri : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, one_login_service : bool, service_type : string }))
   description = "The details of RP clients to provision in the Client table"
+  validation {
+    condition     = length(var.stub_rp_clients) > 0
+    error_message = "At least one RP client must be defined"
+  }
+  validation {
+    condition     = length([for client in var.stub_rp_clients : client if client.at_client == true]) == 1
+    error_message = "Exactly one RP client must be marked as the acceptance test client, with `at_client = true`"
+  }
+}
+
+variable "orch_stub_deployed" {
+  type        = bool
+  default     = true
+  description = "Whether the orchestration stub has been deployed"
 }
 
 variable "aws_region" {

--- a/scripts/fix-lambda-aliases.sh
+++ b/scripts/fix-lambda-aliases.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+export ENVIRONMENT="${1:-}"
+
+if [[ -z ${ENVIRONMENT} ]]; then
+  echo "Usage: $0 <environment>"
+  exit 1
+fi
+
+if [[ ${ENVIRONMENT} == authdev* ]] || [[ ${ENVIRONMENT} == "dev" ]]; then
+  export AWS_PROFILE="di-auth-development-admin"
+elif [ "${ENVIRONMENT}" == "sandpit" ] || [ "${ENVIRONMENT}" == "build" ] || [ "${ENVIRONMENT}" == "integration" ]; then
+  export AWS_PROFILE="gds-di-development-admin"
+elif [ "${ENVIRONMENT}" == "staging" ]; then
+  export AWS_PROFILE="di-auth-staging-admin"
+elif [ "${ENVIRONMENT}" == "production" ]; then
+  export AWS_PROFILE="gds-di-production-admin"
+else
+  echo "Unknown environment: ${ENVIRONMENT}"
+  exit 1
+fi
+
+# shellcheck source=scripts/export_aws_creds.sh
+source "${DIR}/export_aws_creds.sh"
+
+mapfile -t function_names < <(aws lambda list-functions --max-items 10000 --query "Functions[?starts_with(FunctionName, '${ENVIRONMENT}-')].FunctionName" --output text | sed 's/\t/\n/g')
+
+for function_name in "${function_names[@]}"; do
+  if routing_config="$(aws lambda get-alias --function-name "${function_name}" --name "${function_name}-active" 2> /dev/null | jq --exit-status '.RoutingConfig' 2> /dev/null)"; then
+    correct_version="$(echo "${routing_config}" | jq -r '.AdditionalVersionWeights | keys | .[0]')"
+    aws lambda update-alias --function-name "${function_name}" --name "${function_name}-active" --function-version "${correct_version}" --routing-config AdditionalVersionWeights={} > /dev/null
+    echo "Pointed broken alias ${function_name}-active to version ${correct_version}"
+  fi
+done


### PR DESCRIPTION
## What

Create SSM parameters with values required by the acceptance tests.

This allows us to provide the acceptance tests with the actual configured values,
rather than manually duplicating the configured values in each environment

## How to review

- Code review
- test deploy in authdev / sandpit environments and ensure that the right values are created.

