### PR TITLE
Ato 922: add email to all auth user info responses

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -44,6 +44,7 @@ public class UserInfoService {
         var userInfo = new UserInfo(internalPairwiseId);
         addClaimsFromToken(accessTokenInfo, internalSubjectId, userProfile, userInfo);
         addClaimsFromSession(authSession, userInfo);
+        addClaimsFromUserProfile(userProfile, userInfo);
         return userInfo;
     }
 
@@ -71,9 +72,6 @@ public class UserInfoService {
         if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.LOCAL_ACCOUNT_ID.getValue())) {
             userInfo.setClaim("local_account_id", userProfile.getSubjectID());
         }
-        if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.EMAIL.getValue())) {
-            userInfo.setEmailAddress(userProfile.getEmail());
-        }
         if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.EMAIL_VERIFIED.getValue())) {
             userInfo.setEmailVerified(userProfile.isEmailVerified());
         }
@@ -93,6 +91,10 @@ public class UserInfoService {
         userInfo.setClaim(
                 AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
                 authSession.getVerifiedMfaMethodType());
+    }
+
+    private void addClaimsFromUserProfile(UserProfile userProfile, UserInfo userInfo) {
+        userInfo.setEmailAddress(userProfile.getEmail());
     }
 
     private static String bytesToBase64(ByteBuffer byteBuffer) {

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -82,7 +82,6 @@ public class UserInfoServiceTest {
             String expectedLegacySubjectId,
             String expectedPublicSubjectId,
             String expectedLocalAccountId,
-            String expectedEmailAddress,
             Boolean expectedEmailVerified,
             String expectedPhoneNumber,
             Boolean expectedPhoneNumberVerified,
@@ -92,11 +91,11 @@ public class UserInfoServiceTest {
         assertEquals(TEST_INTERNAL_PAIRWISE_ID, actual.getSubject().getValue());
         assertEquals(TEST_RP_PAIRWISE_ID, actual.getClaim("rp_pairwise_id"));
         assertEquals(TEST_IS_NEW_ACCOUNT, actual.getClaim("new_account"));
+        assertEquals(TEST_EMAIL, actual.getEmailAddress());
 
         assertEquals(expectedLegacySubjectId, actual.getClaim("legacy_subject_id"));
         assertEquals(expectedPublicSubjectId, actual.getClaim("public_subject_id"));
         assertEquals(expectedLocalAccountId, actual.getClaim("local_account_id"));
-        assertEquals(expectedEmailAddress, actual.getEmailAddress());
         assertEquals(expectedEmailVerified, actual.getEmailVerified());
         assertEquals(expectedPhoneNumber, actual.getPhoneNumber());
         assertEquals(expectedPhoneNumberVerified, actual.getPhoneNumberVerified());
@@ -114,7 +113,6 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         null,
-                        null,
                         null),
                 Arguments.of(
                         getMockAccessTokenStore(
@@ -122,7 +120,6 @@ public class UserInfoServiceTest {
                         TEST_LEGACY_SUBJECT_ID,
                         null,
                         null,
-                        TEST_EMAIL,
                         TEST_EMAIL_VERIFIED,
                         null,
                         null,
@@ -141,7 +138,6 @@ public class UserInfoServiceTest {
                         TEST_LEGACY_SUBJECT_ID,
                         TEST_PUBLIC_SUBJECT_ID,
                         TEST_SUBJECT.getValue(),
-                        TEST_EMAIL,
                         TEST_EMAIL_VERIFIED,
                         TEST_PHONE,
                         TEST_PHONE_VERIFIED,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -367,6 +367,12 @@ public class AuthenticationCallbackHandler
                             clientService.isTestJourney(clientId, userInfo.getEmailAddress());
                 }
 
+                // TODO-922: temporary logs for checking all is working as expected
+                LOG.info(
+                        "is email attached to auth-external-api userinfo response: {}",
+                        userInfo.getEmailAddress() != null);
+                //
+
                 Boolean newAccount = userInfo.getBooleanClaim("new_account");
                 AccountState accountState = newAccount ? AccountState.NEW : AccountState.EXISTING;
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -113,6 +113,9 @@ public class UserInfoService {
                     "Unable to get user info for Subject", BearerTokenError.INVALID_TOKEN);
         }
 
+        // TODO-922: temporary logs for checking all is working as expected
+        LOG.info("is email attached to userinfo table: {}", tmpUserInfo.getEmailAddress() != null);
+        //
         if (accessTokenInfo.getScopes().contains(OIDCScopeValue.EMAIL.getValue())) {
             userInfo.setEmailAddress(tmpUserInfo.getEmailAddress());
             userInfo.setEmailVerified(tmpUserInfo.getEmailVerified());


### PR DESCRIPTION
## What
Orch needs this so it can be added to the orch session. We need email because a client's list of test emails is in the client registry, which we need to compare against. 

Note that this is only an internal endpoint (orch<->auth). When an RP makes a UserInfo request, we still check they're allowed to (see `UserInfoService` in `oidc-api`). 

## How to review

1. Code Review

I have deployed to Dev and tested that the email is sent to orch even when I set the claims to not include email. In that case, the RP still doesn't get the email, because that list of claims is still used in the RP<->orch UserInfo request.