### PR TITLE
ATO-1118: add phone number to auth UserInfo response for all identity journeys

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -883,6 +883,7 @@ public class AuthorisationHandler
             // Email required for ID journeys for use in Face-to-Face flows
             claimsSet.add(AuthUserInfoClaims.EMAIL);
             claimsSet.add(AuthUserInfoClaims.EMAIL_VERIFIED);
+            claimsSet.add(AuthUserInfoClaims.PHONE_NUMBER);
         }
         if (amScopePresent) {
             LOG.info("am scope is present. Adding the public_subject_id claim");


### PR DESCRIPTION
## What
Orch needs access to a user's phone number only within identity journeys, so following the pattern of email and local_account_id, we add phone number as a claim for all identity journeys.

I've decided to follow this pattern, instead of adding phone number to all UserInfo requests, as we explicitly only need it in identity journeys.

This PR also adds a low-level trust journey test to verify that specifically for high-trust identity journeys, we add in a number of scopes, which now includes phone number.

## How to review
1. Code Review