### PR TITLE
ATO-979/d: Get verifiedMfaMethodType from Orch session instead of shared

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -19,6 +19,7 @@ import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.IdentityClaims;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
@@ -186,6 +187,7 @@ public class IPVCallbackHelper {
             String clientSessionId,
             UserProfile userProfile,
             Session session,
+            OrchSessionItem orchSession,
             ClientSession clientSession,
             Subject rpPairwiseSubject,
             String internalPairwiseSubjectId,
@@ -212,7 +214,7 @@ public class IPVCallbackHelper {
 
         var dimensions =
                 authCodeResponseService.getDimensions(
-                        session, clientSession, clientSessionId, false, false);
+                        session, orchSession, clientSession, clientSessionId, false, false);
 
         var subjectId = authCodeResponseService.getSubjectId(session);
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -48,6 +48,7 @@ import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
+import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
@@ -79,6 +80,7 @@ public class IPVCallbackHandler
     private final IPVAuthorisationService ipvAuthorisationService;
     private final IPVTokenService ipvTokenService;
     private final SessionService sessionService;
+    private final OrchSessionService orchSessionService;
     private final DynamoService dynamoService;
     private final ClientSessionService clientSessionService;
     private final DynamoClientService dynamoClientService;
@@ -100,6 +102,7 @@ public class IPVCallbackHandler
             IPVAuthorisationService responseService,
             IPVTokenService ipvTokenService,
             SessionService sessionService,
+            OrchSessionService orchSessionService,
             DynamoService dynamoService,
             ClientSessionService clientSessionService,
             DynamoClientService dynamoClientService,
@@ -114,6 +117,7 @@ public class IPVCallbackHandler
         this.ipvAuthorisationService = responseService;
         this.ipvTokenService = ipvTokenService;
         this.sessionService = sessionService;
+        this.orchSessionService = orchSessionService;
         this.dynamoService = dynamoService;
         this.clientSessionService = clientSessionService;
         this.dynamoClientService = dynamoClientService;
@@ -136,6 +140,7 @@ public class IPVCallbackHandler
                         kmsConnectionService);
         this.ipvTokenService = new IPVTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService);
+        this.orchSessionService = new OrchSessionService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);
@@ -161,6 +166,7 @@ public class IPVCallbackHandler
                 new IPVAuthorisationService(configurationService, redis, kmsConnectionService);
         this.ipvTokenService = new IPVTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService, redis);
+        this.orchSessionService = new OrchSessionService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService, redis);
         this.dynamoClientService = new DynamoClientService(configurationService);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -391,6 +391,7 @@ public class IPVCallbackHandler
                                         clientSessionId,
                                         userProfile,
                                         session,
+                                        orchSession,
                                         clientSession,
                                         rpPairwiseSubject,
                                         internalPairwiseSubjectId,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -365,9 +365,8 @@ public class IPVCallbackHandler
             var vtrList = clientSession.getVtrList();
             var userIdentityError =
                     ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, vtrList);
