### PR TITLE
BAU: Add `Environment` dimension to all metrics by default

### DIFF
--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -140,7 +140,6 @@ public class NotifyCallbackHandler
             Map<String, String> additionalContext,
             NotifyDeliveryReceipt deliveryReceipt) {
         var sentMetricsMap = new HashMap<String, String>();
-        sentMetricsMap.put("Environment", configurationService.getEnvironment());
         sentMetricsMap.put("NotifyStatus", deliveryReceipt.status());
         sentMetricsMap.putAll(additionalContext);
 
@@ -162,7 +161,6 @@ public class NotifyCallbackHandler
             double duration = Duration.between(createdAt, completedAt).toMillis();
             var metricsContext =
                     Map.ofEntries(
-                            Map.entry("Environment", configurationService.getEnvironment()),
                             Map.entry("NotificationType", deliveryReceipt.notificationType()));
             cloudwatchMetricsService.putEmbeddedValue(
                     "NotifyDeliveryDuration", duration, metricsContext);

--- a/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
+++ b/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
@@ -118,7 +118,6 @@ class NotifyCallbackHandlerTest {
                 Map.ofEntries(
                         Map.entry("SmsType", VERIFY_PHONE_NUMBER.getTemplateAlias()),
                         Map.entry("CountryCode", expectedCountryCode),
-                        Map.entry("Environment", ENVIRONMENT),
                         Map.entry("NotifyStatus", status));
 
         verify(cloudwatchMetricsService).incrementCounter("SmsSent", expectedContext);
@@ -140,10 +139,9 @@ class NotifyCallbackHandlerTest {
                         "sms", "delivered", createdAtDate, completedAt, reference);
         var response = handler.handleRequest(eventWithBody(deliveryReceipt), context);
 
-        var expectedContext = Map.of("Environment", ENVIRONMENT, "NotificationType", "sms");
-
         verify(cloudwatchMetricsService)
-                .putEmbeddedValue("NotifyDeliveryDuration", 1000, expectedContext);
+                .putEmbeddedValue(
+                        "NotifyDeliveryDuration", 1000, Map.of("NotificationType", "sms"));
 
         assertThat(response, hasStatus(204));
         assertThat(logging.events(), haveJourneyId(reference));
@@ -213,7 +211,6 @@ class NotifyCallbackHandlerTest {
         var expectedMetricsContext =
                 Map.ofEntries(
                         Map.entry("EmailName", type.getTemplateAlias()),
-                        Map.entry("Environment", ENVIRONMENT),
                         Map.entry("NotifyStatus", "delivered"));
 
         verify(cloudwatchMetricsService).incrementCounter("EmailSent", expectedMetricsContext);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -37,6 +37,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Map;
 
 import static java.lang.String.valueOf;
@@ -265,8 +266,6 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         cloudwatchMetricsService.incrementCounter(
                 "AuthAisResult",
                 Map.of(
-                        "Environment",
-                        configurationService.getEnvironment(),
                         "blocked",
                         valueOf(response.blocked()),
                         "suspended",
@@ -281,7 +280,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             UnsuccessfulAccountInterventionsResponseException e) {
         cloudwatchMetricsService.incrementCounter(
                 "Auth" + configurationService.getAccountInterventionsErrorMetricName(),
-                Map.of("Environment", configurationService.getEnvironment()));
+                Collections.emptyMap());
         LOG.error(
                 "Error in Account Interventions response HttpCode: {}, ErrorMessage: {}.",
                 e.getHttpCode(),
@@ -291,8 +290,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             try {
                 LOG.error("Swallowing error and returning default account interventions response");
                 cloudwatchMetricsService.incrementCounter(
-                        "AuthAisErrorIgnored",
-                        Map.of("Environment", configurationService.getEnvironment()));
+                        "AuthAisErrorIgnored", Collections.emptyMap());
                 return generateApiGatewayProxyResponse(200, noAccountInterventions(), true);
             } catch (JsonException ex) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -354,11 +354,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                 METRICS.putEmbeddedValue(
                         "SendingSms",
                         1,
-                        Map.of(
-                                "Environment",
-                                configurationService.getEnvironment(),
-                                "Country",
-                                PhoneNumberHelper.getCountry(destination)));
+                        Map.of("Country", PhoneNumberHelper.getCountry(destination)));
             }
 
             var notifyRequest =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -14,6 +14,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -49,7 +50,6 @@ public class TicfCriHandler implements RequestHandler<TICFCRIRequest, Void> {
     @Override
     public Void handleRequest(TICFCRIRequest input, Context context) {
         LOG.debug("received request to TICF CRI Handler");
-        var environmentForMetrics = Map.entry("Environment", configurationService.getEnvironment());
         try {
             var response = sendRequest(input);
             var statusCode = String.valueOf(response.statusCode());
@@ -59,8 +59,7 @@ public class TicfCriHandler implements RequestHandler<TICFCRIRequest, Void> {
                             statusCode, response.body());
             LOG.info(logMessage);
             cloudwatchMetricsService.incrementCounter(
-                    "TicfCriResponseReceived",
-                    Map.ofEntries(environmentForMetrics, Map.entry("StatusCode", statusCode)));
+                    "TicfCriResponseReceived", Map.ofEntries(Map.entry("StatusCode", statusCode)));
         } catch (HttpTimeoutException e) {
             var errorDescription =
                     format(
@@ -86,8 +85,7 @@ public class TicfCriHandler implements RequestHandler<TICFCRIRequest, Void> {
         } else {
             LOG.warn(errorDescription);
         }
-        cloudwatchMetricsService.incrementCounter(
-                metric, Map.of("Environment", configurationService.getEnvironment()));
+        cloudwatchMetricsService.incrementCounter(metric, Collections.emptyMap());
     }
 
     private HttpResponse<String> sendRequest(TICFCRIRequest ticfcriRequest)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -51,6 +51,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -188,9 +189,9 @@ class AccountInterventionsHandlerTest {
         assertThat(result, hasStatus(200));
         assertEquals(DEFAULT_NO_INTERVENTIONS_RESPONSE, result.getBody());
         verify(cloudwatchMetricsService)
-                .incrementCounter("AuthAISException", Map.of("Environment", "test-environment"));
+                .incrementCounter("AuthAISException", Collections.emptyMap());
         verify(cloudwatchMetricsService)
-                .incrementCounter("AuthAisErrorIgnored", Map.of("Environment", "test-environment"));
+                .incrementCounter("AuthAisErrorIgnored", Collections.emptyMap());
     }
 
     @Test
@@ -433,7 +434,6 @@ class AccountInterventionsHandlerTest {
                 result.getBody());
         var expectedMetricDimensions =
                 Map.ofEntries(
-                        Map.entry("Environment", TEST_ENVIRONMENT),
                         Map.entry("blocked", String.valueOf(blocked)),
                         Map.entry("suspended", String.valueOf(suspended)),
                         Map.entry("reproveIdentity", String.valueOf(reproveIdentity)),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
@@ -23,6 +23,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -51,8 +52,6 @@ class TicfCriHandlerTest {
     private static final String JOURNEY_ID = "journey-id";
     private static final List<String> VECTORS_OF_TRUST = List.of("Cl");
     private AutoCloseable mocks;
-    private static final Map<String, String> METRICS_CONTEXT =
-            Map.of("Environment", "test-environment");
 
     @BeforeEach
     void setUp() {
@@ -113,9 +112,7 @@ class TicfCriHandlerTest {
         verify(cloudwatchMetricsService)
                 .incrementCounter(
                         "TicfCriResponseReceived",
-                        Map.ofEntries(
-                                Map.entry("Environment", "test-environment"),
-                                Map.entry("StatusCode", statusCode.toString())));
+                        Map.ofEntries(Map.entry("StatusCode", statusCode.toString())));
     }
 
     @ParameterizedTest
@@ -129,7 +126,7 @@ class TicfCriHandlerTest {
                         COMMON_SUBJECTID, VECTORS_OF_TRUST, JOURNEY_ID, USER_IS_AUTHENTICATED),
                 context);
 
-        verify(cloudwatchMetricsService).incrementCounter(metricName, METRICS_CONTEXT);
+        verify(cloudwatchMetricsService).incrementCounter(metricName, Collections.emptyMap());
     }
 
     private static List<Arguments> exceptions() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenService.java
@@ -14,8 +14,8 @@ import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.ACCESS_TOKEN_SERVICE_CONSISTENT_READ_QUERY_ATTEMPT;
@@ -144,8 +144,7 @@ public class AccessTokenService extends BaseDynamoService<AccessTokenStore> {
 
     void incrementCloudwatchCounter(String metricName) {
         try {
-            cloudwatchMetricsService.incrementCounter(
-                    metricName, Map.of("Environment", configurationService.getEnvironment()));
+            cloudwatchMetricsService.incrementCounter(metricName, Collections.emptyMap());
         } catch (Exception e) {
             LOG.warn("Unable to increment access token service cloudwatch counter", e);
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -41,6 +41,7 @@ public class CloudwatchMetricsService {
                     var dimensionsSet = new DimensionSet();
 
                     dimensions.forEach(dimensionsSet::addDimension);
+                    dimensionsSet.addDimension("Environment", configurationService.getEnvironment());
 
                     metrics.setNamespace("Authentication");
                     metrics.putDimensions(dimensionsSet);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -5,12 +5,12 @@ import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ACCOUNT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.CLIENT_NAME;
-import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.IS_TEST;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_REQUIRED;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.REQUESTED_LEVEL_OF_CONFIDENCE;
@@ -41,7 +41,8 @@ public class CloudwatchMetricsService {
                     var dimensionsSet = new DimensionSet();
 
                     dimensions.forEach(dimensionsSet::addDimension);
-                    dimensionsSet.addDimension("Environment", configurationService.getEnvironment());
+                    dimensionsSet.addDimension(
+                            "Environment", configurationService.getEnvironment());
 
                     metrics.setNamespace("Authentication");
                     metrics.putDimensions(dimensionsSet);
@@ -66,8 +67,6 @@ public class CloudwatchMetricsService {
                 Map.of(
                         ACCOUNT.getValue(),
                         accountState.name(),
-                        ENVIRONMENT.getValue(),
-                        configurationService.getEnvironment(),
                         CLIENT.getValue(),
                         clientId,
                         IS_TEST.getValue(),
@@ -81,37 +80,20 @@ public class CloudwatchMetricsService {
         if (AuthSessionItem.AccountState.NEW.equals(accountState) && !isTestJourney) {
             incrementCounter(
                     AUTHENTICATION_SUCCESS_NEW_ACCOUNT_BY_CLIENT.getValue(),
-                    Map.of(
-                            ENVIRONMENT.getValue(),
-                            configurationService.getEnvironment(),
-                            CLIENT.getValue(),
-                            clientId,
-                            CLIENT_NAME.getValue(),
-                            clientName));
+                    Map.of(CLIENT.getValue(), clientId, CLIENT_NAME.getValue(), clientName));
         }
         if (AuthSessionItem.AccountState.EXISTING.equals(accountState) && !isTestJourney) {
             incrementCounter(
                     AUTHENTICATION_SUCCESS_EXISTING_ACCOUNT_BY_CLIENT.getValue(),
-                    Map.of(
-                            ENVIRONMENT.getValue(),
-                            configurationService.getEnvironment(),
-                            CLIENT.getValue(),
-                            clientId,
-                            CLIENT_NAME.getValue(),
-                            clientName));
+                    Map.of(CLIENT.getValue(), clientId, CLIENT_NAME.getValue(), clientName));
         }
     }
 
     public void logEmailCheckDuration(long duration) {
-        this.putEmbeddedValue(
-                EMAIL_CHECK_DURATION.getValue(),
-                duration,
-                Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
+        this.putEmbeddedValue(EMAIL_CHECK_DURATION.getValue(), duration, Collections.emptyMap());
     }
 
     public void incrementMfaResetHandoffCount() {
-        incrementCounter(
-                MFA_RESET_HANDOFF.getValue(),
-                Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
+        incrementCounter(MFA_RESET_HANDOFF.getValue(), Collections.emptyMap());
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccessTokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccessTokenServiceTest.java
@@ -8,7 +8,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
 
-import java.util.Map;
+import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -59,17 +59,14 @@ class AccessTokenServiceTest {
         accessTokenService.get(TEST_PARTITION);
 
         verify(cloudwatchMetricsService, times(1))
-                .incrementCounter(
-                        "AccessTokenServiceInitialQueryAttempt",
-                        Map.of("Environment", "test-environment"));
+                .incrementCounter("AccessTokenServiceInitialQueryAttempt", Collections.emptyMap());
         verify(cloudwatchMetricsService, times(1))
                 .incrementCounter(
-                        "AccessTokenServiceConsistentReadQueryAttempt",
-                        Map.of("Environment", "test-environment"));
+                        "AccessTokenServiceConsistentReadQueryAttempt", Collections.emptyMap());
         verify(cloudwatchMetricsService, times(1))
                 .incrementCounter(
                         "AccessTokenServiceConsistentReadQueryAttemptSuccess",
-                        Map.of("Environment", "test-environment"));
+                        Collections.emptyMap());
     }
 
     @Test
@@ -79,12 +76,8 @@ class AccessTokenServiceTest {
         accessTokenService.get(TEST_PARTITION);
 
         verify(cloudwatchMetricsService, times(1))
-                .incrementCounter(
-                        "AccessTokenServiceInitialQueryAttempt",
-                        Map.of("Environment", "test-environment"));
+                .incrementCounter("AccessTokenServiceInitialQueryAttempt", Collections.emptyMap());
         verify(cloudwatchMetricsService, times(1))
-                .incrementCounter(
-                        "AccessTokenServiceInitialQuerySuccess",
-                        Map.of("Environment", "test-environment"));
+                .incrementCounter("AccessTokenServiceInitialQuerySuccess", Collections.emptyMap());
     }
 }


### PR DESCRIPTION
We are currently configuring this at every call site.
