### PR TITLE
ATO-1104: turn ttl back on with renamed attribute

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -696,10 +696,10 @@ resource "aws_dynamodb_table" "auth_session_table" {
     type = "S"
   }
 
-  #   ttl {
-  #     attribute_name = "TimeToLive"
-  #     enabled        = false
-  #   }
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
 
   point_in_time_recovery {
     enabled = true


### PR DESCRIPTION
## What

- Follow up PR from https://github.com/govuk-one-login/authentication-api/pull/5572,  this now re-enables the TTL config with the renamed attribute
- Must merge the previous PR first, otherwise this will fail to deploy
- There must be at least 1 hour after the previous PR hits prod to merge this one 

## How to review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs
- https://github.com/govuk-one-login/authentication-api/pull/5572 must be merged first