### PR TITLE
ATO-975: add getter current credential strength in orch session

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -114,12 +114,16 @@ public class UserInfoService {
             userInfo.setClaim(
                     AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
                     authSession.getVerifiedMfaMethodType());
+            LOG.info("verified_mfa value: {}", authSession.getVerifiedMfaMethodType());
         }
         if (accessTokenInfo
                 .getClaims()
                 .contains(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue())) {
             userInfo.setClaim(
                     AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue(),
+                    authSession.getCurrentCredentialStrength());
+            LOG.info(
+                    "current_credential_strength value: {}",
                     authSession.getCurrentCredentialStrength());
         }
     }

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -115,6 +115,13 @@ public class UserInfoService {
                     AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
                     authSession.getVerifiedMfaMethodType());
         }
+        if (accessTokenInfo
+                .getClaims()
+                .contains(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue())) {
+            userInfo.setClaim(
+                    AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue(),
+                    authSession.getCurrentCredentialStrength());
+        }
     }
 
     private static String bytesToBase64(ByteBuffer byteBuffer) {

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
@@ -13,10 +13,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.external.domain.AuthExternalApiAuditableEvent;
 import uk.gov.di.authentication.external.services.UserInfoService;
-import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.MFAMethodType;
-import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.*;
 import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.services.AccessTokenService;
@@ -88,6 +85,8 @@ class UserInfoHandlerTest {
         TEST_SUBJECT_USER_INFO.setPhoneNumber("0123456789");
         TEST_SUBJECT_USER_INFO.setClaim(
                 "verified_mfa_method_type", MFAMethodType.AUTH_APP.getValue());
+        TEST_SUBJECT_USER_INFO.setClaim(
+                "current_credential_strength", CredentialTrustLevel.MEDIUM_LEVEL);
         when(accessTokenStore.getSubjectID()).thenReturn("testSubjectId");
     }
 

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkBytes;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
@@ -51,6 +52,8 @@ public class UserInfoServiceTest {
     private static final String TEST_PHONE = "test-phone";
     private static final boolean TEST_PHONE_VERIFIED = true;
     private static final String TEST_VERIFIED_MFA_METHOD_TYPE = MFAMethodType.EMAIL.getValue();
+    private static final CredentialTrustLevel TEST_CURRENT_CREDENTIAL_STRENGTH =
+            CredentialTrustLevel.MEDIUM_LEVEL;
     private static final boolean TEST_IS_NEW_ACCOUNT = true;
     private static final long TEST_PASSWORD_RESET_TIME = 1710255380L;
     private static final UserProfile TEST_USER_PROFILE =
@@ -64,7 +67,9 @@ public class UserInfoServiceTest {
                     .withPhoneNumberVerified(TEST_PHONE_VERIFIED)
                     .withSalt(TEST_SALT);
     private static final AuthSessionItem authSession =
-            new AuthSessionItem().withVerifiedMfaMethodType(TEST_VERIFIED_MFA_METHOD_TYPE);
+            new AuthSessionItem()
+                    .withVerifiedMfaMethodType(TEST_VERIFIED_MFA_METHOD_TYPE)
+                    .withCurrentCredentialStrength(TEST_CURRENT_CREDENTIAL_STRENGTH);
 
     @BeforeEach
     public void setUp() {
@@ -90,7 +95,8 @@ public class UserInfoServiceTest {
             String expectedPhoneNumber,
             Boolean expectedPhoneNumberVerified,
             String expectedSalt,
-            String expectedVerifiedMfaMethod) {
+            String expectedVerifiedMfaMethod,
+            CredentialTrustLevel expectedCurrentCredentialStrength) {
         UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore, authSession);
 
         assertEquals(TEST_INTERNAL_COMMON_SUBJECT_ID, actual.getSubject().getValue());
@@ -106,6 +112,8 @@ public class UserInfoServiceTest {
         assertEquals(expectedPhoneNumberVerified, actual.getPhoneNumberVerified());
         assertEquals(expectedSalt, actual.getClaim("salt"));
         assertEquals(expectedVerifiedMfaMethod, actual.getClaim("verified_mfa_method_type"));
+        assertEquals(
+                expectedCurrentCredentialStrength, actual.getClaim("current_credential_strength"));
         assertEquals(TEST_PASSWORD_RESET_TIME, actual.getClaim("password_reset_time"));
     }
 
@@ -116,6 +124,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         TEST_SUBJECT.getValue(),
+                        null,
                         null,
                         null,
                         null,
@@ -133,6 +142,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         null,
+                        null,
                         null),
                 Arguments.of(
                         getMockAccessTokenStore(
@@ -145,7 +155,8 @@ public class UserInfoServiceTest {
                                         "phone_number",
                                         "phone_number_verified",
                                         "salt",
-                                        "verified_mfa_method_type")),
+                                        "verified_mfa_method_type",
+                                        "current_credential_strength")),
                         TEST_LEGACY_SUBJECT_ID,
                         TEST_PUBLIC_SUBJECT_ID,
                         TEST_SUBJECT.getValue(),
@@ -154,7 +165,8 @@ public class UserInfoServiceTest {
                         TEST_PHONE,
                         TEST_PHONE_VERIFIED,
                         bytesToBase64(TEST_SALT),
-                        TEST_VERIFIED_MFA_METHOD_TYPE));
+                        TEST_VERIFIED_MFA_METHOD_TYPE,
+                        TEST_CURRENT_CREDENTIAL_STRENGTH));
     }
 
     private static AccessTokenStore getMockAccessTokenStore(List<String> claims) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -414,7 +414,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         .setVerifiedMfaMethodType(codeRequest.getMfaMethodType()));
 
         authSessionService.updateSession(
-                authSession.withVerifiedMfaMethodType(codeRequest.getMfaMethodType().getValue()));
+                authSession
+                        .withVerifiedMfaMethodType(codeRequest.getMfaMethodType().getValue())
+                        .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL));
 
         var clientId = userContext.getClientId();
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -234,6 +234,7 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         authSession.setIsNewAccount(AuthSessionItem.AccountState.NEW);
         var result =
                 makeCallWithCode(
@@ -247,6 +248,9 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                authSession.getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -276,6 +280,7 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
 
         var mfaCodeRequest =
                 new VerifyMfaCodeRequest(
@@ -314,6 +319,7 @@ class VerifyMfaCodeHandlerTest {
         when(configurationService.getInternalSectorUri()).thenReturn("http://" + SECTOR_HOST);
         when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         session.setInternalCommonSubjectIdentifier(null);
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
@@ -329,6 +335,9 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                authSession.getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -359,6 +368,7 @@ class VerifyMfaCodeHandlerTest {
         when(phoneNumberCodeProcessor.validateCode()).thenReturn(Optional.empty());
         authSession.setIsNewAccount(AuthSessionItem.AccountState.NEW);
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
@@ -371,6 +381,9 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                authSession.getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         verify(phoneNumberCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -401,6 +414,7 @@ class VerifyMfaCodeHandlerTest {
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
@@ -413,6 +427,9 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                authSession.getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -443,6 +460,7 @@ class VerifyMfaCodeHandlerTest {
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
         session.setCurrentCredentialStrength(credentialTrustLevel);
+        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
@@ -455,6 +473,9 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                authSession.getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -12,10 +12,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.core.SdkBytes;
 import uk.gov.di.authentication.external.domain.AuthExternalApiAuditableEvent;
 import uk.gov.di.authentication.external.lambda.UserInfoHandler;
-import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.MFAMethodType;
-import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.entity.*;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
@@ -126,6 +123,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
         assertNull(userInfoResponse.getPhoneNumberVerified());
         assertNull(userInfoResponse.getClaim("salt"));
         assertNull(userInfoResponse.getClaim("verified_mfa_method_type"));
+        assertNull(userInfoResponse.getClaim("current_credential_strength"));
 
         assertThat(
                 authSessionExtension.getSession(TEST_SESSION_ID).get().getIsNewAccount(),
@@ -294,6 +292,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                         .getSession(TEST_SESSION_ID)
                         .get()
                         .withAccountState(AuthSessionItem.AccountState.NEW)
-                        .withVerifiedMfaMethodType(MFAMethodType.AUTH_APP.getValue()));
+                        .withVerifiedMfaMethodType(MFAMethodType.AUTH_APP.getValue())
+                        .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL));
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -389,9 +389,11 @@ public class AuthCodeHandler
             session.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
         }
 
+        var currentCredentialStrengthFromOrch = orchSession.getCurrentCredentialStrength();
         if (configurationService.isCurrentCredentialStrengthInOrchSessionEnabled()
-                && (isNull(currentCredentialStrength)
-                        || lowestRequestedCredentialTrustLevel.compareTo(currentCredentialStrength)
+                && (isNull(currentCredentialStrengthFromOrch)
+                        || lowestRequestedCredentialTrustLevel.compareTo(
+                                        currentCredentialStrengthFromOrch)
                                 > 0)) {
             orchSessionService.updateSession(
                     orchSession.withCurrentCredentialStrength(lowestRequestedCredentialTrustLevel));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -384,14 +384,15 @@ public class AuthCodeHandler
         CredentialTrustLevel lowestRequestedCredentialTrustLevel =
                 VectorOfTrust.getLowestCredentialTrustLevel(clientSession.getVtrList());
         var currentCredentialStrength = session.getCurrentCredentialStrength();
-        if (isNull(session.getCurrentCredentialStrength())
-                || lowestRequestedCredentialTrustLevel.compareTo(
-                                session.getCurrentCredentialStrength())
-                        > 0) {
-            session.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
-        }
         if (isNull(currentCredentialStrength)
                 || lowestRequestedCredentialTrustLevel.compareTo(currentCredentialStrength) > 0) {
+            session.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
+        }
+
+        if (configurationService.isCurrentCredentialStrengthInOrchSessionEnabled()
+                && (isNull(currentCredentialStrength)
+                        || lowestRequestedCredentialTrustLevel.compareTo(currentCredentialStrength)
+                                > 0)) {
             orchSessionService.updateSession(
                     orchSession.withCurrentCredentialStrength(lowestRequestedCredentialTrustLevel));
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -375,6 +375,10 @@ public class AuthenticationCallbackHandler
                         "is verified_mfa_method_type attached to auth-external-api userinfo response: {}",
                         userInfo.getClaim(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue())
                                 != null);
+                LOG.info(
+                        "is current_credential_strength attached to auth-external-api userinfo response: {}",
+                        userInfo.getClaim(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue())
+                                != null);
                 //
 
                 Boolean newAccount =

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -177,6 +177,8 @@ class AuthCodeHandlerTest {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(configurationService.getEnvironment()).thenReturn("unit-test");
         when(configurationService.getInternalSectorURI()).thenReturn(INTERNAL_SECTOR_URI);
+        when(configurationService.isCurrentCredentialStrengthInOrchSessionEnabled())
+                .thenReturn(true);
         when(authCodeResponseService.getSubjectId(session)).thenReturn(SUBJECT.getValue());
         when(authCodeResponseService.getRpPairwiseId(session, CLIENT_ID, dynamoClientService))
                 .thenReturn(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -422,6 +422,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("SET_IS_NEW_ACCOUNT_IN_ORCH_SESSION");
     }
 
+    public boolean isCurrentCredentialStrengthInOrchSessionEnabled() {
+        return getFlagOrFalse("CURRENT_CREDENTIAL_STRENGTH_IN_ORCH_SESSION");
+    }
+
     private Map<String, String> getSsmRedisParameters() {
         if (ssmRedisParameters == null) {
             var getParametersRequest =

--- a/template.yaml
+++ b/template.yaml
@@ -2700,8 +2700,7 @@ Resources:
         - !Ref UserProfileTableWriteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref RedisParametersAccessPolicy
-        - !Ref OrchSessionTableReadAccessPolicy
-        - !Ref OrchSessionTableWriteAccessPolicy
+        - !Ref OrchSessionTableReadAndWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 

--- a/template.yaml
+++ b/template.yaml
@@ -103,6 +103,7 @@ Mappings:
       aisUriSecretId: 6b29b810-e509-4354-9d75-934d0f154d07
       setAuthenticatedFlagForIpv: true
       setIsNewAccountInOrchSession: true
+      currentCredentialStrengthInOrchSession: true
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "6of9f4amvg"
@@ -136,6 +137,7 @@ Mappings:
       aisUriSecretId: fd6ef1f1-7d31-40ca-978d-2180199141d8
       setAuthenticatedFlagForIpv: true
       setIsNewAccountInOrchSession: true
+      currentCredentialStrengthInOrchSession: true
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "1rvwudxmbk"
@@ -169,6 +171,7 @@ Mappings:
       aisUriSecretId: 2b9a3315-50e9-4970-87e6-b354cc4a2484
       setAuthenticatedFlagForIpv: true
       setIsNewAccountInOrchSession: true
+      currentCredentialStrengthInOrchSession: true
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "k2skqhxed6"
@@ -202,6 +205,7 @@ Mappings:
       aisUriSecretId: ""
       setAuthenticatedFlagForIpv: true
       setIsNewAccountInOrchSession: true
+      currentCredentialStrengthInOrchSession: false
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       authApiId: "s4gj268zy6"
@@ -235,6 +239,7 @@ Mappings:
       aisUriSecretId: ""
       setAuthenticatedFlagForIpv: true
       setIsNewAccountInOrchSession: true
+      currentCredentialStrengthInOrchSession: false
   ProvisionedConcurrency:
     staging:
       TrustmarkFunction: 1
@@ -2693,6 +2698,12 @@ Resources:
               EnvironmentConfiguration,
               !Ref Environment,
               setIsNewAccountInOrchSession,
+            ]
+          CURRENT_CREDENTIAL_STRENGTH_IN_ORCH_SESSION:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              currentCredentialStrengthInOrchSession,
             ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy


### PR DESCRIPTION
What
Add getting the currentCredentialStrength from the orch session in the authCode

waiting for https://github.com/govuk-one-login/authentication-api/pull/5504 to be merged first

Feature flagged to test in staging