### PR TITLE
ATO-975: add currentCredentialStrength claim to all userinfo requests

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/entity/AuthUserInfoClaims.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/entity/AuthUserInfoClaims.java
@@ -13,7 +13,8 @@ public enum AuthUserInfoClaims {
     PHONE_NUMBER("phone_number"),
     PHONE_VERIFIED("phone_number_verified"),
     SALT("salt"),
-    VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type");
+    VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type"),
+    CURRENT_CREDENTIAL_STRENGTH("current_credential_strength");
 
     private final String value;
 

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -71,6 +71,11 @@ public class UserInfoService {
                 accessTokenInfo
                         .getClaims()
                         .contains(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue()));
+        LOG.info(
+                "is current_credential_strength a requested claim: {}",
+                accessTokenInfo
+                        .getClaims()
+                        .contains(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue()));
         //
 
         if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.LEGACY_SUBJECT_ID.getValue())) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthUserInfoClaims.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthUserInfoClaims.java
@@ -14,7 +14,8 @@ public enum AuthUserInfoClaims {
     PHONE_NUMBER("phone_number"),
     PHONE_VERIFIED("phone_number_verified"),
     SALT("salt"),
-    VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type");
+    VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type"),
+    CURRENT_CREDENTIAL_STRENGTH("current_credential_strength");
 
     private final String value;
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -878,6 +878,7 @@ public class AuthorisationHandler
         var claimsSet = new HashSet<AuthUserInfoClaims>();
         claimsSet.add(AuthUserInfoClaims.EMAIL);
         claimsSet.add(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE);
+        claimsSet.add(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH);
         if (identityRequired) {
             LOG.info(
                     "Identity is required. Adding the local_account_id, salt, email_verified and phone_number claims");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -339,7 +339,8 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldRedirectToLoginWhenUserHasNoExistingSessionWithSignedAndEncryptedJwtInBody() {
+        void shouldRedirectToLoginWhenUserHasNoExistingSessionWithSignedAndEncryptedJwtInBody()
+                throws com.nimbusds.oauth2.sdk.ParseException, ParseException {
             var orchClientId = "orchestration-client-id";
             when(configService.getOrchestrationClientId()).thenReturn(orchClientId);
             when(orchestrationAuthorizationService.getSignedAndEncryptedJWT(any()))
@@ -366,9 +367,13 @@ class AuthorisationHandlerTest {
                     equalTo(ResponseType.CODE.toString()));
             var captor = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
+            var expectedClaimSetRequest =
+                    ClaimsSetRequest.parse(
+                            "{\"userinfo\":{\"email_verified\":null,\"current_credential_strength\":null,\"verified_mfa_method_type\":null,\"email\":null}}");
+            var actualClaimSetRequest =
+                    ClaimsSetRequest.parse(captor.getValue().getStringClaim("claim"));
             assertEquals(
-                    "{\"userinfo\":{\"email_verified\":null,\"verified_mfa_method_type\":null,\"email\":null}}",
-                    captor.getValue().getClaim("claim"));
+                    expectedClaimSetRequest.toJSONObject(), actualClaimSetRequest.toJSONObject());
         }
 
         @Test
@@ -403,7 +408,7 @@ class AuthorisationHandlerTest {
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
             var expectedClaimSetRequest =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"phone_number_verified\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null}}");
+                            "{\"userinfo\":{\"phone_number_verified\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null,\"current_credential_strength\":null}}");
             var actualClaimSetRequest =
                     ClaimsSetRequest.parse(captor.getValue().getStringClaim("claim"));
             assertEquals(
@@ -442,7 +447,7 @@ class AuthorisationHandlerTest {
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
             var expectedClaimSetRequest =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"salt\":null,\"email_verified\":null,\"local_account_id\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null}}");
+                            "{\"userinfo\":{\"salt\":null,\"email_verified\":null,\"local_account_id\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null,\"current_credential_strength\":null}}");
             var actualClaimSetRequest =
                     ClaimsSetRequest.parse(captor.getValue().getStringClaim("claim"));
             assertEquals(
@@ -1625,7 +1630,7 @@ class AuthorisationHandlerTest {
 
             var expectedClaim =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"verified_mfa_method_type\":null,\"public_subject_id\":null,\"email\":null}}");
+                            "{\"userinfo\":{\"verified_mfa_method_type\":null,\"current_credential_strength\":null,\"public_subject_id\":null,\"email\":null}}");
             var actualClaim = ClaimsSetRequest.parse(argument.getValue().getStringClaim("claim"));
             assertEquals(actualClaim.toJSONObject(), expectedClaim.toJSONObject());
         }
@@ -1647,7 +1652,7 @@ class AuthorisationHandlerTest {
 
             var expectedClaim =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"legacy_subject_id\":null,\"verified_mfa_method_type\":null,\"email\":null}}");
+                            "{\"userinfo\":{\"legacy_subject_id\":null,\"current_credential_strength\":null,\"verified_mfa_method_type\":null,\"email\":null}}");
             var actualClaim = ClaimsSetRequest.parse(argument.getValue().getStringClaim("claim"));
             assertEquals(actualClaim.toJSONObject(), expectedClaim.toJSONObject());
         }


### PR DESCRIPTION
## What

Following https://govukverify.atlassian.net/browse/ATO-1129 , adding the currentCredentialStrength to always be requested in the userInfo.

This is to allow auth to be able to send back the currentCredentialStrength from to userInfo to orch.