### PR TITLE
Ato 975/add current credential strength to user info response

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -113,12 +113,16 @@ public class UserInfoService {
             userInfo.setClaim(
                     AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
                     authSession.getVerifiedMfaMethodType());
+            LOG.info("verified_mfa value: {}", authSession.getVerifiedMfaMethodType());
         }
         if (accessTokenInfo
                 .getClaims()
                 .contains(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue())) {
             userInfo.setClaim(
                     AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue(),
+                    authSession.getCurrentCredentialStrength());
+            LOG.info(
+                    "current_credential_strength value: {}",
                     authSession.getCurrentCredentialStrength());
         }
     }

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -114,6 +114,13 @@ public class UserInfoService {
                     AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
                     authSession.getVerifiedMfaMethodType());
         }
+        if (accessTokenInfo
+                .getClaims()
+                .contains(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue())) {
+            userInfo.setClaim(
+                    AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue(),
+                    authSession.getCurrentCredentialStrength());
+        }
     }
 
     private static String bytesToBase64(ByteBuffer byteBuffer) {

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkBytes;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
@@ -51,6 +52,8 @@ public class UserInfoServiceTest {
     private static final String TEST_PHONE = "test-phone";
     private static final boolean TEST_PHONE_VERIFIED = true;
     private static final String TEST_VERIFIED_MFA_METHOD_TYPE = MFAMethodType.EMAIL.getValue();
+    private static final CredentialTrustLevel TEST_CURRENT_CREDENTIAL_STRENGTH =
+            CredentialTrustLevel.MEDIUM_LEVEL;
     private static final boolean TEST_IS_NEW_ACCOUNT = true;
     private static final long TEST_PASSWORD_RESET_TIME = 1710255380L;
     private static final UserProfile TEST_USER_PROFILE =
@@ -64,7 +67,9 @@ public class UserInfoServiceTest {
                     .withPhoneNumberVerified(TEST_PHONE_VERIFIED)
                     .withSalt(TEST_SALT);
     private static final AuthSessionItem authSession =
-            new AuthSessionItem().withVerifiedMfaMethodType(TEST_VERIFIED_MFA_METHOD_TYPE);
+            new AuthSessionItem()
+                    .withVerifiedMfaMethodType(TEST_VERIFIED_MFA_METHOD_TYPE)
+                    .withCurrentCredentialStrength(TEST_CURRENT_CREDENTIAL_STRENGTH);
 
     @BeforeEach
     public void setUp() {
@@ -90,7 +95,8 @@ public class UserInfoServiceTest {
             String expectedPhoneNumber,
             Boolean expectedPhoneNumberVerified,
             String expectedSalt,
-            String expectedVerifiedMfaMethod) {
+            String expectedVerifiedMfaMethod,
+            CredentialTrustLevel expectedCurrentCredentialStrength) {
         UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore, authSession);
 
         assertEquals(TEST_INTERNAL_COMMON_SUBJECT_ID, actual.getSubject().getValue());
@@ -106,6 +112,8 @@ public class UserInfoServiceTest {
         assertEquals(expectedPhoneNumberVerified, actual.getPhoneNumberVerified());
         assertEquals(expectedSalt, actual.getClaim("salt"));
         assertEquals(expectedVerifiedMfaMethod, actual.getClaim("verified_mfa_method_type"));
+        assertEquals(
+                expectedCurrentCredentialStrength, actual.getClaim("current_credential_strength"));
         assertEquals(TEST_PASSWORD_RESET_TIME, actual.getClaim("password_reset_time"));
     }
 
@@ -116,6 +124,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         TEST_SUBJECT.getValue(),
+                        null,
                         null,
                         null,
                         null,
@@ -133,6 +142,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         null,
+                        null,
                         null),
                 Arguments.of(
                         getMockAccessTokenStore(
@@ -145,7 +155,8 @@ public class UserInfoServiceTest {
                                         "phone_number",
                                         "phone_number_verified",
                                         "salt",
-                                        "verified_mfa_method_type")),
+                                        "verified_mfa_method_type",
+                                        "current_credential_strength")),
                         TEST_LEGACY_SUBJECT_ID,
                         TEST_PUBLIC_SUBJECT_ID,
                         TEST_SUBJECT.getValue(),
@@ -154,7 +165,8 @@ public class UserInfoServiceTest {
                         TEST_PHONE,
                         TEST_PHONE_VERIFIED,
                         bytesToBase64(TEST_SALT),
-                        TEST_VERIFIED_MFA_METHOD_TYPE));
+                        TEST_VERIFIED_MFA_METHOD_TYPE,
+                        TEST_CURRENT_CREDENTIAL_STRENGTH));
     }
 
     private static AccessTokenStore getMockAccessTokenStore(List<String> claims) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -413,7 +413,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         .setVerifiedMfaMethodType(codeRequest.getMfaMethodType()));
 
         authSessionService.updateSession(
-                authSession.withVerifiedMfaMethodType(codeRequest.getMfaMethodType().getValue()));
+                authSession
+                        .withVerifiedMfaMethodType(codeRequest.getMfaMethodType().getValue())
+                        .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL));
 
         var clientId = userContext.getClientId();
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -234,6 +234,7 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         authSession.setIsNewAccount(AuthSessionItem.AccountState.NEW);
         var result =
                 makeCallWithCode(
@@ -247,6 +248,9 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                authSession.getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -276,6 +280,7 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
 
         var mfaCodeRequest =
                 new VerifyMfaCodeRequest(
@@ -314,6 +319,7 @@ class VerifyMfaCodeHandlerTest {
         when(configurationService.getInternalSectorUri()).thenReturn("http://" + SECTOR_HOST);
         when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         session.setInternalCommonSubjectIdentifier(null);
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
@@ -329,6 +335,9 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                authSession.getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -359,6 +368,7 @@ class VerifyMfaCodeHandlerTest {
         when(phoneNumberCodeProcessor.validateCode()).thenReturn(Optional.empty());
         authSession.setIsNewAccount(AuthSessionItem.AccountState.NEW);
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
@@ -371,6 +381,9 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                authSession.getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         verify(phoneNumberCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -401,6 +414,7 @@ class VerifyMfaCodeHandlerTest {
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
@@ -413,6 +427,9 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                authSession.getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -443,6 +460,7 @@ class VerifyMfaCodeHandlerTest {
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
@@ -455,6 +473,9 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                authSession.getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -375,6 +375,10 @@ public class AuthenticationCallbackHandler
                         "is verified_mfa_method_type attached to auth-external-api userinfo response: {}",
                         userInfo.getClaim(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue())
                                 != null);
+                LOG.info(
+                        "is current_credential_strength attached to auth-external-api userinfo response: {}",
+                        userInfo.getClaim(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue())
+                                != null);
                 //
 
                 Boolean newAccount = userInfo.getBooleanClaim("new_account");


### PR DESCRIPTION
## What

Last steps on the Auth side for the current credential strength:

- Sets`currentCredentialStrength` as `medium` on the `verifyMfaCode` handler in the auth session
- Takes the `currentCredentialStrength` from the auth session and passes it through the userInfo response

Run acceptance test
Tested on Sandpit