### PR TITLE
AUT-3749: Add reauth metrics

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
@@ -66,15 +66,18 @@ public class ReauthMetadataBuilder {
     }
 
     public ReauthMetadataBuilder withFailureReason(List<CountType> exceededCountTypes) {
+        return withFailureReason(getReauthFailureReasonFromCountTypes(exceededCountTypes));
+    }
+
+    public static ReauthFailureReasons getReauthFailureReasonFromCountTypes(
+            List<CountType> exceededCountTypes) {
         CountType exceededType = exceededCountTypes.get(0);
-        ReauthFailureReasons reauthFailureReason =
-                switch (exceededType) {
-                    case ENTER_EMAIL -> ReauthFailureReasons.INCORRECT_EMAIL;
-                    case ENTER_PASSWORD -> ReauthFailureReasons.INCORRECT_PASSWORD;
-                    case ENTER_AUTH_APP_CODE, ENTER_SMS_CODE -> ReauthFailureReasons.INCORRECT_OTP;
-                    default -> null;
-                };
-        return withFailureReason(reauthFailureReason);
+        return switch (exceededType) {
+            case ENTER_EMAIL -> ReauthFailureReasons.INCORRECT_EMAIL;
+            case ENTER_PASSWORD -> ReauthFailureReasons.INCORRECT_PASSWORD;
+            case ENTER_AUTH_APP_CODE, ENTER_SMS_CODE -> ReauthFailureReasons.INCORRECT_OTP;
+            default -> null;
+        };
     }
 
     public AuditService.MetadataPair[] build() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.frontendapi.entity.StartRequest;
 import uk.gov.di.authentication.frontendapi.entity.StartResponse;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.services.StartService;
+import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
@@ -27,6 +28,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -39,6 +41,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -66,6 +69,7 @@ public class StartHandler
     private final AuthSessionService authSessionService;
     private final ConfigurationService configurationService;
     private final AuthenticationAttemptsService authenticationAttemptsService;
+    private final CloudwatchMetricsService cloudwatchMetricsService;
     private final Json objectMapper = SerializationService.getInstance();
 
     public StartHandler(
@@ -75,7 +79,8 @@ public class StartHandler
             StartService startService,
             AuthSessionService authSessionService,
             ConfigurationService configurationService,
-            AuthenticationAttemptsService authenticationAttemptsService) {
+            AuthenticationAttemptsService authenticationAttemptsService,
+            CloudwatchMetricsService cloudwatchMetricsService) {
         this.clientSessionService = clientSessionService;
         this.sessionService = sessionService;
         this.auditService = auditService;
@@ -83,6 +88,7 @@ public class StartHandler
         this.authSessionService = authSessionService;
         this.configurationService = configurationService;
         this.authenticationAttemptsService = authenticationAttemptsService;
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
     }
 
     public StartHandler(ConfigurationService configurationService) {
@@ -98,6 +104,7 @@ public class StartHandler
                         sessionService);
         this.authSessionService = new AuthSessionService(configurationService);
         this.configurationService = configurationService;
+        this.cloudwatchMetricsService = new CloudwatchMetricsService();
     }
 
     public StartHandler(ConfigurationService configurationService, RedisConnectionService redis) {
@@ -113,6 +120,7 @@ public class StartHandler
                         sessionService);
         this.authSessionService = new AuthSessionService(configurationService);
         this.configurationService = configurationService;
+        this.cloudwatchMetricsService = new CloudwatchMetricsService();
     }
 
     public StartHandler() {
@@ -211,7 +219,7 @@ public class StartHandler
                             txmaAuditHeader);
 
             if (reauthenticate) {
-                emitReauthRequestedEvent(startRequest, auditContext);
+                emitReauthRequestedObservability(startRequest, auditContext);
             }
 
             boolean isBlockedForReauth = false;
@@ -300,7 +308,8 @@ public class StartHandler
         return !blockedCountTypes.isEmpty();
     }
 
