### PR TITLE
ATO-981: Setting feature flag cleanup

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -628,10 +628,5 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         public boolean isIPVNoSessionResponseEnabled() {
             return true;
         }
-
-        @Override
-        public boolean isSetNewAccountInOrchSessionEnabled() {
-            return true;
-        }
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -199,8 +199,7 @@ public class IPVCallbackHelper {
             String internalPairwiseSubjectId,
             UserInfo userIdentityUserInfo,
             String ipAddress,
-            String persistentSessionId,
-            boolean isSetIsNewAccountOrchSessionEnabled)
+            String persistentSessionId)
             throws UserNotFoundException {
         LOG.warn("SPOT will not be invoked due to returnCode. Returning authCode to RP");
         segmentedFunctionCall(
@@ -259,13 +258,8 @@ public class IPVCallbackHelper {
                 clientSession.getClientName(),
                 isTestJourney);
 
-        if (isSetIsNewAccountOrchSessionEnabled) {
-            authCodeResponseService.saveSession(
-                    false, sessionService, session, orchSessionService, orchSession);
-        } else {
-            authCodeResponseService.saveSession(false, sessionService, session);
-        }
-
+        authCodeResponseService.saveSession(
+                false, sessionService, session, orchSessionService, orchSession);
         return authenticationResponse;
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -381,8 +381,6 @@ public class IPVCallbackHandler
                 if (returnCodePresentInIPVResponse(returnCode)) {
                     if (rpRequestedReturnCode(clientRegistry, authRequest)) {
                         LOG.info("Generating auth code response for return code(s)");
-                        boolean setIsNewAccountInOrchSession =
-                                configurationService.isSetNewAccountInOrchSessionEnabled();
                         var authenticationResponse =
                                 ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
                                         authRequest,
@@ -395,8 +393,7 @@ public class IPVCallbackHandler
                                         internalPairwiseSubjectId,
                                         userIdentityUserInfo,
                                         ipAddress,
-                                        persistentId,
-                                        setIsNewAccountInOrchSession);
+                                        persistentId);
                         return generateApiGatewayProxyResponse(
                                 302,
                                 "",

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -379,18 +379,8 @@ class IPVCallbackHandlerTest {
         when(ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, VTR_LIST))
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        anyBoolean()))
+                        any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                        any()))
                 .thenReturn(
                         new AuthenticationSuccessResponse(
                                 REDIRECT_URI, null, null, null, null, null, null));
@@ -421,7 +411,6 @@ class IPVCallbackHandlerTest {
                 throws UnsuccessfulCredentialResponseException,
                         IpvCallbackException,
                         UserNotFoundException {
-            withSetIsNewAccountInOrchSession(isFlagEnabled);
             usingValidSession();
             var claimsSetRequest =
                     new ClaimsSetRequest()
@@ -455,18 +444,8 @@ class IPVCallbackHandlerTest {
             when(ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, VTR_LIST))
                     .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
             when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            any(),
-                            eq(isFlagEnabled)))
+                            any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                            any()))
                     .thenReturn(
                             new AuthenticationSuccessResponse(
                                     REDIRECT_URI, null, null, null, null, null, null));
@@ -490,10 +469,6 @@ class IPVCallbackHandlerTest {
             assertThat(response, hasStatus(302));
             assertEquals(
                     expectedURI.toString(), response.getHeaders().get(ResponseHeaders.LOCATION));
-        }
-
-        void withSetIsNewAccountInOrchSession(boolean isFlagEnabled) {
-            when(configService.isSetNewAccountInOrchSessionEnabled()).thenReturn(isFlagEnabled);
         }
     }
 
@@ -546,18 +521,8 @@ class IPVCallbackHandlerTest {
         when(ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, VTR_LIST))
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        anyBoolean()))
+                        any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                        any()))
                 .thenReturn(
                         new AuthenticationSuccessResponse(
                                 FRONT_END_IPV_CALLBACK_URI, null, null, null, null, null, null));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -278,12 +278,8 @@ public class AuthCodeHandler
                     clientSession.getClientName(),
                     isTestJourney);
 
