### PR TITLE
ATO-1049: Adjust alerting when AIS fails open

### DIFF
--- a/ci/terraform/oidc/account-interventions-alerts.tf
+++ b/ci/terraform/oidc/account-interventions-alerts.tf
@@ -16,9 +16,13 @@ resource "aws_cloudwatch_log_metric_filter" "account_interventions_metric_filter
   }
 }
 
+locals {
+  isP1Alarm = var.environment == "production" && var.account_intervention_service_abort_on_error
+}
+
 resource "aws_cloudwatch_metric_alarm" "account_interventions_p1_cloudwatch_alarm" {
   count               = var.use_localstack ? 0 : 1
-  alarm_name          = replace("${var.environment}-P1-account-interventions-alarm", ".", "")
+  alarm_name          = local.isP1Alarm ? replace("${var.environment}-P1-account-interventions-alarm", ".", "") : replace("${var.environment}-account-interventions-alarm", ".", "")
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.account_interventions_metric_filter[0].metric_transformation[0].name
@@ -27,5 +31,5 @@ resource "aws_cloudwatch_metric_alarm" "account_interventions_p1_cloudwatch_alar
   statistic           = "Sum"
   threshold           = var.account_interventions_p1_alarm_error_threshold
   alarm_description   = "${var.account_interventions_p1_alarm_error_threshold} or more Account Interventions errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
-  alarm_actions       = [var.environment == "production" && var.account_intervention_service_abort_on_error ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : data.aws_sns_topic.slack_events.arn]
+  alarm_actions       = [local.isP1Alarm ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : data.aws_sns_topic.slack_events.arn]
 }

--- a/ci/terraform/oidc/ipv-handback-alerts.tf
+++ b/ci/terraform/oidc/ipv-handback-alerts.tf
@@ -63,6 +63,19 @@ resource "aws_cloudwatch_log_metric_filter" "processing_identity_metric_filter" 
   }
 }
 
+resource "aws_cloudwatch_log_metric_filter" "processing_identity_ais_fail_open_metric_filter" {
+  count          = var.use_localstack ? 0 : 1
+  name           = replace("${var.environment}-processing-identity-ais-fail-open-errors", ".", "")
+  pattern        = "{($.level = \"AIS_FAIL_OPEN\")}"
+  log_group_name = data.aws_cloudwatch_log_group.processing_identity_lambda_log_group[0].name
+
+  metric_transformation {
+    name      = replace("${var.environment}-ipv-handback-error-count", ".", "")
+    namespace = "LambdaErrorsNamespace"
+    value     = "1"
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "ipv_handback_p1_cloudwatch_alarm" {
   count               = var.use_localstack ? 0 : 1
   alarm_name          = replace("${var.environment}-P1-ipv-handback-alarm", ".", "")
@@ -75,5 +88,20 @@ resource "aws_cloudwatch_metric_alarm" "ipv_handback_p1_cloudwatch_alarm" {
   threshold           = var.ipv_p1_alarm_error_threshold
   alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more IPV handback errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
   alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : data.aws_sns_topic.slack_events.arn]
+  treat_missing_data  = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "ipv_handback_ais_fail_open_cloudwatch_alarm" {
+  count               = var.use_localstack ? 0 : 1
+  alarm_name          = replace("${var.environment}-ais-fail-open-ipv-handback-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.processing_identity_ais_fail_open_metric_filter[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.processing_identity_ais_fail_open_metric_filter[0].metric_transformation[0].namespace
+  period              = var.ipv_p1_alarm_error_time_period
+  statistic           = "Sum"
+  threshold           = var.ipv_p1_alarm_error_threshold
+  alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more errors have occured while communicating with Account Intervention Service in ${var.environment}. Currently failing open and assuming no intervention. ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
+  alarm_actions       = data.aws_sns_topic.slack_events.arn
   treat_missing_data  = "notBreaching"
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/contract/AccountInterventionServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/contract/AccountInterventionServiceTest.java
@@ -328,7 +328,8 @@ class AccountInterventionServiceTest {
                                 accountInterventionService.getAccountIntervention(
                                         INTERNAL_PAIRWISE_SUBJECT_ID, auditContext));
         assertEquals(
-                "Problem communicating with Account Intervention Service", exception.getMessage());
+                "Problem communicating with Account Intervention Service. Aborting user journey",
+                exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## What

A pager duty (P1) alarm shouldn't be triggered in the case that communication with Account Intervention Service fails, and the "abort on error" flag is false (ie. assuming no intervention).

This PR defines a custom log level (AIS_FAIL_OPEN) which a metric is set up on so we can have finer control over AIS alarms, and only send alerts to slack.

An alarm is also renamed to not include "P1" in the case that AIS fails open.

## Testing

AIS is only set up in staging and higher envs, so this needs to be deployed there to test. 

The plan is to force calls to AIS to fail by using an incorrect URI for AIS and check that the alarms are triggered as intended. I don't know how this can be fully tested as forcing AIS errors in prod isn't an option - suggestions welcome.
