### PR TITLE
ATO-983: Remove InternalCommonSubjectIdentifier From Session (Auth ICSID 3/3)

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
@@ -9,7 +9,6 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 public class SessionHelper {
@@ -18,7 +17,6 @@ public class SessionHelper {
     public static void updateSessionWithSubject(
             UserContext userContext,
             AuthSessionItem authSession,
-            SessionService sessionService,
             AuthSessionService authSessionService,
             AuthenticationService authenticationService,
             ConfigurationService configurationService) {
@@ -37,8 +35,6 @@ public class SessionHelper {
                                         authenticationService)
                                 .getValue();
         LOG.info("Setting internal common subject identifier in user session");
-        session.setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier);
-        sessionService.storeOrUpdateSession(session);
         authSession.setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier);
         authSessionService.updateSession(authSession);
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
@@ -29,8 +29,8 @@ public class SessionHelper {
                         ? userContext.getUserProfile().get()
                         : authenticationService.getUserProfileByEmail(session.getEmailAddress());
         var internalCommonSubjectIdentifier =
-                session.getInternalCommonSubjectIdentifier() != null
-                        ? session.getInternalCommonSubjectIdentifier()
+                authSession.getInternalCommonSubjectIdentifier() != null
+                        ? authSession.getInternalCommonSubjectIdentifier()
                         : ClientSubjectHelper.getSubjectWithSectorIdentifier(
                                         userProfile,
                                         configurationService.getInternalSectorUri(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
@@ -3,9 +3,10 @@ package uk.gov.di.authentication.frontendapi.helpers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler;
-import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
@@ -16,11 +17,13 @@ public class SessionHelper {
 
     public static void updateSessionWithSubject(
             UserContext userContext,
-            AuthenticationService authenticationService,
-            ConfigurationService configurationService,
+            AuthSessionItem authSession,
             SessionService sessionService,
-            Session session) {
+            AuthSessionService authSessionService,
+            AuthenticationService authenticationService,
+            ConfigurationService configurationService) {
         LOG.info("Calculating internal common subject identifier");
+        var session = userContext.getSession();
         UserProfile userProfile =
                 userContext.getUserProfile().isPresent()
                         ? userContext.getUserProfile().get()
@@ -34,9 +37,9 @@ public class SessionHelper {
                                         authenticationService)
                                 .getValue();
         LOG.info("Setting internal common subject identifier in user session");
-        sessionService.storeOrUpdateSession(
-                userContext
-                        .getSession()
-                        .setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier));
+        session.setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier);
+        sessionService.storeOrUpdateSession(session);
+        authSession.setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier);
+        authSessionService.updateSession(authSession);
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsRequest;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsResponse;
 import uk.gov.di.authentication.frontendapi.entity.State;
 import uk.gov.di.authentication.frontendapi.services.AccountInterventionsService;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException;
@@ -25,6 +26,7 @@ import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -38,6 +40,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.lang.String.valueOf;
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
@@ -54,6 +57,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final Gson gson;
     private final LambdaInvokerService lambdaInvoker;
+    private final AuthSessionService authSessionService;
 
     private final NowClock clock;
 
@@ -90,12 +94,14 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.clock = new NowClock(Clock.systemUTC());
         this.lambdaInvoker = new LambdaInvokerService(configurationService);
+        this.authSessionService = new AuthSessionService(configurationService);
         gson = new Gson();
     }
 
     protected AccountInterventionsHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
@@ -116,6 +122,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.clock = clock;
         this.lambdaInvoker = lambdaInvoker;
+        this.authSessionService = authSessionService;
 
         gson = new Gson();
     }
@@ -127,6 +134,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         super(AccountInterventionsRequest.class, configurationService, redis);
 
         this.lambdaInvoker = lambdaInvokerService;
+        this.authSessionService = new AuthSessionService(configurationService);
 
         accountInterventionsService = new AccountInterventionsService(configurationService);
         this.auditService = new AuditService(configurationService);
@@ -183,8 +191,15 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
 
             logAisResponse(accountInterventionsInboundResponse);
 
+            var sessionId = userContext.getSession().getSessionId();
+            var authSession = authSessionService.getSession(sessionId);
+
             submitAuditEvents(
-                    accountInterventionsInboundResponse, input, userContext, persistentSessionID);
+                    accountInterventionsInboundResponse,
+                    input,
+                    userContext,
+                    persistentSessionID,
+                    authSession.map(AuthSessionItem::getInternalCommonSubjectIdentifier));
 
             if (configurationService.isInvokeTicfCRILambdaEnabled()
                     && request.authenticated() != null) {
@@ -312,7 +327,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             AccountInterventionsInboundResponse accountInterventionsInboundResponse,
             APIGatewayProxyRequestEvent input,
             UserContext userContext,
-            String persistentSessionID) {
+            String persistentSessionID,
+            Optional<String> internalCommonSubjectIdentifier) {
         State requiredInterventionsState = accountInterventionsInboundResponse.state();
 
         FrontendAuditableEvent auditEvent =
@@ -321,7 +337,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
-                        userContext.getSession().getInternalCommonSubjectIdentifier(),
+                        internalCommonSubjectIdentifier.orElse(AuditService.UNKNOWN),
                         userContext.getSession().getEmailAddress(),
                         IpAddressHelper.extractIpAddress(input),
                         userContext

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -156,8 +156,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             AuditableEvent auditableEvent;
             var rpPairwiseId = AuditService.UNKNOWN;
             var userMfaDetail = new UserMfaDetail();
-            var session = userContext.getSession();
-            var sessionId = session.getSessionId();
+            var sessionId = userContext.getSession().getSessionId();
             var maybeAuthSession = authSessionService.getSession(sessionId);
             if (userExists) {
                 auditableEvent = FrontendAuditableEvent.AUTH_CHECK_USER_KNOWN_EMAIL;
@@ -177,7 +176,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
                 LOG.info("Setting internal common subject identifier in user session");
 
-                session.setInternalCommonSubjectIdentifier(internalPairwiseId);
                 maybeAuthSession.ifPresent(
                         s -> s.setInternalCommonSubjectIdentifier(internalPairwiseId));
                 var isPhoneNumberVerified = userProfile.get().isPhoneNumberVerified();
@@ -191,7 +189,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                                 isPhoneNumberVerified);
                 auditContext = auditContext.withSubjectId(internalPairwiseId);
             } else {
-                session.setInternalCommonSubjectIdentifier(null);
                 maybeAuthSession.ifPresent(s -> s.setInternalCommonSubjectIdentifier(null));
                 auditableEvent = FrontendAuditableEvent.AUTH_CHECK_USER_NO_ACCOUNT_WITH_EMAIL;
             }
