### PR TITLE
Bau/refactor mfa reset handlers

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
@@ -29,8 +29,6 @@ import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.TokenService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
-import java.util.Optional;
-
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1060;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
@@ -100,16 +98,13 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
             attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
 
             AuditContext auditContext =
-                    new AuditContext(
-                            userContext.getClientId(),
-                            userContext.getClientSessionId(),
-                            userContext.getSession().getSessionId(),
+                    AuditContext.auditContextFromUserContext(
+                            userContext,
                             AuditService.UNKNOWN,
                             request.email(),
                             IpAddressHelper.extractIpAddress(input),
                             AuditService.UNKNOWN,
-                            PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+                            PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
             Subject internalCommonSubjectId =
                     new Subject(userSession.getInternalCommonSubjectIdentifier());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.entity.MfaResetRequest;
+import uk.gov.di.authentication.frontendapi.entity.MfaResetResponse;
 import uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException;
 import uk.gov.di.authentication.frontendapi.services.JwtService;
 import uk.gov.di.authentication.frontendapi.services.MfaResetIPVAuthorizationService;
@@ -109,8 +110,12 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
             Subject internalCommonSubjectId =
                     new Subject(userSession.getInternalCommonSubjectIdentifier());
 
-            return mfaResetIPVAuthorizationService.buildMfaResetIpvRedirectRequest(
-                    internalCommonSubjectId, clientSessionId, userSession, auditContext);
+            var ipvAuthorisationRequestURI =
+                    mfaResetIPVAuthorizationService.buildMfaResetIpvRedirectUri(
+                            internalCommonSubjectId, clientSessionId, userSession, auditContext);
+
+            return generateApiGatewayProxyResponse(
+                    200, new MfaResetResponse(ipvAuthorisationRequestURI));
         } catch (JwtServiceException e) {
             LOG.error("Error in JWT service", e);
             return generateApiGatewayProxyResponse(500, ERROR_1060.getMessage());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/MfaResetIPVAuthorizationService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/MfaResetIPVAuthorizationService.java
@@ -22,7 +22,6 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper.NowClock;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -45,21 +44,18 @@ public class MfaResetIPVAuthorizationService {
     private final TokenService tokenService;
     private final RedisConnectionService redisConnectionService;
     private final Json objectMapper = SerializationService.getInstance();
-    private final CloudwatchMetricsService cloudwatchMetricsService;
 
     public MfaResetIPVAuthorizationService(
             ConfigurationService configurationService,
             JwtService jwtService,
             TokenService tokenService,
-            RedisConnectionService redisConnectionService,
-            CloudwatchMetricsService cloudwatchMetricsService) {
+            RedisConnectionService redisConnectionService) {
         this(
                 configurationService,
                 new NowClock(Clock.systemUTC()),
                 jwtService,
                 tokenService,
-                redisConnectionService,
-                cloudwatchMetricsService);
+                redisConnectionService);
     }
 
     public MfaResetIPVAuthorizationService(
@@ -67,14 +63,12 @@ public class MfaResetIPVAuthorizationService {
             NowClock nowClock,
             JwtService jwtService,
             TokenService tokenService,
-            RedisConnectionService redisConnectionService,
-            CloudwatchMetricsService cloudwatchMetricsService) {
+            RedisConnectionService redisConnectionService) {
         this.configurationService = configurationService;
         this.nowClock = nowClock;
         this.jwtService = jwtService;
         this.tokenService = tokenService;
         this.redisConnectionService = redisConnectionService;
-        this.cloudwatchMetricsService = cloudwatchMetricsService;
     }
 
     public String buildMfaResetIpvRedirectUri(
@@ -95,7 +89,6 @@ public class MfaResetIPVAuthorizationService {
         String ipvAuthorisationRequestURI = ipvAuthorisationRequest.toURI().toString();
 
         storeState(session.getSessionId(), state);
-        cloudwatchMetricsService.incrementMfaResetHandoffCount();
 
         LOG.info("MFA reset JAR created, redirect URI {}", ipvAuthorisationRequestURI);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/MfaResetIPVAuthorizationService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/MfaResetIPVAuthorizationService.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.frontendapi.services;
 
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.JWK;
@@ -19,7 +18,6 @@ import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditContext;
-import uk.gov.di.authentication.frontendapi.entity.MfaResetResponse;
 import uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
@@ -39,7 +37,6 @@ import java.util.Date;
 import java.util.List;
 
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_REVERIFY_AUTHORISATION_REQUESTED;
-import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
 public class MfaResetIPVAuthorizationService {
     private static final Logger LOG = LogManager.getLogger(MfaResetIPVAuthorizationService.class);
@@ -89,9 +86,9 @@ public class MfaResetIPVAuthorizationService {
         this.cloudwatchMetricsService = cloudwatchMetricsService;
     }
 
-    public APIGatewayProxyResponseEvent buildMfaResetIpvRedirectRequest(
+    public String buildMfaResetIpvRedirectUri(
             Subject subject, String clientSessionId, Session session, AuditContext auditContext)
-            throws Json.JsonException, JwtServiceException {
+            throws JwtServiceException {
         State state = new State();
         ClaimsSetRequest claims = buildMfaResetClaimsRequest(subject);
         EncryptedJWT requestJWT =
@@ -113,8 +110,7 @@ public class MfaResetIPVAuthorizationService {
 
         LOG.info("MFA reset JAR created, redirect URI {}", ipvAuthorisationRequestURI);
 
-        return generateApiGatewayProxyResponse(
-                200, new MfaResetResponse(ipvAuthorisationRequestURI));
+        return ipvAuthorisationRequestURI;
     }
 
     private EncryptedJWT constructMfaResetAuthorizationJWT(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
@@ -59,6 +60,8 @@ class MfaResetAuthorizeHandlerTest {
     private static final UserContext userContext = mock(UserContext.class);
     private static final Session session = mock(Session.class);
     private static final AuditService auditService = mock(AuditService.class);
+    private static final CloudwatchMetricsService cloudwatchMetricsService =
+            mock(CloudwatchMetricsService.class);
     private static final AuditContext testAuditContext =
             new AuditContext(
                     AuditService.UNKNOWN,
@@ -95,7 +98,8 @@ class MfaResetAuthorizeHandlerTest {
                         clientService,
                         authenticationService,
                         mfaResetIPVAuthorizationService,
-                        auditService);
+                        auditService,
+                        cloudwatchMetricsService);
     }
 
     @Test
@@ -111,6 +115,7 @@ class MfaResetAuthorizeHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(AUTH_REVERIFY_AUTHORISATION_REQUESTED, testAuditContext);
+        verify(cloudwatchMetricsService).incrementMfaResetHandoffCount();
 
         assertThat(response, hasStatus(200));
         assertThat(response, hasBody(expectedBody));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/MfaResetIPVAuthorizationServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/MfaResetIPVAuthorizationServiceTest.java
@@ -33,7 +33,6 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -97,8 +96,6 @@ class MfaResetIPVAuthorizationServiceTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
-    private final CloudwatchMetricsService cloudwatchMetricsService =
-            mock(CloudwatchMetricsService.class);
     private final JWTClaimsSet testJwtClaims = constructTestClaimSet();
     private final MfaResetIPVAuthorizationService mfaResetIPVAuthorizationService =
             new MfaResetIPVAuthorizationService(
@@ -106,8 +103,7 @@ class MfaResetIPVAuthorizationServiceTest {
                     nowClock,
                     jwtService,
                     tokenService,
-                    redisConnectionService,
-                    cloudwatchMetricsService);
+                    redisConnectionService);
     private SignedJWT testSignedJwt;
     private EncryptedJWT testEncryptedJwt;
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/MfaResetIPVAuthorizationServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/MfaResetIPVAuthorizationServiceTest.java
@@ -29,12 +29,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
@@ -59,7 +57,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_REVERIFY_AUTHORISATION_REQUESTED;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.COMMON_SUBJECT_ID;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.KeyPairHelper.GENERATE_RSA_KEY_PAIR;
@@ -100,8 +97,6 @@ class MfaResetIPVAuthorizationServiceTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
-    private final AuditService auditService = mock(AuditService.class);
-    private final AuditContext auditContext = mock(AuditContext.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
     private final JWTClaimsSet testJwtClaims = constructTestClaimSet();
@@ -112,7 +107,6 @@ class MfaResetIPVAuthorizationServiceTest {
                     jwtService,
                     tokenService,
                     redisConnectionService,
-                    auditService,
                     cloudwatchMetricsService);
     private SignedJWT testSignedJwt;
     private EncryptedJWT testEncryptedJwt;
@@ -158,7 +152,7 @@ class MfaResetIPVAuthorizationServiceTest {
 
             String redirectUri =
                     mfaResetIPVAuthorizationService.buildMfaResetIpvRedirectUri(
-                            TEST_SUBJECT, TEST_CLIENT_SESSION_ID, TEST_SESSION, auditContext);
+                            TEST_SUBJECT, TEST_CLIENT_SESSION_ID, TEST_SESSION);
 
             RSAPublicKey expectedPublicKey =
                     new RSAKey.Builder(
@@ -188,8 +182,6 @@ class MfaResetIPVAuthorizationServiceTest {
 
             assertEquals(expectedUri, redirectUri);
             assertClaims(redirectUri);
-            verify(auditService)
-                    .submitAuditEvent(AUTH_REVERIFY_AUTHORISATION_REQUESTED, auditContext);
         }
     }
 


### PR DESCRIPTION
## What

Minor refactors to the MFA Reset Authorize handler:
* Some test cleanups
* Construct the api response in the handler, not the service it delegates to to build the redirect uri
* Move some logic not necessary to construct the redirect uri from the service to the handler

## How to review

1. Code Review commit by commit

