### PR TITLE
ATO-1117: add authUserInfo to IPV callback handler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -191,7 +191,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                 List.of(OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED));
 
         Optional<AuthenticationUserInfo> userInfoDbEntry =
-                userInfoStoreExtension.getUserInfoBySubjectId(SUBJECT_ID.getValue());
+                userInfoStoreExtension.getUserInfoDataBySubjectId(SUBJECT_ID.getValue());
         assertFalse(userInfoDbEntry.isPresent());
     }
 
@@ -864,7 +864,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         OidcAuditableEvent.AUTH_CODE_ISSUED));
 
         Optional<AuthenticationUserInfo> userInfoDbEntry =
-                userInfoStoreExtension.getUserInfoBySubjectId(SUBJECT_ID.getValue());
+                userInfoStoreExtension.getUserInfoDataBySubjectId(SUBJECT_ID.getValue());
         assertTrue(userInfoDbEntry.isPresent());
         assertEquals(SUBJECT_ID.getValue(), userInfoDbEntry.get().getSubjectID());
         assertThat(userInfoDbEntry.get().getUserInfo(), containsString("new_account"));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -541,6 +541,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
     private void setupUserProfileAndUserCredentials() {
         userStore.signUp(TEST_EMAIL_ADDRESS, "password", TEST_SUBJECT);
+        userStore.addVerifiedPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);
     }
 
     private void setupClientStore() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
