### PR TITLE
ATO-1104: Fix broken Auth session expiry

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -21,7 +21,7 @@ public class AuthSessionItem {
 
     private String sessionId;
     private String verifiedMfaMethodType;
-    private long timeToLive;
+    private long ttl;
     private AccountState isNewAccount;
 
     public AuthSessionItem() {}
@@ -56,16 +56,16 @@ public class AuthSessionItem {
     }
 
     @DynamoDbAttribute("ttl")
-    public long getTimeToLive() {
-        return timeToLive;
+    public long getTtl() {
+        return ttl;
     }
 
-    public void setTimeToLive(long timeToLive) {
-        this.timeToLive = timeToLive;
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
     }
 
-    public AuthSessionItem withTimeToLive(long timeToLive) {
-        this.timeToLive = timeToLive;
+    public AuthSessionItem withTtl(long ttl) {
+        this.ttl = ttl;
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 public class AuthSessionItem {
 
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
+    public static final String ATTRIBUTE_TIME_TO_LIVE = "TimeToLive";
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "isNewAccount";
 
     public enum AccountState {
@@ -20,6 +21,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
 
     private String sessionId;
+    private long timeToLive;
     private String verifiedMfaMethodType;
     private long ttl;
     private AccountState isNewAccount;
@@ -38,6 +40,20 @@ public class AuthSessionItem {
 
     public AuthSessionItem withSessionId(String sessionId) {
         this.sessionId = sessionId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_TIME_TO_LIVE)
+    public long getTimeToLive() {
+        return timeToLive;
+    }
+
+    public void setTimeToLive(long timeToLive) {
+        this.timeToLive = timeToLive;
+    }
+
+    public AuthSessionItem withTimeToLive(long timeToLive) {
+        this.timeToLive = timeToLive;
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -50,7 +50,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                 AuthSessionItem newItem =
                         oldItem.get()
                                 .withSessionId(newSessionId)
-                                .withTimeToLive(
+                                .withTtl(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()
                                                 .getEpochSecond());
@@ -65,7 +65,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                         new AuthSessionItem()
                                 .withSessionId(newSessionId)
                                 .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
-                                .withTimeToLive(
+                                .withTtl(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()
                                                 .getEpochSecond());
@@ -91,8 +91,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
         }
 
         Optional<AuthSessionItem> validAuthSession =
-                authSession.filter(
-                        s -> s.getTimeToLive() > NowHelper.now().toInstant().getEpochSecond());
+                authSession.filter(s -> s.getTtl() > NowHelper.now().toInstant().getEpochSecond());
         if (validAuthSession.isEmpty()) {
             LOG.info("Auth session item with expired TTL found. Session ID: {}", sessionId);
         }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -80,7 +80,7 @@ class AuthSessionServiceTest {
         AuthSessionItem savedItem = captor.getValue();
 
         assertThat(savedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertTrue(savedItem.getTtl() > Instant.now().getEpochSecond());
+        assertTrue(savedItem.getTimeToLive() > Instant.now().getEpochSecond());
     }
 
     @Test
@@ -94,7 +94,7 @@ class AuthSessionServiceTest {
         AuthSessionItem savedItem = captor.getValue();
 
         assertThat(savedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertTrue(savedItem.getTtl() > Instant.now().getEpochSecond());
+        assertTrue(savedItem.getTimeToLive() > Instant.now().getEpochSecond());
     }
 
     @Test
@@ -108,7 +108,7 @@ class AuthSessionServiceTest {
         AuthSessionItem updatedItem = captor.getValue();
 
         assertThat(updatedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertTrue(updatedItem.getTtl() > Instant.now().getEpochSecond());
+        assertTrue(updatedItem.getTimeToLive() > Instant.now().getEpochSecond());
         verify(table).deleteItem(existingSession);
     }
 
@@ -163,14 +163,17 @@ class AuthSessionServiceTest {
 
     private AuthSessionItem withValidSession() {
         AuthSessionItem existingSession =
-                new AuthSessionItem().withSessionId(SESSION_ID).withTtl(VALID_TTL);
+                new AuthSessionItem().withSessionId(SESSION_ID).withTimeToLive(VALID_TTL);
         when(table.getItem(SESSION_ID_PARTITION_KEY)).thenReturn(existingSession);
         return existingSession;
     }
 
     private void withExpiredSession() {
         when(table.getItem(SESSION_ID_PARTITION_KEY))
-                .thenReturn(new AuthSessionItem().withSessionId(SESSION_ID).withTtl(EXPIRED_TTL));
+                .thenReturn(
+                        new AuthSessionItem()
+                                .withSessionId(SESSION_ID)
+                                .withTimeToLive(EXPIRED_TTL));
     }
 
     private void withNoSession() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -80,7 +80,7 @@ class AuthSessionServiceTest {
         AuthSessionItem savedItem = captor.getValue();
 
         assertThat(savedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertTrue(savedItem.getTimeToLive() > Instant.now().getEpochSecond());
+        assertTrue(savedItem.getTtl() > Instant.now().getEpochSecond());
     }
 
     @Test
@@ -94,7 +94,7 @@ class AuthSessionServiceTest {
         AuthSessionItem savedItem = captor.getValue();
 
         assertThat(savedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertTrue(savedItem.getTimeToLive() > Instant.now().getEpochSecond());
+        assertTrue(savedItem.getTtl() > Instant.now().getEpochSecond());
     }
 
     @Test
@@ -108,7 +108,7 @@ class AuthSessionServiceTest {
         AuthSessionItem updatedItem = captor.getValue();
 
         assertThat(updatedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertTrue(updatedItem.getTimeToLive() > Instant.now().getEpochSecond());
+        assertTrue(updatedItem.getTtl() > Instant.now().getEpochSecond());
         verify(table).deleteItem(existingSession);
     }
 
@@ -163,17 +163,14 @@ class AuthSessionServiceTest {
 
     private AuthSessionItem withValidSession() {
         AuthSessionItem existingSession =
-                new AuthSessionItem().withSessionId(SESSION_ID).withTimeToLive(VALID_TTL);
+                new AuthSessionItem().withSessionId(SESSION_ID).withTtl(VALID_TTL);
         when(table.getItem(SESSION_ID_PARTITION_KEY)).thenReturn(existingSession);
         return existingSession;
     }
 
     private void withExpiredSession() {
         when(table.getItem(SESSION_ID_PARTITION_KEY))
-                .thenReturn(
-                        new AuthSessionItem()
-                                .withSessionId(SESSION_ID)
-                                .withTimeToLive(EXPIRED_TTL));
+                .thenReturn(new AuthSessionItem().withSessionId(SESSION_ID).withTtl(EXPIRED_TTL));
     }
 
     private void withNoSession() {


### PR DESCRIPTION
## Issue

Auth DynamoDB sessions aren't expiring and being deleted. This is because the `ttl` `attribute_name`, defined in the `auth_session_table` terraform resource, doesn't match any AuthSessionItem attribute.

## Fix

1. Introduce a new "TimeToLive" attribute which matches the existing terraform. Set this value on session creation. Set the exisiting "ttl" attribute to 0.
2. Modify the `getSession` logic in AuthSessionService to filter on the exisiting "ttl" attribute if it's non-zero, otherwise filter on the new "TimeToLive" attribute.
3. Wait some time (> session expiry) so that all live sessions have the new "TimeToLive" attribute.
4. Deprecate "ttl" in code.
5. Remove all sessions in DynamoDB that have a value set for "ttl" - will likely need to write a script for this.

This PR covers 1 and 2 above. This will be carefully tested in lower envs before releasing to prod.

## How to review
1. Review plan for fix above
2. Check code matches plan steps 1 and 2