### PR TITLE
ATO-1182: Refactor sessions setting in AuthenticationCallback

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -396,11 +396,14 @@ public class AuthenticationCallbackHandler
                                     ? OrchSessionItem.AccountState.NEW
                                     : OrchSessionItem.AccountState.EXISTING;
                 }
+                userSession.setNewAccount(accountState);
+                orchSession.withAccountState(orchAccountState);
 
-                sessionService.storeOrUpdateSession(
-                        userSession.setNewAccount(accountState).setAuthenticated(true));
+                userSession.setAuthenticated(true);
 
-                orchSessionService.updateSession(orchSession.withAccountState(orchAccountState));
+                sessionService.storeOrUpdateSession(userSession);
+                orchSessionService.updateSession(orchSession);
+
                 var docAppJourney = isDocCheckingAppUserWithSubjectId(clientSession);
                 Map<String, String> dimensions =
                         buildDimensions(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -383,19 +383,8 @@ public class AuthenticationCallbackHandler
 
                 Boolean newAccount =
                         userInfo.getBooleanClaim(AuthUserInfoClaims.NEW_ACCOUNT.getValue());
-                AccountState accountState;
-                OrchSessionItem.AccountState orchAccountState;
-
-                if (newAccount == null) {
-                    accountState = AccountState.UNKNOWN;
-                    orchAccountState = OrchSessionItem.AccountState.UNKNOWN;
-                } else {
-                    accountState = newAccount ? AccountState.NEW : AccountState.EXISTING;
-                    orchAccountState =
-                            newAccount
-                                    ? OrchSessionItem.AccountState.NEW
-                                    : OrchSessionItem.AccountState.EXISTING;
-                }
+                AccountState accountState = deduceAccountState(newAccount);
+                OrchSessionItem.AccountState orchAccountState = deduceOrchAccountState(newAccount);
                 userSession.setNewAccount(accountState);
                 orchSession.withAccountState(orchAccountState);
 
@@ -570,6 +559,29 @@ public class AuthenticationCallbackHandler
             LOG.info("Cannot retrieve auth request params from client session id");
             return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
         }
+    }
+
+    private AccountState deduceAccountState(Boolean newAccount) {
+        AccountState accountState;
+        if (newAccount == null) {
+            accountState = AccountState.UNKNOWN;
+        } else {
+            accountState = newAccount ? AccountState.NEW : AccountState.EXISTING;
+        }
+        return accountState;
+    }
+
+    private OrchSessionItem.AccountState deduceOrchAccountState(Boolean newAccount) {
+        OrchSessionItem.AccountState accountState;
+        if (newAccount == null) {
+            accountState = OrchSessionItem.AccountState.UNKNOWN;
+        } else {
+            accountState =
+                    newAccount
+                            ? OrchSessionItem.AccountState.NEW
+                            : OrchSessionItem.AccountState.EXISTING;
+        }
+        return accountState;
     }
 
     private Map<String, String> buildDimensions(


### PR DESCRIPTION
## What

While working on setting auth_time in AuthenticationCallback, it was becoming a bit complex and hard to read. For maintainability, this PR contains two small refactors:

1. Where possible, separate setting to the session objects, and updating the database.
2. Use private method to separate logic from main handler.

## Testing
No changes to tests required, so I'm confident this is OK, but I will

- [x] Run through auth journey in dev
