### PR TITLE
ATO-1049: Improvements to Account Intervention Service alerting

### DIFF
--- a/ci/terraform/oidc/account-interventions-alerts.tf
+++ b/ci/terraform/oidc/account-interventions-alerts.tf
@@ -16,9 +16,13 @@ resource "aws_cloudwatch_log_metric_filter" "account_interventions_metric_filter
   }
 }
 
+locals {
+  isP1Alarm = var.environment == "production" && var.account_intervention_service_abort_on_error
+}
+
 resource "aws_cloudwatch_metric_alarm" "account_interventions_p1_cloudwatch_alarm" {
   count               = var.use_localstack ? 0 : 1
-  alarm_name          = replace("${var.environment}-P1-account-interventions-alarm", ".", "")
+  alarm_name          = local.isP1Alarm ? replace("${var.environment}-P1-account-interventions-alarm", ".", "") : replace("${var.environment}-account-interventions-alarm", ".", "")
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.account_interventions_metric_filter[0].metric_transformation[0].name
@@ -27,5 +31,5 @@ resource "aws_cloudwatch_metric_alarm" "account_interventions_p1_cloudwatch_alar
   statistic           = "Sum"
   threshold           = var.account_interventions_p1_alarm_error_threshold
   alarm_description   = "${var.account_interventions_p1_alarm_error_threshold} or more Account Interventions errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
-  alarm_actions       = [var.environment == "production" && var.account_intervention_service_abort_on_error ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : data.aws_sns_topic.slack_events.arn]
+  alarm_actions       = [local.isP1Alarm ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : data.aws_sns_topic.slack_events.arn]
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/contract/AccountInterventionServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/contract/AccountInterventionServiceTest.java
@@ -328,7 +328,8 @@ class AccountInterventionServiceTest {
                                 accountInterventionService.getAccountIntervention(
                                         INTERNAL_PAIRWISE_SUBJECT_ID, auditContext));
         assertEquals(
-                "Problem communicating with Account Intervention Service", exception.getMessage());
+                "Problem communicating with Account Intervention Service. Aborting user journey.",
+                exception.getMessage());
     }
 
     @Test

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -141,11 +141,13 @@ public class AccountInterventionService {
                 configurationService.getAccountInterventionsErrorMetricName(),
                 Map.of("Environment", configurationService.getEnvironment()));
         if (accountInterventionsActionEnabled && acountInterventionsAbortOnError) {
-            throw new AccountInterventionException(
-                    "Problem communicating with Account Intervention Service", e);
+            String errorMessage =
+                    "Problem communicating with Account Intervention Service. Aborting user journey.";
+            LOG.error(errorMessage, e);
+            throw new AccountInterventionException(errorMessage, e);
         }
-        LOG.error(
-                "Problem communicating with Account Intervention Service. Assuming no intervention. ",
+        LOG.warn(
+                "Problem communicating with Account Intervention Service. Assuming no intervention and continuing with user journey.",
                 e);
         return noInterventionResponse();
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -139,7 +139,11 @@ public class AccountInterventionService {
     private AccountIntervention handleException(Exception e) {
         cloudwatchMetricsService.incrementCounter(
                 configurationService.getAccountInterventionsErrorMetricName(),
-                Map.of("Environment", configurationService.getEnvironment()));
+                Map.of(
+                        "Environment",
+                        configurationService.getEnvironment(),
+                        "AbortOnError",
+                        String.valueOf(acountInterventionsAbortOnError)));
         if (accountInterventionsActionEnabled && acountInterventionsAbortOnError) {
             String errorMessage =
                     "Problem communicating with Account Intervention Service. Aborting user journey.";

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AccountInterventionServiceTest.java
@@ -245,7 +245,8 @@ class AccountInterventionServiceTest {
                 () -> accountInterventionService.getAccountIntervention(internalPairwiseSubjectId));
 
         verify(cloudwatchMetricsService)
-                .incrementCounter("AISException", Map.of("Environment", ENVIRONMENT));
+                .incrementCounter(
+                        "AISException", Map.of("Environment", ENVIRONMENT, "AbortOnError", "true"));
     }
 
     @Test

--- a/template.yaml
+++ b/template.yaml
@@ -1892,6 +1892,61 @@ Resources:
             Period: 60
             Stat: Sum
             Unit: Count
+
+  AuthenticationCallbackAisErrorFailOpenMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterName: !Sub ${Environment}-ais-error-fail-open
+      FilterPattern: '{$.AISException = 1 && $.AbortOnError = "false"}'
+      LogGroupName: !Ref AuthenticationCallbackFunctionLogGroup
+      MetricTransformations:
+        - MetricName: !Sub ${Environment}-ais-error-fail-open-count
+          MetricNamespace: LambdaErrorsNamespace
+          MetricValue: 1
+
+  AuthenticationCallbackAisErrorFailOpenAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref SlackEvents
+      AlarmDescription: !Sub "10 or more Account Intervention Service errors have occurred in ${Environment}-AuthenticationCallbackFunction. Assuming no intervention and continuing with user journey. ACCOUNT: di-orchestration-${Environment}"
+      AlarmName: !Sub ${Environment}-authentication-callback-ais-error-fail-open-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: !Sub ${Environment}-ais-error-fail-open-count
+      Namespace: LambdaErrorsNamespace
+      Period: 3600
+      Statistic: Sum
+      Threshold: 10
+
+  AuthenticationCallbackAisErrorAbortMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterName: !Sub ${Environment}-ais-error-abort
+      FilterPattern: '{$.AISException = 1 && $.AbortOnError = "true"}'
+      LogGroupName: !Ref AuthenticationCallbackFunctionLogGroup
+      MetricTransformations:
+        - MetricName: !Sub ${Environment}-ais-error-abort-count
+          MetricNamespace: LambdaErrorsNamespace
+          MetricValue: 1
+
+  AuthenticationCallbackAisErrorAbortAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref SlackEvents
+      AlarmDescription: !Sub "10 or more Account Intervention Service errors have occurred in ${Environment}-AuthenticationCallbackFunction. Aborting user journey - P1 alarm. ACCOUNT: di-orchestration-${Environment}"
+      AlarmName: !Sub ${Environment}-authentication-callback-ais-error-abort-p1-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: !Sub ${Environment}-ais-error-abort-count
+      Namespace: LambdaErrorsNamespace
+      Period: 3600
+      Statistic: Sum
+      Threshold: 10
+
   #endregion
 
   #region Jwks Lambda


### PR DESCRIPTION
## What

- A pager duty (P1) alarm shouldn't be triggered in the case that communication with Account Intervention Service fails open (ie. assumes no intervention). To ensure this, a dimension has been added to the AISException metric, which is used to determine the type of alarm

- `env-P1-account-interventions-alarm` alarm is renamed to not include "P1" in the case that AIS fails open. This alarm shouldn't be triggered, as its metric monitors a deprecated log group (orchestration_redirect_lambda_log_group).

## What's not included

- Setting up a pager duty alarm for the P1 AIS error
- Adding alarms for the other lambdas which call AIS (IpvCallback and ProcessingIdentity). This isn't too bad as AuthenticationCallback calls AIS first in all journeys.

These will form part of a wider piece of work to audit and improve the handling of alarms in Orchestration.

## Testing
Forced the alarms in dev and functioning as intended:

<img width="450" alt="image" src="https://github.com/user-attachments/assets/c01e8fed-2079-46f6-b609-312cac8b2045">
<img width="474" alt="image" src="https://github.com/user-attachments/assets/f58652e8-7d45-43ff-b4a9-4659200fc24c">


