### PR TITLE
ATO-1088: Set authenticated flag in all cases a user is handed back from Auth

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -152,7 +152,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     }
 
     @Test
-    void shouldStoreUserInfoAndRedirectToRpWhenSuccessfullyProcessedCallbackResponse() {
+    void shouldStoreUserInfoAndRedirectToRpWhenSuccessfullyProcessedCallbackResponse()
+            throws Json.JsonException {
         var response =
                 makeRequest(
                         Optional.empty(),
@@ -162,6 +163,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         assertUserInfoStoredAndRedirectedToRp(response);
         assertOrchSessionIsUpdatedWithUserInfoClaims();
+        assertTrue(redis.getSession(SESSION_ID).isAuthenticated());
     }
 
     @Test
@@ -262,6 +264,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         assertRedirectToIpv(response, false);
         assertOrchSessionIsUpdatedWithUserInfoClaims();
+        assertTrue(redis.getSession(SESSION_ID).isAuthenticated());
     }
 
     void accountInterventionSetup() throws Json.JsonException {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -376,7 +376,8 @@ public class AuthenticationCallbackHandler
                 Boolean newAccount = userInfo.getBooleanClaim("new_account");
                 AccountState accountState = newAccount ? AccountState.NEW : AccountState.EXISTING;
 
-                sessionService.storeOrUpdateSession(userSession.setNewAccount(accountState));
+                sessionService.storeOrUpdateSession(
+                        userSession.setNewAccount(accountState).setAuthenticated(true));
                 var docAppJourney = isDocCheckingAppUserWithSubjectId(clientSession);
                 Map<String, String> dimensions =
                         buildDimensions(
@@ -494,8 +495,6 @@ public class AuthenticationCallbackHandler
                 var authenticationResponse =
                         new AuthenticationSuccessResponse(
                                 clientRedirectURI, authCode, null, null, state, null, responseMode);
-
-                sessionService.storeOrUpdateSession(userSession.setAuthenticated(true));
 
                 cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
                 cloudwatchMetricsService.incrementSignInByClient(


### PR DESCRIPTION
## What
- We now set the user as authenticated in the session when they are handed back from Auth regardless of whether they are on an identity or auth-only journey. 
- The practical effect of this on a User's journey is that now if they abandon an identity journey from a fresh session, they will pass through Auth as logged in when they return if their session has not expired. The current behaviour is that they would be prompted to log in before being passed to back IPV.

- There is a second part of this change which involves removing the redundant setting this field in IPV callback handler in this PR https://github.com/govuk-one-login/authentication-api/pull/5430, however this change is the part that will have a user facing change. 

## How to review
- Code review commit-by-commit 
- Deploy to a dev environment
    - Check that silent login is not affected by this 
    - There is not much testing that can be done in dev as IPV is not hooked up
    - Check with IPV before merging

- Before deploying to Prod:
    - Pause promotion from staging  
    - Run through an identity journey and abandon it when handed over to IPV 
    - Return to the stub and request a new identity journey 
    - Observe skipping auth
    - Check that the handover back from IPV -> Orch works fine
## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs
- PR to remove redundant setting: https://github.com/govuk-one-login/authentication-api/pull/5430