### PR TITLE
AUT-3845: Temporary logging of `internalPairwiseId` in lower envs

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
@@ -72,7 +72,18 @@ public class AccountInterventionsService {
                                                 .getAccountInterventionServiceCallTimeout()))
                         .build();
         try {
-            return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (configurationService.canLogInternalPairwiseId()) {
+                LOG.info(
+                        "Sending account interventions request with internalPairwiseId {}",
+                        internalPairwiseId);
+            }
+            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (configurationService.canLogInternalPairwiseId()) {
+                LOG.info(
+                        "Recieved account interventions response for internalPairwiseId {}",
+                        internalPairwiseId);
+            }
+            return response;
         } catch (HttpTimeoutException e) {
             throw timeoutException(
                     configurationService.getAccountInterventionServiceCallTimeout(), e);

--- a/interventions-api-stub/src/test/java/uk/gov/di/authentication/interventions/api/stub/lambda/AccountInterventionsApiStubHandlerTest.java
+++ b/interventions-api-stub/src/test/java/uk/gov/di/authentication/interventions/api/stub/lambda/AccountInterventionsApiStubHandlerTest.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.interventions.api.stub.entity.AccountInterventionsStore;
 import uk.gov.di.authentication.interventions.api.stub.services.AccountInterventionsDbService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Map;
 import java.util.Optional;
@@ -34,7 +35,9 @@ class AccountInterventionsApiStubHandlerTest {
 
     @Test
     void shouldReturn200ForSuccessfulRequest() {
-        var handler = new AccountInterventionsApiStubHandler(accountInterventionsDbService);
+        var handler =
+                new AccountInterventionsApiStubHandler(
+                        accountInterventionsDbService, new ConfigurationService());
         when(accountInterventionsDbService.getAccountInterventions(PAIRWISE_ID))
                 .thenReturn(Optional.of(accountInterventionsStore));
 
@@ -54,7 +57,9 @@ class AccountInterventionsApiStubHandlerTest {
 
     @Test
     void shouldReturn200WhenThePairwiseIdDoesNotExistInTheDatabase() {
-        var handler = new AccountInterventionsApiStubHandler(accountInterventionsDbService);
+        var handler =
+                new AccountInterventionsApiStubHandler(
+                        accountInterventionsDbService, new ConfigurationService());
         when(accountInterventionsDbService.getAccountInterventions(PAIRWISE_ID))
                 .thenReturn(Optional.empty());
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -508,6 +508,11 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return List.of("build", "staging", "integration", "production").contains(getEnvironment());
     }
 
+    public boolean canLogInternalPairwiseId() {
+        return List.of("test", "dev", "authdev1", "authdev2", "sandpit", "build")
+                .contains(getEnvironment());
+    }
+
     private Map<String, String> getSsmRedisParameters() {
         if (ssmRedisParameters == null) {
             var getParametersRequest =


### PR DESCRIPTION
## What

We have a sporadic issue with our Accounts Intervention stub failing during parallel acceptance tests runs, however we do not have any ids logged that can be used to corrolate the logs between the backend and stub.

Here we modify the logging of both the `AccountInterventionsService` and `AccountInterventionsApiStubHandler` to log the only common identifier, `internalPairwiseId`.

This only happens in lower environments. Staging, Integration and Production do not have these logs turned on.

As an abundance of caution, this will be reverted when we determine the cause of the issue.


## How to review

1. Code Review

