### PR TITLE
ATO-1134: add policies to read and write to orchSesssionItem table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1503,6 +1503,8 @@ Resources:
         - !Ref IdTokenKmsAccessPolicy
         - !Ref IdTokenKmsRsaAccessPolicy
         - !Ref BackChannelLogoutQueueWritePolicy
+        - !Ref OrchSessionTableReadAccessPolicy
+        - !Ref OrchSessionTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 


### PR DESCRIPTION
## What
Adds r+w permissions to OrchSession table for LogoutHandler. 
AuthenticationCallbackHandler and IPVCallbackHandler already have the required permissions.
ProcessingIdentityHandler permissions are being addressed in https://github.com/govuk-one-login/authentication-api/pull/5511 and https://github.com/govuk-one-login/authentication-api/pull/5512, as it is a bit more complex.

Nothing specific to test here. This work is needed for https://github.com/govuk-one-login/authentication-api/pull/5482, which will be tested thoroughly.

## How to review

1. Code Review
