### PR TITLE
Revert "AUT-3845: Temporary logging of `internalPairwiseId` in lower envs"

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
@@ -72,18 +72,7 @@ public class AccountInterventionsService {
                                                 .getAccountInterventionServiceCallTimeout()))
                         .build();
         try {
-            if (configurationService.canLogInternalPairwiseId()) {
-                LOG.info(
-                        "Sending account interventions request with internalPairwiseId {}",
-                        internalPairwiseId);
-            }
-            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            if (configurationService.canLogInternalPairwiseId()) {
-                LOG.info(
-                        "Recieved account interventions response for internalPairwiseId {}",
-                        internalPairwiseId);
-            }
-            return response;
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         } catch (HttpTimeoutException e) {
             throw timeoutException(
                     configurationService.getAccountInterventionServiceCallTimeout(), e);

--- a/interventions-api-stub/src/main/java/uk/gov/di/authentication/interventions/api/stub/lambda/AccountInterventionsApiStubHandler.java
+++ b/interventions-api-stub/src/main/java/uk/gov/di/authentication/interventions/api/stub/lambda/AccountInterventionsApiStubHandler.java
@@ -18,7 +18,6 @@ public class AccountInterventionsApiStubHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private final AccountInterventionsDbService db;
-    private final ConfigurationService configurationService;
     private static final Logger LOG =
             LogManager.getLogger(AccountInterventionsApiStubHandler.class);
     private static final String PATH_PARAM_NAME_IN_API_GW = "internalPairwiseId";
@@ -28,14 +27,12 @@ public class AccountInterventionsApiStubHandler
     }
 
     public AccountInterventionsApiStubHandler(ConfigurationService configurationService) {
-        this(new AccountInterventionsDbService(configurationService), configurationService);
+        this(new AccountInterventionsDbService(configurationService));
     }
 
     public AccountInterventionsApiStubHandler(
-            AccountInterventionsDbService accountInterventionsDbService,
-            ConfigurationService configurationService) {
+            AccountInterventionsDbService accountInterventionsDbService) {
         this.db = accountInterventionsDbService;
-        this.configurationService = configurationService;
     }
 
     @Override
@@ -43,34 +40,16 @@ public class AccountInterventionsApiStubHandler
             APIGatewayProxyRequestEvent input, Context context) {
         String internalPairwiseId = input.getPathParameters().get(PATH_PARAM_NAME_IN_API_GW);
 
-        if (configurationService.canLogInternalPairwiseId()) {
-            LOG.info(
-                    "Received account interventions request with internalPairwiseId {}",
-                    internalPairwiseId);
-        }
-
         var maybeAccountInterventionsStore = db.getAccountInterventions(internalPairwiseId);
 
         try {
             if (maybeAccountInterventionsStore.isPresent()) {
-                if (configurationService.canLogInternalPairwiseId()) {
-                    LOG.info(
-                            "Account Interventions response being generated for internalPairwiseId {}",
-                            internalPairwiseId);
-                } else {
-                    LOG.info("Account Interventions response being generated");
-                }
+                LOG.info("Account Interventions response being generated");
                 return generateApiGatewayProxyResponse(
                         200,
                         new InterventionsApiStubResponse(maybeAccountInterventionsStore.get()));
             } else {
-                if (configurationService.canLogInternalPairwiseId()) {
-                    LOG.info(
-                            "No matching account found. Default response sent instead. For internalPairwiseId {}",
-                            internalPairwiseId);
-                } else {
-                    LOG.info("No matching account found. Default response sent instead.");
-                }
+                LOG.info("No matching account found. Default response sent instead.");
                 AccountInterventionsStore noAccountInterventionStore =
                         new AccountInterventionsStore();
                 noAccountInterventionStore
@@ -83,11 +62,6 @@ public class AccountInterventionsApiStubHandler
                         200, new InterventionsApiStubResponse(noAccountInterventionStore));
             }
         } catch (Json.JsonException e) {
-            if (configurationService.canLogInternalPairwiseId()) {
-                LOG.info(
-                        "JSON Exception during Account Interventions check for internalPairwiseId {}",
-                        internalPairwiseId);
-            }
             return generateApiGatewayProxyResponse(
                     500, "server error - unable to construct response body");
         }

--- a/interventions-api-stub/src/test/java/uk/gov/di/authentication/interventions/api/stub/lambda/AccountInterventionsApiStubHandlerTest.java
+++ b/interventions-api-stub/src/test/java/uk/gov/di/authentication/interventions/api/stub/lambda/AccountInterventionsApiStubHandlerTest.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.interventions.api.stub.entity.AccountInterventionsStore;
 import uk.gov.di.authentication.interventions.api.stub.services.AccountInterventionsDbService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Map;
 import java.util.Optional;
@@ -35,9 +34,7 @@ class AccountInterventionsApiStubHandlerTest {
 
     @Test
     void shouldReturn200ForSuccessfulRequest() {
-        var handler =
-                new AccountInterventionsApiStubHandler(
-                        accountInterventionsDbService, new ConfigurationService());
+        var handler = new AccountInterventionsApiStubHandler(accountInterventionsDbService);
         when(accountInterventionsDbService.getAccountInterventions(PAIRWISE_ID))
                 .thenReturn(Optional.of(accountInterventionsStore));
 
@@ -57,9 +54,7 @@ class AccountInterventionsApiStubHandlerTest {
 
     @Test
     void shouldReturn200WhenThePairwiseIdDoesNotExistInTheDatabase() {
-        var handler =
-                new AccountInterventionsApiStubHandler(
-                        accountInterventionsDbService, new ConfigurationService());
+        var handler = new AccountInterventionsApiStubHandler(accountInterventionsDbService);
         when(accountInterventionsDbService.getAccountInterventions(PAIRWISE_ID))
                 .thenReturn(Optional.empty());
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -508,11 +508,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return List.of("build", "staging", "integration", "production").contains(getEnvironment());
     }
 
-    public boolean canLogInternalPairwiseId() {
-        return List.of("test", "dev", "authdev1", "authdev2", "sandpit", "build")
-                .contains(getEnvironment());
-    }
-
     private Map<String, String> getSsmRedisParameters() {
         if (ssmRedisParameters == null) {
             var getParametersRequest =


### PR DESCRIPTION
We can now remove these additional logs now that we know the source of the error (cold start of the stub meant the response took longer than the configured client timeout).

PR to revert: https://github.com/govuk-one-login/authentication-api/pull/5502
