### PR TITLE
Ato 1088 set autnethicated flag for all journeys

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -43,6 +43,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -187,6 +188,7 @@ class AuthenticationCallbackHandlerTest {
         usingValidSession();
         usingValidClientSession();
         usingValidClient();
+        withAuthenticatedFlagForIPV(false);
 
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
@@ -204,12 +206,7 @@ class AuthenticationCallbackHandlerTest {
                 equalTo(REDIRECT_URI + "?code=" + AUTH_CODE_RP_TO_ORCH + "&state=" + RP_STATE));
         verifyUserInfoRequest();
 
-        var sessionSaveCaptor = ArgumentCaptor.forClass(Session.class);
-        verify(sessionService, times(2)).storeOrUpdateSession(sessionSaveCaptor.capture());
-        assertThat(
-                Session.AccountState.NEW,
-                equalTo(sessionSaveCaptor.getAllValues().get(0).isNewAccount()));
-        assertTrue(sessionSaveCaptor.getAllValues().get(1).isAuthenticated());
+        assertSessionUpdatedAuthJourney(false);
 
         verify(cloudwatchMetricsService).incrementCounter(eq("AuthenticationCallback"), any());
         verify(cloudwatchMetricsService).incrementCounter(eq("SignIn"), any());
@@ -260,6 +257,26 @@ class AuthenticationCallbackHandlerTest {
                         eq(pair("rpPairwiseId", RP_PAIRWISE_ID.getValue())),
                         eq(pair("authCode", AUTH_CODE_RP_TO_ORCH.getValue())),
                         eq(pair("nonce", RP_NONCE.getValue())));
+    }
+
+    @Test
+    void shouldStillSaveSameSessionValuesWhenSetAuthenticatedFlagForIPVEnabled()
+            throws UnsuccessfulCredentialResponseException {
+        usingValidSession();
+        usingValidClientSession();
+        usingValidClient();
+        withAuthenticatedFlagForIPV(true);
+
+        var event = new APIGatewayProxyRequestEvent();
+        setValidHeadersAndQueryParameters(event);
+
+        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+
+        when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
+
+        handler.handleRequest(event, null);
+
+        assertSessionUpdatedAuthJourney(true);
     }
 
     @Test
@@ -403,6 +420,84 @@ class AuthenticationCallbackHandlerTest {
                 MFAMethodType.AUTH_APP.getValue(),
                 equalTo(orchSessionCaptor.getValue().getVerifiedMfaMethodType()));
         assertEquals(RP_PAIRWISE_ID.getValue(), orchSessionCaptor.getValue().getRpPairwiseId());
+    }
+
+    @Nested
+    class SetAuthenticatedForIpvFeatureFlag {
+        private static MockedStatic<IdentityHelper> mockedIdentityHelper;
+
+        @BeforeEach
+        void setup() throws UnsuccessfulCredentialResponseException {
+            mockedIdentityHelper = mockStatic(IdentityHelper.class);
+
+            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
+                    .thenReturn(USER_INFO);
+            when(configurationService.isAccountInterventionServiceCallEnabled()).thenReturn(false);
+            when(configurationService.isAccountInterventionServiceActionEnabled())
+                    .thenReturn(false);
+            session.setAuthenticated(false);
+        }
+
+        @AfterEach
+        void afterEach() {
+            mockedIdentityHelper.close();
+        }
+
+        @Test
+        void shouldSetAuthenticatedWhenFlagEnabledForIpvJourney()
+                throws UnsuccessfulCredentialResponseException {
+            withAuthenticatedFlagForIPV(true);
+            usingValidSession();
+            usingValidClientSession();
+            usingValidClient();
+            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
+                    .thenReturn(USER_INFO);
+            identityJourney();
+
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            handler.handleRequest(event, null);
+
+            var sessionSaveCaptor = ArgumentCaptor.forClass(Session.class);
+            verify(sessionService, times(1)).storeOrUpdateSession(sessionSaveCaptor.capture());
+            assertTrue(sessionSaveCaptor.getValue().isAuthenticated());
+            verify(initiateIPVAuthorisationService)
+                    .sendRequestToIPV(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
+        void shouldNotSetAuthenticatedForIpvJourneyWhenFlagIsFalse()
+                throws UnsuccessfulCredentialResponseException {
+            withAuthenticatedFlagForIPV(false);
+            usingValidSession();
+            usingValidClientSession();
+            usingValidClient();
+            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
+                    .thenReturn(USER_INFO);
+            identityJourney();
+
+            var event = new APIGatewayProxyRequestEvent();
+            setValidHeadersAndQueryParameters(event);
+
+            handler.handleRequest(event, null);
+
+            var sessionSaveCaptor = ArgumentCaptor.forClass(Session.class);
+            verify(sessionService, times(1)).storeOrUpdateSession(sessionSaveCaptor.capture());
+            assertFalse(sessionSaveCaptor.getAllValues().get(0).isAuthenticated());
+            verify(initiateIPVAuthorisationService)
+                    .sendRequestToIPV(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+        }
+
+        private void identityJourney() {
+            when(IdentityHelper.identityRequired(anyMap(), anyBoolean(), anyBoolean()))
+                    .thenReturn(true);
+        }
     }
 
     @Nested
@@ -772,5 +867,26 @@ class AuthenticationCallbackHandlerTest {
         assertEquals(expectedUserInfoRequest.getURI(), userInfoRequest.getValue().getURI());
         assertEquals(
                 expectedUserInfoRequest.getHeaderMap(), userInfoRequest.getValue().getHeaderMap());
+    }
+
+    private void assertSessionUpdatedAuthJourney(boolean setAuthenticatedFlagForIPV) {
+        var sessionSaveCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionService, times(2)).storeOrUpdateSession(sessionSaveCaptor.capture());
+        assertThat(
+                sessionSaveCaptor.getAllValues().get(1).getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.LOW_LEVEL));
+        assertThat(
+                Session.AccountState.NEW,
+                equalTo(sessionSaveCaptor.getAllValues().get(0).isNewAccount()));
+        if (setAuthenticatedFlagForIPV) {
+            assertTrue(sessionSaveCaptor.getAllValues().get(0).isAuthenticated());
+        } else {
+            assertTrue(sessionSaveCaptor.getAllValues().get(1).isAuthenticated());
+        }
+    }
+
+    private void withAuthenticatedFlagForIPV(boolean setAuthenticatedFlagForIPV) {
+        when(configurationService.isAuthenticatedFlagForIpvEnabled())
+                .thenReturn(setAuthenticatedFlagForIPV);
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -414,6 +414,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         }
     }
 
