### PR TITLE
AUT-3828: Bump terms and conditions version number

### DIFF
--- a/ci/terraform/oidc/localstack.tfvars
+++ b/ci/terraform/oidc/localstack.tfvars
@@ -11,6 +11,6 @@ test_client_verify_email_otp        = "123456"
 test_client_verify_phone_number_otp = "123456"
 test_clients_enabled                = "true"
 client_registry_api_enabled         = true
-terms_and_conditions                = "1.0"
+terms_and_conditions                = "1.12"
 notify_url                          = "http://notify.internal:8888"
 notify_api_key                      = "test-0123456789-0123456789-0123456789-0123456789-0123456789"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -142,7 +142,7 @@ variable "use_localstack" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.11"
+  default = "1.12"
 }
 
 variable "localstack_endpoint" {

--- a/ci/terraform/shared/localstack.tfvars
+++ b/ci/terraform/shared/localstack.tfvars
@@ -4,5 +4,5 @@ aws_dynamodb_endpoint       = "http://localhost:8000"
 use_localstack              = true
 stub_rp_clients             = []
 test_client_email_allowlist = "testclient.user1@digital.cabinet-office.gov.uk,testclient.user2@digital.cabinet-office.gov.uk"
-terms_and_conditions        = "1.0"
+terms_and_conditions        = "1.12"
 password_pepper             = "fake-pepper"

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -36,7 +36,7 @@ variable "external_redis_host" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.11"
+  default = "1.12"
 }
 
 variable "external_redis_port" {

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -63,7 +63,7 @@ variable "cloudwatch_log_retention" {
 
 variable "terms_and_conditions" {
   type        = string
-  default     = "1.11"
+  default     = "1.12"
   description = "The latest Terms and Conditions version number"
 }
 


### PR DESCRIPTION
## What

Bumps Terms and Conditions version number to reflect a change in the personal data retention period. As suggested in the guidance, I've searched for instances of `terms_and_conditions` and updated these to reflect the new version too.

## How to review

1. Code Review

## Related PRs

Privacy notice updates to reflect the changed retention period are made in https://github.com/govuk-one-login/authentication-frontend/pull/2252 
