### PR TITLE
ATO-1129: move claims to be conditional

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -44,7 +44,6 @@ public class UserInfoService {
         var userInfo = new UserInfo(internalPairwiseId);
         addClaimsFromToken(accessTokenInfo, internalSubjectId, userProfile, userInfo);
         addClaimsFromSession(authSession, userInfo);
-        addClaimsFromUserProfile(userProfile, userInfo);
         return userInfo;
     }
 
@@ -83,6 +82,9 @@ public class UserInfoService {
         if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.LOCAL_ACCOUNT_ID.getValue())) {
             userInfo.setClaim("local_account_id", userProfile.getSubjectID());
         }
+        if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.EMAIL.getValue())) {
+            userInfo.setEmailAddress(userProfile.getEmail());
+        }
         if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.EMAIL_VERIFIED.getValue())) {
             userInfo.setEmailVerified(userProfile.isEmailVerified());
         }
@@ -102,10 +104,6 @@ public class UserInfoService {
         userInfo.setClaim(
                 AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
                 authSession.getVerifiedMfaMethodType());
-    }
-
-    private void addClaimsFromUserProfile(UserProfile userProfile, UserInfo userInfo) {
-        userInfo.setEmailAddress(userProfile.getEmail());
     }
 
     private static String bytesToBase64(ByteBuffer byteBuffer) {

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -43,7 +43,7 @@ public class UserInfoService {
 
         var userInfo = new UserInfo(internalPairwiseId);
         addClaimsFromToken(accessTokenInfo, internalSubjectId, userProfile, userInfo);
-        addClaimsFromSession(authSession, userInfo);
+        addClaimsFromSession(accessTokenInfo, authSession, userInfo);
         return userInfo;
     }
 
@@ -100,10 +100,15 @@ public class UserInfoService {
         }
     }
 
