### PR TITLE
BAU: update OrchSessionItem item to always require a sessionId

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1119,7 +1119,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     private void withExistingOrchSession(String sessionId) {
-        orchSessionExtension.addSession(new OrchSessionItem().withSessionId(sessionId));
+        orchSessionExtension.addSession(new OrchSessionItem(sessionId));
         assertTrue(orchSessionExtension.getSession(sessionId).isPresent());
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchSessionServiceIntegrationTest.java
@@ -36,6 +36,6 @@ class OrchSessionServiceIntegrationTest {
     }
 
     private void withSession() {
-        orchSessionExtension.addSession(new OrchSessionItem().withSessionId(SESSION_ID));
+        orchSessionExtension.addSession(new OrchSessionItem(SESSION_ID));
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -512,7 +512,7 @@ public class AuthorisationHandler
         OrchSessionItem orchSession;
         String newSessionId = session.getSessionId();
         if (orchSessionOptional.isEmpty()) {
-            orchSession = new OrchSessionItem().withSessionId(newSessionId);
+            orchSession = new OrchSessionItem(newSessionId);
             LOG.info("Created new Orch session");
         } else {
             String previousOrchSessionId = orchSessionOptional.get().getSessionId();
@@ -625,7 +625,7 @@ public class AuthorisationHandler
         OrchSessionItem orchSession;
         String newSessionId = session.getSessionId();
         if (orchSessionOptional.isEmpty()) {
-            orchSession = new OrchSessionItem().withSessionId(newSessionId);
+            orchSession = new OrchSessionItem(newSessionId);
             LOG.info("Created new Orch session");
         } else {
             String previousOrchSessionId = orchSessionOptional.get().getSessionId();

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -292,7 +292,7 @@ class AuthorisationHandlerTest {
                         authFrontend,
                         authorisationService);
         session = new Session(SESSION_ID);
-        orchSession = new OrchSessionItem().withSessionId(SESSION_ID);
+        orchSession = new OrchSessionItem(SESSION_ID);
         when(sessionService.generateSession()).thenReturn(session);
         when(clientSessionService.generateClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(clientSessionService.generateClientSession(any(), any(), any(), any()))

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -14,6 +14,10 @@ public class OrchSessionItem {
 
     public OrchSessionItem() {}
 
+    public OrchSessionItem(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
     @DynamoDbPartitionKey
     @DynamoDbAttribute(ATTRIBUTE_SESSION_ID)
     public String getSessionId() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
@@ -75,8 +75,7 @@ public class OrchSessionService extends BaseDynamoService<OrchSessionItem> {
                         newSessionId);
             } else {
                 newItem =
-                        new OrchSessionItem()
-                                .withSessionId(newSessionId)
+                        new OrchSessionItem(newSessionId)
                                 .withTimeToLive(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
@@ -60,7 +60,7 @@ class OrchSessionServiceTest {
     @Test
     void updateSessionThrowsOrchSessionExceptionWhenUpdateFails() {
         withFailedUpdate();
-        var sessionToBeUpdated = new OrchSessionItem().withSessionId(SESSION_ID);
+        var sessionToBeUpdated = new OrchSessionItem(SESSION_ID);
         assertThrows(
                 OrchSessionException.class,
                 () -> orchSessionService.updateSession(sessionToBeUpdated));
@@ -106,18 +106,14 @@ class OrchSessionServiceTest {
     }
 
     private OrchSessionItem withValidSession() {
-        OrchSessionItem existingSession =
-                new OrchSessionItem().withSessionId(SESSION_ID).withTimeToLive(VALID_TTL);
+        OrchSessionItem existingSession = new OrchSessionItem(SESSION_ID).withTimeToLive(VALID_TTL);
         when(table.getItem(SESSION_ID_PARTITION_KEY)).thenReturn(existingSession);
         return existingSession;
     }
 
     private void withExpiredSession() {
         when(table.getItem(SESSION_ID_PARTITION_KEY))
-                .thenReturn(
-                        new OrchSessionItem()
-                                .withSessionId(SESSION_ID)
-                                .withTimeToLive(EXPIRED_TTL));
+                .thenReturn(new OrchSessionItem(SESSION_ID).withTimeToLive(EXPIRED_TTL));
     }
 
     private void withFailedUpdate() {


### PR DESCRIPTION
## What
sessionId is the primary key of the table, so any OrchSessionItem must have a sessionId associated with it. By removing the OrchSessionItem constructor with no arguments, we insist that any OrchSessionItem will have a sessionId.

## How to review
1. Code Review