### PR TITLE
BAU: Enable identity for all stub clients

### DIFF
--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -18,9 +18,8 @@ stub_rp_clients = [
     logout_urls = [
       "https://rp-dev.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "1"
-    client_type                     = "web"
-    identity_verification_supported = "0"
+    test_client = "1"
+    client_type = "web"
     scopes = [
       "openid",
       "email",
@@ -44,9 +43,8 @@ stub_rp_clients = [
       "https://doc-app-rp-dev.build.stubs.account.gov.uk/signed-out",
       "http://localhost:8080/signed-out",
     ]
-    test_client                     = "1"
-    identity_verification_supported = "1"
-    client_type                     = "app"
+    test_client = "1"
+    client_type = "app"
     scopes = [
       "openid",
       "email",

--- a/ci/terraform/shared/authdev2.tfvars
+++ b/ci/terraform/shared/authdev2.tfvars
@@ -18,9 +18,8 @@ stub_rp_clients = [
     logout_urls = [
       "https://rp-dev.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "1"
-    client_type                     = "web"
-    identity_verification_supported = "0"
+    test_client = "1"
+    client_type = "web"
     scopes = [
       "openid",
       "email",
@@ -43,9 +42,8 @@ stub_rp_clients = [
       "https://doc-app-rp-dev.build.stubs.account.gov.uk/signed-out",
       "http://localhost:8080/signed-out",
     ]
-    test_client                     = "1"
-    identity_verification_supported = "1"
-    client_type                     = "app"
+    test_client = "1"
+    client_type = "app"
     scopes = [
       "openid",
       "email",

--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -11,9 +11,8 @@ stub_rp_clients = [
       "https://rp-build.build.stubs.account.gov.uk/signed-out",
       "http://localhost:8080/signed-out",
     ]
-    test_client                     = "0"
-    identity_verification_supported = "1"
-    client_type                     = "web"
+    test_client = "0"
+    client_type = "web"
     scopes = [
       "openid",
       "email",
@@ -38,9 +37,8 @@ stub_rp_clients = [
       "http://localhost:8080/signed-out",
       "https://rp-build.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "1"
-    identity_verification_supported = "1"
-    client_type                     = "app"
+    test_client = "1"
+    client_type = "app"
     scopes = [
       "openid",
       "doc-checking-app",
@@ -62,9 +60,8 @@ stub_rp_clients = [
       "http://localhost:8080/signed-out",
       "https://rp-build.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "1"
-    identity_verification_supported = "1"
-    client_type                     = "web"
+    test_client = "1"
+    client_type = "web"
     scopes = [
       "openid",
       "email",
@@ -87,9 +84,8 @@ stub_rp_clients = [
       "http://localhost:3031/signed-out",
       "http://localhost:8080/signed-out",
     ]
-    test_client                     = "1"
-    identity_verification_supported = "1"
-    client_type                     = "web"
+    test_client = "1"
+    client_type = "web"
     scopes = [
       "openid",
       "email",
@@ -115,9 +111,8 @@ stub_rp_clients = [
       "http://localhost:8080/signed-out",
       "https://rp-build.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "0"
-    identity_verification_supported = "1"
-    client_type                     = "web"
+    test_client = "0"
+    client_type = "web"
     scopes = [
       "openid",
       "email",

--- a/ci/terraform/shared/dev-stub-clients.tfvars
+++ b/ci/terraform/shared/dev-stub-clients.tfvars
@@ -11,9 +11,8 @@ stub_rp_clients = [
       "https://rp-dev.build.stubs.account.gov.uk/signed-out",
       "http://localhost:8080/signed-out",
     ]
-    test_client                     = "1"
-    identity_verification_supported = "1"
-    client_type                     = "web"
+    test_client = "1"
+    client_type = "web"
     scopes = [
       "openid",
       "email",
@@ -36,9 +35,8 @@ stub_rp_clients = [
       "https://doc-app-rp-dev.build.stubs.account.gov.uk/signed-out",
       "http://localhost:8080/signed-out",
     ]
-    test_client                     = "1"
-    identity_verification_supported = "1"
-    client_type                     = "app"
+    test_client = "1"
+    client_type = "app"
     scopes = [
       "openid",
       "email",

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -9,9 +9,8 @@ stub_rp_clients = [
     logout_urls = [
       "https://rp-integration.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "0"
-    identity_verification_supported = "1"
-    client_type                     = "web"
+    test_client = "0"
+    client_type = "web"
     scopes = [
       "openid",
       "email",
@@ -31,9 +30,8 @@ stub_rp_clients = [
     logout_urls = [
       "https://doc-app-rp-integration.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "1"
-    identity_verification_supported = "1"
-    client_type                     = "app"
+    test_client = "1"
+    client_type = "app"
     scopes = [
       "openid",
       "doc-checking-app",

--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -9,9 +9,8 @@ stub_rp_clients = [
     logout_urls = [
       "https://rp.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "0"
-    identity_verification_supported = "1"
-    client_type                     = "web"
+    test_client = "0"
+    client_type = "web"
     scopes = [
       "openid",
       "email",
@@ -31,9 +30,8 @@ stub_rp_clients = [
     logout_urls = [
       "https://doc-app-rp.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "1"
-    identity_verification_supported = "1"
-    client_type                     = "app"
+    test_client = "1"
+    client_type = "app"
     scopes = [
       "openid",
       "doc-checking-app",

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -18,9 +18,8 @@ stub_rp_clients = [
     logout_urls = [
       "https://rp-dev.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "1"
-    client_type                     = "web"
-    identity_verification_supported = "0"
+    test_client = "1"
+    client_type = "web"
     scopes = [
       "openid",
       "email",
@@ -42,9 +41,8 @@ stub_rp_clients = [
       "https://doc-app-rp-dev.build.stubs.account.gov.uk/signed-out",
       "https://rp-dev.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "1"
-    client_type                     = "app"
-    identity_verification_supported = "1"
+    test_client = "1"
+    client_type = "app"
     scopes = [
       "openid",
       "email",

--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -9,9 +9,8 @@ stub_rp_clients = [
     logout_urls = [
       "https://rp-staging.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "0"
-    identity_verification_supported = "1"
-    client_type                     = "web"
+    test_client = "0"
+    client_type = "web"
     scopes = [
       "openid",
       "email",
@@ -32,9 +31,8 @@ stub_rp_clients = [
     logout_urls = [
       "https://doc-app-rp-staging.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "1"
-    identity_verification_supported = "1"
-    client_type                     = "app"
+    test_client = "1"
+    client_type = "app"
     scopes = [
       "openid",
       "doc-checking-app",
@@ -52,9 +50,8 @@ stub_rp_clients = [
     logout_urls = [
       "https://perf-test-rp-staging.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client                     = "1"
-    identity_verification_supported = "1"
-    client_type                     = "web"
+    test_client = "1"
+    client_type = "web"
     scopes = [
       "openid",
       "email",

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -99,7 +99,7 @@ resource "aws_dynamodb_table_item" "stub_relying_party_client" {
       N = "1"
     }
     IdentityVerificationSupported = {
-      N = each.value.identity_verification_supported
+      N = 1
     }
     ClientType = {
       S = each.value.client_type

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -89,7 +89,7 @@ variable "logging_endpoint_arns" {
 
 variable "stub_rp_clients" {
   default     = []
-  type        = list(object({ client_name : string, at_client : bool, sector_identifier_uri : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, one_login_service : bool, service_type : string }))
+  type        = list(object({ client_name : string, at_client : bool, sector_identifier_uri : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, one_login_service : bool, service_type : string }))
   description = "The details of RP clients to provision in the Client table"
   validation {
     condition     = length(var.stub_rp_clients) > 0


### PR DESCRIPTION
## What

Set up all stub clients to support identity, in preparation for the IPV and SPOT stubs