-    private void addClaimsFromSession(AuthSessionItem authSession, UserInfo userInfo) {
-        userInfo.setClaim(
-                AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
-                authSession.getVerifiedMfaMethodType());
+    private void addClaimsFromSession(
+            AccessTokenStore accessTokenInfo, AuthSessionItem authSession, UserInfo userInfo) {
+        if (accessTokenInfo
+                .getClaims()
+                .contains(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue())) {
+            userInfo.setClaim(
+                    AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
+                    authSession.getVerifiedMfaMethodType());
+        }
     }
 
     private static String bytesToBase64(ByteBuffer byteBuffer) {

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -82,6 +82,7 @@ public class UserInfoServiceTest {
             String expectedLegacySubjectId,
             String expectedPublicSubjectId,
             String expectedLocalAccountId,
+            String expectedEmailAddress,
             Boolean expectedEmailVerified,
             String expectedPhoneNumber,
             Boolean expectedPhoneNumberVerified,
@@ -91,11 +92,11 @@ public class UserInfoServiceTest {
         assertEquals(TEST_INTERNAL_PAIRWISE_ID, actual.getSubject().getValue());
         assertEquals(TEST_RP_PAIRWISE_ID, actual.getClaim("rp_pairwise_id"));
         assertEquals(TEST_IS_NEW_ACCOUNT, actual.getClaim("new_account"));
-        assertEquals(TEST_EMAIL, actual.getEmailAddress());
 
         assertEquals(expectedLegacySubjectId, actual.getClaim("legacy_subject_id"));
         assertEquals(expectedPublicSubjectId, actual.getClaim("public_subject_id"));
         assertEquals(expectedLocalAccountId, actual.getClaim("local_account_id"));
+        assertEquals(expectedEmailAddress, actual.getEmailAddress());
         assertEquals(expectedEmailVerified, actual.getEmailVerified());
         assertEquals(expectedPhoneNumber, actual.getPhoneNumber());
         assertEquals(expectedPhoneNumberVerified, actual.getPhoneNumberVerified());
@@ -113,6 +114,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         null,
+                        null,
                         null),
                 Arguments.of(
                         getMockAccessTokenStore(
@@ -120,6 +122,7 @@ public class UserInfoServiceTest {
                         TEST_LEGACY_SUBJECT_ID,
                         null,
                         null,
+                        TEST_EMAIL,
                         TEST_EMAIL_VERIFIED,
                         null,
                         null,
@@ -138,6 +141,7 @@ public class UserInfoServiceTest {
                         TEST_LEGACY_SUBJECT_ID,
                         TEST_PUBLIC_SUBJECT_ID,
                         TEST_SUBJECT.getValue(),
+                        TEST_EMAIL,
                         TEST_EMAIL_VERIFIED,
                         TEST_PHONE,
                         TEST_PHONE_VERIFIED,

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkBytes;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -49,6 +50,7 @@ public class UserInfoServiceTest {
     private static final boolean TEST_EMAIL_VERIFIED = true;
     private static final String TEST_PHONE = "test-phone";
     private static final boolean TEST_PHONE_VERIFIED = true;
+    private static final String TEST_VERIFIED_MFA_METHOD_TYPE = MFAMethodType.EMAIL.getValue();
     private static final boolean TEST_IS_NEW_ACCOUNT = true;
     private static final long TEST_PASSWORD_RESET_TIME = 1710255380L;
     private static final UserProfile TEST_USER_PROFILE =
@@ -61,7 +63,8 @@ public class UserInfoServiceTest {
                     .withPhoneNumber(TEST_PHONE)
                     .withPhoneNumberVerified(TEST_PHONE_VERIFIED)
                     .withSalt(TEST_SALT);
-    private static final AuthSessionItem authSession = new AuthSessionItem();
+    private static final AuthSessionItem authSession =
+            new AuthSessionItem().withVerifiedMfaMethodType(TEST_VERIFIED_MFA_METHOD_TYPE);
 
     @BeforeEach
     public void setUp() {
@@ -86,7 +89,8 @@ public class UserInfoServiceTest {
             Boolean expectedEmailVerified,
             String expectedPhoneNumber,
             Boolean expectedPhoneNumberVerified,
-            String expectedSalt) {
+            String expectedSalt,
+            String expectedVerifiedMfaMethod) {
         UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore, authSession);
 
         assertEquals(TEST_INTERNAL_PAIRWISE_ID, actual.getSubject().getValue());
@@ -101,6 +105,7 @@ public class UserInfoServiceTest {
         assertEquals(expectedPhoneNumber, actual.getPhoneNumber());
         assertEquals(expectedPhoneNumberVerified, actual.getPhoneNumberVerified());
         assertEquals(expectedSalt, actual.getClaim("salt"));
+        assertEquals(expectedVerifiedMfaMethod, actual.getClaim("verified_mfa_method_type"));
         assertEquals(TEST_PASSWORD_RESET_TIME, actual.getClaim("password_reset_time"));
     }
 
@@ -111,6 +116,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         TEST_SUBJECT.getValue(),
+                        null,
                         null,
                         null,
                         null,
@@ -126,6 +132,7 @@ public class UserInfoServiceTest {
                         TEST_EMAIL_VERIFIED,
                         null,
                         null,
+                        null,
                         null),
                 Arguments.of(
                         getMockAccessTokenStore(
@@ -137,7 +144,8 @@ public class UserInfoServiceTest {
                                         "email_verified",
                                         "phone_number",
                                         "phone_number_verified",
-                                        "salt")),
+                                        "salt",
+                                        "verified_mfa_method_type")),
                         TEST_LEGACY_SUBJECT_ID,
                         TEST_PUBLIC_SUBJECT_ID,
                         TEST_SUBJECT.getValue(),
@@ -145,7 +153,8 @@ public class UserInfoServiceTest {
                         TEST_EMAIL_VERIFIED,
                         TEST_PHONE,
                         TEST_PHONE_VERIFIED,
-                        bytesToBase64(TEST_SALT)));
+                        bytesToBase64(TEST_SALT),
+                        TEST_VERIFIED_MFA_METHOD_TYPE));
     }
 
     private static AccessTokenStore getMockAccessTokenStore(List<String> claims) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -125,9 +125,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
         assertNull(userInfoResponse.getPhoneNumber());
         assertNull(userInfoResponse.getPhoneNumberVerified());
         assertNull(userInfoResponse.getClaim("salt"));
-        assertThat(
-                userInfoResponse.getClaim("verified_mfa_method_type"),
-                equalTo(MFAMethodType.AUTH_APP.getValue()));
+        assertNull(userInfoResponse.getClaim("verified_mfa_method_type"));
 
         assertThat(
                 authSessionExtension.getSession(TEST_SESSION_ID).get().getIsNewAccount(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -371,6 +371,10 @@ public class AuthenticationCallbackHandler
                 LOG.info(
                         "is email attached to auth-external-api userinfo response: {}",
                         userInfo.getEmailAddress() != null);
+                LOG.info(
+                        "is verified_mfa_method_type attached to auth-external-api userinfo response: {}",
+                        userInfo.getClaim(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue())
+                                != null);
                 //
 
                 Boolean newAccount = userInfo.getBooleanClaim("new_account");


### PR DESCRIPTION
## What
Currently, email and verified_mfa_method_type are sent in all responses. Instead, I'm updating orch code so we always request these claims https://github.com/govuk-one-login/authentication-api/pull/5451. 

Authentication shouldn't know that we always want it as the provider of this data - it should just provide whatever orch asks for. From ticket description:
> _For authentication to be truly separate from orch and for their interaction to be a by-the-book oidc flow, auth should not be at all aware of what orch is using the data for - it should just provide whatever data the consuming service asks for (and is allowed). Currently, authentication code has been changed to send back email and verified mfa method. Instead, we should change orch code to always request these claims. Else, the two services remain coupled._

This shouldn't have any functional change. To verify this, I added logging in the previous PR (https://github.com/govuk-one-login/authentication-api/pull/5451) to check the email and verified_mfa_method_type claims are always present. This seems to be all ok from looking at the logs: [verifed_mfa_method_type](https://gds.splunkcloud.com/en-GB/app/search/search?display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=-24h%40m&latest=now&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&q=search%20(index%3D%22gds_di_production%22%20message%3D%22is%20verified_mfa%20a%20requested%20claim*%22)&sid=1730304453.176762) and [email](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20(index%3D%22gds_di_production%22%20message%3D%22is%20email%20a%20requested%20claim*%22)&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=-24h%40m&latest=now&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&sid=1730304458.176767).

I've also added some logging in this PR to verify that both email and verified_mfa_method_type claims are populated and sent back to orch, so we can be sure it's safe to use them within orch.

## How to review
1. Code Review
1. Deploy to dev and run through a journey. Check all is working as expected.