+    public boolean isAuthenticatedFlagForIpvEnabled() {
+        return getFlagOrFalse("SET_AUTHENTICATED_FLAG_FOR_IPV");
+    }
+
     private Map<String, String> getSsmRedisParameters() {
         if (ssmRedisParameters == null) {
             var getParametersRequest =

--- a/template.yaml
+++ b/template.yaml
@@ -100,6 +100,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/8bc4e01c-466b-4663-9c60-c29d5e9f2fcf
       defaultProvisionedConcurrency: 0
       aisUriSecretId: 6b29b810-e509-4354-9d75-934d0f154d07
+      setAuthenticatedFlagForIpv: true
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "6of9f4amvg"
@@ -131,6 +132,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/5fdfad8b-ca31-4afc-a948-59fd498c0f3c
       defaultProvisionedConcurrency: 1
       aisUriSecretId: fd6ef1f1-7d31-40ca-978d-2180199141d8
+      setAuthenticatedFlagForIpv: true
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "1rvwudxmbk"
@@ -162,6 +164,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:758531536632:key/3d990d7b-0042-4115-8263-e6b472d84cc2
       defaultProvisionedConcurrency: 3
       aisUriSecretId: 2b9a3315-50e9-4970-87e6-b354cc4a2484
+      setAuthenticatedFlagForIpv: true
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "k2skqhxed6"
@@ -193,6 +196,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/e34095ae-a65b-4609-99b3-9c1f407eff73
       defaultProvisionedConcurrency: 1
       aisUriSecretId: ""
+      setAuthenticatedFlagForIpv: false
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       authApiId: "s4gj268zy6"
@@ -224,6 +228,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:172348255554:key/0e5c92f4-26a1-442d-a57b-87db810a40d1
       defaultProvisionedConcurrency: 3
       aisUriSecretId: ""
+      setAuthenticatedFlagForIpv: false
   ProvisionedConcurrency:
     staging:
       TrustmarkFunction: 1
@@ -1753,6 +1758,12 @@ Resources:
                 ]
           ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR:
             !If [AisAbortOnError, true, false]
+          SET_AUTHENTICATED_FLAG_FOR_IPV:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              setAuthenticatedFlagForIpv,
+            ]
           STORAGE_TOKEN_SIGNING_KEY_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,


### PR DESCRIPTION
## What
- Sets up a feature flag `SET_AUTHENTICATED_FOR_IPV` which controls whether we enable Authenticated in the session once a User is handed back from Auth in all journeys
- Feature flag is set to true for `dev` , `build` and `staging` but turned off for `integration` and `production`

## How to review
- Code review commit-by-commit
- Deploy to dev, I did sandpit:
   - Run through a journey - done
   - Run Auth acceptance tests against the deployed environment - Ran against sandpit, did have 9 failing tests but these also failed when ran on main in sandpit so writing off as noise in sandpit. These were all lockout tests which failed at the  6 wrong MFA code step

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
