### PR TITLE
BAU: bump alarm threshold for the email notification dlq

### DIFF
--- a/ci/terraform/oidc/alerts.tf
+++ b/ci/terraform/oidc/alerts.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs_deadletter_cloudwatch_alarm" {
   namespace           = "AWS/SQS"
   period              = "300"
   statistic           = "Average"
-  threshold           = var.dlq_alarm_threshold
+  threshold           = var.email-notification-dlq-threshold
 
   dimensions = {
     QueueName = aws_sqs_queue.email_dead_letter_queue.name

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -296,6 +296,12 @@ variable "dlq_alarm_threshold" {
   description = "The number of messages on a DLQ before a Cloudwatch alarm is generated"
 }
 
+variable "email-notification-dlq-threshold" {
+  default     = 30
+  type        = number
+  description = "The number of messages on the email notification DLQ before a Cloudwatch alarm is generated"
+}
+
 variable "waf_alarm_blocked_reqeuest_threshold" {
   default     = 1000
   type        = number


### PR DESCRIPTION
## What

It is actually expected that some sqs messages end up in the dlq as Notify may not be able to send messages to some numbers (e.g. international numbers), for example. As such, di-2nd-line should not be alerted for low numbers of messages in the dlq. I've created a ticket to create a tiered alerting system (AUT-3854) where a lower threshold sends an alarm to auth for investigation, and a higher threshold alerts to di-2nd-line. For the time being, this commit bumps the threshold so we don't send alarms to 2nd line unnecessarily.

## How to review

1. Code Review

