### PR TITLE
ATO-983: Copy InternalCommonSubjectIdentifier From UserInfo Response Subject To OrchSession (Orch ICSID 1/3)

### DIFF
--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -38,7 +38,7 @@ public class UserInfoServiceTest {
                     SdkBytes.fromByteBuffer(TEST_SALT).asByteArray());
     private static final String TEST_INTERNAL_SECTOR_URI = "https://test-internal-sector-uri";
     private static final String TEST_INTERNAL_SECTOR_HOST = "test-internal-sector-uri";
-    private static final String TEST_INTERNAL_PAIRWISE_ID =
+    private static final String TEST_INTERNAL_COMMON_SUBJECT_ID =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     TEST_SUBJECT.getValue(),
                     TEST_INTERNAL_SECTOR_HOST,
@@ -88,7 +88,7 @@ public class UserInfoServiceTest {
             String expectedSalt) {
         UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore, authSession);
 
-        assertEquals(TEST_INTERNAL_PAIRWISE_ID, actual.getSubject().getValue());
+        assertEquals(TEST_INTERNAL_COMMON_SUBJECT_ID, actual.getSubject().getValue());
         assertEquals(TEST_RP_PAIRWISE_ID, actual.getClaim("rp_pairwise_id"));
         assertEquals(TEST_IS_NEW_ACCOUNT, actual.getClaim("new_account"));
         assertEquals(TEST_EMAIL, actual.getEmailAddress());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AccountInterventionsDbServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AccountInterventionsDbServiceIntegrationTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AccountInterventionsDbServiceIntegrationTest {
 
-    private static final String INTERNAL_PAIRWISE_ID = "test-pairwise-id";
+    private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
 
     @RegisterExtension
     protected static final AccountInterventionsStubStoreExtension dbExtension =
@@ -24,10 +24,11 @@ class AccountInterventionsDbServiceIntegrationTest {
 
     @Test
     void shouldReturnAccountInterventionsStoreWhereItExists() {
-        dbExtension.addAccountInterventions(INTERNAL_PAIRWISE_ID, true, true, true, true);
+        dbExtension.addAccountInterventions(
+                TEST_INTERNAL_COMMON_SUBJECT_ID, true, true, true, true);
         Optional<AccountInterventionsStore> accountInterventionsStore;
         accountInterventionsStore =
-                dynamoAuthCodeService.getAccountInterventions(INTERNAL_PAIRWISE_ID);
+                dynamoAuthCodeService.getAccountInterventions(TEST_INTERNAL_COMMON_SUBJECT_ID);
 
         assertTrue(accountInterventionsStore.isPresent());
         assertTrue(accountInterventionsStore.get().isBlocked());
@@ -40,7 +41,7 @@ class AccountInterventionsDbServiceIntegrationTest {
     void shouldReturnNoneWhereThePairwiseIdDoesNotExist() {
         dbExtension.addAccountInterventions("anotherPairwiseId", true, true, true, true);
         var accountInterventionsStore =
-                dynamoAuthCodeService.getAccountInterventions(INTERNAL_PAIRWISE_ID);
+                dynamoAuthCodeService.getAccountInterventions(TEST_INTERNAL_COMMON_SUBJECT_ID);
 
         assertTrue(accountInterventionsStore.isEmpty());
     }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -95,9 +95,9 @@ class IPVCallbackHelperTest {
             new Subject("TsEVC7vg0NPAmzB33vRUFztL2c0-fecKWKcc73fuDhc");
     private static final Subject SUBJECT = new Subject("subject-id");
     private static final ClientID CLIENT_ID = new ClientID();
-    private static final String INTERNAL_PAIRWISE_ID = "internal-pairwise-id";
-    private static final String INTERNAL_PAIRWISE_ID_WITH_INTERVENTION =
-            "internal-pairwise-id-with-intervention";
+    private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
+    private static final String TEST_INTERNAL_COMMON_SUBJECT_ID_WITH_INTERVENTION =
+            "internal-common-subject-id-with-intervention";
     private static final List<VectorOfTrust> VTR_LIST_P1_AND_P2 =
             List.of(
                     VectorOfTrust.of(CredentialTrustLevel.MEDIUM_LEVEL, LevelOfConfidence.NONE),
@@ -157,12 +157,13 @@ class IPVCallbackHelperTest {
                         sessionService,
                         sqsClient,
                         oidcAPI);
-        when(accountInterventionService.getAccountIntervention(INTERNAL_PAIRWISE_ID, auditContext))
+        when(accountInterventionService.getAccountIntervention(
+                        TEST_INTERNAL_COMMON_SUBJECT_ID, auditContext))
                 .thenReturn(
                         new AccountIntervention(
                                 new AccountInterventionState(false, false, false, false)));
         when(accountInterventionService.getAccountIntervention(
-                        INTERNAL_PAIRWISE_ID_WITH_INTERVENTION, auditContext))
+                        TEST_INTERNAL_COMMON_SUBJECT_ID_WITH_INTERVENTION, auditContext))
                 .thenReturn(
                         new AccountIntervention(
                                 new AccountInterventionState(false, true, false, false)));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -671,16 +671,22 @@ public class AuthenticationCallbackHandler
                         AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(), String.class);
         String rpPairwiseId =
                 userInfo.getClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue(), String.class);
+        String internalCommonSubjectId = userInfo.getSubject().getValue();
 
         OrchSessionItem updatedOrchSession =
                 orchSession
                         .withVerifiedMfaMethodType(verifiedMfaMethodType)
-                        .withRpPairwiseId(rpPairwiseId);
+                        .withRpPairwiseId(rpPairwiseId)
+                        .withInternalCommonSubjectId(internalCommonSubjectId);
+
         LOG.info("Updating Orch session with claims from userinfo response");
         // TODO-922: temporary logs for checking all is working as expected
         LOG.info(
                 "is rpPairwiseId attached to orch session: {}",
                 orchSession.getRpPairwiseId() != null);
+        LOG.info(
+                "is internalCommonSubjectId attached to orch session: {}",
+                orchSession.getInternalCommonSubjectId() != null);
         //
         orchSessionService.updateSession(updatedOrchSession);
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -90,7 +90,9 @@ class AuthenticationCallbackHandlerTest {
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String CLIENT_NAME = "client-name";
-    private static final Subject INTERNAL_PAIRWISE_ID = new Subject();
+    private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
+    private static final Subject INTERNAL_PAIRWISE_ID =
+            new Subject(TEST_INTERNAL_COMMON_SUBJECT_ID);
     private static final Subject RP_PAIRWISE_ID = new Subject();
     private static final URI REDIRECT_URI = URI.create("https://test.rp.redirect.uri");
     private static final URI IPV_REDIRECT_URI = URI.create("https://test.ipv.redirect.uri");
@@ -399,10 +401,13 @@ class AuthenticationCallbackHandlerTest {
 
         var orchSessionCaptor = ArgumentCaptor.forClass(OrchSessionItem.class);
         verify(orchSessionService, times(1)).updateSession(orchSessionCaptor.capture());
-        assertThat(
+        assertEquals(
                 MFAMethodType.AUTH_APP.getValue(),
-                equalTo(orchSessionCaptor.getValue().getVerifiedMfaMethodType()));
+                orchSessionCaptor.getValue().getVerifiedMfaMethodType());
         assertEquals(RP_PAIRWISE_ID.getValue(), orchSessionCaptor.getValue().getRpPairwiseId());
+        assertEquals(
+                TEST_INTERNAL_COMMON_SUBJECT_ID,
+                orchSessionCaptor.getValue().getInternalCommonSubjectId());
     }
 
     @Nested

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -91,8 +91,6 @@ class AuthenticationCallbackHandlerTest {
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String CLIENT_NAME = "client-name";
     private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
-    private static final Subject INTERNAL_PAIRWISE_ID =
-            new Subject(TEST_INTERNAL_COMMON_SUBJECT_ID);
     private static final Subject RP_PAIRWISE_ID = new Subject();
     private static final URI REDIRECT_URI = URI.create("https://test.rp.redirect.uri");
     private static final URI IPV_REDIRECT_URI = URI.create("https://test.ipv.redirect.uri");
@@ -137,7 +135,7 @@ class AuthenticationCallbackHandlerTest {
         when(UNSUCCESSFUL_TOKEN_RESPONSE.toErrorResponse())
                 .thenReturn(new TokenErrorResponse(new ErrorObject("1", TEST_ERROR_MESSAGE)));
         when(USER_INFO.getEmailAddress()).thenReturn(TEST_EMAIL_ADDRESS);
-        when(USER_INFO.getSubject()).thenReturn(INTERNAL_PAIRWISE_ID);
+        when(USER_INFO.getSubject()).thenReturn(new Subject(TEST_INTERNAL_COMMON_SUBJECT_ID));
         when(USER_INFO.getBooleanClaim("new_account")).thenReturn(true);
         when(USER_INFO.getClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue(), String.class))
                 .thenReturn(RP_PAIRWISE_ID.getValue());
@@ -239,7 +237,7 @@ class AuthenticationCallbackHandlerTest {
                                         .withPersistentSessionId(PERSISTENT_SESSION_ID)
                                         .withGovukSigninJourneyId(CLIENT_SESSION_ID)
                                         .withIpAddress("123.123.123.123")
-                                        .withUserId(INTERNAL_PAIRWISE_ID.getValue())
+                                        .withUserId(TEST_INTERNAL_COMMON_SUBJECT_ID)
                                         .withEmail(TEST_EMAIL_ADDRESS)
                                         .withPhone("1234")),
                         eq(pair("new_account", true)),
@@ -254,7 +252,7 @@ class AuthenticationCallbackHandlerTest {
                                         .withPersistentSessionId(PERSISTENT_SESSION_ID)
                                         .withGovukSigninJourneyId(CLIENT_SESSION_ID)
                                         .withIpAddress("123.123.123.123")
-                                        .withUserId(INTERNAL_PAIRWISE_ID.getValue())
+                                        .withUserId(TEST_INTERNAL_COMMON_SUBJECT_ID)
                                         .withEmail(TEST_EMAIL_ADDRESS)
                                         .withPhone("1234")),
                         eq(pair("internalSubjectId", AuditService.UNKNOWN)),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -45,7 +45,7 @@ class UserInfoHandlerTest {
     private static final Subject SUBJECT = new Subject();
     private static final String TOKEN = "token";
     private static final String INTERNAL_SUBJECT_ID = "internal-subject-id";
-    private static final String INTERNAL_PAIRWISE_ID = "internal-pairwise-subject-id";
+    private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
     private static final String JOURNEY_ID = "client-session-id";
     private static final Subject AUDIT_SUBJECT_ID = new Subject();
     private final Context context = mock(Context.class);
@@ -70,7 +70,10 @@ class UserInfoHandlerTest {
         when(accessTokenInfo.getAccessTokenStore())
                 .thenReturn(
                         new AccessTokenStore(
-                                TOKEN, INTERNAL_SUBJECT_ID, INTERNAL_PAIRWISE_ID, JOURNEY_ID));
+                                TOKEN,
+                                INTERNAL_SUBJECT_ID,
+                                TEST_INTERNAL_COMMON_SUBJECT_ID,
+                                JOURNEY_ID));
     }
 
     @Test

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -11,6 +11,7 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
     public static final String ATTRIBUTE_RP_PAIRWISE_ID = "RpPairwiseId";
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "IsNewAccount";
+    public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
 
     public enum AccountState {
         NEW,
@@ -24,6 +25,7 @@ public class OrchSessionItem {
     private String verifiedMfaMethodType;
     private String rpPairwiseId;
     private AccountState isNewAccount;
+    private String internalCommonSubjectId;
 
     public OrchSessionItem() {}
 
@@ -100,6 +102,20 @@ public class OrchSessionItem {
 
     public OrchSessionItem withAccountState(AccountState accountState) {
         this.isNewAccount = accountState;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID)
+    public String getInternalCommonSubjectId() {
+        return internalCommonSubjectId;
+    }
+
+    public void setInternalCommonSubjectId(String internalCommonSubjectId) {
+        this.internalCommonSubjectId = internalCommonSubjectId;
+    }
+
+    public OrchSessionItem withInternalCommonSubjectId(String internalCommonSubjectId) {
+        this.internalCommonSubjectId = internalCommonSubjectId;
         return this;
     }
 }


### PR DESCRIPTION
## What

Copy Internal Common Subject Identifier From User Info Subject To Orch Session

## How to review

1. Code Review

## Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.

Next PR: https://github.com/govuk-one-login/authentication-api/pull/5452