-    private void emitReauthRequestedEvent(StartRequest startRequest, AuditContext auditContext) {
+    private void emitReauthRequestedObservability(
+            StartRequest startRequest, AuditContext auditContext) {
         var metadataPairs = new ArrayList<AuditService.MetadataPair>();
         var previousSigninJourneyId = startRequest.previousGovUkSigninJourneyId();
         if (!(previousSigninJourneyId == null || previousSigninJourneyId.isEmpty())) {
@@ -314,5 +323,8 @@ public class StartHandler
                 FrontendAuditableEvent.AUTH_REAUTH_REQUESTED,
                 auditContext,
                 metadataPairs.toArray(AuditService.MetadataPair[]::new));
+        cloudwatchMetricsService.incrementCounter(
+                CloudwatchMetrics.REAUTH_REQUESTED.getValue(),
+                Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -82,6 +82,7 @@ import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.I
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.frontendapi.lambda.StartHandler.REAUTHENTICATE_HEADER;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_AUTH_APP_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
@@ -455,6 +456,14 @@ class StartHandlerTest {
                         AuditService.MetadataPair.pair(
                                 "incorrect_otp_code_attempt_count", expectedOtpAttemptCount),
                         AuditService.MetadataPair.pair("failure-reason", expectedFailureReason));
+        verify(cloudwatchMetricsService)
+                .incrementCounter(
+                        CloudwatchMetrics.REAUTH_FAILED.getValue(),
+                        Map.of(
+                                ENVIRONMENT.getValue(),
+                                configurationService.getEnvironment(),
+                                FAILURE_REASON.getValue(),
+                                expectedFailureReason));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -29,6 +29,7 @@ import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.entity.StartResponse;
 import uk.gov.di.authentication.frontendapi.entity.UserStartInfo;
 import uk.gov.di.authentication.frontendapi.services.StartService;
+import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CountType;
@@ -43,6 +44,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
@@ -79,6 +81,7 @@ import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.E
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.frontendapi.lambda.StartHandler.REAUTHENTICATE_HEADER;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_AUTH_APP_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
@@ -118,6 +121,8 @@ class StartHandlerTest {
     private final UserContext userContext = mock(UserContext.class);
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final CloudwatchMetricsService cloudwatchMetricsService =
+            mock(CloudwatchMetricsService.class);
     private final Session session = new Session(SESSION_ID);
     private final ClientSession clientSession = getClientSession();
     private final ClientSession docAppClientSession = getDocAppClientSession();
@@ -136,6 +141,7 @@ class StartHandlerTest {
     @BeforeEach
     void beforeEach() {
         when(configurationService.isIdentityEnabled()).thenReturn(true);
+        when(configurationService.getEnvironment()).thenReturn("test");
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(sessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(new Session("session-id")));
@@ -150,7 +156,8 @@ class StartHandlerTest {
                         startService,
                         authSessionService,
                         configurationService,
-                        authenticationAttemptsService);
+                        authenticationAttemptsService,
+                        cloudwatchMetricsService);
     }
 
     private static Stream<Arguments> cookieConsentGaTrackingIdValues() {
@@ -265,6 +272,10 @@ class StartHandlerTest {
                         AUDIT_CONTEXT,
                         pair("previous_govuk_signin_journey_id", TEST_PREVIOUS_SIGN_IN_JOURNEY_ID),
                         pair("rpPairwiseId", TEST_RP_PAIRWISE_ID));
+        verify(cloudwatchMetricsService)
+                .incrementCounter(
+                        CloudwatchMetrics.REAUTH_REQUESTED.getValue(),
+                        Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
     }
 
     @Test
@@ -339,6 +350,10 @@ class StartHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_REAUTH_REQUESTED,
                         AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()));
+        verify(cloudwatchMetricsService)
+                .incrementCounter(
+                        CloudwatchMetrics.REAUTH_REQUESTED.getValue(),
+                        Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
     }
 
     @Test
@@ -362,6 +377,10 @@ class StartHandlerTest {
                         eq(FrontendAuditableEvent.AUTH_REAUTH_REQUESTED),
                         any(),
                         any(AuditService.MetadataPair[].class));
+        verify(cloudwatchMetricsService, never())
+                .incrementCounter(
+                        CloudwatchMetrics.REAUTH_REQUESTED.getValue(),
+                        Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
     }
 
     private static Stream<Arguments> reauthCountTypesAndExpectedMetadata() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
@@ -9,7 +9,8 @@ public enum CloudwatchMetricDimensions {
     MFA_REQUIRED("MfaRequired"),
     CLIENT_NAME("ClientName"),
     CREDENTIAL_TYPE("CredentialType"),
-    JOURNEY_TYPE("JourneyType");
+    JOURNEY_TYPE("JourneyType"),
+    FAILURE_REASON("FailureReason");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -9,6 +9,7 @@ public enum CloudwatchMetrics {
     SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT("SignInExistingAccountByClient"),
     LOGOUT_SUCCESS("LogoutSuccess"),
     EMAIL_CHECK_DURATION("EmailCheckDuration"),
+    REAUTH_REQUESTED("ReauthRequested"),
     MFA_RESET_HANDOFF("MfaResetHandoff"),
     ACCESS_TOKEN_SERVICE_INITIAL_QUERY_ATTEMPT("AccessTokenServiceInitialQueryAttempt"),
     ACCESS_TOKEN_SERVICE_INITIAL_QUERY_SUCCESS("AccessTokenServiceInitialQuerySuccess"),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -10,6 +10,7 @@ public enum CloudwatchMetrics {
     LOGOUT_SUCCESS("LogoutSuccess"),
     EMAIL_CHECK_DURATION("EmailCheckDuration"),
     REAUTH_REQUESTED("ReauthRequested"),
+    REAUTH_SUCCESS("ReauthSuccess"),
     MFA_RESET_HANDOFF("MfaResetHandoff"),
     ACCESS_TOKEN_SERVICE_INITIAL_QUERY_ATTEMPT("AccessTokenServiceInitialQueryAttempt"),
     ACCESS_TOKEN_SERVICE_INITIAL_QUERY_SUCCESS("AccessTokenServiceInitialQuerySuccess"),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -10,6 +10,7 @@ public enum CloudwatchMetrics {
     LOGOUT_SUCCESS("LogoutSuccess"),
     EMAIL_CHECK_DURATION("EmailCheckDuration"),
     REAUTH_REQUESTED("ReauthRequested"),
+    REAUTH_FAILED("ReauthFailed"),
     REAUTH_SUCCESS("ReauthSuccess"),
     MFA_RESET_HANDOFF("MfaResetHandoff"),
     ACCESS_TOKEN_SERVICE_INITIAL_QUERY_ATTEMPT("AccessTokenServiceInitialQueryAttempt"),


### PR DESCRIPTION
## What

- Add `ReauthRequested` metric
  - Metric raised when the reauth journey is started. 
- Add `ReauthSuccess` metric
  - Metric raised when the reauth journey is successfully completed. 
- Add `ReauthFailed` metric
  - Metric raised when the reauth journey has failed.
  - With this, also create `getReauthFailureReasonFromCountTypes()` method
    - The logic for deciding the reason from count types is extracted into it's own method so it can be used by both metric and audit event code.

These metrics are raised next to corresponding audit events for. They will allow us to chart this metric in dashboards and establish a pattern of use that will could spot issues.

## How to review

1. Code Review
