### PR TITLE
ATO-1117: grant access to auth user info table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -3284,6 +3284,7 @@ Resources:
         - !Ref SpotRequestQueueWritePolicy
         - !Ref AccountInterventionsServiceUriSecretAccessPolicy
         - !Ref OrchSessionTableReadAccessPolicy
+        - !Ref AuthenticationCallbackUserInfoTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 


### PR DESCRIPTION
## What
The IPV Callback Handler needs access to this so that instead of the UserProfile table, it can make use of the UserInfo table to get details about a user (eg phone number).

## How to review
1. Code Review