### PR TITLE
ATO 980 use authenticated claim in backend

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -9,5 +9,6 @@ public record StartRequest(
         @Expose @SerializedName("rp-pairwise-id-for-reauth") String rpPairwiseIdForReauth,
         @Expose @SerializedName("previous-govuk-signin-journey-id")
                 String previousGovUkSigninJourneyId,
+        @Expose @SerializedName("authenticated") boolean authenticated,
         @Expose @SerializedName("current-credential-strength")
                 CredentialTrustLevel currentCredentialStrength) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -149,6 +149,14 @@ public class StartHandler
         if (clientSession.isEmpty()) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1018);
         }
+
+        StartRequest startRequest;
+        try {
+            startRequest = objectMapper.readValue(input.getBody(), StartRequest.class);
+        } catch (JsonException e) {
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+        }
+
         try {
             session =
                     startService.validateSession(
@@ -188,7 +196,6 @@ public class StartHandler
             Optional<String> maybeInternalCommonSubjectIdentifier =
                     Optional.ofNullable(session.getInternalCommonSubjectIdentifier());
 
-            StartRequest startRequest = objectMapper.readValue(input.getBody(), StartRequest.class);
             Optional<String> previousSessionId =
                     Optional.ofNullable(startRequest.previousSessionId());
             CredentialTrustLevel currentCredentialStrength =
@@ -272,7 +279,9 @@ public class StartHandler
             return generateApiGatewayProxyResponse(200, startResponse);
 
         } catch (JsonException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+            var errorMessage = "Unable to serialize start response";
+            LOG.error(errorMessage, e);
+            return generateApiGatewayProxyResponse(400, errorMessage);
         } catch (NoSuchElementException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1015);
         } catch (ParseException e) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -183,7 +183,9 @@ class StartHandlerTest {
         usingValidClientSession();
         usingValidSession();
 
-        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, "{}");
+        var event =
+                apiRequestEventWithHeadersAndBody(
+                        VALID_HEADERS, makeRequestBodyWithAuthenticatedField(false));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
@@ -203,6 +205,7 @@ class StartHandlerTest {
     @Test
     void shouldReturn200WhenDocCheckingAppUserIsPresent()
             throws ParseException, Json.JsonException {
+        var isAuthenticated = false;
         when(userContext.getClientSession()).thenReturn(docAppClientSession);
         when(configurationService.getDocAppDomain()).thenReturn(URI.create("https://doc-app"));
         var userStartInfo = new UserStartInfo(false, false, false, null, null, true, null, false);
@@ -219,7 +222,9 @@ class StartHandlerTest {
         usingValidDocAppClientSession();
         usingValidSession();
 
-        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, "{}");
+        var event =
+                apiRequestEventWithHeadersAndBody(
+                        VALID_HEADERS, makeRequestBodyWithAuthenticatedField(isAuthenticated));
         var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
@@ -241,6 +246,7 @@ class StartHandlerTest {
     @Test
     void shouldReturn200WithAuthenticatedFalseWhenAReauthenticationJourney()
             throws ParseException, Json.JsonException {
+        var isAuthenticated = false;
         var userStartInfo = new UserStartInfo(false, false, false, null, null, false, null, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         usingValidSession();
@@ -250,9 +256,10 @@ class StartHandlerTest {
                 format(
                         """
                { "rp-pairwise-id-for-reauth": %s,
-               "previous-govuk-signin-journey-id": %s }
+               "previous-govuk-signin-journey-id": %s,
+                "authenticated": %s}
                 """,
-                        TEST_RP_PAIRWISE_ID, TEST_PREVIOUS_SIGN_IN_JOURNEY_ID);
+                        TEST_RP_PAIRWISE_ID, TEST_PREVIOUS_SIGN_IN_JOURNEY_ID, isAuthenticated);
         var event = apiRequestEventWithHeadersAndBody(headersWithReauthenticate("true"), body);
         var result = handler.handleRequest(event, context);
 
@@ -281,6 +288,7 @@ class StartHandlerTest {
 
     @Test
     void shouldNotCallAuthenticationAttemptsServiceWhenFeatureFlagIsOff() throws ParseException {
+        var isAuthenticated = false;
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(false);
         var userStartInfo = new UserStartInfo(false, false, false, null, null, false, null, false);
 
@@ -296,9 +304,9 @@ class StartHandlerTest {
         var body =
                 format(
                         """
-               { "rp-pairwise-id-for-reauth": %s }
+               { "rp-pairwise-id-for-reauth": %s, "authenticated": %s }
                 """,
-                        TEST_RP_PAIRWISE_ID);
+                        TEST_RP_PAIRWISE_ID, isAuthenticated);
         var event = apiRequestEventWithHeadersAndBody(headersWithReauthenticate("true"), body);
         handler.handleRequest(event, context);
 
@@ -306,7 +314,8 @@ class StartHandlerTest {
     }
 
     @Test
-    void shouldUseCountsAgainstTheRpPairwiseIdWHhenThereIsNoSubjectId() throws ParseException {
+    void shouldUseCountsAgainstTheRpPairwiseIdWhenThereIsNoSubjectId() throws ParseException {
+        var isAuthenticated = false;
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
         when(userProfile.getSubjectID()).thenReturn(null);
 
@@ -318,9 +327,9 @@ class StartHandlerTest {
         var body =
                 format(
                         """
-               { "rp-pairwise-id-for-reauth": %s }
+               { "rp-pairwise-id-for-reauth": %s, "authenticated": %s }
                 """,
-                        TEST_RP_PAIRWISE_ID);
+                        TEST_RP_PAIRWISE_ID, isAuthenticated);
         var event = apiRequestEventWithHeadersAndBody(headersWithReauthenticate("true"), body);
         handler.handleRequest(event, context);
 
@@ -330,6 +339,7 @@ class StartHandlerTest {
 
     @Test
     void checkAuditEventStillEmittedWhenTICFHeaderNotProvided() throws ParseException {
+        var isAuthenticated = false;
         var userStartInfo = new UserStartInfo(false, false, false, null, null, false, null, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         usingValidSession();
@@ -337,7 +347,9 @@ class StartHandlerTest {
 
         var headers = headersWithReauthenticate("true");
         headers.remove(TXMA_AUDIT_ENCODED_HEADER);
-        var event = apiRequestEventWithHeadersAndBody(headers, "{}");
+        var event =
+                apiRequestEventWithHeadersAndBody(
+                        headers, makeRequestBodyWithAuthenticatedField(isAuthenticated));
 
         var result = handler.handleRequest(event, context);
 
@@ -360,12 +372,14 @@ class StartHandlerTest {
     @Test
     void shouldReturn200WithAuthenticatedTrueWhenReauthenticateHeaderNotSetToTrue()
             throws ParseException, Json.JsonException {
-        var userStartInfo = new UserStartInfo(false, false, true, null, null, false, null, false);
-        usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
+        var isAuthenticated = true;
         usingValidSession();
         usingValidClientSession();
 
-        var event = apiRequestEventWithHeadersAndBody(headersWithReauthenticate("false"), "{}");
+        var event =
+                apiRequestEventWithHeadersAndBody(
+                        headersWithReauthenticate("false"),
+                        makeRequestBodyWithAuthenticatedField(isAuthenticated));
         var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
@@ -428,17 +442,16 @@ class StartHandlerTest {
                         any(), any(), eq(JourneyType.REAUTHENTICATION)))
                 .thenReturn(Map.of(countType, MAX_ALLOWED_RETRIES));
 
-        var userStartInfo = new UserStartInfo(false, false, true, null, null, false, null, true);
-        usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
+        var isAuthenticated = true;
         usingValidSession();
         usingValidClientSession();
 
         var body =
                 format(
                         """
-               { "rp-pairwise-id-for-reauth": %s }
+               { "rp-pairwise-id-for-reauth": %s, "authenticated": %s }
                 """,
-                        TEST_RP_PAIRWISE_ID);
+                        TEST_RP_PAIRWISE_ID, isAuthenticated);
         var event = apiRequestEventWithHeadersAndBody(headersWithReauthenticate("true"), body);
 
         var result = handler.handleRequest(event, context);
@@ -469,7 +482,9 @@ class StartHandlerTest {
     @Test
     void shouldReturn400WhenClientSessionIsNotFound() throws Json.JsonException {
         usingInvalidClientSession();
-        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, "{}");
+        var event =
+                apiRequestEventWithHeadersAndBody(
+                        VALID_HEADERS, makeRequestBodyWithAuthenticatedField(false));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -484,7 +499,9 @@ class StartHandlerTest {
     void shouldReturn400WhenSessionIsNotFound() throws Json.JsonException {
         usingValidClientSession();
         usingInvalidSession();
-        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, "{}");
+        var event =
+                apiRequestEventWithHeadersAndBody(
+                        VALID_HEADERS, makeRequestBodyWithAuthenticatedField(false));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -504,7 +521,9 @@ class StartHandlerTest {
         usingValidClientSession();
         usingValidSession();
 
-        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, "{}");
+        var event =
+                apiRequestEventWithHeadersAndBody(
+                        VALID_HEADERS, makeRequestBodyWithAuthenticatedField(false));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -513,6 +532,10 @@ class StartHandlerTest {
         assertThat(result, hasBody(expectedResponse));
 
         verifyNoInteractions(auditService);
+    }
+
+    private String makeRequestBodyWithAuthenticatedField(boolean authenticated) {
+        return String.format("{\"authenticated\": %s}", authenticated);
     }
 
     private void usingValidClientSession() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -72,7 +72,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
     public static final String PREVIOUS_SESSION_ID = "4waJ14KA9IyxKzY7bIGIA3hUDos";
     public static final String REQUEST_BODY =
-            "{\"previous-session-id\":\"4waJ14KA9IyxKzY7bIGIA3hUDos\"}";
+            "{\"previous-session-id\":\"4waJ14KA9IyxKzY7bIGIA3hUDos\", \"authenticated\": %s}";
 
     @RegisterExtension
     protected static final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
@@ -98,7 +98,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             boolean identityRequired,
             boolean isAuthenticated)
             throws Json.JsonException {
-        String sessionId = redis.createSession(isAuthenticated);
+        String sessionId = redis.createSession();
         userStore.signUp(EMAIL, "password");
         redis.addEmailToSession(sessionId, EMAIL);
         var state = new State();
@@ -115,10 +115,9 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         redis.createClientSession(CLIENT_SESSION_ID, TEST_CLIENT_NAME, authRequest.toParameters());
 
         registerClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR(), ClientType.WEB);
-
         var response =
                 makeRequest(
-                        Optional.of(REQUEST_BODY),
+                        Optional.of(makeRequestBody(isAuthenticated)),
                         standardHeadersWithSessionId(sessionId),
                         Map.of());
         assertThat(response, hasStatus(200));
@@ -165,7 +164,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn200AndStartResponseWithAuthenticatedFalseWhenReauthenticationIsRequested()
             throws Json.JsonException {
-        String sessionId = redis.createSession(true);
+        String sessionId = redis.createSession();
         userStore.signUp(EMAIL, "password");
         redis.addEmailToSession(sessionId, EMAIL);
         var state = new State();
@@ -185,7 +184,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var headers = standardHeadersWithSessionId(sessionId);
         headers.put("Reauthenticate", "true");
 
-        var response = makeRequest(Optional.of(REQUEST_BODY), headers, Map.of());
+        var response = makeRequest(Optional.of(makeRequestBody(true)), headers, Map.of());
         assertThat(response, hasStatus(200));
 
         StartResponse startResponse =
@@ -206,7 +205,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldReturn200WithCorrectMfaMethodTypeWhenTheseIsAnExistingSession(
             MFAMethodType mfaMethodType) throws Json.JsonException {
         var userEmail = "joe.bloggs+3@digital.cabinet-office.gov.uk";
-        var sessionId = redis.createSession(true);
+        var isAuthenticated = true;
+        var sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, userEmail);
 
         userStore.signUp(userEmail, "rubbbishPassword");
@@ -234,7 +234,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         var response =
                 makeRequest(
-                        Optional.of(REQUEST_BODY),
+                        Optional.of(makeRequestBody(isAuthenticated)),
                         standardHeadersWithSessionId(sessionId),
                         Map.of());
         assertThat(response, hasStatus(200));
@@ -285,7 +285,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         var response =
                 makeRequest(
-                        Optional.of(REQUEST_BODY),
+                        Optional.of(makeRequestBody(isAuthenticated)),
                         standardHeadersWithSessionId(sessionId),
                         Map.of());
         assertThat(response, hasStatus(200));
@@ -310,6 +310,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void userShouldNotComeBackAsAuthenticatedWhenSessionIsAuthenticatedButNoUserProfileExists()
             throws Json.JsonException {
         var scope = new Scope(OIDCScopeValue.OPENID);
+        var isAuthenticated = true;
         var authRequest =
                 new AuthenticationRequest.Builder(
                                 ResponseType.CODE, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
@@ -319,14 +320,14 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .build();
         redis.createClientSession(CLIENT_SESSION_ID, TEST_CLIENT_NAME, authRequest.toParameters());
         var userEmail = "joe.bloggs+3@digital.cabinet-office.gov.uk";
-        var sessionId = redis.createSession(true);
+        var sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, userEmail);
         redis.addClientSessionIdToSession(CLIENT_SESSION_ID, sessionId);
         registerClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR(), ClientType.WEB);
 
         var response =
                 makeRequest(
-                        Optional.of(REQUEST_BODY),
+                        Optional.of(makeRequestBody(isAuthenticated)),
                         standardHeadersWithSessionId(sessionId),
                         Map.of());
 
@@ -382,7 +383,9 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     equalTo(true));
 
             makeRequest(
-                    Optional.of(REQUEST_BODY), standardHeadersWithSessionId(sessionId), Map.of());
+                    Optional.of(makeRequestBody(false)),
+                    standardHeadersWithSessionId(sessionId),
+                    Map.of());
 
             assertThat(
                     authSessionExtension.getSession(PREVIOUS_SESSION_ID).isPresent(),
@@ -393,13 +396,19 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         @Test
         void shouldAddSessionToDynamoWhenPreviousSessionIsProvidedInRequestBodyButIsNotInDynamo() {
             makeRequest(
-                    Optional.of(REQUEST_BODY), standardHeadersWithSessionId(sessionId), Map.of());
+                    Optional.of(makeRequestBody(false)),
+                    standardHeadersWithSessionId(sessionId),
+                    Map.of());
 
             assertThat(
                     authSessionExtension.getSession(PREVIOUS_SESSION_ID).isPresent(),
                     equalTo(false));
             assertThat(authSessionExtension.getSession(sessionId).isPresent(), equalTo(true));
         }
+    }
+
+    private String makeRequestBody(boolean isAuthenticated) {
+        return String.format(REQUEST_BODY, isAuthenticated);
     }
 
     private void registerClient(KeyPair keyPair, ClientType clientType) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -33,6 +33,7 @@ import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
+import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
 import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
@@ -76,6 +77,10 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @RegisterExtension
     protected static final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
+
+    @RegisterExtension
+    protected static final AuthenticationAttemptsStoreExtension authAttemptsExtension =
+            new AuthenticationAttemptsStoreExtension();
 
     @BeforeEach
     void setup() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -10,6 +10,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "isNewAccount";
     public static final String ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH = "currentCredentialStrength";
+    public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
 
     public enum AccountState {
         NEW,
@@ -17,8 +18,6 @@ public class AuthSessionItem {
         EXISTING_DOC_APP_JOURNEY,
         UNKNOWN
     }
-
-    public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
 
     private String sessionId;
     private String verifiedMfaMethodType;


### PR DESCRIPTION
## What
- Uses the `authenticated` field from the start request body to determine whether a user is authenticated
- Removes looking in the shared session store for this value and instead relies on [orchestration to pass this](https://github.com/govuk-one-login/authentication-api/pull/5310) to Auth
## How to review
- Code review commit-by-commit
- Deployed to sandpit
   - Ran through a sign in journey from the stub
   - Did not log out 
   - Went through the stub again
   - Observe being redirected to RP without sign in as expected
   - Ran Auth acceptance tests against sandpit - all passed fine 
   -  Followed the instruction in the commit https://github.com/govuk-one-login/authentication-api/commit/3a3752321071e6398b6ea7031bb58486d66b5016 to ensure no regression on the bugfix:
       - Signed in and had an authenticated session in sandpit 
       - Deleted my account from the user tables
       - Navigated back to the stub and tried to initiate a journey 
       - Prompted with sign in page (expected)
## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs
- https://github.com/govuk-one-login/authentication-api/pull/5310
- https://github.com/govuk-one-login/authentication-frontend/pull/2118
