### PR TITLE
BAU: Target which tests should run depending on changed files

### DIFF
--- a/.github/workflows/call_get_changed_files.yml
+++ b/.github/workflows/call_get_changed_files.yml
@@ -1,0 +1,74 @@
+name: Get changed files
+on:
+  workflow_call:
+    outputs:
+      java_changed:
+        description: "Whether any Java files have changed"
+        value: ${{ jobs.check-changed-files.outputs.java_changed}}
+
+jobs:
+  check-changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      java_changed: ${{ steps.changed-java-files.outputs.any_changed }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Get changed Java files
+        id: changed-java-files
+        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf # v45.0.4
+        with:
+          # If you change the paths here, ensure they are synchronised with the paths in the other jobs.
+          # Find these by searching for "Ensure these are synchronized with the paths in the check-changed-files job"
+          files: |
+            **/src/**
+            **/*.java
+            **/*.gradle
+            **/*.properties
+            gradle*
+
+      - name: Find PR comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Comment added by Check Java Files Action
+
+      - name: Update java comment to indicate test skipping
+        if: github.event_name == 'pull_request' && steps.changed-java-files.outputs.any_changed == 'false'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Java Tests Skipped
+
+            No Java files were changed in this pull request. Java tests will be skipped[^1].
+
+            [^1]: These tests will still show as passing in the PR status check, but will not actually have run.
+
+            Any Java files that are changed in a subsequent commit will trigger the Java tests.
+
+            <!-- Comment added by Check Java Files Action -->
+          edit-mode: replace
+
+      - name: Update java comment to indicate test running
+        if: github.event_name == 'pull_request' && steps.changed-java-files.outputs.any_changed == 'true' && steps.fc.outputs.comment-id != 0
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Java Tests Not Skipped
+
+            Java files were previously skipped in this pull request. Subsequent changes have caused the tests to be run.
+
+            <!-- Comment added by Check Java Files Action -->
+          edit-mode: replace
+
+      - name: Add a warning to the job output if no Java files have changed
+        if: steps.changed-java-files.outputs.any_changed == 'false'
+        run: echo "::notice title=Java tests skipped::No Java files have changed in this pull request. Java tests will not be run (but will still show as passing)"

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -4,9 +4,18 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "ci/terraform/**"
+      - "template.yaml"
+      - "checkov-policies/**"
   pull_request:
     branches:
       - main
+    paths:
+      - "ci/terraform/**"
+      - "template.yaml"
+      - "checkov-policies/**"
+      - ".github/workflows/checkov.yml"
 
   workflow_dispatch:
 

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -17,9 +17,24 @@ on:
       - reopened
       - ready_for_review
       - synchronize
+    paths:
+      - ".github/workflows/contract-tests.yml"
+      # Ensure these are synchronized with the paths in the check-changed-files job
+      - "**/src/**"
+      - "**/*.java"
+      - "**/*.gradle"
+      - "**/*.properties"
+      - "gradle*"
   push:
     branches:
       - main
+    paths:
+      # Ensure these are synchronized with the paths in the check-changed-files job
+      - "**/src/**"
+      - "**/*.java"
+      - "**/*.gradle"
+      - "**/*.properties"
+      - "gradle*"
 
 jobs:
   contract-testing:
@@ -44,11 +59,11 @@ jobs:
         run: ./gradlew pactConsumerTests
 
       - name: Upload pacts to broker
-        if: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' && github.event_name != 'push' }}
+        if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' && github.event_name != 'push'
         run: ./gradlew pactPublish
 
       - name: Upload pacts to broker on push to main
-        if: ${{ github.actor != 'dependabot[bot]' && github.event_name == 'push' }}
+        if: github.actor != 'dependabot[bot]' && github.event_name == 'push'
         env:
           CONSUMER_APP_VERSION: ${{ github.sha }}
         run: ./gradlew pactPublish

--- a/.github/workflows/dependency-review-on-pr.yml
+++ b/.github/workflows/dependency-review-on-pr.yml
@@ -2,6 +2,14 @@ name: Dependency review for pull requests
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/dependency-review-on-pr.yml"
+      # Ensure these are synchronized with the paths in the check-changed-files job
+      - "**/src/**"
+      - "**/*.java"
+      - "**/*.gradle"
+      - "**/*.properties"
+      - "gradle*"
 
 permissions:
   contents: write

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -2,7 +2,15 @@ name: Dependency Submission
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
+    paths:
+      # Ensure these are synchronized with the paths in the check-changed-files job
+      - "**/src/**"
+      - "**/*.java"
+      - "**/*.gradle"
+      - "**/*.properties"
+      - "gradle*"
 
 permissions:
   contents: write

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -175,7 +175,7 @@ jobs:
       - check-changed-files
     services:
       localstack:
-        image: localstack/localstack:3.0.0
+        image: ${{ (needs.check-changed-files.outputs.java_changed == 'true') && 'localstack/localstack:3.0.0' || '' }}
         env:
           SERVICES: "lambda, apigateway, iam, ec2, sqs, s3, sts, kms, sns, ssm, events"
           GATEWAY_LISTEN: 0.0.0.0:45678
@@ -187,7 +187,7 @@ jobs:
         ports:
           - 45678:45678
       redis:
-        image: redis:6.0.5-alpine
+        image: ${{ (needs.check-changed-files.outputs.java_changed == 'true') && 'redis:6.0.5-alpine' || '' }}
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -196,7 +196,7 @@ jobs:
         ports:
           - 6379:6379
       dynamodb:
-        image: amazon/dynamodb-local:1.22.0
+        image: ${{ (needs.check-changed-files.outputs.java_changed == 'true') && 'amazon/dynamodb-local:1.22.0' || '' }}
         options: >-
           --health-cmd "curl http://localhost:8000"
           --health-interval 10s
@@ -258,7 +258,7 @@ jobs:
       - check-changed-files
     services:
       localstack:
-        image: localstack/localstack:3.0.0
+        image: ${{ (needs.check-changed-files.outputs.java_changed == 'true') && 'localstack/localstack:3.0.0' || '' }}
         env:
           SERVICES: "lambda, apigateway, iam, ec2, sqs, s3, sts, kms, sns, ssm, events"
           DEFAULT_REGION: eu-west-2
@@ -272,7 +272,7 @@ jobs:
         ports:
           - 45678:45678
       redis:
-        image: redis:6.0.5-alpine
+        image: ${{ (needs.check-changed-files.outputs.java_changed == 'true') && 'redis:6.0.5-alpine' || '' }}
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -281,7 +281,7 @@ jobs:
         ports:
           - 6379:6379
       dynamodb:
-        image: amazon/dynamodb-local:1.22.0
+        image: ${{ (needs.check-changed-files.outputs.java_changed == 'true') && 'amazon/dynamodb-local:1.22.0' || '' }}
         options: >-
           --health-cmd "curl http://localhost:8000"
           --health-interval 10s

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -12,6 +12,11 @@ on:
   merge_group:
 
 jobs:
+  check-changed-files:
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/call_get_changed_files.yml
+
   check-openapi-specs:
     runs-on: ubuntu-latest
     steps:
@@ -30,20 +35,27 @@ jobs:
           find ci/terraform -type f -name "*openapi*.yaml" -exec python scripts/validate_openapi_definition.py {} \;
   build:
     runs-on: ubuntu-latest
+    needs:
+      - check-changed-files
     steps:
       - name: Check out repository code
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Set up JDK 17
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b #v4.5.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Set up Gradle
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4
         with:
           gradle-version: wrapper
           cache-read-only: false
       - name: Build Cache
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
@@ -53,26 +65,32 @@ jobs:
             !*/build/jacoco
           key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Run Build
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         run: ./gradlew --parallel build -x test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck
 
   style-checks:
     runs-on: ubuntu-latest
     needs:
       - build
+      - check-changed-files
     steps:
       - name: Check out repository code
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up JDK 17
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b #v4.5.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Set up Gradle
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4
         with:
           gradle-version: wrapper
           cache-read-only: true
       - name: Restore Build Cache
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
@@ -83,26 +101,32 @@ jobs:
           key: ${{ runner.os }}-build-${{ github.sha }}
 
       - name: Run Spotless
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         run: ./gradlew --no-daemon spotlessCheck
 
   run-unit-tests:
     runs-on: ubuntu-latest
     needs:
       - build
+      - check-changed-files
     steps:
       - name: Check out repository code
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up JDK 17
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b #v4.5.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Set up Gradle
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4
         with:
           gradle-version: wrapper
           cache-read-only: true
       - name: Restore Build Cache
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
@@ -112,11 +136,13 @@ jobs:
             !*/build/jacoco
           key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Run Unit Tests
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew --parallel test jacocoTestReport -x integration-tests:test -x account-management-integration-tests:test -x delivery-receipts-integration-tests:test -x spotlessApply -x spotlessCheck
 
       - name: Cache Unit Test Reports
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
@@ -131,7 +157,7 @@ jobs:
             !delivery-receipts-integration-tests/build/reports/
       - name: Upload Unit Test Reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: failure()
+        if: failure() && needs.check-changed-files.outputs.java_changed == 'true'
         with:
           name: unit-test-reports
           path: |
@@ -146,6 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - check-changed-files
     services:
       localstack:
         image: localstack/localstack:3.0.0
@@ -179,18 +206,22 @@ jobs:
           - 8000:8000
     steps:
       - name: Check out repository code
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up JDK 17
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b #v4.5.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Set up Gradle
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4
         with:
           gradle-version: wrapper
           cache-read-only: true
       - name: Restore Build Cache
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
@@ -200,10 +231,12 @@ jobs:
             !*/build/jacoco
           key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Run Integration Tests
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         run: |
           ./gradlew :integration-tests:test :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
 
       - name: Cache Test Reports
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           key: ${{ runner.os }}-integration-test-reports-${{ github.sha }}
@@ -212,7 +245,7 @@ jobs:
             integration-tests/build/reports/
       - name: Upload Integration Test Reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: failure()
+        if: failure() && needs.check-changed-files.outputs.java_changed == 'true'
         with:
           name: integration-test-reports
           path: integration-tests/build/reports/tests/test/
@@ -222,6 +255,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - check-changed-files
     services:
       localstack:
         image: localstack/localstack:3.0.0
@@ -257,18 +291,22 @@ jobs:
           - 8000:8000
     steps:
       - name: Check out repository code
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up JDK 17
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b #v4.5.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Set up Gradle
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4
         with:
           gradle-version: wrapper
           cache-read-only: true
       - name: Restore Build Cache
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
@@ -279,20 +317,23 @@ jobs:
           key: ${{ runner.os }}-build-${{ github.sha }}
 
       - name: Run Account Management Integration Tests
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         run: |
           ./gradlew :account-management-integration-tests:test :account-management-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
       - name: Upload Account Management Integration Test Reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: failure()
+        if: failure() && needs.check-changed-files.outputs.java_changed == 'true'
         with:
           name: account-management-integration-test-reports
           path: account-management-integration-tests/build/reports/tests/test/
           retention-days: 5
       - name: Run Delivery Receipts Integration Tests
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         run: |
           ./gradlew :delivery-receipts-integration-tests:test :delivery-receipts-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
 
       - name: Cache Test Reports
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           key: ${{ runner.os }}-am-dr-integration-test-reports-${{ github.sha }}
@@ -304,7 +345,7 @@ jobs:
 
       - name: Upload Account Management Integration Test Reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: failure()
+        if: failure() && needs.check-changed-files.outputs.java_changed == 'true'
         with:
           name: delivery-receipts-integration-test-reports
           path: delivery-receipts-integration-tests/build/reports/tests/test/
@@ -316,23 +357,28 @@ jobs:
       - run-unit-tests
       - run-integration-tests
       - run-account-management-and-delivery-receipts-tests
+      - check-changed-files
     if: github.event_name != 'merge_group'
     steps:
       - name: Check out repository code
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Set up JDK 17
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b #v4.5.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Set up Gradle
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4
         with:
           gradle-version: wrapper
           cache-read-only: true
       - name: Restore Build Cache
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
@@ -343,6 +389,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ github.sha }}
 
       - name: Restore Cached Unit Test Reports
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
@@ -356,6 +403,7 @@ jobs:
             !delivery-receipts-integration-tests/build/jacoco/
             !delivery-receipts-integration-tests/build/reports/
       - name: Restore Cached Integration Test Reports
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           key: ${{ runner.os }}-integration-test-reports-${{ github.sha }}
@@ -363,6 +411,7 @@ jobs:
             integration-tests/build/jacoco/
             integration-tests/build/reports/
       - name: Restore Cached AM DR Integration Test Reports
