### PR TITLE
ATO-1147: add IAM policy to access orch session

### DIFF
--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -59,6 +59,7 @@ reauth_enter_sms_code_count_ttl           = 120
 
 orch_client_id  = "orchestrationAuth"
 orch_account_id = "816047645251"
+is_orch_stubbed = true
 
 contra_state_bucket = "di-auth-development-tfstate"
 

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -59,6 +59,7 @@ reauth_enter_auth_app_code_count_ttl      = 120
 
 orch_client_id  = "orchestrationAuth"
 orch_account_id = "816047645251"
+is_orch_stubbed = true
 
 contra_state_bucket = "di-auth-development-tfstate"
 

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -45,9 +45,10 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-dev-tfstate"
 
-orch_account_id  = "767397776536"
-is_orch_stubbed  = false
-orch_environment = "build"
+orch_account_id                       = "767397776536"
+is_orch_stubbed                       = false
+orch_environment                      = "build"
+orch_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:767397776536:key/b7cb6340-0d22-4b6a-8702-b5ec17d4f979"
 
 orch_storage_token_jwk_enabled       = true
 orch_trustmark_enabled               = true

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -46,6 +46,7 @@ authorize_protected_subnet_enabled = true
 contra_state_bucket = "digital-identity-dev-tfstate"
 
 orch_account_id = "767397776536"
+is_orch_stubbed = false
 
 orch_storage_token_jwk_enabled       = true
 orch_trustmark_enabled               = true

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -45,8 +45,9 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-dev-tfstate"
 
-orch_account_id = "767397776536"
-is_orch_stubbed = false
+orch_account_id  = "767397776536"
+is_orch_stubbed  = false
+orch_environment = "build"
 
 orch_storage_token_jwk_enabled       = true
 orch_trustmark_enabled               = true

--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -56,6 +56,7 @@ orch_redirect_uri                  = "https://oidc.dev.account.gov.uk/orchestrat
 authorize_protected_subnet_enabled = true
 
 orch_account_id = "816047645251"
+is_orch_stubbed = true
 
 contra_state_bucket = "di-auth-development-tfstate"
 

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -732,6 +732,46 @@ data "aws_iam_policy_document" "dynamo_auth_session_read_write_policy_document" 
   }
 }
 
