### PR TITLE
AUT-3767: Add account_deletion_reason extension to AUTH_DELETE_ACCOUNT

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AccountDeletionReason.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AccountDeletionReason.java
@@ -1,0 +1,6 @@
+package uk.gov.di.accountmanagement.entity;
+
+public enum AccountDeletionReason {
+    USER_INITIATED,
+    SUPPORT_INITIATED
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.RemoveAccountRequest;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
 import uk.gov.di.accountmanagement.helpers.AuditHelper;
@@ -120,7 +121,8 @@ public class RemoveAccountHandler
             accountDeletionService.removeAccount(
                     Optional.of(input),
                     userProfile,
-                    AuditHelper.getTxmaAuditEncoded(input.getHeaders()));
+                    AuditHelper.getTxmaAuditEncoded(input.getHeaders()),
+                    AccountDeletionReason.USER_INITIATED);
 
             return generateEmptySuccessApiGatewayResponse();
         } catch (UserNotFoundException e) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -3,6 +3,7 @@ package uk.gov.di.accountmanagement.services;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.audit.AuditContext;
@@ -25,6 +26,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class AccountDeletionService {
     private static final Logger LOG = LogManager.getLogger(AccountDeletionService.class);
@@ -52,7 +54,8 @@ public class AccountDeletionService {
     public void removeAccount(
             Optional<APIGatewayProxyRequestEvent> input,
             UserProfile userProfile,
-            Optional<String> txmaAuditEncoded)
+            Optional<String> txmaAuditEncoded,
+            AccountDeletionReason reason)
             throws Json.JsonException {
         LOG.info("Calculating internal common subject identifier");
         var internalCommonSubjectIdentifier =
@@ -119,7 +122,8 @@ public class AccountDeletionService {
                             userProfile.getPhoneNumber(),
                             persistentSessionID,
                             txmaAuditEncoded);
-            auditService.submitAuditEvent(AUTH_DELETE_ACCOUNT, auditContext);
+            auditService.submitAuditEvent(
+                    AUTH_DELETE_ACCOUNT, auditContext, pair("account_deletion_reason", reason));
         } catch (Exception e) {
             LOG.error("Failed to audit account deletion: ", e);
         }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
@@ -3,6 +3,7 @@ package uk.gov.di.accountmanagement.services;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
+import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.DeletedAccountIdentifiers;
 import uk.gov.di.accountmanagement.entity.LegacyAccountDeletionMessage;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -41,7 +42,11 @@ public class ManualAccountDeletionService {
                         userProfile.getLegacySubjectID(),
                         getCommonSubjectId(userProfile));
         try {
-            accountDeletionService.removeAccount(Optional.empty(), userProfile, Optional.empty());
+            accountDeletionService.removeAccount(
+                    Optional.empty(),
+                    userProfile,
+                    Optional.empty(),
+                    AccountDeletionReason.SUPPORT_INITIATED);
             var deletedAccountPayload =
                     SerializationService.getInstance()
                             .writeValueAsString(legacyAccountDeletionMessage);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
 import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
@@ -89,7 +90,10 @@ class RemoveAccountHandlerTest {
         assertThat(result, hasStatus(204));
         verify(accountDeletionService)
                 .removeAccount(
-                        Optional.of(event), userProfile, Optional.of(TXMA_ENCODED_HEADER_VALUE));
+                        Optional.of(event),
+                        userProfile,
+                        Optional.of(TXMA_ENCODED_HEADER_VALUE),
+                        AccountDeletionReason.USER_INITIATED);
     }
 
     @Test
@@ -107,7 +111,11 @@ class RemoveAccountHandlerTest {
 
         assertThat(result, hasStatus(204));
         verify(accountDeletionService)
-                .removeAccount(Optional.of(event), userProfile, Optional.empty());
+                .removeAccount(
+                        Optional.of(event),
+                        userProfile,
+                        Optional.empty(),
+                        AccountDeletionReason.USER_INITIATED);
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.DeletedAccountIdentifiers;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -60,7 +61,11 @@ class ManualAccountDeletionServiceTest {
 
         // then
         verify(accountDeletionService)
-                .removeAccount(Optional.empty(), USER_PROFILE, Optional.empty());
+                .removeAccount(
+                        Optional.empty(),
+                        USER_PROFILE,
+                        Optional.empty(),
+                        AccountDeletionReason.SUPPORT_INITIATED);
     }
 
     @Test
@@ -116,7 +121,7 @@ class ManualAccountDeletionServiceTest {
         // given
         doThrow(new Json.JsonException("error"))
                 .when(accountDeletionService)
-                .removeAccount(any(), any(), any());
+                .removeAccount(any(), any(), any(), any());
 
         // then
         assertThrows(RuntimeException.class, () -> underTest.manuallyDeleteAccount(USER_PROFILE));


### PR DESCRIPTION

## What
Replaces #4901 
This will allow us to distinguish between a user deleting their own account, and support deleting an account on behalf of a user.


