### PR TITLE
ATO-922: verify internalCommonSubjectIdentifier and internalPairwiseI…

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -371,6 +371,14 @@ public class AuthenticationCallbackHandler
                 LOG.info(
                         "is email attached to auth-external-api userinfo response: {}",
                         userInfo.getEmailAddress() != null);
+                LOG.info(
+                        "is internalCommonSubjectIdentifier defined: {}",
+                        userSession.getInternalCommonSubjectIdentifier() != null);
+                LOG.info(
+                        "is internalCommonSubjectIdentifier the same as internalPairwiseId: {}",
+                        userInfo.getSubject()
+                                .getValue()
+                                .equals(userSession.getInternalCommonSubjectIdentifier()));
                 //
 
                 Boolean newAccount = userInfo.getBooleanClaim("new_account");


### PR DESCRIPTION
## What
tl;dr: Temporary logs to verify that these two have the same value.

In UserInfoService, the definition of internalPairwiseId is the **subject** of the UserInfo request. Then in LogoutService, createAuditUser uses getInternalCommonSubjectIdentifier(), which is set in updateSessionWithSubject() with the value returned from getSubjectWithSectorIdentifier() which has exactly the same definition as internalPairwiseId! This logging is to verify that these two are in fact the same value. If they are, then we don't need to get the subject from the userInfo response, and can instead just get `internalPairwiseId` from `userInfo.getSubject()` in AuthenticaionCallbackHandler, add it to the orchSession and call that when we want i`nternalCommonSubjectIdentifier`. 

## How to review
1. Code Review. No impact, just test logs.