### PR TITLE
ATO-1129: add email and verified MFA claims to all userinfo requests

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -63,6 +63,17 @@ public class UserInfoService {
         userInfo.setClaim("new_account", accessTokenInfo.getIsNewAccount());
         userInfo.setClaim("password_reset_time", accessTokenInfo.getPasswordResetTime());
 
+        // TODO: ATO-1129: delete temporary logs
+        LOG.info(
+                "is email a requested claim: {}",
+                accessTokenInfo.getClaims().contains(AuthUserInfoClaims.EMAIL.getValue()));
+        LOG.info(
+                "is verified_mfa a requested claim: {}",
+                accessTokenInfo
+                        .getClaims()
+                        .contains(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue()));
+        //
+
         if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.LEGACY_SUBJECT_ID.getValue())) {
             userInfo.setClaim("legacy_subject_id", userProfile.getLegacySubjectID());
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -876,12 +876,14 @@ public class AuthorisationHandler
         var emailScopePresent = requestedScopesContain(OIDCScopeValue.EMAIL, authenticationRequest);
 
         var claimsSet = new HashSet<AuthUserInfoClaims>();
+        claimsSet.add(AuthUserInfoClaims.EMAIL);
+        claimsSet.add(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE);
         if (identityRequired) {
-            LOG.info("Identity is required. Adding the local_account_id and salt claims");
+            LOG.info(
+                    "Identity is required. Adding the local_account_id, salt, email_verified and phone_number claims");
             claimsSet.add(AuthUserInfoClaims.LOCAL_ACCOUNT_ID);
             claimsSet.add(AuthUserInfoClaims.SALT);
             // Email required for ID journeys for use in Face-to-Face flows
-            claimsSet.add(AuthUserInfoClaims.EMAIL);
             claimsSet.add(AuthUserInfoClaims.EMAIL_VERIFIED);
             claimsSet.add(AuthUserInfoClaims.PHONE_NUMBER);
         }
@@ -900,8 +902,7 @@ public class AuthorisationHandler
             claimsSet.add(AuthUserInfoClaims.PHONE_VERIFIED);
         }
         if (emailScopePresent) {
-            LOG.info("email scope is present. Adding the email and email_verified claim");
-            claimsSet.add(AuthUserInfoClaims.EMAIL);
+            LOG.info("email scope is present. Adding the email_verified claim");
             claimsSet.add(AuthUserInfoClaims.EMAIL_VERIFIED);
         }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -368,7 +368,7 @@ class AuthorisationHandlerTest {
             var captor = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
             assertEquals(
-                    "{\"userinfo\":{\"email_verified\":null,\"email\":null}}",
+                    "{\"userinfo\":{\"email_verified\":null,\"verified_mfa_method_type\":null,\"email\":null}}",
                     captor.getValue().getClaim("claim"));
         }
 
@@ -381,7 +381,7 @@ class AuthorisationHandlerTest {
                     .thenReturn(TEST_ENCRYPTED_JWT);
 
             var requestParams =
-                    buildRequestParams(Map.of("scope", "openid email", "vtr", "[\"Cl\"]"));
+                    buildRequestParams(Map.of("scope", "openid phone", "vtr", "[\"Cl\"]"));
             var event = withRequestEvent(requestParams);
             event.setRequestContext(
                     new ProxyRequestContext()
@@ -404,7 +404,7 @@ class AuthorisationHandlerTest {
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
             var expectedClaimSetRequest =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"email_verified\":null,\"email\":null}}");
+                            "{\"userinfo\":{\"phone_number_verified\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null}}");
             var actualClaimSetRequest =
                     ClaimsSetRequest.parse(captor.getValue().getStringClaim("claim"));
             assertEquals(
@@ -443,7 +443,7 @@ class AuthorisationHandlerTest {
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
             var expectedClaimSetRequest =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"salt\":null,\"email_verified\":null,\"local_account_id\":null,\"phone_number\":null,\"email\":null}}");
+                            "{\"userinfo\":{\"salt\":null,\"email_verified\":null,\"local_account_id\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null}}");
             var actualClaimSetRequest =
                     ClaimsSetRequest.parse(captor.getValue().getStringClaim("claim"));
             assertEquals(
@@ -1623,7 +1623,8 @@ class AuthorisationHandlerTest {
             ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
 
-            var expectedClaim = "{\"userinfo\":{\"public_subject_id\":null}}";
+            var expectedClaim =
+                    "{\"userinfo\":{\"verified_mfa_method_type\":null,\"public_subject_id\":null,\"email\":null}}";
             var actualClaim = argument.getValue().getStringClaim("claim");
             assertThat(actualClaim, is(equalTo(expectedClaim)));
         }
@@ -1642,7 +1643,8 @@ class AuthorisationHandlerTest {
             ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
 
-            var expectedClaim = "{\"userinfo\":{\"legacy_subject_id\":null}}";
+            var expectedClaim =
+                    "{\"userinfo\":{\"legacy_subject_id\":null,\"verified_mfa_method_type\":null,\"email\":null}}";
             var actualClaim = argument.getValue().getStringClaim("claim");
             assertThat(actualClaim, is(equalTo(expectedClaim)));
         }


### PR DESCRIPTION

## What
We need these claims in every UserInfo response, so we always adds these claims.

Currently, we always add these within the auth UserInfo response, but (taken from the ticket description),
> _For authentication to be truly separate from orch and for their interaction to be a by-the-book oidc flow, auth should not be at all aware of what orch is using the data for - it should just provide whatever data the consuming service asks for (and is allowed). Currently, authentication code has been changed to send back email and verified mfa method. Instead, we should change orch code to always request these claims. Else, the two services remain coupled._

This shouldn't make any functional difference, as currently, both of these are always sent back (auth code has been changed such that this is the case). Instead of migrating all at once, I've updated orch's code and added some logging in authentication to verify that the request always contains these claims. Once this is the case, I can safely add back in authentications "if claim is present" logic for email and verified MFA type.

## How to review
1. Code Review
