### PR TITLE
ATO-922: set internal subject id in orch session

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -676,13 +676,17 @@ public class AuthenticationCallbackHandler
                 orchSession
                         .withVerifiedMfaMethodType(verifiedMfaMethodType)
                         .withEmailAddress(userInfo.getEmailAddress())
-                        .withRpPairwiseId(rpPairwiseId);
+                        .withRpPairwiseId(rpPairwiseId)
+                        .withInternalPairwiseId(userInfo.getSubject().getValue());
         LOG.info("Updating Orch session with claims from userinfo response");
         // TODO-922: temporary logs for checking all is working as expected
         LOG.info("is email attached to orch session: {}", orchSession.getEmailAddress() != null);
         LOG.info(
                 "is rpPairwiseId attached to orch session: {}",
                 orchSession.getRpPairwiseId() != null);
+        LOG.info(
+                "is internalPairwiseId attached to orch session: {}",
+                orchSession.getInternalPairwiseId() != null);
         //
         orchSessionService.updateSession(updatedOrchSession);
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -404,6 +404,9 @@ class AuthenticationCallbackHandlerTest {
                 equalTo(orchSessionCaptor.getValue().getVerifiedMfaMethodType()));
         assertEquals(TEST_EMAIL_ADDRESS, orchSessionCaptor.getValue().getEmailAddress());
         assertEquals(RP_PAIRWISE_ID.getValue(), orchSessionCaptor.getValue().getRpPairwiseId());
+        assertEquals(
+                INTERNAL_PAIRWISE_ID.getValue(),
+                orchSessionCaptor.getValue().getInternalPairwiseId());
     }
 
     @Nested

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -11,12 +11,14 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_EMAIL = "Email";
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
     public static final String ATTRIBUTE_RP_PAIRWISE_ID = "RpPairwiseId";
+    public static final String ATTRIBUTE_INTERNAL_PAIRWISE_ID = "InternalPairwiseId";
 
     private String sessionId;
     private long timeToLive;
     private String email;
     private String verifiedMfaMethodType;
     private String rpPairwiseId;
+    private String internalPairwiseId;
 
     public OrchSessionItem() {}
 
@@ -92,6 +94,20 @@ public class OrchSessionItem {
 
     public OrchSessionItem withRpPairwiseId(String rpPairwiseId) {
         this.rpPairwiseId = rpPairwiseId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_INTERNAL_PAIRWISE_ID)
+    public String getInternalPairwiseId() {
+        return internalPairwiseId;
+    }
+
+    public void setInternalPairwiseId(String internalPairwiseId) {
+        this.internalPairwiseId = internalPairwiseId;
+    }
+
+    public OrchSessionItem withInternalPairwiseId(String internalPairwiseId) {
+        this.internalPairwiseId = internalPairwiseId;
         return this;
     }
 }


### PR DESCRIPTION
## What
Adds internalSubjectId to the orch session. This is needed in LogoutService, which currently takes the subjectId and builds the internalSubjectId again (named as subjectWithSectorIdentifier). By having this in the orch session, we can skip having to rebuild it, and also consolidate the name of this value to hopefully be named the same thing (internalSubjectId) everywhere.

Code does not affect any journey's. It just sets it in the orch session with some logging to verify the value is defined.

## How to review
1. Code Review