### PR TITLE
ATO-1115: get email from userinfo response instead of session

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -392,8 +392,8 @@ public class AuthenticationCallbackHandler
                 user =
                         user.withUserId(userInfo.getSubject().getValue())
                                 .withEmail(
-                                        Optional.of(userSession)
-                                                .map(Session::getEmailAddress)
+                                        Optional.of(userInfo)
+                                                .map(UserInfo::getEmailAddress)
                                                 .orElse(UNKNOWN))
                                 .withPhone(
                                         Optional.of(userInfo)
@@ -416,9 +416,9 @@ public class AuthenticationCallbackHandler
                                 userSession.getSessionId(),
                                 clientId,
                                 userInfo.getSubject().getValue(),
-                                Objects.isNull(userSession.getEmailAddress())
+                                Objects.isNull(userInfo.getEmailAddress())
                                         ? UNKNOWN
-                                        : userSession.getEmailAddress(),
+                                        : userInfo.getEmailAddress(),
                                 IpAddressHelper.extractIpAddress(input),
                                 Objects.isNull(userInfo.getPhoneNumber())
                                         ? UNKNOWN
@@ -489,7 +489,7 @@ public class AuthenticationCallbackHandler
 
                 var authCode =
                         authorisationCodeService.generateAndSaveAuthorisationCode(
-                                clientSessionId, userSession.getEmailAddress(), clientSession);
+                                clientSessionId, userInfo.getEmailAddress(), clientSession);
 
                 var authenticationResponse =
                         new AuthenticationSuccessResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -84,9 +84,7 @@ class AuthenticationCallbackHandlerTest {
             "uDjIfGhoKwP8bFpRewlpd-AVrI4--1700750982787";
     private static final String SESSION_ID = "a-session-id";
     private static final Session session =
-            new Session(SESSION_ID)
-                    .setEmailAddress(TEST_EMAIL_ADDRESS)
-                    .setVerifiedMfaMethodType(MFAMethodType.EMAIL);
+            new Session(SESSION_ID).setVerifiedMfaMethodType(MFAMethodType.EMAIL);
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String CLIENT_NAME = "client-name";


### PR DESCRIPTION
## What
This email is sent back in the UserInfo response from auth on every request, so we can safely use this to get email instead ot the session ([see logs here](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20(index%3D%22gds_di_production%22%20message%3D%22is%20email%20attached%20to%20auth-external-api%20userinfo%20response*%22)&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=-7d%40h&latest=now&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&sid=1730127482.802442)).

## How to review
1. Code Review
1. Deployed to dev, and ran through a journey. Working as expected
