### PR TITLE
OLH-2122: Permit access to the KMS key for the account deletion topic

### DIFF
--- a/ci/terraform/account-management/staging.tfvars
+++ b/ci/terraform/account-management/staging.tfvars
@@ -5,4 +5,5 @@ common_state_bucket   = "di-auth-staging-tfstate"
 
 openapi_spec_filename = "openapi_v2.yaml"
 
-legacy_account_deletion_topic_arn = "arn:aws:sns:eu-west-2:539729775994:UserAccountDeletion"
+legacy_account_deletion_topic_arn     = "arn:aws:sns:eu-west-2:539729775994:UserAccountDeletion"
+legacy_account_deletion_topic_key_arn = "arn:aws:kms:eu-west-2:539729775994:key/d33e9077-8d66-4f63-99a1-f90e29b4aabe"

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -230,6 +230,12 @@ variable "legacy_account_deletion_topic_arn" {
   default     = null
 }
 
+variable "legacy_account_deletion_topic_key_arn" {
+  type        = string
+  description = "KMS ARN for the key for the account deletion topic owned by Home for use with the manual account deletion lambda."
+  default     = ""
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What

Add permissions for KMS key on SNS topic, follow up to https://github.com/govuk-one-login/authentication-api/pull/5364
