### PR TITLE
BAU: Group minor and patch gradle dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: daily
       time: "03:00"
     open-pull-requests-limit: 100
+    groups:
+      gradle-security-updates:
+        applies-to: security-updates
+        update-types:
+          - minor
+          - patch
     target-branch: main
     commit-message:
       prefix: BAU


### PR DESCRIPTION
## What

Attempt to configure dependabot security updates to group minor and patch changes into one PR.

The only reason for trying this is after reviewing the documentation at https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups & https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates it seems to infer that groups are nessesary to have the security updates configured as we'd like.

In this case it is to resolve an issue where BAU is not prefixed on security update PRs, e.g. https://github.com/govuk-one-login/authentication-api/pull/5387

## How to review

1. Code Review