### PR TITLE
ATO-1104: Temporarily disable TTL configuration

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -674,7 +674,7 @@ resource "aws_dynamodb_table" "auth_session_table" {
 
   ttl {
     attribute_name = "TimeToLive"
-    enabled        = true
+    enabled        = false
   }
 
   point_in_time_recovery {


### PR DESCRIPTION
Re-enables disabling the ttl configuration for the auth session table.