+data "aws_iam_policy_document" "dynamo_orch_session_encryption_key_cross_account_decrypt_policy_document" {
+  statement {
+    sid    = "AllowOrchSessionEncryptionKeyCrossAccountDecryptAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = [
+      var.orch_session_table_encryption_key_arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_access_policy_document" {
+  statement {
+    sid    = "AllowOrchSessionCrossAccountReadAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+    ]
+    resources = [
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Orch-Session",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_orch_session_cross_account_delete_access_policy_document" {
+  statement {
+    sid    = "AllowOrchSessionCrossAccountDeleteAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DeleteItem",
+    ]
+    resources = [
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Orch-Session",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "dynamo_client_registry_write_access_policy" {
   name_prefix = "dynamo-client-registry-write-policy"
   path        = "/${var.environment}/oidc-default/"
@@ -956,4 +996,28 @@ resource "aws_iam_policy" "dynamo_auth_session_delete_policy" {
   description = "IAM policy for managing delete permissions to the auth session table"
 
   policy = data.aws_iam_policy_document.dynamo_auth_session_delete_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_orch_session_encryption_key_cross_account_decrypt_policy" {
+  name_prefix = "dynamo-orch-session-encryption-key-cross-account-decrypt-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing decrypt and describe permissions to the orch session table's KMS encryption key"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_session_encryption_key_cross_account_decrypt_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_access_policy" {
+  name_prefix = "dynamo-orch-session-cross-account-read-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing read permissions to the orch session table"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_orch_session_cross_account_delete_access_policy" {
+  name_prefix = "dynamo-orch-session-cross-account-delete-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing delete permissions to the orch session table"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_delete_access_policy_document.json
 }

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -40,8 +40,9 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-dev-tfstate"
 
-orch_account_id = "058264132019"
-is_orch_stubbed = false
+orch_account_id  = "058264132019"
+is_orch_stubbed  = false
+orch_environment = "integration"
 
 orch_trustmark_enabled               = true
 orch_openid_configuration_enabled    = true

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -40,9 +40,10 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-dev-tfstate"
 
-orch_account_id  = "058264132019"
-is_orch_stubbed  = false
-orch_environment = "integration"
+orch_account_id                       = "058264132019"
+is_orch_stubbed                       = false
+orch_environment                      = "integration"
+orch_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:058264132019:key/1b5c001b-ed53-4a7b-bfbe-5d0f596110b5"
 
 orch_trustmark_enabled               = true
 orch_openid_configuration_enabled    = true

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -41,6 +41,7 @@ authorize_protected_subnet_enabled = true
 contra_state_bucket = "digital-identity-dev-tfstate"
 
 orch_account_id = "058264132019"
+is_orch_stubbed = false
 
 orch_trustmark_enabled               = true
 orch_openid_configuration_enabled    = true

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -20,6 +20,31 @@ module "ipv_processing_identity_role" {
   ]
 }
 
+module "ipv_processing_identity_role_with_orch_session_table_access" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-processing-identity-role-with-orch-session-access"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.pepper_parameter_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    local.identity_credentials_encryption_policy_arn,
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_decrypt_policy.arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy.arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_delete_access_policy.arn
+  ]
+}
+
 module "processing-identity" {
   source = "../modules/endpoint-module"
 

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -37,8 +37,9 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-prod-tfstate"
 
-orch_account_id = "533266965190"
-is_orch_stubbed = false
+orch_account_id  = "533266965190"
+is_orch_stubbed  = false
+orch_environment = "production"
 
 orch_trustmark_enabled               = true
 orch_openid_configuration_enabled    = true

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -38,6 +38,7 @@ authorize_protected_subnet_enabled = true
 contra_state_bucket = "digital-identity-prod-tfstate"
 
 orch_account_id = "533266965190"
+is_orch_stubbed = false
 
 orch_trustmark_enabled               = true
 orch_openid_configuration_enabled    = true

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -37,9 +37,10 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-prod-tfstate"
 
-orch_account_id  = "533266965190"
-is_orch_stubbed  = false
-orch_environment = "production"
+orch_account_id                       = "533266965190"
+is_orch_stubbed                       = false
+orch_environment                      = "production"
+orch_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:533266965190:key/7ad27a55-9d21-47f2-be03-b61f2c9a8ce6"
 
 orch_trustmark_enabled               = true
 orch_openid_configuration_enabled    = true

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -76,4 +76,5 @@ orch_userinfo_enabled                = true
 orch_storage_token_jwk_enabled       = true
 
 orch_account_id                     = "816047645251"
+is_orch_stubbed                     = false
 cmk_for_back_channel_logout_enabled = true

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -75,7 +75,8 @@ orch_auth_code_enabled               = true
 orch_userinfo_enabled                = true
 orch_storage_token_jwk_enabled       = true
 
-orch_account_id                     = "816047645251"
-is_orch_stubbed                     = false
-orch_environment                    = "dev"
-cmk_for_back_channel_logout_enabled = true
+orch_account_id                       = "816047645251"
+is_orch_stubbed                       = false
+orch_environment                      = "dev"
+orch_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:816047645251:key/645669ba-b288-4b63-bfe1-9d8bde9956ec"
+cmk_for_back_channel_logout_enabled   = true

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -77,4 +77,5 @@ orch_storage_token_jwk_enabled       = true
 
 orch_account_id                     = "816047645251"
 is_orch_stubbed                     = false
+orch_environment                    = "dev"
 cmk_for_back_channel_logout_enabled = true

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -19,10 +19,11 @@ ticf_cri_service_call_timeout           = 10000
 support_reauth_signout_enabled          = true
 authentication_attempts_service_enabled = true
 
-orch_account_id                     = "590183975515"
-is_orch_stubbed                     = false
-orch_environment                    = "staging"
-cmk_for_back_channel_logout_enabled = true
+orch_account_id                       = "590183975515"
+is_orch_stubbed                       = false
+orch_environment                      = "staging"
+orch_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:590183975515:key/156f87e0-001a-4ae8-a6c1-23f8f68b6e84"
+cmk_for_back_channel_logout_enabled   = true
 
 contra_state_bucket = "di-auth-staging-tfstate"
 

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -21,6 +21,7 @@ authentication_attempts_service_enabled = true
 
 orch_account_id                     = "590183975515"
 is_orch_stubbed                     = false
+orch_environment                    = "staging"
 cmk_for_back_channel_logout_enabled = true
 
 contra_state_bucket = "di-auth-staging-tfstate"

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -20,6 +20,7 @@ support_reauth_signout_enabled          = true
 authentication_attempts_service_enabled = true
 
 orch_account_id                     = "590183975515"
+is_orch_stubbed                     = false
 cmk_for_back_channel_logout_enabled = true
 
 contra_state_bucket = "di-auth-staging-tfstate"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -696,6 +696,11 @@ variable "is_orch_stubbed" {
   default = false
 }
 
+variable "orch_environment" {
+  type    = string
+  default = ""
+}
+
 variable "cmk_for_back_channel_logout_enabled" {
   default     = false
   type        = bool

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -691,6 +691,11 @@ variable "orch_account_id" {
   default = ""
 }
 
+variable "is_orch_stubbed" {
+  type    = string
+  default = false
+}
+
 variable "cmk_for_back_channel_logout_enabled" {
   default     = false
   type        = bool

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -701,6 +701,11 @@ variable "orch_environment" {
   default = ""
 }
 
+variable "orch_session_table_encryption_key_arn" {
+  type    = string
+  default = ""
+}
+
 variable "cmk_for_back_channel_logout_enabled" {
   default     = false
   type        = bool


### PR DESCRIPTION
## What
Adds policy for ProcessingIdentityHandler to access the Orch Session table on Orch AWS accounts for logout (resource policy for the DynamboDb table here https://github.com/govuk-one-login/authentication-api/pull/5511)

## How to review

1. Code Review
2. Deployed to dev (along with https://github.com/govuk-one-login/authentication-api/pull/5512 to sandpit). I was able to describe the table when I sign into the Auth dev account from command line. I also created a lambda in Auth dev and verified that I wasn't able to access the orch session table. I then added the policies in https://github.com/govuk-one-login/authentication-api/pull/5512, and verified I was able to both describe and delete an item from the orch session table.