-            if (configurationService.isSetNewAccountInOrchSessionEnabled()) {
-                authCodeResponseService.saveSession(
-                        docAppJourney, sessionService, session, orchSessionService, orchSession);
-            } else {
-                authCodeResponseService.saveSession(docAppJourney, sessionService, session);
-            }
+            authCodeResponseService.saveSession(
+                    docAppJourney, sessionService, session, orchSessionService, orchSession);
 
             LOG.info("Generating successful auth code response");
             return generateApiGatewayProxyResponse(

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -336,11 +336,5 @@ public class IntegrationTest {
         public Optional<String> getIPVCapacity() {
             return Optional.of("1");
         }
-
-        @Override
-        public boolean isSetNewAccountInOrchSessionEnabled() {
-
-            return true;
-        }
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -418,10 +418,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("SET_AUTHENTICATED_FLAG_FOR_IPV");
     }
 
-    public boolean isSetNewAccountInOrchSessionEnabled() {
-        return getFlagOrFalse("SET_IS_NEW_ACCOUNT_IN_ORCH_SESSION");
-    }
-
     private Map<String, String> getSsmRedisParameters() {
         if (ssmRedisParameters == null) {
             var getParametersRequest =

--- a/template.yaml
+++ b/template.yaml
@@ -102,7 +102,6 @@ Mappings:
       defaultProvisionedConcurrency: 0
       aisUriSecretId: 6b29b810-e509-4354-9d75-934d0f154d07
       setAuthenticatedFlagForIpv: true
-      setIsNewAccountInOrchSession: true
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "6of9f4amvg"
@@ -135,7 +134,6 @@ Mappings:
       defaultProvisionedConcurrency: 1
       aisUriSecretId: fd6ef1f1-7d31-40ca-978d-2180199141d8
       setAuthenticatedFlagForIpv: true
-      setIsNewAccountInOrchSession: true
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "1rvwudxmbk"
@@ -168,7 +166,6 @@ Mappings:
       defaultProvisionedConcurrency: 3
       aisUriSecretId: 2b9a3315-50e9-4970-87e6-b354cc4a2484
       setAuthenticatedFlagForIpv: true
-      setIsNewAccountInOrchSession: true
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "k2skqhxed6"
@@ -201,7 +198,6 @@ Mappings:
       defaultProvisionedConcurrency: 1
       aisUriSecretId: ""
       setAuthenticatedFlagForIpv: true
-      setIsNewAccountInOrchSession: true
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       authApiId: "s4gj268zy6"
@@ -234,7 +230,6 @@ Mappings:
       defaultProvisionedConcurrency: 3
       aisUriSecretId: ""
       setAuthenticatedFlagForIpv: true
-      setIsNewAccountInOrchSession: true
   ProvisionedConcurrency:
     staging:
       TrustmarkFunction: 1
@@ -2688,12 +2683,6 @@ Resources:
                   !Ref Environment,
                   serviceDomain,
                 ]
-          SET_IS_NEW_ACCOUNT_IN_ORCH_SESSION:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              setIsNewAccountInOrchSession,
-            ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy
@@ -3296,12 +3285,6 @@ Resources:
                     authEnvironment,
                   ]
             - !Ref AWS::NoValue
-          SET_IS_NEW_ACCOUNT_IN_ORCH_SESSION:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              setIsNewAccountInOrchSession,
-            ]
       Policies:
         - !Ref IdentityCredentialsTableReadAccessPolicy
         - !Ref IdentityCredentialsTableWriteAccessPolicy


### PR DESCRIPTION
## What: 
- Removes feature flag setup from handlers as this is now enabled in production - https://github.com/govuk-one-login/authentication-api/pull/5527

## How to review
- Code review commit-by-commit
- Deployed to dev 
   - Run Auth acceptance tests against it, all but one passed (Assuming test flakiness)

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
