### PR TITLE
ATO-1096: Add auth time to Orch session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -77,6 +77,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -162,6 +163,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         assertUserInfoStoredAndRedirectedToRp(response);
         assertOrchSessionIsUpdatedWithUserInfoClaims();
+        assertAuthTimeHasBeenSetInOrchSessionTable();
     }
 
     @Test
@@ -806,6 +808,13 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
         assertEquals(
                 MFAMethodType.AUTH_APP.getValue(), orchSession.get().getVerifiedMfaMethodType());
         assertThat(OrchSessionItem.AccountState.NEW, equalTo(orchSession.get().getIsNewAccount()));
+    }
+
+    private void assertAuthTimeHasBeenSetInOrchSessionTable() {
+        Optional<OrchSessionItem> orchSession = orchSessionExtension.getSession(SESSION_ID);
+        assertTrue(orchSession.isPresent());
+        var session = orchSession.get();
+        assertNotEquals(0L, session.getAuthTime());
     }
 
     private void setupClientReg(boolean identityVerificationSupported) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -47,6 +47,7 @@ import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
@@ -389,6 +390,7 @@ public class AuthenticationCallbackHandler
                 orchSession.withAccountState(orchAccountState);
 
                 userSession.setAuthenticated(true);
+                orchSession.setAuthTime(NowHelper.now().toInstant().getEpochSecond());
 
                 sessionService.storeOrUpdateSession(userSession);
                 orchSessionService.updateSession(orchSession);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -391,13 +391,30 @@ public class AuthenticationCallbackHandler
 
                 CredentialTrustLevel lowestRequestedCredentialTrustLevel =
                         VectorOfTrust.getLowestCredentialTrustLevel(clientSession.getVtrList());
+
+                LOG.info("userSession.isAuthenticated(): {}", userSession.isAuthenticated());
+
+                if (userSession.getCurrentCredentialStrength() == null) {
+                    LOG.info("userSession.getCurrentCredentialStrength(): null");
+                } else {
+                    LOG.info(
+                            "userSession.getCurrentCredentialStrength(): {}",
+                            userSession.getCurrentCredentialStrength().getValue());
+                }
+                LOG.info(
+                        "lowestRequestedCredentialTrustLevel: {}",
+                        lowestRequestedCredentialTrustLevel.getValue());
+
                 boolean userWasUplifted =
                         userSession.isAuthenticated()
                                 && userSession.getCurrentCredentialStrength() != null
                                 && lowestRequestedCredentialTrustLevel.compareTo(
                                                 userSession.getCurrentCredentialStrength())
                                         > 0;
+
+                LOG.info("userWasUplifted: {}", userWasUplifted);
                 if (!userSession.isAuthenticated() || userWasUplifted) {
+                    LOG.info("authTime set");
                     orchSession.setAuthTime(NowHelper.now().toInstant().getEpochSecond());
                 }
                 userSession.setAuthenticated(true);

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -162,6 +162,14 @@ public class RedisExtension
                 session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
     }
 
+    public void setAuthenticated(String sessionId, boolean authenticated)
+            throws Json.JsonException {
+        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
+        session.setAuthenticated(authenticated);
+        redis.saveWithExpiry(
+                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+    }
+
     public Session getSession(String sessionId) throws Json.JsonException {
         return objectMapper.readValue(redis.getValue(sessionId), Session.class);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -12,6 +12,7 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "IsNewAccount";
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
+    public static final String ATTRIBUTE_AUTH_TIME = "AuthTime";
 
     public enum AccountState {
         NEW,
@@ -26,6 +27,7 @@ public class OrchSessionItem {
     private String verifiedMfaMethodType;
     private AccountState isNewAccount;
     private String internalCommonSubjectId;
+    private long authTime;
 
     public OrchSessionItem() {}
 
@@ -116,6 +118,20 @@ public class OrchSessionItem {
 
     public OrchSessionItem withInternalCommonSubjectId(String internalCommonSubjectId) {
         this.internalCommonSubjectId = internalCommonSubjectId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_AUTH_TIME)
+    public long getAuthTime() {
+        return authTime;
+    }
+
+    public void setAuthTime(long authTime) {
+        this.authTime = authTime;
+    }
+
+    public OrchSessionItem withAuthTime(long authTime) {
+        this.authTime = authTime;
         return this;
     }
 }


### PR DESCRIPTION
## What

As part of the max_age initiative, Orch are to begin setting `authTime` in the Orch session, at the time that the user is authenticated (ie. when the `authenticated` session field goes from `false` to `true`).

There is another case that Orch need to set `authTime`, which is when the user has had their credential strength uplifted (eg. from LOW to MEDIUM), which happens when a user with an existing session authenticates with a higher trust level on a second journey.

This PR is based off two others and so PRs need to be merged in this order:
1. https://github.com/govuk-one-login/authentication-api/pull/5522
2. https://github.com/govuk-one-login/authentication-api/pull/5529
3. https://github.com/govuk-one-login/authentication-api/pull/5531

## Testing
- [ ] Run through affected journeys in dev 
- [ ] Run Auth acceptance tests against dev


[ATO-1088]: https://govukverify.atlassian.net/browse/ATO-1088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