### PR TITLE
ATO-975: Add current credential strength into the auth session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -2,9 +2,12 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 
 public record StartRequest(
         @Expose @SerializedName("previous-session-id") String previousSessionId,
         @Expose @SerializedName("rp-pairwise-id-for-reauth") String rpPairwiseIdForReauth,
         @Expose @SerializedName("previous-govuk-signin-journey-id")
-                String previousGovUkSigninJourneyId) {}
+                String previousGovUkSigninJourneyId,
+        @Expose @SerializedName("current-credential-strength")
+                CredentialTrustLevel currentCredentialStrength) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -16,10 +16,7 @@ import uk.gov.di.authentication.frontendapi.entity.StartResponse;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.services.StartService;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
-import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.entity.*;
 import uk.gov.di.authentication.shared.helpers.DocAppSubjectIdHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.ReauthAuthenticationAttemptsHelper;
@@ -194,7 +191,10 @@ public class StartHandler
             StartRequest startRequest = objectMapper.readValue(input.getBody(), StartRequest.class);
             Optional<String> previousSessionId =
                     Optional.ofNullable(startRequest.previousSessionId());
-            authSessionService.addOrUpdateSessionId(previousSessionId, session.getSessionId());
+            CredentialTrustLevel currentCredentialStrength =
+                    startRequest.currentCredentialStrength();
+            authSessionService.addOrUpdateSessionId(
+                    previousSessionId, session.getSessionId(), currentCredentialStrength);
 
             var clientSessionId =
                     getHeaderValueFromHeaders(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -72,7 +72,7 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
     }
 
     public void addSession(Optional<String> previousSessionId, String sessionId) {
-        authSessionService.addOrUpdateSessionId(previousSessionId, sessionId);
+        authSessionService.addOrUpdateSessionId(previousSessionId, sessionId, null);
     }
 
     public void updateSession(AuthSessionItem sessionItem) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -9,6 +9,7 @@ public class AuthSessionItem {
 
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "isNewAccount";
+    public static final String ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH = "currentCredentialStrength";
 
     public enum AccountState {
         NEW,
@@ -23,6 +24,7 @@ public class AuthSessionItem {
     private String verifiedMfaMethodType;
     private long timeToLive;
     private AccountState isNewAccount;
+    private CredentialTrustLevel currentCredentialStrength;
 
     public AuthSessionItem() {}
 
@@ -80,6 +82,21 @@ public class AuthSessionItem {
 
     public AuthSessionItem withAccountState(AccountState accountState) {
         this.isNewAccount = accountState;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH)
+    public CredentialTrustLevel getCurrentCredentialStrength() {
+        return this.currentCredentialStrength;
+    }
+
+    public void setCurrentCredentialStrength(CredentialTrustLevel currentCredentialStrength) {
+        this.currentCredentialStrength = currentCredentialStrength;
+    }
+
+    public AuthSessionItem withCurrentCredentialStrength(
+            CredentialTrustLevel currentCredentialStrength) {
+        this.currentCredentialStrength = currentCredentialStrength;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.exceptions.AuthSessionException;
 import uk.gov.di.authentication.shared.helpers.InputSanitiser;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -39,7 +40,10 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
         this.configurationService = configurationService;
     }
 
-    public void addOrUpdateSessionId(Optional<String> previousSessionId, String newSessionId) {
+    public void addOrUpdateSessionId(
+            Optional<String> previousSessionId,
+            String newSessionId,
+            CredentialTrustLevel currentCredentialStrength) {
         try {
             Optional<AuthSessionItem> oldItem = Optional.empty();
             if (previousSessionId.isPresent()) {
@@ -50,6 +54,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                 AuthSessionItem newItem =
                         oldItem.get()
                                 .withSessionId(newSessionId)
+                                .withCurrentCredentialStrength(currentCredentialStrength)
                                 .withTimeToLive(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()
@@ -65,6 +70,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                         new AuthSessionItem()
                                 .withSessionId(newSessionId)
                                 .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
+                                .withCurrentCredentialStrength(currentCredentialStrength)
                                 .withTimeToLive(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()


### PR DESCRIPTION
## What

This is used alongside https://github.com/govuk-one-login/authentication-frontend/pull/2164/files to take the `currentCredentialStrength` from the `start` frontend and set it into the auth session.

The `currentCredentialStrength` is passed to the frontend through the authorize request and set in the auth session so it can be taken and passed on in the userinfo back to orch.

Noted: in later lambdas we do null checks for this value.