@@ -28,7 +28,7 @@ class AuthenticationUserInfoStorageServiceIntegrationTest {
         userInfoExtension.addAuthenticationUserInfoData(SUBJECT_ID, userInfo);
 
         Optional<AuthenticationUserInfo> retrievedUserInfoData =
-                userInfoExtension.getUserInfoBySubjectId(SUBJECT_ID);
+                userInfoExtension.getUserInfoDataBySubjectId(SUBJECT_ID);
 
         UserInfo retrievedUserInfo = userInfoExtension.getUserInfo(SUBJECT_ID).orElseThrow();
 
@@ -41,7 +41,7 @@ class AuthenticationUserInfoStorageServiceIntegrationTest {
     @Test
     void shouldReturnOptionalEmptyWhenNoUserInfo() {
         Optional<AuthenticationUserInfo> retrievedUserInfo =
-                userInfoExtension.getUserInfoBySubjectId(SUBJECT_ID);
+                userInfoExtension.getUserInfoDataBySubjectId(SUBJECT_ID);
 
         assertThat(retrievedUserInfo.isEmpty(), equalTo(true));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.services;
 
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.Test;
@@ -21,15 +22,27 @@ class AuthenticationUserInfoStorageServiceIntegrationTest {
             new AuthenticationCallbackUserInfoStoreExtension(180);
 
     @Test
-    void shouldAddAndRetrieveUserInfo() {
+    void shouldAddAndRetrieveUserInfo() throws ParseException {
         UserInfo userInfo = new UserInfo(new Subject(SUBJECT_ID));
 
         userInfoExtension.addAuthenticationUserInfoData(SUBJECT_ID, userInfo);
 
+        Optional<AuthenticationUserInfo> retrievedUserInfoData =
+                userInfoExtension.getUserInfoBySubjectId(SUBJECT_ID);
+
+        UserInfo retrievedUserInfo = userInfoExtension.getUserInfo(SUBJECT_ID).orElseThrow();
+
+        assertThat(retrievedUserInfoData.isPresent(), equalTo(true));
+        assertThat(retrievedUserInfoData.get().getSubjectID(), equalTo(SUBJECT_ID));
+
+        assertThat(retrievedUserInfo.getSubject().getValue(), equalTo(SUBJECT_ID));
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyWhenNoUserInfo() {
         Optional<AuthenticationUserInfo> retrievedUserInfo =
                 userInfoExtension.getUserInfoBySubjectId(SUBJECT_ID);
 
-        assertThat(retrievedUserInfo.isPresent(), equalTo(true));
-        assertThat(retrievedUserInfo.get().getSubjectID(), equalTo(SUBJECT_ID));
+        assertThat(retrievedUserInfo.isEmpty(), equalTo(true));
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -41,6 +41,7 @@ import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -82,6 +83,7 @@ public class IPVCallbackHandler
     private final IPVTokenService ipvTokenService;
     private final SessionService sessionService;
     private final OrchSessionService orchSessionService;
+    private final AuthenticationUserInfoStorageService authUserInfoStorageService;
     private final DynamoService dynamoService;
     private final ClientSessionService clientSessionService;
     private final DynamoClientService dynamoClientService;
@@ -104,6 +106,7 @@ public class IPVCallbackHandler
             IPVTokenService ipvTokenService,
             SessionService sessionService,
             OrchSessionService orchSessionService,
+            AuthenticationUserInfoStorageService authUserInfoStorageService,
             DynamoService dynamoService,
             ClientSessionService clientSessionService,
             DynamoClientService dynamoClientService,
@@ -119,6 +122,7 @@ public class IPVCallbackHandler
         this.ipvTokenService = ipvTokenService;
         this.sessionService = sessionService;
         this.orchSessionService = orchSessionService;
+        this.authUserInfoStorageService = authUserInfoStorageService;
         this.dynamoService = dynamoService;
         this.clientSessionService = clientSessionService;
         this.dynamoClientService = dynamoClientService;
@@ -142,6 +146,8 @@ public class IPVCallbackHandler
         this.ipvTokenService = new IPVTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
+        this.authUserInfoStorageService =
+                new AuthenticationUserInfoStorageService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);
@@ -168,6 +174,8 @@ public class IPVCallbackHandler
         this.ipvTokenService = new IPVTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService, redis);
         this.orchSessionService = new OrchSessionService(configurationService);
+        this.authUserInfoStorageService =
+                new AuthenticationUserInfoStorageService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService, redis);
         this.dynamoClientService = new DynamoClientService(configurationService);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -66,6 +66,7 @@ import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.AwsSqsClient;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -123,6 +124,8 @@ class IPVCallbackHandlerTest {
     private final IPVTokenService ipvTokenService = mock(IPVTokenService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
+    private final AuthenticationUserInfoStorageService authUserInfoStorageService =
+            mock(AuthenticationUserInfoStorageService.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
     private final CookieHelper cookieHelper = mock(CookieHelper.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
@@ -269,6 +272,7 @@ class IPVCallbackHandlerTest {
                         ipvTokenService,
                         sessionService,
                         orchSessionService,
+                        authUserInfoStorageService,
                         dynamoService,
                         clientSessionService,
                         dynamoClientService,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -117,7 +117,6 @@ import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMes
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVCallbackHandlerTest {
-    private static final Subject SUBJECT = new Subject();
     private final Context context = mock(Context.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final IPVAuthorisationService responseService = mock(IPVAuthorisationService.class);
@@ -167,7 +166,7 @@ class IPVCallbackHandlerTest {
                     new VectorOfTrust(CredentialTrustLevel.LOW_LEVEL),
                     new VectorOfTrust(CredentialTrustLevel.MEDIUM_LEVEL));
     private IPVCallbackHandler handler;
-    private final byte[] salt =
+    private static final byte[] salt =
             "Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw=".getBytes(StandardCharsets.UTF_8);
     private final String redirectUriErrorMessage = "redirect_uri param must be provided";
     private final URI accessDeniedURI =
@@ -179,9 +178,11 @@ class IPVCallbackHandlerTest {
                     .toURI();
     private final ClientRegistry clientRegistry = generateClientRegistryNoClaims();
     private final UserProfile userProfile = generateUserProfile();
-    private final String expectedCommonSubject =
+
+    private static final Subject TEST_SUBJECT = new Subject();
+    private static final String TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER =
             ClientSubjectHelper.calculatePairwiseIdentifier(
-                    SUBJECT.getValue(), "test.account.gov.uk", salt);
+                    TEST_SUBJECT.getValue(), "test.account.gov.uk", salt);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =
@@ -190,7 +191,7 @@ class IPVCallbackHandlerTest {
     private final Session session =
             new Session(SESSION_ID)
                     .setEmailAddress(TEST_EMAIL_ADDRESS)
-                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+                    .setInternalCommonSubjectIdentifier(TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER);
 
     private final OrchSessionItem orchSession = new OrchSessionItem(SESSION_ID);
 
@@ -1015,7 +1016,7 @@ class IPVCallbackHandlerTest {
                 .withPhoneNumber("012345678902")
                 .withPhoneNumberVerified(true)
                 .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
-                .withSubjectID(SUBJECT.getValue());
+                .withSubjectID(TEST_SUBJECT.getValue());
     }
 
     private static ClientRegistry generateClientRegistryNoClaims() {
@@ -1059,7 +1060,7 @@ class IPVCallbackHandlerTest {
                         TxmaAuditUser.user()
                                 .withGovukSigninJourneyId(CLIENT_SESSION_ID)
                                 .withSessionId(SESSION_ID)
-                                .withUserId(expectedCommonSubject)
+                                .withUserId(TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER)
                                 .withEmail(TEST_EMAIL_ADDRESS)
                                 .withPhone(userProfile.getPhoneNumber())
                                 .withPersistentSessionId(PERSISTENT_SESSION_ID));

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
@@ -1,5 +1,6 @@
 package uk.gov.di.orchestration.sharedtest.extensions;
 
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -77,6 +78,10 @@ public class AuthenticationCallbackUserInfoStoreExtension extends DynamoExtensio
 
     public Optional<AuthenticationUserInfo> getUserInfoBySubjectId(String subjectId) {
         return userInfoService.getAuthenticationUserInfoData(subjectId);
+    }
+
+    public Optional<UserInfo> getUserInfo(String subjectId) throws ParseException {
+        return userInfoService.getAuthenticationUserInfo(subjectId);
     }
 
     public void addAuthenticationUserInfoData(String subjectId, UserInfo userInfo) {

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
@@ -76,7 +76,7 @@ public class AuthenticationCallbackUserInfoStoreExtension extends DynamoExtensio
         dynamoDB.createTable(request);
     }
 
-    public Optional<AuthenticationUserInfo> getUserInfoBySubjectId(String subjectId) {
+    public Optional<AuthenticationUserInfo> getUserInfoDataBySubjectId(String subjectId) {
         return userInfoService.getAuthenticationUserInfoData(subjectId);
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
@@ -34,6 +34,16 @@ public class AuthenticationUserInfoStorageService
         put(userInfoDbObject);
     }
 
+    public Optional<UserInfo> getAuthenticationUserInfo(String subjectID)
+            throws com.nimbusds.oauth2.sdk.ParseException {
+        var userInfoData = getAuthenticationUserInfoData(subjectID);
+        if (userInfoData.isEmpty()) {
+            return Optional.empty();
+        }
+        var userInfo = UserInfo.parse(userInfoData.get().getUserInfo());
+        return Optional.ofNullable(userInfo);
+    }
+
     public Optional<AuthenticationUserInfo> getAuthenticationUserInfoData(String subjectID) {
         return get(subjectID)
                 .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());


### PR DESCRIPTION
## What
Adds `authUserInfo` to the IPVCallbackHandler. Read access has been added here https://github.com/govuk-one-login/authentication-api/pull/5475. 

I first want to verify that authUserInfo is both defined, and that the values are as expected. This PR therefore just adds some logging to compare the values used in this handler and the corresponding values in the orchSession and the authUserInfo table entry.

## How to review
1. Code Review
2. Deploy to dev to make sure permissions are set up ok
