### PR TITLE
BAU: Set sandpit stub to be test client

### DIFF
--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -18,7 +18,7 @@ stub_rp_clients = [
     logout_urls = [
       "https://rp-dev.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "0"
+    test_client                     = "1"
     client_type                     = "web"
     identity_verification_supported = "0"
     scopes = [


### PR DESCRIPTION
## What
- This enables the sandpit RP stub as a test client, which will allow running the fully automated acceptance tests against sandpit environment. This brings sandpit inline with the other auth dev environments

## How to review
- Code review commit by commit 
- Deploy to sandpit (sandpit is the only dev environment that makes sense here)
   - Check the client registry entry for the stub and observe this flag is set to the same value as the terraform
   - Run the acceptance tests against sandpit - all but 9 should pass. (The 9 that don't pass will be ones which enter an incorrect OTP code, which will pass if you modify the acceptance test code not to use the in main) 
   - 
## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
