### PR TITLE
AUT-3750: add relevant runbook to DLQ alerts

### DIFF
--- a/ci/terraform/oidc/alerts.tf
+++ b/ci/terraform/oidc/alerts.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs_deadletter_cloudwatch_alarm" {
   dimensions = {
     QueueName = aws_sqs_queue.email_dead_letter_queue.name
   }
-  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.email_dead_letter_queue.name}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
+  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.email_dead_letter_queue.name}. ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}. Runbook: https://govukverify.atlassian.net/wiki/spaces/LO/pages/4164649233/BAU+Daytime+Support+Hygiene+and+Optimisation+Rota#SUP-7%3A-Resolve-DLQ-messages"
   alarm_actions     = [data.aws_sns_topic.slack_events.arn]
 }
 

--- a/ci/terraform/shared/sqs.tf
+++ b/ci/terraform/shared/sqs.tf
@@ -73,6 +73,6 @@ resource "aws_cloudwatch_metric_alarm" "pending_email_check_dlq_cloudwatch_alarm
   dimensions = {
     QueueName = aws_sqs_queue.pending_email_check_dead_letter_queue.name
   }
-  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.pending_email_check_dead_letter_queue.name}"
+  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.pending_email_check_dead_letter_queue.name}. Runbook: https://govukverify.atlassian.net/wiki/spaces/LO/pages/4164649233/BAU+Daytime+Support+Hygiene+and+Optimisation+Rota#SUP-7%3A-Resolve-DLQ-messages"
   alarm_actions     = [aws_sns_topic.slack_events.arn]
 }


### PR DESCRIPTION
## What

Added the relevant runbook to the alarm message for the [production-pending-email-check-dlq](https://uk-digital-identity.awsapps.com/start/#/console?account_id=172348255554&destination=https%3A%2F%2Feu-west-2.console.aws.amazon.com%2Fsqs%2Fv3%2Fhome%3Fregion%3Deu-west-2%23%2Fqueues%2Fhttps%253A%252F%252Fsqs.eu-west-2.amazonaws.com%252F172348255554%252Fproduction-pending-email-check-dlq%2Fdlq-redrive) and [production-email-notification-dlq](https://uk-digital-identity.awsapps.com/start/#/console?account_id=172348255554&destination=https%3A%2F%2Feu-west-2.console.aws.amazon.com%2Fsqs%2Fv3%2Fhome%3Fregion%3Deu-west-2%23%2Fqueues%2Fhttps%253A%252F%252Fsqs.eu-west-2.amazonaws.com%252F172348255554%252Fproduction-email-notification-dlq%2Fdlq-redrive) alarms.

Took inspiration from how runbooks have been added to orch alarms. They have been implemented in the same way and have seen that they render and are click-able in slack, so believe it will work the same here.

The ticket wants a POC for how we can add runbooks to alarm messages. We don't have specific runbooks for other alarms as of yet. We should include adding runbook links to relevant alarm messages to acceptance criteria for runbook creation tickets in future.

## How to review

For example:

1. Code Review
2. Check link in alarm message links to relevant runbook