-            LOG.info("orchSession: {}", orchSession);
             LOG.info(
-                    "orchSession.getVerifiedMfaMethodType(): {}",
+                    "IPVCallback orchSession.getVerifiedMfaMethodType(): {}",
                     orchSession.getVerifiedMfaMethodType());
             if (userIdentityError.isPresent()) {
                 AccountIntervention intervention =

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -71,6 +71,7 @@ import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
+import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
@@ -119,6 +120,7 @@ class IPVCallbackHandlerTest {
     private final IPVAuthorisationService responseService = mock(IPVAuthorisationService.class);
     private final IPVTokenService ipvTokenService = mock(IPVTokenService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
     private final CookieHelper cookieHelper = mock(CookieHelper.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
@@ -260,6 +262,7 @@ class IPVCallbackHandlerTest {
                         responseService,
                         ipvTokenService,
                         sessionService,
+                        orchSessionService,
                         dynamoService,
                         clientSessionService,
                         dynamoClientService,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -377,7 +377,8 @@ class IPVCallbackHandlerTest {
         when(ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, VTR_LIST))
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
-                        any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                        any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                        any()))
                 .thenReturn(
                         new AuthenticationSuccessResponse(
                                 REDIRECT_URI, null, null, null, null, null, null));
@@ -449,7 +450,8 @@ class IPVCallbackHandlerTest {
         when(ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, VTR_LIST))
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
-                        any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                        any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                        any()))
                 .thenReturn(
                         new AuthenticationSuccessResponse(
                                 FRONT_END_IPV_CALLBACK_URI, null, null, null, null, null, null));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -225,6 +225,7 @@ public class AuthCodeHandler
             var dimensions =
                     authCodeResponseService.getDimensions(
                             session,
+                            orchSession,
                             clientSession,
                             clientID.getValue(),
                             isTestJourney,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -67,6 +67,7 @@ public class AuthCodeHandler
     private static final Logger LOG = LogManager.getLogger(AuthCodeHandler.class);
 
     private final SessionService sessionService;
+    private final OrchSessionService orchSessionService;
     private final AuthCodeResponseGenerationService authCodeResponseService;
     private final AuthorisationCodeService authorisationCodeService;
     private final OrchestrationAuthorizationService orchestrationAuthorizationService;
@@ -79,6 +80,7 @@ public class AuthCodeHandler
 
     public AuthCodeHandler(
             SessionService sessionService,
+            OrchSessionService orchSessionService,
             AuthCodeResponseGenerationService authCodeResponseService,
             AuthorisationCodeService authorisationCodeService,
             OrchestrationAuthorizationService orchestrationAuthorizationService,
@@ -89,6 +91,7 @@ public class AuthCodeHandler
             DynamoService dynamoService,
             DynamoClientService dynamoClientService) {
         this.sessionService = sessionService;
+        this.orchSessionService = orchSessionService;
         this.authCodeResponseService = authCodeResponseService;
         this.authorisationCodeService = authorisationCodeService;
         this.orchestrationAuthorizationService = orchestrationAuthorizationService;
@@ -102,6 +105,7 @@ public class AuthCodeHandler
 
     public AuthCodeHandler(ConfigurationService configurationService) {
         sessionService = new SessionService(configurationService);
+        orchSessionService = new OrchSessionService(configurationService);
         authorisationCodeService = new AuthorisationCodeService(configurationService);
         orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(configurationService);
@@ -118,6 +122,7 @@ public class AuthCodeHandler
     public AuthCodeHandler(
             ConfigurationService configurationService, RedisConnectionService redis) {
         sessionService = new SessionService(configurationService, redis);
+        orchSessionService = new OrchSessionService(configurationService);
         authorisationCodeService = new AuthorisationCodeService(configurationService);
         orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(configurationService);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -173,6 +173,10 @@ public class AuthCodeHandler
             return generateApiGatewayProxyErrorResponse(e.getStatusCode(), e.getErrorResponse());
         }
 
+        LOG.info(
+                "AuthCode orchSession.getVerifiedMfaMethodType(): {}",
+                orchSession.getVerifiedMfaMethodType());
+
         attachSessionIdToLogs(session);
         attachOrchSessionIdToLogs(orchSession.getSessionId());
         attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -379,7 +379,9 @@ public class AuthenticationCallbackHandler
                                 isTestJourney,
                                 docAppJourney,
                                 clientSession,
-                                userSession);
+                                userInfo.getClaim(
+                                        AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
+                                        String.class));
 
                 user =
                         user.withUserId(userInfo.getSubject().getValue())
@@ -539,7 +541,7 @@ public class AuthenticationCallbackHandler
             boolean isTestJourney,
             boolean docAppJourney,
             ClientSession clientSession,
-            Session userSession) {
+            String verifiedMfaMethodType) {
         Map<String, String> dimensions =
                 new HashMap<>(
                         Map.of(
@@ -556,8 +558,8 @@ public class AuthenticationCallbackHandler
                                 "ClientName",
                                 clientSession.getClientName()));
 
-        if (Objects.nonNull(userSession.getVerifiedMfaMethodType())) {
-            dimensions.put("MfaMethod", userSession.getVerifiedMfaMethodType().getValue());
+        if (Objects.nonNull(verifiedMfaMethodType)) {
+            dimensions.put("MfaMethod", verifiedMfaMethodType);
         } else {
             LOG.info(
                     "No mfa method to set. User is either authenticated or signing in from a low level service");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -35,6 +35,7 @@ import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
 import uk.gov.di.orchestration.shared.entity.MFAMethodType;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
@@ -53,6 +54,7 @@ import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
+import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
@@ -116,6 +118,7 @@ class AuthCodeHandlerTest {
     private final OrchestrationAuthorizationService orchestrationAuthorizationService =
             mock(OrchestrationAuthorizationService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
     private final VectorOfTrust vectorOfTrust = mock(VectorOfTrust.class);
 
     private static final String SESSION_ID = IdGenerator.generate();
@@ -136,6 +139,7 @@ class AuthCodeHandlerTest {
     private AuthCodeHandler handler;
 
     private final Session session = new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID);
+    private final OrchSessionItem orchSession = new OrchSessionItem(SESSION_ID);
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =
@@ -160,6 +164,7 @@ class AuthCodeHandlerTest {
         handler =
                 new AuthCodeHandler(
                         sessionService,
+                        orchSessionService,
                         authCodeResponseService,
                         authorisationCodeService,
                         orchestrationAuthorizationService,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -222,6 +222,7 @@ class AuthCodeHandlerTest {
         if (Objects.nonNull(mfaMethodType)) {
             when(authCodeResponseService.getDimensions(
                             eq(session),
+                            eq(orchSession),
                             eq(clientSession),
                             eq(CLIENT_ID.getValue()),
                             anyBoolean(),
@@ -367,6 +368,7 @@ class AuthCodeHandlerTest {
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(
                         eq(session),
+                        eq(orchSession),
                         eq(clientSession),
                         eq(CLIENT_ID.getValue()),
                         anyBoolean(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -447,6 +447,22 @@ class AuthCodeHandlerTest {
     }
 
     @Test
+    void shouldGenerateErrorResponseWhenOrchSessionIsNotFound() {
+        when(sessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(session));
+        when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(clientSession));
+        when(clientSession.getClientName()).thenReturn(CLIENT_NAME);
+
+        APIGatewayProxyResponseEvent response = generateApiRequest();
+
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1000));
+
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
     void shouldGenerateErrorResponseWhenRedirectUriIsInvalid()
             throws ClientNotFoundException, JOSEException {
         session.setEmailAddress(EMAIL);
@@ -545,6 +561,8 @@ class AuthCodeHandlerTest {
                         PERSISTENT_SESSION_ID));
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));
+        when(orchSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(orchSession));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -577,6 +595,8 @@ class AuthCodeHandlerTest {
             Map<String, List<String>> authRequestParams, CredentialTrustLevel requestedLevel) {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));
+        when(orchSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(orchSession));
         when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(clientSession));
         when(vectorOfTrust.getCredentialTrustLevel()).thenReturn(requestedLevel);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
@@ -41,6 +42,7 @@ public class AuthCodeResponseGenerationService {
 
     public Map<String, String> getDimensions(
             Session session,
+            OrchSessionItem orchSession,
             ClientSession clientSession,
             String clientSessionId,
             boolean isTestJourney,
@@ -61,8 +63,8 @@ public class AuthCodeResponseGenerationService {
                                 "ClientName",
                                 clientSession.getClientName()));
 
-        if (Objects.nonNull(session.getVerifiedMfaMethodType())) {
-            dimensions.put("MfaMethod", session.getVerifiedMfaMethodType().getValue());
+        if (Objects.nonNull(orchSession.getVerifiedMfaMethodType())) {
+            dimensions.put("MfaMethod", orchSession.getVerifiedMfaMethodType());
         } else {
             LOG.info(
                     "No mfa method to set. User is either authenticated or signing in from a low level service");

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -64,6 +64,7 @@ public class AuthCodeResponseGenerationService {
                                 clientSession.getClientName()));
 
         if (Objects.nonNull(orchSession.getVerifiedMfaMethodType())) {
+            LOG.info("Setting verifiedMfaMethodType from orch session to dimension.");
             dimensions.put("MfaMethod", orchSession.getVerifiedMfaMethodType());
         } else {
             LOG.info(

--- a/template.yaml
+++ b/template.yaml
@@ -2677,6 +2677,7 @@ Resources:
         - !Ref UserProfileTableWriteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref RedisParametersAccessPolicy
+        - !Ref OrchSessionTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 

--- a/template.yaml
+++ b/template.yaml
@@ -3282,6 +3282,7 @@ Resources:
         - !Ref IpvTokenSigningKmsAccessPolicy
         - !Ref SpotRequestQueueWritePolicy
         - !Ref AccountInterventionsServiceUriSecretAccessPolicy
+        - !Ref OrchSessionTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 


### PR DESCRIPTION
## What

Now that `verifiedMfaMethodType` is passed as a claim in the userinfo response from Auth and stored in the Orch session, we can get and use the value from the Orch session instead of the shared session.

## Testing
This needs to be tested in staging as it affects IpvCallback and AuthCode lambdas.
