### PR TITLE
ATO-922: remove email from orch session

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -675,11 +675,9 @@ public class AuthenticationCallbackHandler
         OrchSessionItem updatedOrchSession =
                 orchSession
                         .withVerifiedMfaMethodType(verifiedMfaMethodType)
-                        .withEmailAddress(userInfo.getEmailAddress())
                         .withRpPairwiseId(rpPairwiseId);
         LOG.info("Updating Orch session with claims from userinfo response");
         // TODO-922: temporary logs for checking all is working as expected
-        LOG.info("is email attached to orch session: {}", orchSession.getEmailAddress() != null);
         LOG.info(
                 "is rpPairwiseId attached to orch session: {}",
                 orchSession.getRpPairwiseId() != null);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -402,7 +402,6 @@ class AuthenticationCallbackHandlerTest {
         assertThat(
                 MFAMethodType.AUTH_APP.getValue(),
                 equalTo(orchSessionCaptor.getValue().getVerifiedMfaMethodType()));
-        assertEquals(TEST_EMAIL_ADDRESS, orchSessionCaptor.getValue().getEmailAddress());
         assertEquals(RP_PAIRWISE_ID.getValue(), orchSessionCaptor.getValue().getRpPairwiseId());
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -8,7 +8,6 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 public class OrchSessionItem {
 
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
-    public static final String ATTRIBUTE_EMAIL = "Email";
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
     public static final String ATTRIBUTE_RP_PAIRWISE_ID = "RpPairwiseId";
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "IsNewAccount";
@@ -22,7 +21,6 @@ public class OrchSessionItem {
 
     private String sessionId;
     private long timeToLive;
-    private String email;
     private String verifiedMfaMethodType;
     private String rpPairwiseId;
     private AccountState isNewAccount;
@@ -60,20 +58,6 @@ public class OrchSessionItem {
 
     public OrchSessionItem withTimeToLive(long timeToLive) {
         this.timeToLive = timeToLive;
-        return this;
-    }
-
-    @DynamoDbAttribute(ATTRIBUTE_EMAIL)
-    public String getEmailAddress() {
-        return email;
-    }
-
-    public void setEmailAddress(String email) {
-        this.email = email;
-    }
-
-    public OrchSessionItem withEmailAddress(String email) {
-        this.email = email;
         return this;
     }
 


### PR DESCRIPTION
## What
Removes email from the orch session. We actually already have a means to get this data via the UserInfo table, and because it isn't session-specific, it makes more sense for this info to live in the UserInfo table.

Nowhere uses this yet, so no danger in just removing it.

## How to review
1. Code Review