### PR TITLE
ATO-1096: Add auth time to Orch session

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -399,17 +399,18 @@ public class AuthenticationCallbackHandler
 
                 CredentialTrustLevel lowestRequestedCredentialTrustLevel =
                         VectorOfTrust.getLowestCredentialTrustLevel(clientSession.getVtrList());
-                long authTime = NowHelper.now().toInstant().getEpochSecond();
                 if (setAuthenticatedFlagForIPV) {
-                    if (userSession.isAuthenticated()) {
-                        if (lowestRequestedCredentialTrustLevel.compareTo(
-                                        userSession.getCurrentCredentialStrength())
-                                > 0) {
-                            orchSessionService.updateSession(orchSession.withAuthTime(authTime));
-                        }
-                    } else {
+                    long authTime = NowHelper.now().toInstant().getEpochSecond();
+                    boolean userHasUplifted =
+                            userSession.getCurrentCredentialStrength() != null
+                                    && lowestRequestedCredentialTrustLevel.compareTo(
+                                                    userSession.getCurrentCredentialStrength())
+                                            > 0;
+                    if (!userSession.isAuthenticated()) {
                         sessionService.storeOrUpdateSession(
                                 userSession.setNewAccount(accountState).setAuthenticated(true));
+                        orchSessionService.updateSession(orchSession.withAuthTime(authTime));
+                    } else if (userHasUplifted) {
                         orchSessionService.updateSession(orchSession.withAuthTime(authTime));
                     }
                 } else {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -47,6 +47,7 @@ import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
@@ -399,6 +400,8 @@ public class AuthenticationCallbackHandler
                 if (setAuthenticatedFlagForIPV) {
                     sessionService.storeOrUpdateSession(
                             userSession.setNewAccount(accountState).setAuthenticated(true));
+                    orchSessionService.updateSession(
+                            orchSession.withAuthTime(NowHelper.now().toInstant().getEpochSecond()));
                 } else {
                     sessionService.storeOrUpdateSession(userSession.setNewAccount(accountState));
                 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -85,8 +85,7 @@ class AuthenticationCallbackHandlerTest {
     private static final String PERSISTENT_SESSION_ID =
             "uDjIfGhoKwP8bFpRewlpd-AVrI4--1700750982787";
     private static final String SESSION_ID = "a-session-id";
-    private static final Session session =
-            new Session(SESSION_ID).setVerifiedMfaMethodType(MFAMethodType.EMAIL);
+    private static Session session;
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String CLIENT_NAME = "client-name";
@@ -147,6 +146,11 @@ class AuthenticationCallbackHandlerTest {
 
     @BeforeEach
     void setUp() {
+        session =
+                new Session(SESSION_ID)
+                        .setVerifiedMfaMethodType(MFAMethodType.EMAIL)
+                        .setAuthenticated(false);
+        when(configurationService.isAuthenticatedFlagForIpvEnabled()).thenReturn(true);
         reset(initiateIPVAuthorisationService);
         reset(logoutService);
         reset(authorizationService);
@@ -187,7 +191,6 @@ class AuthenticationCallbackHandlerTest {
         usingValidSession();
         usingValidClientSession();
         usingValidClient();
-        withAuthenticatedFlagForIPV(false);
 
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
@@ -264,7 +267,6 @@ class AuthenticationCallbackHandlerTest {
         usingValidSession();
         usingValidClientSession();
         usingValidClient();
-        withAuthenticatedFlagForIPV(true);
 
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
@@ -451,7 +453,6 @@ class AuthenticationCallbackHandlerTest {
         @Test
         void shouldSetAuthenticatedWhenFlagEnabledForIpvJourney()
                 throws UnsuccessfulCredentialResponseException {
-            withAuthenticatedFlagForIPV(true);
             usingValidSession();
             usingValidClientSession();
             usingValidClient();
@@ -476,7 +477,7 @@ class AuthenticationCallbackHandlerTest {
         @Test
         void shouldNotSetAuthenticatedForIpvJourneyWhenFlagIsFalse()
                 throws UnsuccessfulCredentialResponseException {
-            withAuthenticatedFlagForIPV(false);
+            when(configurationService.isAuthenticatedFlagForIpvEnabled()).thenReturn(false);
             usingValidSession();
             usingValidClientSession();
             usingValidClient();
@@ -908,10 +909,5 @@ class AuthenticationCallbackHandlerTest {
         } else {
             assertTrue(sessionSaveCaptor.getAllValues().get(1).isAuthenticated());
         }
-    }
-
-    private void withAuthenticatedFlagForIPV(boolean setAuthenticatedFlagForIPV) {
-        when(configurationService.isAuthenticatedFlagForIpvEnabled())
-                .thenReturn(setAuthenticatedFlagForIPV);
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -162,6 +162,14 @@ public class RedisExtension
                 session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
     }
 
+    public void setAuthenticated(String sessionId, boolean authenticated)
+            throws Json.JsonException {
+        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
+        session.setAuthenticated(authenticated);
+        redis.saveWithExpiry(
+                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+    }
+
     public Session getSession(String sessionId) throws Json.JsonException {
         return objectMapper.readValue(redis.getValue(sessionId), Session.class);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -12,6 +12,7 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "IsNewAccount";
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
+    public static final String ATTRIBUTE_AUTH_TIME = "AuthTime";
 
     public enum AccountState {
         NEW,
@@ -26,6 +27,7 @@ public class OrchSessionItem {
     private String verifiedMfaMethodType;
     private AccountState isNewAccount;
     private String internalCommonSubjectId;
+    private long authTime;
 
     public OrchSessionItem() {}
 
@@ -116,6 +118,20 @@ public class OrchSessionItem {
 
     public OrchSessionItem withInternalCommonSubjectId(String internalCommonSubjectId) {
         this.internalCommonSubjectId = internalCommonSubjectId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_AUTH_TIME)
+    public long getAuthTime() {
+        return authTime;
+    }
+
+    public void setAuthTime(long authTime) {
+        this.authTime = authTime;
+    }
+
+    public OrchSessionItem withAuthTime(long authTime) {
+        this.authTime = authTime;
         return this;
     }
 }


### PR DESCRIPTION
## What

As part of the max_age initiative, Orch are to begin setting `authTime` in the Orch session, at the time that the user is authenticated (ie. when the `authenticated` session field goes from `false` to `true`).

Currently `authenticated` is set like this in a number of places, but there is ongoing work ([ATO-1088](https://govukverify.atlassian.net/browse/ATO-1088)) to set it just once in AuthenticationCallback (under the feature flag `SET_AUTHENTICATED_FLAG_FOR_IPV`). To avoid this ongoing work being a blocker, this PR considers only the place that the `authenticated` flag will be set once the flag is live in production.

There is another case that Orch need to set `authTime`, which is when the user has had their credential strength uplifted (eg. from LOW to MEDIUM), which happens when a user with an existing session authenticates with a higher trust level on a second journey.

## Testing
- [x] Run through affected journeys in dev with flag on
- [x] Run through affected journeys in dev with flag off
- [x] Run Auth acceptance tests against dev with flag on
- [x] Run Auth acceptance tests against dev with flag off


[ATO-1088]: https://govukverify.atlassian.net/browse/ATO-1088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