### PR TITLE
ATO 922: set email in orch session

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -657,8 +657,13 @@ public class AuthenticationCallbackHandler
                 userInfo.getClaim(
                         AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(), String.class);
         OrchSessionItem updatedOrchSession =
-                orchSession.withVerifiedMfaMethodType(verifiedMfaMethodType);
+                orchSession
+                        .withVerifiedMfaMethodType(verifiedMfaMethodType)
+                        .withEmailAddress(userInfo.getEmailAddress());
         LOG.info("Updating Orch session with claims from userinfo response");
+        // TODO-922: temporary logs for checking all is working as expected
+        LOG.info("is email attached to orch session: {}", orchSession.getEmailAddress() != null);
+        //
         orchSessionService.updateSession(updatedOrchSession);
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -32,7 +32,6 @@ import uk.gov.di.orchestration.shared.entity.*;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.services.*;
-import uk.gov.di.orchestration.shared.services.LogoutService;
 
 import java.net.URI;
 import java.util.*;
@@ -47,7 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.eq;
 import static uk.gov.di.orchestration.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
@@ -401,7 +399,8 @@ class AuthenticationCallbackHandlerTest {
         verify(orchSessionService, times(1)).updateSession(orchSessionCaptor.capture());
         assertThat(
                 MFAMethodType.AUTH_APP.getValue(),
-                equalTo(orchSessionCaptor.getAllValues().get(0).getVerifiedMfaMethodType()));
+                equalTo(orchSessionCaptor.getValue().getVerifiedMfaMethodType()));
+        assertEquals(TEST_EMAIL_ADDRESS, orchSessionCaptor.getValue().getEmailAddress());
     }
 
     @Nested

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -8,10 +8,12 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 public class OrchSessionItem {
 
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
+    public static final String ATTRIBUTE_EMAIL = "Email";
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
 
     private String sessionId;
     private long timeToLive;
+    private String email;
     private String verifiedMfaMethodType;
 
     public OrchSessionItem() {}
@@ -46,6 +48,20 @@ public class OrchSessionItem {
 
     public OrchSessionItem withTimeToLive(long timeToLive) {
         this.timeToLive = timeToLive;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_EMAIL)
+    public String getEmailAddress() {
+        return email;
+    }
+
+    public void setEmailAddress(String email) {
+        this.email = email;
+    }
+
+    public OrchSessionItem withEmailAddress(String email) {
+        this.email = email;
         return this;
     }
 


### PR DESCRIPTION
## What
Adds email to the orch session. The orch<->auth userInfo request now always returns email, as of https://github.com/govuk-one-login/authentication-api/pull/5403

## How to review
1. Code Review