### PR TITLE
BAU: remove rpPairwiseId from orchSessionItem

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -686,21 +686,15 @@ public class AuthenticationCallbackHandler
         String verifiedMfaMethodType =
                 userInfo.getClaim(
                         AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(), String.class);
-        String rpPairwiseId =
-                userInfo.getClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue(), String.class);
         String internalCommonSubjectId = userInfo.getSubject().getValue();
 
         OrchSessionItem updatedOrchSession =
                 orchSession
                         .withVerifiedMfaMethodType(verifiedMfaMethodType)
-                        .withRpPairwiseId(rpPairwiseId)
                         .withInternalCommonSubjectId(internalCommonSubjectId);
 
         LOG.info("Updating Orch session with claims from userinfo response");
         // TODO-922: temporary logs for checking all is working as expected
-        LOG.info(
-                "is rpPairwiseId attached to orch session: {}",
-                orchSession.getRpPairwiseId() != null);
         LOG.info(
                 "is internalCommonSubjectId attached to orch session: {}",
                 orchSession.getInternalCommonSubjectId() != null);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -417,7 +417,6 @@ class AuthenticationCallbackHandlerTest {
         assertEquals(
                 MFAMethodType.AUTH_APP.getValue(),
                 orchSessionCaptor.getValue().getVerifiedMfaMethodType());
-        assertEquals(RP_PAIRWISE_ID.getValue(), orchSessionCaptor.getValue().getRpPairwiseId());
         assertEquals(
                 TEST_INTERNAL_COMMON_SUBJECT_ID,
                 orchSessionCaptor.getValue().getInternalCommonSubjectId());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -9,7 +9,6 @@ public class OrchSessionItem {
 
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
-    public static final String ATTRIBUTE_RP_PAIRWISE_ID = "RpPairwiseId";
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "IsNewAccount";
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
 
@@ -23,7 +22,6 @@ public class OrchSessionItem {
     private String sessionId;
     private long timeToLive;
     private String verifiedMfaMethodType;
-    private String rpPairwiseId;
     private AccountState isNewAccount;
     private String internalCommonSubjectId;
 
@@ -74,20 +72,6 @@ public class OrchSessionItem {
 
     public OrchSessionItem withVerifiedMfaMethodType(String verifiedMfaMethodType) {
         this.verifiedMfaMethodType = verifiedMfaMethodType;
-        return this;
-    }
-
-    @DynamoDbAttribute(ATTRIBUTE_RP_PAIRWISE_ID)
-    public String getRpPairwiseId() {
-        return rpPairwiseId;
-    }
-
-    public void setRpPairwiseId(String rpPairwiseId) {
-        this.rpPairwiseId = rpPairwiseId;
-    }
-
-    public OrchSessionItem withRpPairwiseId(String rpPairwiseId) {
-        this.rpPairwiseId = rpPairwiseId;
         return this;
     }
 


### PR DESCRIPTION
## What
This value changes depending on the RP currently interacting with orch. This means if a user gets part way through a journey, then starts a new one, the rpPairwiseId will become out of sync with the first journey. RpPairwiseId therefore must be robust to this. Currently, we calculate it using the client sector Id. Another solution is having it live in the ClientSession. But it cannot live on the session.

This property on the orch session is currently only used in logs, so no impact on removing it.

## How to review
1. Code Review