+        if: needs.check-changed-files.outputs.java_changed == 'true'
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           key: ${{ runner.os }}-am-dr-integration-test-reports-${{ github.sha }}
@@ -372,7 +421,7 @@ jobs:
             delivery-receipts-integration-tests/build/jacoco/
             delivery-receipts-integration-tests/build/reports/
       - name: Run SonarCloud Analysis
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: github.actor != 'dependabot[bot]'  && needs.check-changed-files.outputs.java_changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/require-pinned-github-actions.yml
+++ b/.github/workflows/require-pinned-github-actions.yml
@@ -6,7 +6,9 @@ on:
       - reopened
       - ready_for_review
       - synchronize
-  merge_group:
+    paths:
+      - ".github/workflows/**.yml"
+      - ".github/workflows/**.yaml"
 
 jobs:
   check-actions-sha:

--- a/.github/workflows/sonar-analysis-on-merge.yml
+++ b/.github/workflows/sonar-analysis-on-merge.yml
@@ -3,6 +3,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      # Ensure these are synchronized with the paths in the check-changed-files job
+      - "**/src/**"
+      - "**/*.java"
+      - "**/*.gradle"
+      - "**/*.properties"
+      - "gradle*"
 
 jobs:
   run-code-analysis:


### PR DESCRIPTION
## What

We run a lot of unnecessary tests. This is a horrible experience when your PR doesn't touch anything that the tests are testing.

### Ways this fixes this problem

#### Non-Required status checks

Filter runs using the built-in `paths` specifier in the `on:` event specifier

#### Required status checks

Filter runs using `tj-actions/changed-files`:

1. Get the list of changed files
2. If the files are not java'y, add a comment to the PR explaining that the checks have been skipped, but they still show as passed
3. If a java file is subsequently added, modify the comment to say that the tests are now meaningful.
4. In the actual test, use `if` statements to only run specific steps if java files are present (there is no way with GHA to exit early and mark the test as passed.

### Reason for logical choice

I've chosen to detect java changes rather than terraform ones because this logic is to control whether or not we run the java tests.

I believe that the globs will always catch any java changes, so the risk is a false-positive (ie. a non-java change triggers all the checks to run. IMO, that is a reasonable risk

## How to review

Code Review
