### PR TITLE
ATO-981: set is new account in orch session

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/entity/AuthUserInfoClaims.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/entity/AuthUserInfoClaims.java
@@ -14,7 +14,8 @@ public enum AuthUserInfoClaims {
     PHONE_VERIFIED("phone_number_verified"),
     SALT("salt"),
     VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type"),
-    CURRENT_CREDENTIAL_STRENGTH("current_credential_strength");
+    CURRENT_CREDENTIAL_STRENGTH("current_credential_strength"),
+    NEW_ACCOUNT("new_account");
 
     private final String value;
 

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -59,7 +59,8 @@ public class UserInfoService {
                         SdkBytes.fromByteBuffer(userProfile.getSalt()).asByteArray());
 
         userInfo.setClaim("rp_pairwise_id", rpPairwiseId);
-        userInfo.setClaim("new_account", accessTokenInfo.getIsNewAccount());
+        userInfo.setClaim(
+                AuthUserInfoClaims.NEW_ACCOUNT.getValue(), accessTokenInfo.getIsNewAccount());
         userInfo.setClaim("password_reset_time", accessTokenInfo.getPasswordResetTime());
 
         // TODO: ATO-1129: delete temporary logs

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -805,6 +805,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
         assertTrue(orchSession.isPresent());
         assertEquals(
                 MFAMethodType.AUTH_APP.getValue(), orchSession.get().getVerifiedMfaMethodType());
+        assertThat(OrchSessionItem.AccountState.NEW, equalTo(orchSession.get().getIsNewAccount()));
     }
 
     private void setupClientReg(boolean identityVerificationSupported) {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -381,6 +381,8 @@ public class IPVCallbackHandler
                 if (returnCodePresentInIPVResponse(returnCode)) {
                     if (rpRequestedReturnCode(clientRegistry, authRequest)) {
                         LOG.info("Generating auth code response for return code(s)");
+                        boolean setIsNewAccountInOrchSession =
+                                configurationService.isSetNewAccountInOrchSessionEnabled();
                         var authenticationResponse =
                                 ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
                                         authRequest,
@@ -393,7 +395,8 @@ public class IPVCallbackHandler
                                         internalPairwiseSubjectId,
                                         userIdentityUserInfo,
                                         ipAddress,
-                                        persistentId);
+                                        persistentId,
+                                        setIsNewAccountInOrchSession);
                         return generateApiGatewayProxyResponse(
                                 302,
                                 "",

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -45,6 +45,7 @@ import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
+import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
@@ -85,6 +86,7 @@ class IPVCallbackHelperTest {
     private final SessionService sessionService = mock(SessionService.class);
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final OidcAPI oidcAPI = mock(OidcAPI.class);
+    private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
 
     private static final URI OIDC_TRUSTMARK_URI = URI.create("https://base-url.com/trustmark");
     private static final URI REDIRECT_URI = URI.create("test-uri");
@@ -156,7 +158,8 @@ class IPVCallbackHelperTest {
                         SerializationService.getInstance(),
                         sessionService,
                         sqsClient,
-                        oidcAPI);
+                        oidcAPI,
+                        orchSessionService);
         when(accountInterventionService.getAccountIntervention(
                         TEST_INTERNAL_COMMON_SUBJECT_ID, auditContext))
                 .thenReturn(
@@ -293,7 +296,8 @@ class IPVCallbackHelperTest {
                         objectMapper,
                         sessionService,
                         sqsClient,
-                        oidcAPI);
+                        oidcAPI,
+                        orchSessionService);
         when(objectMapper.writeValueAsString(any())).thenThrow(new JsonException("json-exception"));
 
         var exception =

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthUserInfoClaims.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthUserInfoClaims.java
@@ -15,7 +15,8 @@ public enum AuthUserInfoClaims {
     PHONE_VERIFIED("phone_number_verified"),
     SALT("salt"),
     VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type"),
-    CURRENT_CREDENTIAL_STRENGTH("current_credential_strength");
+    CURRENT_CREDENTIAL_STRENGTH("current_credential_strength"),
+    NEW_ACCOUNT("new_account");
 
     private final String value;
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -278,7 +278,12 @@ public class AuthCodeHandler
                     clientSession.getClientName(),
                     isTestJourney);
 
-            authCodeResponseService.saveSession(docAppJourney, sessionService, session);
+            if (configurationService.isSetNewAccountInOrchSessionEnabled()) {
+                authCodeResponseService.saveSession(
+                        docAppJourney, sessionService, session, orchSessionService, orchSession);
+            } else {
+                authCodeResponseService.saveSession(docAppJourney, sessionService, session);
+            }
 
             LOG.info("Generating successful auth code response");
             return generateApiGatewayProxyResponse(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -377,7 +377,8 @@ public class AuthenticationCallbackHandler
                                 != null);
                 //
 
-                Boolean newAccount = userInfo.getBooleanClaim("new_account");
+                Boolean newAccount =
+                        userInfo.getBooleanClaim(AuthUserInfoClaims.NEW_ACCOUNT.getValue());
                 AccountState accountState = newAccount ? AccountState.NEW : AccountState.EXISTING;
                 OrchSessionItem.AccountState orchAccountState =
                         newAccount

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -379,6 +379,10 @@ public class AuthenticationCallbackHandler
 
                 Boolean newAccount = userInfo.getBooleanClaim("new_account");
                 AccountState accountState = newAccount ? AccountState.NEW : AccountState.EXISTING;
+                OrchSessionItem.AccountState orchAccountState =
+                        newAccount
+                                ? OrchSessionItem.AccountState.NEW
+                                : OrchSessionItem.AccountState.EXISTING;
 
                 boolean setAuthenticatedFlagForIPV =
                         configurationService.isAuthenticatedFlagForIpvEnabled();
@@ -389,7 +393,7 @@ public class AuthenticationCallbackHandler
                 } else {
                     sessionService.storeOrUpdateSession(userSession.setNewAccount(accountState));
                 }
-
+                orchSessionService.updateSession(orchSession.withAccountState(orchAccountState));
                 var docAppJourney = isDocCheckingAppUserWithSubjectId(clientSession);
                 Map<String, String> dimensions =
                         buildDimensions(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -379,11 +379,19 @@ public class AuthenticationCallbackHandler
 
                 Boolean newAccount =
                         userInfo.getBooleanClaim(AuthUserInfoClaims.NEW_ACCOUNT.getValue());
-                AccountState accountState = newAccount ? AccountState.NEW : AccountState.EXISTING;
-                OrchSessionItem.AccountState orchAccountState =
-                        newAccount
-                                ? OrchSessionItem.AccountState.NEW
-                                : OrchSessionItem.AccountState.EXISTING;
+                AccountState accountState;
+                OrchSessionItem.AccountState orchAccountState;
+
+                if (newAccount == null) {
+                    accountState = AccountState.UNKNOWN;
+                    orchAccountState = OrchSessionItem.AccountState.UNKNOWN;
+                } else {
+                    accountState = newAccount ? AccountState.NEW : AccountState.EXISTING;
+                    orchAccountState =
+                            newAccount
+                                    ? OrchSessionItem.AccountState.NEW
+                                    : OrchSessionItem.AccountState.EXISTING;
+                }
 
                 boolean setAuthenticatedFlagForIPV =
                         configurationService.isAuthenticatedFlagForIpvEnabled();

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -413,10 +413,13 @@ class AuthenticationCallbackHandlerTest {
         handler.handleRequest(event, null);
 
         var orchSessionCaptor = ArgumentCaptor.forClass(OrchSessionItem.class);
-        verify(orchSessionService, times(1)).updateSession(orchSessionCaptor.capture());
-        assertEquals(
+        verify(orchSessionService, times(2)).updateSession(orchSessionCaptor.capture());
+        assertThat(
+                OrchSessionItem.AccountState.NEW,
+                equalTo(orchSessionCaptor.getAllValues().get(0).getIsNewAccount()));
+        assertThat(
                 MFAMethodType.AUTH_APP.getValue(),
-                orchSessionCaptor.getValue().getVerifiedMfaMethodType());
+                equalTo(orchSessionCaptor.getAllValues().get(1).getVerifiedMfaMethodType()));
         assertEquals(
                 TEST_INTERNAL_COMMON_SUBJECT_ID,
                 orchSessionCaptor.getValue().getInternalCommonSubjectId());

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -336,5 +336,11 @@ public class IntegrationTest {
         public Optional<String> getIPVCapacity() {
             return Optional.of("1");
         }
+
+        @Override
+        public boolean isSetNewAccountInOrchSessionEnabled() {
+
+            return true;
+        }
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthExternalApiStubExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthExternalApiStubExtension.java
@@ -6,6 +6,7 @@ import uk.gov.di.orchestration.shared.entity.MFAMethodType;
 import uk.gov.di.orchestration.sharedtest.httpstub.HttpStubExtension;
 
 import static java.lang.String.format;
+import static uk.gov.di.authentication.oidc.entity.AuthUserInfoClaims.NEW_ACCOUNT;
 
 public class AuthExternalApiStubExtension extends HttpStubExtension {
 
@@ -32,7 +33,7 @@ public class AuthExternalApiStubExtension extends HttpStubExtension {
                         getHttpPort()));
 
         UserInfo userInfo = new UserInfo(subjectId);
-        userInfo.setClaim("new_account", true);
+        userInfo.setClaim(NEW_ACCOUNT.getValue(), true);
         userInfo.setClaim("verified_mfa_method_type", MFAMethodType.AUTH_APP.getValue());
         register("/userinfo", 200, "application/json", userInfo.toJSONString());
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -125,4 +125,23 @@ public class AuthCodeResponseGenerationService {
                     session.setAuthenticated(true).setNewAccount(EXISTING));
         }
     }
+
+    public void saveSession(
+            boolean docAppJourney,
+            SessionService sessionService,
+            Session session,
+            OrchSessionService orchSessionService,
+            OrchSessionItem orchSession) {
+        if (docAppJourney) {
+            sessionService.storeOrUpdateSession(session.setNewAccount(EXISTING_DOC_APP_JOURNEY));
+            orchSessionService.updateSession(
+                    orchSession.withAccountState(
+                            OrchSessionItem.AccountState.EXISTING_DOC_APP_JOURNEY));
+        } else {
+            sessionService.storeOrUpdateSession(
+                    session.setAuthenticated(true).setNewAccount(EXISTING));
+            orchSessionService.updateSession(
+                    orchSession.withAccountState(OrchSessionItem.AccountState.EXISTING));
+        }
+    }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -418,6 +418,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("SET_AUTHENTICATED_FLAG_FOR_IPV");
     }
 
+    public boolean isSetNewAccountInOrchSessionEnabled() {
+        return getFlagOrFalse("SET_IS_NEW_ACCOUNT_IN_ORCH_SESSION");
+    }
+
     private Map<String, String> getSsmRedisParameters() {
         if (ssmRedisParameters == null) {
             var getParametersRequest =

--- a/template.yaml
+++ b/template.yaml
@@ -101,6 +101,7 @@ Mappings:
       defaultProvisionedConcurrency: 0
       aisUriSecretId: 6b29b810-e509-4354-9d75-934d0f154d07
       setAuthenticatedFlagForIpv: true
+      setIsNewAccountInOrchSession: true
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "6of9f4amvg"
@@ -133,6 +134,7 @@ Mappings:
       defaultProvisionedConcurrency: 1
       aisUriSecretId: fd6ef1f1-7d31-40ca-978d-2180199141d8
       setAuthenticatedFlagForIpv: true
+      setIsNewAccountInOrchSession: true
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "1rvwudxmbk"
@@ -165,6 +167,7 @@ Mappings:
       defaultProvisionedConcurrency: 3
       aisUriSecretId: 2b9a3315-50e9-4970-87e6-b354cc4a2484
       setAuthenticatedFlagForIpv: true
+      setIsNewAccountInOrchSession: true
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "k2skqhxed6"
@@ -197,6 +200,7 @@ Mappings:
       defaultProvisionedConcurrency: 1
       aisUriSecretId: ""
       setAuthenticatedFlagForIpv: true
+      setIsNewAccountInOrchSession: false
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       authApiId: "s4gj268zy6"
@@ -229,6 +233,7 @@ Mappings:
       defaultProvisionedConcurrency: 3
       aisUriSecretId: ""
       setAuthenticatedFlagForIpv: true
+      setIsNewAccountInOrchSession: false
   ProvisionedConcurrency:
     staging:
       TrustmarkFunction: 1
@@ -2682,6 +2687,12 @@ Resources:
                   !Ref Environment,
                   serviceDomain,
                 ]
+          SET_IS_NEW_ACCOUNT_IN_ORCH_SESSION:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              setIsNewAccountInOrchSession,
+            ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy
@@ -3284,6 +3295,12 @@ Resources:
                     authEnvironment,
                   ]
             - !Ref AWS::NoValue
+          SET_IS_NEW_ACCOUNT_IN_ORCH_SESSION:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              setIsNewAccountInOrchSession,
+            ]
       Policies:
         - !Ref IdentityCredentialsTableReadAccessPolicy
         - !Ref IdentityCredentialsTableWriteAccessPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -2689,6 +2689,7 @@ Resources:
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref RedisParametersAccessPolicy
         - !Ref OrchSessionTableReadAccessPolicy
+        - !Ref OrchSessionTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -3295,6 +3296,7 @@ Resources:
         - !Ref SpotRequestQueueWritePolicy
         - !Ref AccountInterventionsServiceUriSecretAccessPolicy
         - !Ref OrchSessionTableReadAccessPolicy
+        - !Ref OrchSessionTableWriteAccessPolicy
         - !Ref AuthenticationCallbackUserInfoTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173


### PR DESCRIPTION
## What:

- Sets the value of isNewAccount in the Orch session at the same point as it is set in the regular session
- This includes updating:
   -  Authentication Callback Handler to update this using Auth's userinfo response
   - Updates the AuthCodeGenerationService to update the Orch session alongside the redis session
## How to review
- Code review commit-by-commit
- Deploy to orch dev environment
    - Run through a journey 
    - Check all is well
    - Ran auth acceptance tests against deployed env (sandpit), tests passed
 - Once deployed:
     - Run through journey in staging as feature will be enabled 
     - Verify that in the case of a return code this value is set  
     - Check doc app journey
     - Enable feature flag in higher environments in future PRs

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
