### PR TITLE
AUT-3845: Enable snapstart for AIS stub

### DIFF
--- a/ci/terraform/interventions-api-stub/lambda.tf
+++ b/ci/terraform/interventions-api-stub/lambda.tf
@@ -18,11 +18,13 @@ module "account_interventions_stub_lambda" {
   }
   handler_function_name = "uk.gov.di.authentication.interventions.api.stub.lambda.AccountInterventionsApiStubHandler::handleRequest"
   handler_runtime       = "java17"
+  architectures         = ["arm64"]
 
   memory_size                 = local.default_performance_parameters.memory
-  provisioned_concurrency     = local.default_performance_parameters.concurrency
+  provisioned_concurrency     = 0
   max_provisioned_concurrency = local.default_performance_parameters.max_concurrency
   scaling_trigger             = local.default_performance_parameters.scaling_trigger
+  snapstart                   = true
 
   source_bucket           = aws_s3_bucket.interventions_api_stub_source_bucket.bucket
   lambda_zip_file         = aws_s3_object.interventions_api_stub_release_zip.key

--- a/ci/terraform/modules/endpoint-lambda/variables.tf
+++ b/ci/terraform/modules/endpoint-lambda/variables.tf
@@ -149,3 +149,13 @@ variable "dynatrace_secret" {
   })
   sensitive = true
 }
+
+variable "snapstart" {
+  type    = bool
+  default = false
+}
+
+variable "architectures" {
+  type    = list(string)
+  default = ["x86_64"]
+}


### PR DESCRIPTION
## What

The AIS stub is causing acceptance tests to fail when run in parallel. This happened because the stub lambda cold started another instance during the run, meaning the response took longer than the client configured timeout.

Here we remove the provisioned concurrency for the stub lambda, replacing it with snapstart. We also switch the architecture for this lambda to arm64 for the snapstart support.

## How to review

1. Code Review
1. Deploy to sandpit with `./deploy-dev.sh sandpit -b -c -s -o -i`
1. Run though sign in journey
1. See no error

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.
