### PR TITLE
BAU: refactor verify mfa code handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -202,7 +202,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     userContext,
                     subjectID,
                     authSession.get(),
-                    auditContext,
                     maybeRpPairwiseId);
         } catch (Exception e) {
             LOG.error("Unexpected exception thrown");
@@ -284,7 +283,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             UserContext userContext,
             String subjectId,
             AuthSessionItem authSession,
-            AuditContext auditContext,
             Optional<String> maybeRpPairwiseId) {
 
         var session = userContext.getSession();
@@ -348,7 +346,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         .map(this::errorResponseAsFrontendAuditableEvent)
                         .orElse(AUTH_CODE_VERIFIED);
 
-        var auditContextForCodeProcessing =
+        var auditContext =
                 auditContextFromUserContext(
                         userContext,
                         session.getInternalCommonSubjectIdentifier(),
@@ -360,7 +358,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         var metadataPairs =
                 metadataPairsForEvent(auditableEvent, session.getEmailAddress(), codeRequest);
 
-        auditService.submitAuditEvent(auditableEvent, auditContextForCodeProcessing, metadataPairs);
+        auditService.submitAuditEvent(auditableEvent, auditContext, metadataPairs);
 
         sessionService.storeOrUpdateSession(session);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
@@ -36,14 +36,14 @@ public class MfaCodeProcessorFactory {
 
     public Optional<MfaCodeProcessor> getMfaCodeProcessor(
             MFAMethodType mfaMethodType, CodeRequest codeRequest, UserContext userContext) {
-        switch (mfaMethodType) {
-            case AUTH_APP:
+        return switch (mfaMethodType) {
+            case AUTH_APP -> {
                 int codeMaxRetries =
                         List.of(JourneyType.REGISTRATION, JourneyType.ACCOUNT_RECOVERY)
                                         .contains(codeRequest.getJourneyType())
                                 ? configurationService.getIncreasedCodeMaxRetries()
                                 : configurationService.getCodeMaxRetries();
-                return Optional.of(
+                yield Optional.of(
                         new AuthAppCodeProcessor(
                                 userContext,
                                 codeStorageService,
@@ -53,18 +53,17 @@ public class MfaCodeProcessorFactory {
                                 codeRequest,
                                 auditService,
                                 accountModifiersService));
-            case SMS:
-                return Optional.of(
-                        new PhoneNumberCodeProcessor(
-                                codeStorageService,
-                                userContext,
-                                configurationService,
-                                codeRequest,
-                                authenticationService,
-                                auditService,
-                                accountModifiersService));
-            default:
-                return Optional.empty();
-        }
+            }
+            case SMS -> Optional.of(
+                    new PhoneNumberCodeProcessor(
+                            codeStorageService,
+                            userContext,
+                            configurationService,
+                            codeRequest,
+                            authenticationService,
+                            auditService,
+                            accountModifiersService));
+            default -> Optional.empty();
+        };
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -922,6 +922,23 @@ class VerifyMfaCodeHandlerTest {
                                                 existingCounts)));
     }
 
+    @Test
+    void shouldReturn400AndThrowClientNotFoundExceptionIfNoClientIsPresent()
+            throws Json.JsonException {
+        when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.empty());
+
+        var result =
+                makeCallWithCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP,
+                                CODE,
+                                JourneyType.REGISTRATION,
+                                AUTH_APP_SECRET));
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1015));
+    }
+
     private static Stream<Arguments> reauthCountTypesAndMetadata() {
         return Stream.of(
                 Arguments.arguments(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -884,7 +884,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         var response =
                 makeRequest(
-                        Optional.of(codeRequest), constructFrontendHeaders(sessionId), Map.of());
+                        Optional.of(codeRequest),
+                        constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
+                        Map.of());
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1034));
@@ -922,7 +924,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         var response =
                 makeRequest(
-                        Optional.of(codeRequest), constructFrontendHeaders(sessionId), Map.of());
+                        Optional.of(codeRequest),
+                        constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
+                        Map.of());
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1034));

--- a/shared/src/main/java/uk/gov/di/authentication/entity/VerifyMfaCodeRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/VerifyMfaCodeRequest.java
@@ -8,8 +8,6 @@ import uk.gov.di.authentication.shared.validation.Required;
 
 public class VerifyMfaCodeRequest extends CodeRequest {
 
-    public VerifyMfaCodeRequest() {}
-
     public VerifyMfaCodeRequest(MFAMethodType mfaMethodType, String code, JourneyType journeyType) {
         this(mfaMethodType, code, journeyType, null);
     }


### PR DESCRIPTION
## What

- Moved the error handling and audit event emission out of the processCodeSession method. This means that error handling (predominantly) happens in one place, followed by processing a successful code request, followed by audit event emission. This gives the processSuccessfulCodeSession (successor to processCodeSession) method a single purpose and makes the logic easier to follow..
- Stopped passing unnecessary audit context through to verify code method.
- Replaced switch with enhanced switch in the MfaCodeProcessorFactory
- Throw and catch exception when the client is not present in the VerifyMfaCodeHandler
- Delete unused empty constructor in the VerifyMfaCodeRequest

## How to review

1. Code Review
2. Deploy to dev and run through auth app journey successfully