### PR TITLE
ATO-1088: remove setting authenticated in ipv callback

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -44,7 +44,6 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTH_CODE_ISSUED;
 import static uk.gov.di.authentication.shared.lambda.BaseFrontendHandler.TXMA_AUDIT_ENCODED_HEADER;
 import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
@@ -99,7 +98,6 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 authCodeResponse.getLocation(),
                 startsWith("https://rp-build.build.stubs.account.gov.uk/?code="));
 
-        assertTrue(redis.getSession(sessionID).isAuthenticated());
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_ISSUED));
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -252,8 +252,6 @@ public class IPVCallbackHelper {
                 clientSession.getClientName(),
                 isTestJourney);
 
-        authCodeResponseService.saveSession(false, sessionService, session);
-
         return authenticationResponse;
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import static java.util.Objects.isNull;
 import static uk.gov.di.orchestration.shared.conditions.DocAppUserHelper.isDocCheckingAppUserWithSubjectId;
 import static uk.gov.di.orchestration.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
+import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING_DOC_APP_JOURNEY;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.addAnnotation;
@@ -278,7 +279,10 @@ public class AuthCodeHandler
                     clientSession.getClientName(),
                     isTestJourney);
 
-            authCodeResponseService.saveSession(docAppJourney, sessionService, session);
+            if (docAppJourney) {
+                sessionService.storeOrUpdateSession(
+                        session.setNewAccount(EXISTING_DOC_APP_JOURNEY));
+            }
 
             LOG.info("Generating successful auth code response");
             return generateApiGatewayProxyResponse(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -16,9 +16,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING;
-import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING_DOC_APP_JOURNEY;
-
 public class AuthCodeResponseGenerationService {
     private static final Logger LOG = LogManager.getLogger(AuthCodeResponseGenerationService.class);
 
@@ -115,14 +112,5 @@ public class AuthCodeResponseGenerationService {
                         dynamoService,
                         configurationService.getInternalSectorURI())
                 .getValue();
-    }
-
-    public void saveSession(boolean docAppJourney, SessionService sessionService, Session session) {
-        if (docAppJourney) {
-            sessionService.storeOrUpdateSession(session.setNewAccount(EXISTING_DOC_APP_JOURNEY));
-        } else {
-            sessionService.storeOrUpdateSession(
-                    session.setAuthenticated(true).setNewAccount(EXISTING));
-        }
     }
 }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs
- Branches off of https://github.com/govuk-one-login/authentication-api/pull/5429 so must be merged first