@@ -224,7 +221,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                             userMfaDetail.getMfaMethodType(),
                             getLastDigitsOfPhoneNumber(userMfaDetail),
                             lockoutInformation);
-            sessionService.storeOrUpdateSession(session);
             maybeAuthSession.ifPresent(authSessionService::updateSession);
 
             LOG.info("Successfully processed request");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -302,11 +302,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             UserProfile userProfile,
             AuditContext auditContext,
             AuthSessionItem authSessionItem) {
-        sessionService.storeOrUpdateSession(
-                userContext
-                        .getSession()
-                        .setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier));
-
         authSessionService.updateSession(
                 authSessionItem
                         .withAccountState(AuthSessionItem.AccountState.EXISTING)

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -308,7 +308,9 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         .setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier));
 
         authSessionService.updateSession(
-                authSessionItem.withAccountState(AuthSessionItem.AccountState.EXISTING));
+                authSessionItem
+                        .withAccountState(AuthSessionItem.AccountState.EXISTING)
+                        .withInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier));
 
         var userMfaDetail =
                 getUserMFADetail(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -177,11 +177,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
 
             LOG.info("Setting internal common subject identifier in user session");
             sessionService.storeOrUpdateSession(
-                    userContext
-                            .getSession()
-                            .setEmailAddress(request.getEmail())
-                            .setInternalCommonSubjectIdentifier(
-                                    internalCommonSubjectIdentifier.getValue()));
+                    userContext.getSession().setEmailAddress(request.getEmail()));
 
             authSessionService.updateSession(
                     authSessionItem

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -184,7 +184,10 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                                     internalCommonSubjectIdentifier.getValue()));
 
             authSessionService.updateSession(
-                    authSessionItem.withAccountState(AuthSessionItem.AccountState.NEW));
+                    authSessionItem
+                            .withAccountState(AuthSessionItem.AccountState.NEW)
+                            .withInternalCommonSubjectIdentifier(
+                                    internalCommonSubjectIdentifier.getValue()));
             LOG.info("Successfully processed request");
             return generateApiGatewayProxyResponse(200, "");
         } else {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -188,12 +188,16 @@ public class StartHandler
 
             Optional<String> maybeInternalSubjectId =
                     userContext.getUserProfile().map(UserProfile::getSubjectID);
-            Optional<String> maybeInternalCommonSubjectIdentifier =
-                    Optional.ofNullable(session.getInternalCommonSubjectIdentifier());
 
             StartRequest startRequest = objectMapper.readValue(input.getBody(), StartRequest.class);
             Optional<String> previousSessionId =
                     Optional.ofNullable(startRequest.previousSessionId());
+            var maybeInternalCommonSubjectIdentifier =
+                    previousSessionId.flatMap(
+                            prevId ->
+                                    authSessionService
+                                            .getSession(prevId)
+                                            .map(s -> s.getInternalCommonSubjectIdentifier()));
             authSessionService.addOrUpdateSessionId(previousSessionId, session.getSessionId());
 
             var clientSessionId =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.entity.UpdateProfileRequest;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -17,6 +18,7 @@ import uk.gov.di.authentication.shared.helpers.LogLineHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -42,10 +44,12 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
     private static final Logger LOG = LogManager.getLogger(UpdateProfileHandler.class);
 
     private final AuditService auditService;
+    private final AuthSessionService authSessionService;
 
     protected UpdateProfileHandler(
             AuthenticationService authenticationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ConfigurationService configurationService,
             AuditService auditService,
@@ -58,6 +62,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 clientService,
                 authenticationService);
         this.auditService = auditService;
+        this.authSessionService = authSessionService;
     }
 
     public UpdateProfileHandler() {
@@ -67,12 +72,14 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
     public UpdateProfileHandler(ConfigurationService configurationService) {
         super(UpdateProfileRequest.class, configurationService);
         auditService = new AuditService(configurationService);
+        authSessionService = new AuthSessionService(configurationService);
     }
 
     public UpdateProfileHandler(
             ConfigurationService configurationService, RedisConnectionService redis) {
         super(UpdateProfileRequest.class, configurationService, redis);
         auditService = new AuditService(configurationService);
+        authSessionService = new AuthSessionService(configurationService);
     }
 
     @Override
@@ -103,6 +110,9 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
             UserContext userContext) {
 
         Session session = userContext.getSession();
+        var authSession = authSessionService.getSession(session.getSessionId());
+        var internalCommonSubjectId =
+                authSession.map(AuthSessionItem::getInternalCommonSubjectIdentifier).orElseThrow();
 
         String persistentSessionId =
                 PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
@@ -130,7 +140,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
-                        session.getInternalCommonSubjectIdentifier(),
+                        internalCommonSubjectId,
                         session.getEmailAddress(),
                         ipAddress,
                         auditablePhoneNumber,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -236,7 +236,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 SessionHelper.updateSessionWithSubject(
                         userContext,
                         authSessionOptional.get(),
-                        sessionService,
                         authSessionService,
                         authenticationService,
                         configurationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -235,10 +235,11 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             if (codeRequestType.equals(CodeRequestType.PW_RESET_MFA_SMS)) {
                 SessionHelper.updateSessionWithSubject(
                         userContext,
-                        authenticationService,
-                        configurationService,
+                        authSession.get(),
                         sessionService,
-                        session);
+                        authSessionService,
+                        authenticationService,
+                        configurationService);
             }
 
             processSuccessfulCodeRequest(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -312,7 +312,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             SessionHelper.updateSessionWithSubject(
                     userContext,
                     authSession,
-                    sessionService,
                     authSessionService,
                     authenticationService,
                     configurationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -309,10 +309,11 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         if (JourneyType.PASSWORD_RESET_MFA.equals(codeRequest.getJourneyType())) {
             SessionHelper.updateSessionWithSubject(
                     userContext,
-                    authenticationService,
-                    configurationService,
+                    authSession,
                     sessionService,
-                    session);
+                    authSessionService,
+                    authenticationService,
+                    configurationService);
         }
 
         var errorResponseMaybe = mfaCodeProcessor.validateCode();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -110,7 +110,8 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
     }
 
     @Override
-    public void processSuccessfulCodeRequest(String ipAddress, String persistentSessionId) {
+    public void processSuccessfulCodeRequest(
+            String ipAddress, String persistentSessionId, String internalCommonSubjectId) {
         switch (codeRequest.getJourneyType()) {
             case REGISTRATION:
                 dynamoService.setAuthAppAndAccountVerified(
@@ -121,6 +122,7 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
                         AuditService.UNKNOWN,
                         ipAddress,
                         persistentSessionId,
+                        internalCommonSubjectId,
                         false);
                 break;
             case ACCOUNT_RECOVERY:
@@ -132,11 +134,13 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
                         AuditService.UNKNOWN,
                         ipAddress,
                         persistentSessionId,
+                        internalCommonSubjectId,
                         true);
                 break;
             case SIGN_IN:
             case PASSWORD_RESET_MFA:
-                clearAccountRecoveryBlockIfPresent(AUTH_APP, ipAddress, persistentSessionId);
+                clearAccountRecoveryBlockIfPresent(
+                        AUTH_APP, ipAddress, persistentSessionId, internalCommonSubjectId);
         }
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
@@ -67,12 +67,13 @@ public abstract class MfaCodeProcessor {
             String phoneNumber,
             String ipAddress,
             String persistentSessionId,
+            String internalCommonSubjectId,
             boolean accountRecovery) {
 
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
-                        userContext.getSession().getInternalCommonSubjectIdentifier(),
+                        internalCommonSubjectId,
                         emailAddress,
                         ipAddress,
                         phoneNumber,
@@ -86,18 +87,19 @@ public abstract class MfaCodeProcessor {
     }
 
     void clearAccountRecoveryBlockIfPresent(
-            MFAMethodType mfaMethodType, String ipAddress, String persistentSessionId) {
+            MFAMethodType mfaMethodType,
+            String ipAddress,
+            String persistentSessionId,
+            String internalCommonSubjectId) {
         var accountRecoveryBlockPresent =
-                accountModifiersService.isAccountRecoveryBlockPresent(
-                        userContext.getSession().getInternalCommonSubjectIdentifier());
+                accountModifiersService.isAccountRecoveryBlockPresent(internalCommonSubjectId);
         if (accountRecoveryBlockPresent) {
             LOG.info("AccountRecovery block is present. Removing block");
-            accountModifiersService.removeAccountRecoveryBlockIfPresent(
-                    userContext.getSession().getInternalCommonSubjectIdentifier());
+            accountModifiersService.removeAccountRecoveryBlockIfPresent(internalCommonSubjectId);
             var auditContext =
                     auditContextFromUserContext(
                             userContext,
-                            userContext.getSession().getInternalCommonSubjectIdentifier(),
+                            internalCommonSubjectId,
                             emailAddress,
                             ipAddress,
                             AuditService.UNKNOWN,
@@ -111,5 +113,6 @@ public abstract class MfaCodeProcessor {
 
     public abstract Optional<ErrorResponse> validateCode();
 
-    public abstract void processSuccessfulCodeRequest(String ipAddress, String persistentSessionId);
+    public abstract void processSuccessfulCodeRequest(
+            String ipAddress, String persistentSessionId, String internalCommonSubjectId);
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.frontendapi.entity.Intervention;
 import uk.gov.di.authentication.frontendapi.entity.State;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.frontendapi.services.AccountInterventionsService;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -37,6 +38,7 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -101,6 +103,7 @@ class AccountInterventionsHandlerTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -113,11 +116,11 @@ class AccountInterventionsHandlerTest {
     private final LambdaInvokerService mockLambdaInvokerService = mock(LambdaInvokerService.class);
 
     private static final ClientSession clientSession = getClientSession();
-    private final Session session =
-            new Session(SESSION_ID)
-                    .setEmailAddress(EMAIL)
-                    .setSessionId(SESSION_ID)
-                    .setInternalCommonSubjectIdentifier(TEST_INTERNAL_SUBJECT_ID);
+    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withInternalCommonSubjectIdentifier(TEST_INTERNAL_SUBJECT_ID);
 
     private static final AuditContext AUDIT_CONTEXT =
             new AuditContext(
@@ -156,11 +159,13 @@ class AccountInterventionsHandlerTest {
         when(configurationService.getAccountInterventionsErrorMetricName())
                 .thenReturn("AISException");
         when(configurationService.getEnvironment()).thenReturn(TEST_ENVIRONMENT);
+        when(authSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(authSession));
 
         handler =
                 new AccountInterventionsHandler(
                         configurationService,
                         sessionService,
+                        authSessionService,
                         clientSessionService,
                         clientService,
                         authenticationService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -86,10 +86,7 @@ class CheckReAuthUserHandlerTest {
     private static final APIGatewayProxyRequestEvent API_REQUEST_EVENT_WITH_VALID_HEADERS =
             apiRequestEventWithHeadersAndBody(VALID_HEADERS, null);
 
-    private final Session session =
-            new Session(SESSION_ID)
-                    .setEmailAddress(EMAIL_USED_TO_SIGN_IN)
-                    .setInternalCommonSubjectIdentifier(TEST_SUBJECT_ID);
+    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL_USED_TO_SIGN_IN);
 
     private final AuditContext testAuditContextWithoutAuditEncoded =
             new AuditContext(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -96,6 +97,7 @@ class CheckUserExistsHandlerTest {
     private CheckUserExistsHandler handler;
     private static final Json objectMapper = SerializationService.getInstance();
     private final Session session = mock(Session.class);
+    private final AuthSessionItem authSession = mock(AuthSessionItem.class);
     private static final String CLIENT_ID = "test-client-id";
     private static final String CLIENT_NAME = "test-client-name";
     private static final Subject SUBJECT = new Subject();
@@ -132,6 +134,7 @@ class CheckUserExistsHandlerTest {
         when(codeStorageService.isBlockedForEmail(any(), any())).thenReturn(false);
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
         when(session.getSessionId()).thenReturn(SESSION_ID);
+        when(authSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(authSession));
 
         handler =
                 new CheckUserExistsHandler(
@@ -181,7 +184,7 @@ class CheckUserExistsHandlerTest {
             assertEquals(
                     JsonParser.parseString(result.getBody()),
                     JsonParser.parseString(expectedResponse));
-            verify(session).setInternalCommonSubjectIdentifier(getExpectedInternalPairwiseId());
+            verify(authSession).setInternalCommonSubjectIdentifier(getExpectedInternalPairwiseId());
         }
 
         @Test
@@ -299,7 +302,7 @@ class CheckUserExistsHandlerTest {
                 objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
         assertThat(checkUserExistsResponse.email(), equalTo(EMAIL_ADDRESS));
         assertFalse(checkUserExistsResponse.doesUserExist());
-        verify(session).setInternalCommonSubjectIdentifier(null);
+        verify(authSession).setInternalCommonSubjectIdentifier(null);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CHECK_USER_NO_ACCOUNT_WITH_EMAIL,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -34,6 +34,7 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -87,6 +88,7 @@ class CheckUserExistsHandlerTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final ClientService clientService = mock(ClientService.class);
@@ -135,6 +137,7 @@ class CheckUserExistsHandlerTest {
                 new CheckUserExistsHandler(
                         configurationService,
                         sessionService,
+                        authSessionService,
                         clientSessionService,
                         clientService,
                         authenticationService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -254,7 +254,7 @@ class LoginHandlerTest {
                         false,
                         false);
 
-        verifySessionIsSaved();
+        verifyInternalCommonSubjectIdentifierSaved();
     }
 
     @Test
@@ -306,7 +306,7 @@ class LoginHandlerTest {
 
         verifyNoInteractions(cloudwatchMetricsService);
 
-        verifySessionIsSaved();
+        verifyInternalCommonSubjectIdentifierSaved();
     }
 
     @ParameterizedTest
@@ -332,7 +332,7 @@ class LoginHandlerTest {
         assertThat(response.latestTermsAndConditionsAccepted(), equalTo(false));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verifySessionIsSaved();
+        verifyInternalCommonSubjectIdentifierSaved();
     }
 
     @Test
@@ -368,7 +368,7 @@ class LoginHandlerTest {
 
         verifyNoInteractions(cloudwatchMetricsService);
 
-        verifySessionIsSaved();
+        verifyInternalCommonSubjectIdentifierSaved();
     }
 
     @ParameterizedTest
@@ -398,7 +398,7 @@ class LoginHandlerTest {
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("passwordResetType", PasswordResetType.FORCED_WEAK_PASSWORD));
         verifyNoInteractions(cloudwatchMetricsService);
-        verifySessionIsSaved();
+        verifyInternalCommonSubjectIdentifierSaved();
     }
 
     @ParameterizedTest
@@ -429,7 +429,7 @@ class LoginHandlerTest {
         assertThat(response.latestTermsAndConditionsAccepted(), equalTo(true));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verifySessionIsSaved();
+        verifyInternalCommonSubjectIdentifierSaved();
     }
 
     @ParameterizedTest
@@ -576,7 +576,7 @@ class LoginHandlerTest {
 
         assertThat(result, hasStatus(200));
         verifyNoInteractions(cloudwatchMetricsService);
-        verifySessionIsSaved();
+        verifyInternalCommonSubjectIdentifierSaved();
     }
 
     @ParameterizedTest
@@ -749,7 +749,7 @@ class LoginHandlerTest {
         assertThat(response.latestTermsAndConditionsAccepted(), equalTo(true));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verifySessionIsSaved();
+        verifyInternalCommonSubjectIdentifierSaved();
     }
 
     @Test
@@ -800,7 +800,7 @@ class LoginHandlerTest {
         var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
-        verifyAuthSessionIsSaved();
+        verifyAccountStateSaved();
     }
 
     private AuthenticationRequest generateAuthRequest() {
@@ -897,16 +897,16 @@ class LoginHandlerTest {
                                         .withSectorIdentifierUri("https://test.com")));
     }
 
-    private void verifySessionIsSaved() {
-        verify(sessionService, atLeastOnce())
-                .storeOrUpdateSession(
+    private void verifyInternalCommonSubjectIdentifierSaved() {
+        verify(authSessionService, atLeastOnce())
+                .updateSession(
                         argThat(
                                 t ->
                                         t.getInternalCommonSubjectIdentifier()
                                                 .equals(expectedCommonSubject)));
     }
 
-    private void verifyAuthSessionIsSaved() {
+    private void verifyAccountStateSaved() {
         verify(authSessionService, times(1))
                 .updateSession(
                         argThat(s -> s.getIsNewAccount() == AuthSessionItem.AccountState.EXISTING));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaRequest;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
@@ -35,6 +36,7 @@ import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -99,6 +101,7 @@ class MfaHandlerTest {
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
     private final Context context = mock(Context.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
@@ -123,10 +126,11 @@ class MfaHandlerTest {
                     DI_PERSISTENT_SESSION_ID,
                     Optional.of(ENCODED_DEVICE_DETAILS));
 
-    private final Session session =
-            new Session(SESSION_ID)
-                    .setEmailAddress(EMAIL)
-                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withInternalCommonSubjectIdentifier(expectedCommonSubject);
     private final ClientRegistry testClientRegistry =
             new ClientRegistry()
                     .withTestClient(true)
@@ -164,6 +168,7 @@ class MfaHandlerTest {
                 new MfaHandler(
                         configurationService,
                         sessionService,
+                        authSessionService,
                         codeGeneratorService,
                         codeStorageService,
                         clientSessionService,
@@ -172,6 +177,7 @@ class MfaHandlerTest {
                         auditService,
                         sqsClient);
         when(clientService.getClient(TEST_CLIENT_ID)).thenReturn(Optional.of(testClientRegistry));
+        when(authSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(authSession));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
@@ -13,9 +13,11 @@ import uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException;
 import uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.frontendapi.services.MfaResetIPVAuthorizationService;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -60,8 +62,13 @@ class MfaResetAuthorizeHandlerTest {
     private static final ClientService clientService = mock(ClientService.class);
     private static final Context context = mock(Context.class);
     private static final SessionService sessionService = mock(SessionService.class);
+    private static final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private static final UserContext userContext = mock(UserContext.class);
     private static final Session session = mock(Session.class);
+    private static final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withInternalCommonSubjectIdentifier(COMMON_SUBJECT_ID);
     private static final AuditContext testAuditContext =
             new AuditContext(
                     AuditService.UNKNOWN,
@@ -82,10 +89,10 @@ class MfaResetAuthorizeHandlerTest {
     static void globalSetup() {
         when(userContext.getSession()).thenReturn(new Session(SESSION_ID));
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
-        when(session.getInternalCommonSubjectIdentifier()).thenReturn(COMMON_SUBJECT_ID);
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));
         when(session.getSessionId()).thenReturn(SESSION_ID);
+        when(authSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(authSession));
     }
 
     @BeforeEach
@@ -94,6 +101,7 @@ class MfaResetAuthorizeHandlerTest {
                 new MfaResetAuthorizeHandler(
                         configurationService,
                         sessionService,
+                        authSessionService,
                         clientSessionService,
                         clientService,
                         authenticationService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.PasswordResetType;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
@@ -42,6 +43,7 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -109,6 +111,7 @@ class ResetPasswordRequestHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AwsSqsClient awsSqsClient = mock(AwsSqsClient.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ClientSession clientSession = mock(ClientSession.class);
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
@@ -135,13 +138,18 @@ class ResetPasswordRequestHandlerTest {
                                     "jb2@digital.cabinet-office.gov.uk"));
 
     private final Session session =
-            new Session(SESSION_ID)
-                    .setEmailAddress(CommonTestVariables.EMAIL)
-                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+            new Session(SESSION_ID).setEmailAddress(CommonTestVariables.EMAIL);
+
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withInternalCommonSubjectIdentifier(expectedCommonSubject);
+
     private final ResetPasswordRequestHandler handler =
             new ResetPasswordRequestHandler(
                     configurationService,
                     sessionService,
+                    authSessionService,
                     clientSessionService,
                     clientService,
                     authenticationService,
@@ -180,6 +188,7 @@ class ResetPasswordRequestHandlerTest {
         when(codeGeneratorService.twentyByteEncodedRandomCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(configurationService.getCodeMaxRetries()).thenReturn(6);
+        when(authSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(authSession));
     }
 
     @Nested

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mockito;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
@@ -38,6 +39,7 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -116,6 +118,7 @@ class SendNotificationHandlerTest {
     private final AwsSqsClient emailSqsClient = mock(AwsSqsClient.class);
     private final AwsSqsClient pendingEmailCheckSqsClient = mock(AwsSqsClient.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
@@ -136,10 +139,12 @@ class SendNotificationHandlerTest {
     private final Context context = mock(Context.class);
     private static final Json objectMapper = SerializationService.getInstance();
 
-    private final Session session =
-            new Session(SESSION_ID)
-                    .setEmailAddress(EMAIL)
-                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withInternalCommonSubjectIdentifier(expectedCommonSubject);
 
     private final AuditContext auditContext =
             new AuditContext(
@@ -157,6 +162,7 @@ class SendNotificationHandlerTest {
             new SendNotificationHandler(
                     configurationService,
                     sessionService,
+                    authSessionService,
                     clientSessionService,
                     clientService,
                     authenticationService,
@@ -199,6 +205,7 @@ class SendNotificationHandlerTest {
         when(clientService.getClient(TEST_CLIENT_ID)).thenReturn(Optional.of(testClientRegistry));
         when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(clientSession));
+        when(authSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(authSession));
     }
 
     private static Stream<Arguments> notificationTypeAndJourneyTypeArgs() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -41,6 +41,7 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -51,7 +52,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -193,13 +193,12 @@ class SignUpHandlerTest {
 
         verify(authSessionService)
                 .updateSession(
-                        argThat(s -> s.getIsNewAccount() == AuthSessionItem.AccountState.NEW));
-        verify(sessionService, atLeastOnce())
-                .storeOrUpdateSession(
                         argThat(
-                                t ->
-                                        t.getInternalCommonSubjectIdentifier()
-                                                .equals(expectedCommonSubject)));
+                                s ->
+                                        s.getIsNewAccount() == AuthSessionItem.AccountState.NEW
+                                                && Objects.equals(
+                                                        s.getInternalCommonSubjectIdentifier(),
+                                                        expectedCommonSubject)));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -26,6 +27,7 @@ import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -84,6 +86,7 @@ class UpdateProfileHandlerTest {
     private UpdateProfileHandler handler;
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
@@ -92,10 +95,11 @@ class UpdateProfileHandlerTest {
 
     private final String TERMS_AND_CONDITIONS_VERSION =
             configurationService.getTermsAndConditionsVersion();
-    private final Session session =
-            new Session(SESSION_ID)
-                    .setEmailAddress(EMAIL)
-                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withInternalCommonSubjectIdentifier(expectedCommonSubject);
 
     private final AuditContext auditContextWithAllUserInfo =
             new AuditContext(
@@ -146,10 +150,12 @@ class UpdateProfileHandlerTest {
                 new UpdateProfileHandler(
                         authenticationService,
                         sessionService,
+                        authSessionService,
                         clientSessionService,
                         configurationService,
                         auditService,
                         clientService);
+        when(authSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(authSession));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -128,13 +128,13 @@ class VerifyCodeHandlerTest {
     private final UserProfile userProfile = mock(UserProfile.class);
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(TEST_SUBJECT_ID, SECTOR_HOST, SALT);
-    private final Session session =
-            new Session(SESSION_ID)
-                    .setEmailAddress(EMAIL)
-                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
     private final Session testSession =
             new Session("test-client-session-id").setEmailAddress(TEST_CLIENT_EMAIL);
-    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withInternalCommonSubjectIdentifier(expectedCommonSubject);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -389,7 +389,7 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(TEST_CLIENT_CODE));
         when(codeStorageService.getOtpCode(email, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
         testSession.setEmailAddress(email);
-        testSession.setInternalCommonSubjectIdentifier(expectedCommonSubject);
+        authSession.setInternalCommonSubjectIdentifier(expectedCommonSubject);
         String body =
                 format(
                         "{ \"code\": \"%s\", \"notificationType\": \"%s\"  }",
@@ -425,7 +425,7 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(TEST_CLIENT_CODE));
         when(codeStorageService.getOtpCode(email, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
         testSession.setEmailAddress(email);
-        testSession.setInternalCommonSubjectIdentifier(expectedCommonSubject);
+        authSession.setInternalCommonSubjectIdentifier(expectedCommonSubject);
         String body =
                 format("{ \"code\": \"%s\", \"notificationType\": \"%s\"  }", CODE, VERIFY_EMAIL);
         var result = makeCallWithCode(body, Optional.of(testSession), TEST_CLIENT_ID);
@@ -558,8 +558,7 @@ class VerifyCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         verify(codeStorageService).deleteOtpCode(EMAIL, MFA_SMS);
         verify(accountModifiersService).removeAccountRecoveryBlockIfPresent(expectedCommonSubject);
-        var saveSessionCount = journeyType == JourneyType.PASSWORD_RESET_MFA ? 3 : 2;
-        verify(sessionService, times(saveSessionCount)).storeOrUpdateSession(session);
+        verify(sessionService, times(2)).storeOrUpdateSession(session);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_VERIFIED,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -124,11 +124,11 @@ class VerifyMfaCodeHandlerTest {
 
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(TEST_SUBJECT_ID, SECTOR_HOST, SALT);
-    private final Session session =
-            new Session(SESSION_ID)
-                    .setEmailAddress(EMAIL)
-                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
-    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
+    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withInternalCommonSubjectIdentifier(expectedCommonSubject);
     private final Json objectMapper = SerializationService.getInstance();
     public VerifyMfaCodeHandler handler;
 
@@ -247,7 +247,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
-        verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
+        verify(authAppCodeProcessor)
+                .processSuccessfulCodeRequest(anyString(), anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
@@ -329,7 +330,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
-        verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
+        verify(authAppCodeProcessor)
+                .processSuccessfulCodeRequest(anyString(), anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
@@ -371,7 +373,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
-        verify(phoneNumberCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
+        verify(phoneNumberCodeProcessor)
+                .processSuccessfulCodeRequest(anyString(), anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
@@ -413,7 +416,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
-        verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
+        verify(authAppCodeProcessor)
+                .processSuccessfulCodeRequest(anyString(), anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
@@ -455,7 +459,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
-        verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
+        verify(authAppCodeProcessor)
+                .processSuccessfulCodeRequest(anyString(), anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -315,8 +315,8 @@ class VerifyMfaCodeHandlerTest {
         when(configurationService.getInternalSectorUri()).thenReturn("http://" + SECTOR_HOST);
         when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
         session.setCurrentCredentialStrength(credentialTrustLevel);
-        session.setInternalCommonSubjectIdentifier(null);
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
+        authSession.setInternalCommonSubjectIdentifier(null);
 
         var result =
                 makeCallWithCode(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -202,7 +202,8 @@ class AuthAppCodeProcessorTest {
                         JourneyType.REGISTRATION,
                         AUTH_APP_SECRET));
 
-        authAppCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        authAppCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_SUB_ID);
 
         verify(mockDynamoService, never())
                 .setVerifiedAuthAppAndRemoveExistingMfaMethod(anyString(), anyString());
@@ -225,7 +226,8 @@ class AuthAppCodeProcessorTest {
                         JourneyType.ACCOUNT_RECOVERY,
                         AUTH_APP_SECRET));
 
-        authAppCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        authAppCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_SUB_ID);
 
         verify(mockDynamoService, never()).setAuthAppAndAccountVerified(anyString(), anyString());
         verify(mockDynamoService)
@@ -246,7 +248,8 @@ class AuthAppCodeProcessorTest {
         setUpSuccessfulCodeRequest(
                 new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, "111111", JourneyType.SIGN_IN));
 
-        authAppCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        authAppCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_SUB_ID);
 
         verifyNoInteractions(mockDynamoService);
         verify(mockAccountModifiersService).removeAccountRecoveryBlockIfPresent(INTERNAL_SUB_ID);
@@ -264,7 +267,8 @@ class AuthAppCodeProcessorTest {
         setUpSuccessfulCodeRequest(
                 new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, "111111", JourneyType.SIGN_IN));
 
-        authAppCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        authAppCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_SUB_ID);
 
         verifyNoInteractions(mockDynamoService);
         verify(mockAccountModifiersService, never())
@@ -275,7 +279,6 @@ class AuthAppCodeProcessorTest {
     private void setUpSuccessfulCodeRequest(CodeRequest codeRequest) {
         when(mockSession.getEmailAddress()).thenReturn(CommonTestVariables.EMAIL);
         when(mockSession.getSessionId()).thenReturn(SESSION_ID);
-        when(mockSession.getInternalCommonSubjectIdentifier()).thenReturn(INTERNAL_SUB_ID);
         when(mockUserContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(mockUserContext.getSession()).thenReturn(mockSession);
         when(mockUserContext.getClientId()).thenReturn(CLIENT_ID);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -256,7 +256,8 @@ class PhoneNumberCodeProcessorTest {
                         CommonTestVariables.UK_MOBILE_NUMBER),
                 CodeRequestType.SMS_REGISTRATION);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_SUB_ID);
 
         verify(authenticationService)
                 .updatePhoneNumberAndAccountVerifiedStatus(
@@ -284,7 +285,8 @@ class PhoneNumberCodeProcessorTest {
                         CommonTestVariables.UK_MOBILE_NUMBER),
                 CodeRequestType.SMS_ACCOUNT_RECOVERY);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_SUB_ID);
 
         verify(authenticationService)
                 .setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(
@@ -306,7 +308,8 @@ class PhoneNumberCodeProcessorTest {
                 new VerifyMfaCodeRequest(MFAMethodType.SMS, VALID_CODE, JourneyType.SIGN_IN),
                 CodeRequestType.SMS_REGISTRATION);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_SUB_ID);
 
         verifyNoInteractions(authenticationService);
         verifyNoInteractions(auditService);
@@ -324,7 +327,8 @@ class PhoneNumberCodeProcessorTest {
                         CommonTestVariables.UK_MOBILE_NUMBER),
                 CodeRequestType.SMS_REGISTRATION);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_SUB_ID);
 
         verify(sqsClient)
                 .send(
@@ -351,7 +355,8 @@ class PhoneNumberCodeProcessorTest {
                 CodeRequestType.SMS_ACCOUNT_RECOVERY);
         when(userProfile.getPhoneNumber()).thenReturn(CommonTestVariables.UK_MOBILE_NUMBER);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_SUB_ID);
 
         verifyNoInteractions(sqsClient);
     }
@@ -367,7 +372,8 @@ class PhoneNumberCodeProcessorTest {
                         CommonTestVariables.UK_MOBILE_NUMBER),
                 CodeRequestType.SMS_REGISTRATION);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_SUB_ID);
 
         verifyNoInteractions(sqsClient);
     }
@@ -384,7 +390,8 @@ class PhoneNumberCodeProcessorTest {
         when(clientRegistry.isSmokeTest()).thenReturn(true);
         when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_SUB_ID);
 
         verifyNoInteractions(sqsClient);
     }
@@ -393,7 +400,6 @@ class PhoneNumberCodeProcessorTest {
         var differentPhoneNumber = CommonTestVariables.UK_MOBILE_NUMBER.replace("789", "987");
         when(session.getEmailAddress()).thenReturn(CommonTestVariables.EMAIL);
         when(session.getSessionId()).thenReturn(SESSION_ID);
-        when(session.getInternalCommonSubjectIdentifier()).thenReturn(INTERNAL_SUB_ID);
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(userContext.getClientId()).thenReturn(CLIENT_ID);
         when(userContext.getSession()).thenReturn(session);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -147,7 +147,11 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(loginResponse.mfaMethodType(), equalTo(expectedMfaType));
         assertThat(loginResponse.mfaMethodVerified(), equalTo(mfaMethodVerified));
         assertTrue(
-                Objects.nonNull(redis.getSession(sessionId).getInternalCommonSubjectIdentifier()));
+                Objects.nonNull(
+                        authSessionExtension
+                                .getSession(sessionId)
+                                .orElseThrow()
+                                .getInternalCommonSubjectIdentifier()));
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_LOG_IN_SUCCESS));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -78,7 +78,11 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(200));
         assertTrue(
-                Objects.nonNull(redis.getSession(SESSION_ID).getInternalCommonSubjectIdentifier()));
+                Objects.nonNull(
+                        authSessionExtension
+                                .getSession(SESSION_ID)
+                                .orElseThrow()
+                                .getInternalCommonSubjectIdentifier()));
         assertTrue(userStore.userExists("joe.bloggs+5@digital.cabinet-office.gov.uk"));
         assertThat(authSessionExtension.getSession(SESSION_ID).isPresent(), equalTo(true));
         assertThat(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -34,6 +34,7 @@ import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -42,6 +43,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_CODE_VERIFIED;
@@ -425,8 +427,12 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        Session session = redis.getSession(sessionId);
-        assertThat(session.getInternalCommonSubjectIdentifier(), notNullValue());
+        assertTrue(
+                Objects.nonNull(
+                        authSessionExtension
+                                .getSession(sessionId)
+                                .orElseThrow()
+                                .getInternalCommonSubjectIdentifier()));
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -108,7 +108,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         this.sessionId = redis.createSession();
         authSessionExtension.addSession(Optional.empty(), this.sessionId);
-        redis.addInternalCommonSubjectIdToSession(this.sessionId, internalCommonSubjectId);
+        addInternalCommonSubjectIdToAuthSession(internalCommonSubjectId);
+
         setUpTest(sessionId, withScope());
     }
 
@@ -1019,5 +1020,11 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             userStore.setAccountVerified(EMAIL_ADDRESS);
             userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, phoneNumber);
         }
+    }
+
+    private void addInternalCommonSubjectIdToAuthSession(String internalCommonSubjectId) {
+        var authSession = authSessionExtension.getSession(sessionId).orElseThrow();
+        authSession.setInternalCommonSubjectIdentifier(internalCommonSubjectId);
+        authSessionExtension.updateSession(authSession);
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -159,15 +159,6 @@ public class RedisExtension
                 3600);
     }
 
-    public void addInternalCommonSubjectIdToSession(
-            String sessionId, String internalCommonSubjectId) throws Json.JsonException {
-        var session =
-                objectMapper
-                        .readValue(redis.getValue(sessionId), Session.class)
-                        .setInternalCommonSubjectIdentifier(internalCommonSubjectId);
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
-    }
-
     public void addEmailToSession(String sessionId, String emailAddress) throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.setEmailAddress(emailAddress);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -9,6 +9,9 @@ public class AuthSessionItem {
 
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "isNewAccount";
+    public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
+    public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_IDENTIFIER =
+            "InternalCommonSubjectIdentifier";
 
     public enum AccountState {
         NEW,
@@ -17,12 +20,11 @@ public class AuthSessionItem {
         UNKNOWN
     }
 
-    public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
-
     private String sessionId;
     private String verifiedMfaMethodType;
     private long timeToLive;
     private AccountState isNewAccount;
+    private String internalCommonSubjectIdentifier;
 
     public AuthSessionItem() {}
 
@@ -52,6 +54,21 @@ public class AuthSessionItem {
 
     public AuthSessionItem withVerifiedMfaMethodType(String verifiedMfaMethodType) {
         this.verifiedMfaMethodType = verifiedMfaMethodType;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_INTERNAL_COMMON_SUBJECT_IDENTIFIER)
+    public String getInternalCommonSubjectIdentifier() {
+        return internalCommonSubjectIdentifier;
+    }
+
+    public void setInternalCommonSubjectIdentifier(String internalCommonSubjectIdentifier) {
+        this.internalCommonSubjectIdentifier = internalCommonSubjectIdentifier;
+    }
+
+    public AuthSessionItem withInternalCommonSubjectIdentifier(
+            String internalCommonSubjectIdentifier) {
+        this.internalCommonSubjectIdentifier = internalCommonSubjectIdentifier;
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -42,8 +42,6 @@ public class Session {
 
     @Expose private MFAMethodType verifiedMfaMethodType;
 
-    @Expose private String internalCommonSubjectIdentifier;
-
     public Session(String sessionId) {
         this.sessionId = sessionId;
         this.clientSessions = new ArrayList<>();
@@ -174,15 +172,6 @@ public class Session {
 
     public Session setVerifiedMfaMethodType(MFAMethodType verifiedMfaMethodType) {
         this.verifiedMfaMethodType = verifiedMfaMethodType;
-        return this;
-    }
-
-    public String getInternalCommonSubjectIdentifier() {
-        return internalCommonSubjectIdentifier;
-    }
-
-    public Session setInternalCommonSubjectIdentifier(String internalCommonSubjectIdentifier) {
-        this.internalCommonSubjectIdentifier = internalCommonSubjectIdentifier;
         return this;
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/SessionTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/SessionTest.java
@@ -17,9 +17,7 @@ class SessionTest {
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     new Subject().getValue(), "test.account.gov.uk", SaltHelper.generateNewSalt());
     private final Session session =
-            new Session(IdGenerator.generate())
-                    .setEmailAddress("joe.bloggs@test.com")
-                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+            new Session(IdGenerator.generate()).setEmailAddress("joe.bloggs@test.com");
 
     @RegisterExtension
     private final CaptureLoggingExtension logging = new CaptureLoggingExtension(Session.class);


### PR DESCRIPTION
## What

Remove Internal Common Subject Identifier From Session

## How to review

1. Code Review

## Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.

Previous PR: https://github.com/govuk-one-login/authentication-api/pull/5455
