### PR TITLE
ATO-922: add rp pairwise id to orch session

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthUserInfoClaims.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthUserInfoClaims.java
@@ -8,6 +8,7 @@ public enum AuthUserInfoClaims {
     LEGACY_SUBJECT_ID("legacy_subject_id"),
     PUBLIC_SUBJECT_ID("public_subject_id"),
     LOCAL_ACCOUNT_ID("local_account_id"),
+    RP_PAIRWISE_ID("rp_pairwise_id"),
     EMAIL("email"),
     EMAIL_VERIFIED("email_verified"),
     PHONE_NUMBER("phone_number"),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -506,7 +506,12 @@ public class AuthenticationCallbackHandler
                 var metadataPairs = new ArrayList<AuditService.MetadataPair>();
                 metadataPairs.add(pair("internalSubjectId", UNKNOWN));
                 metadataPairs.add(pair("isNewAccount", newAccount));
-                metadataPairs.add(pair("rpPairwiseId", userInfo.getClaim("rp_pairwise_id")));
+                metadataPairs.add(
+                        pair(
+                                "rpPairwiseId",
+                                userInfo.getClaim(
+                                        AuthUserInfoClaims.RP_PAIRWISE_ID.getValue(),
+                                        String.class)));
                 metadataPairs.add(pair("authCode", authCode.getValue()));
                 if (authenticationRequest.getNonce() != null) {
                     metadataPairs.add(pair("nonce", authenticationRequest.getNonce().getValue()));
@@ -664,13 +669,20 @@ public class AuthenticationCallbackHandler
         String verifiedMfaMethodType =
                 userInfo.getClaim(
                         AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(), String.class);
+        String rpPairwiseId =
+                userInfo.getClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue(), String.class);
+
         OrchSessionItem updatedOrchSession =
                 orchSession
                         .withVerifiedMfaMethodType(verifiedMfaMethodType)
-                        .withEmailAddress(userInfo.getEmailAddress());
+                        .withEmailAddress(userInfo.getEmailAddress())
+                        .withRpPairwiseId(rpPairwiseId);
         LOG.info("Updating Orch session with claims from userinfo response");
         // TODO-922: temporary logs for checking all is working as expected
         LOG.info("is email attached to orch session: {}", orchSession.getEmailAddress() != null);
+        LOG.info(
+                "is rpPairwiseId attached to orch session: {}",
+                orchSession.getRpPairwiseId() != null);
         //
         orchSessionService.updateSession(updatedOrchSession);
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -137,7 +137,8 @@ class AuthenticationCallbackHandlerTest {
         when(USER_INFO.getEmailAddress()).thenReturn(TEST_EMAIL_ADDRESS);
         when(USER_INFO.getSubject()).thenReturn(INTERNAL_PAIRWISE_ID);
         when(USER_INFO.getBooleanClaim("new_account")).thenReturn(true);
-        when(USER_INFO.getClaim("rp_pairwise_id")).thenReturn(RP_PAIRWISE_ID.getValue());
+        when(USER_INFO.getClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue(), String.class))
+                .thenReturn(RP_PAIRWISE_ID.getValue());
         when(USER_INFO.getPhoneNumber()).thenReturn("1234");
         when(USER_INFO.getClaim(
                         AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(), String.class))
@@ -402,6 +403,7 @@ class AuthenticationCallbackHandlerTest {
                 MFAMethodType.AUTH_APP.getValue(),
                 equalTo(orchSessionCaptor.getValue().getVerifiedMfaMethodType()));
         assertEquals(TEST_EMAIL_ADDRESS, orchSessionCaptor.getValue().getEmailAddress());
+        assertEquals(RP_PAIRWISE_ID.getValue(), orchSessionCaptor.getValue().getRpPairwiseId());
     }
 
     @Nested

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -10,11 +10,13 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
     public static final String ATTRIBUTE_EMAIL = "Email";
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
+    public static final String ATTRIBUTE_RP_PAIRWISE_ID = "RpPairwiseId";
 
     private String sessionId;
     private long timeToLive;
     private String email;
     private String verifiedMfaMethodType;
+    private String rpPairwiseId;
 
     public OrchSessionItem() {}
 
@@ -76,6 +78,20 @@ public class OrchSessionItem {
 
     public OrchSessionItem withVerifiedMfaMethodType(String verifiedMfaMethodType) {
         this.verifiedMfaMethodType = verifiedMfaMethodType;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_RP_PAIRWISE_ID)
+    public String getRpPairwiseId() {
+        return rpPairwiseId;
+    }
+
+    public void setRpPairwiseId(String rpPairwiseId) {
+        this.rpPairwiseId = rpPairwiseId;
+    }
+
+    public OrchSessionItem withRpPairwiseId(String rpPairwiseId) {
+        this.rpPairwiseId = rpPairwiseId;
         return this;
     }
 }


### PR DESCRIPTION
## What
Adds rpPairwiseId to the Orch session. This field is already being sent in the auth userinfo response. This is needed because in `AuthCodeHandler`, there is a function `getRpPairwiseId`, which uses the userProfile table to get the `rpPairwiseId`. We instead want to get it from the orch session here, so we can remove orch's use of the userProfileTable

## How to review

1. Code Review commit by commit