### PR TITLE
ATO-1118: add phone number to all auth userinfo responses

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -75,9 +75,6 @@ public class UserInfoService {
         if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.EMAIL_VERIFIED.getValue())) {
             userInfo.setEmailVerified(userProfile.isEmailVerified());
         }
-        if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.PHONE_NUMBER.getValue())) {
-            userInfo.setPhoneNumber(userProfile.getPhoneNumber());
-        }
         if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.PHONE_VERIFIED.getValue())) {
             userInfo.setPhoneNumberVerified(userProfile.isPhoneNumberVerified());
         }
@@ -95,6 +92,7 @@ public class UserInfoService {
 
     private void addClaimsFromUserProfile(UserProfile userProfile, UserInfo userInfo) {
         userInfo.setEmailAddress(userProfile.getEmail());
+        userInfo.setPhoneNumber(userProfile.getPhoneNumber());
     }
 
     private static String bytesToBase64(ByteBuffer byteBuffer) {

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -83,7 +83,6 @@ public class UserInfoServiceTest {
             String expectedPublicSubjectId,
             String expectedLocalAccountId,
             Boolean expectedEmailVerified,
-            String expectedPhoneNumber,
             Boolean expectedPhoneNumberVerified,
             String expectedSalt) {
         UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore, authSession);
@@ -92,12 +91,12 @@ public class UserInfoServiceTest {
         assertEquals(TEST_RP_PAIRWISE_ID, actual.getClaim("rp_pairwise_id"));
         assertEquals(TEST_IS_NEW_ACCOUNT, actual.getClaim("new_account"));
         assertEquals(TEST_EMAIL, actual.getEmailAddress());
+        assertEquals(TEST_PHONE, actual.getPhoneNumber());
 
         assertEquals(expectedLegacySubjectId, actual.getClaim("legacy_subject_id"));
         assertEquals(expectedPublicSubjectId, actual.getClaim("public_subject_id"));
         assertEquals(expectedLocalAccountId, actual.getClaim("local_account_id"));
         assertEquals(expectedEmailVerified, actual.getEmailVerified());
-        assertEquals(expectedPhoneNumber, actual.getPhoneNumber());
         assertEquals(expectedPhoneNumberVerified, actual.getPhoneNumberVerified());
         assertEquals(expectedSalt, actual.getClaim("salt"));
         assertEquals(TEST_PASSWORD_RESET_TIME, actual.getClaim("password_reset_time"));
@@ -112,7 +111,6 @@ public class UserInfoServiceTest {
                         TEST_SUBJECT.getValue(),
                         null,
                         null,
-                        null,
                         null),
                 Arguments.of(
                         getMockAccessTokenStore(
@@ -121,7 +119,6 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         TEST_EMAIL_VERIFIED,
-                        null,
                         null,
                         null),
                 Arguments.of(
@@ -139,7 +136,6 @@ public class UserInfoServiceTest {
                         TEST_PUBLIC_SUBJECT_ID,
                         TEST_SUBJECT.getValue(),
                         TEST_EMAIL_VERIFIED,
-                        TEST_PHONE,
                         TEST_PHONE_VERIFIED,
                         bytesToBase64(TEST_SALT)));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -45,6 +45,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
     private static final String INTERNAL_SECTOR_ID_HOST = "test.account.gov.uk";
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String TEST_PHONE_NUMBER = "01234567890";
+    private static final String FORMATTED_PHONE_NUMBER = "+441234567890";
     private static final String TEST_PASSWORD = "password-1";
     private static final Subject TEST_SUBJECT = new Subject();
     private static final String TEST_SESSION_ID = UUID.randomUUID().toString();
@@ -118,11 +119,11 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
         assertThat(
                 userInfoResponse.getClaim(OIDCScopeValue.EMAIL.getValue()),
                 equalTo(TEST_EMAIL_ADDRESS));
+        assertThat(userInfoResponse.getPhoneNumber(), equalTo(FORMATTED_PHONE_NUMBER));
 
         assertNull(userInfoResponse.getClaim("legacy_subject_id"));
         assertNull(userInfoResponse.getClaim("public_subject_id"));
         assertNull(userInfoResponse.getClaim("local_account_id"));
-        assertNull(userInfoResponse.getPhoneNumber());
         assertNull(userInfoResponse.getPhoneNumberVerified());
         assertNull(userInfoResponse.getClaim("salt"));
         assertThat(


### PR DESCRIPTION
## What
Orch needs phone number to add to the orch session, so eg in IPVCallbackHandler, the phone number can be used without using the UserProfile table. This is an internal endpoint, so although phone number is always sent back, the RP to Orch UserInfo response will still use the set of requested claims to determine what to send to the RP.

## How to review
1. Code Review
2. Tested in dev