### PR TITLE
BAU: update URL method, as it is deprecated in Java 20

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -13,7 +13,8 @@ import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.KeyFactory;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
@@ -210,9 +211,9 @@ public class ClientConfigValidationService {
     private boolean areUrisValid(List<String> uris) {
         try {
             for (String uri : uris) {
-                new URL(uri);
+                new URI(uri).toURL();
             }
-        } catch (MalformedURLException e) {
+        } catch (URISyntaxException | MalformedURLException e) {
             return false;
         }
         return true;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
@@ -11,7 +11,8 @@ import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 public class FetchJwksHandler implements RequestHandler<Map<String, String>, String> {
@@ -43,7 +44,7 @@ public class FetchJwksHandler implements RequestHandler<Map<String, String>, Str
                 throw new IllegalArgumentException(
                         "FetchJwksHandler invoked with invalid argument(s)");
             }
-            JWK jwk = jwksService.retrieveJwkFromURLWithKeyId(new URL(url), keyId);
+            JWK jwk = jwksService.retrieveJwkFromURLWithKeyId(new URI(url).toURL(), keyId);
             return jwk.toJSONString();
         } catch (KeySourceException e) {
             String errorMsg =
@@ -56,6 +57,10 @@ public class FetchJwksHandler implements RequestHandler<Map<String, String>, Str
             return errorResponse;
         } catch (IllegalArgumentException e) {
             String errorMsg = "Failed to fetch JWKS: url and/or keyId parameter not present";
+            LOG.error(errorMsg, e);
+            return errorResponse;
+        } catch (URISyntaxException e) {
+            String errorMsg = "string could not be parsed as a URI reference";
             LOG.error(errorMsg, e);
             return errorResponse;
         }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandlerTest.java
@@ -7,7 +7,8 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.services.JwksService;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.Map;
 
@@ -26,13 +27,13 @@ class FetchJwksHandlerTest {
 
     @Test
     void returnsAJwkWhenUrlAndKeyIdAreValid()
-            throws MalformedURLException, KeySourceException, ParseException {
+            throws MalformedURLException, URISyntaxException, KeySourceException, ParseException {
         // given
         Map<String, String> event = Map.of("url", url, "keyId", keyId);
         String jwkJson =
                 "{\"kty\":\"EC\",\"use\":\"sig\",\"crv\":\"P-256\",\"kid\":\"f27ff20940cdc6c8b34f97f44c24c8601ded9465c0713dd190ed152272d07ddb\",\"x\":\"sSdmBkED2EfjTdX-K2_cT6CfBwXQFt-DJ6v8-6tr_n8\",\"y\":\"WTXmQdqLwrmHN5tiFsTFUtNAvDYhhTQB4zyfteCrWIE\",\"alg\":\"ES256\"}";
         JWK jwk = JWK.parse(jwkJson);
-        when(jwksService.retrieveJwkFromURLWithKeyId(new URL(url), keyId)).thenReturn(jwk);
+        when(jwksService.retrieveJwkFromURLWithKeyId(new URI(url).toURL(), keyId)).thenReturn(jwk);
 
         // when
         String response = handler.handleRequest(event, CONTEXT);
@@ -43,10 +44,10 @@ class FetchJwksHandlerTest {
 
     @Test
     void returnsErrorWhenServiceThrowsKeySourceException()
-            throws MalformedURLException, KeySourceException {
+            throws MalformedURLException, URISyntaxException, KeySourceException {
         // given
         Map<String, String> event = Map.of("url", url, "keyId", keyId);
-        when(jwksService.retrieveJwkFromURLWithKeyId(new URL(url), keyId))
+        when(jwksService.retrieveJwkFromURLWithKeyId(new URI(url).toURL(), keyId))
                 .thenThrow(new KeySourceException());
 
         // when


### PR DESCRIPTION
## What
`URL(string)` is depricated in Java 20, which causes code locally that uses it (including any auth deployments) to fail.
https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/net/URL.html#constructor-deprecation.

I'm using the recommended approach as given in the above docs to update them with minimal code diff.

## How to review
1. Code Review