### PR TITLE
ATO-980:  Switch getter to Orch session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -179,6 +179,12 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 public String getOrchestrationToAuthenticationEncryptionPublicKey() {
                     return publicKey;
                 }
+
+                @Override
+                public boolean isUseOrchSessionForAuthenticatedClaimEnabled() {
+                    return true;
+                }
+                ;
             };
 
     @Test

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -401,6 +401,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("STORAGE_TOKEN_SIGNING_KEY_ALIAS");
     }
 
+    public boolean isUseOrchSessionForAuthenticatedClaimEnabled() {
+        return getFlagOrFalse("USE_ORCH_SESSION_FOR_AUTHENTICATED_CLAIM");
+    }
+
     public boolean isCurrentCredentialStrengthInOrchSessionEnabled() {
         return getFlagOrFalse("CURRENT_CREDENTIAL_STRENGTH_IN_ORCH_SESSION");
     }

--- a/template.yaml
+++ b/template.yaml
@@ -107,6 +107,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/8bc4e01c-466b-4663-9c60-c29d5e9f2fcf
       defaultProvisionedConcurrency: 0
       aisUriSecretId: 6b29b810-e509-4354-9d75-934d0f154d07
+      getAuthenticatedFromOrchSession: true
       currentCredentialStrengthInOrchSession: true
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -140,6 +141,7 @@ Mappings:
       defaultProvisionedConcurrency: 1
       aisUriSecretId: fd6ef1f1-7d31-40ca-978d-2180199141d8
       currentCredentialStrengthInOrchSession: true
+      getAuthenticatedFromOrchSession: true
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "1rvwudxmbk"
@@ -172,6 +174,7 @@ Mappings:
       defaultProvisionedConcurrency: 3
       aisUriSecretId: 2b9a3315-50e9-4970-87e6-b354cc4a2484
       currentCredentialStrengthInOrchSession: true
+      getAuthenticatedFromOrchSession: true
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "k2skqhxed6"
@@ -204,6 +207,7 @@ Mappings:
       defaultProvisionedConcurrency: 1
       aisUriSecretId: ""
       currentCredentialStrengthInOrchSession: true
+      getAuthenticatedFromOrchSession: false
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       authApiId: "s4gj268zy6"
@@ -236,6 +240,7 @@ Mappings:
       defaultProvisionedConcurrency: 3
       aisUriSecretId: ""
       currentCredentialStrengthInOrchSession: true
+      getAuthenticatedFromOrchSession: false
   ProvisionedConcurrency:
     staging:
       TrustmarkFunction: 1
@@ -2353,6 +2358,12 @@ Resources:
             - EnableFetchJwks
             - true
             - false
+          USE_ORCH_SESSION_FOR_AUTHENTICATED_CLAIM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              getAuthenticatedFromOrchSession,
+            ]
 
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy


### PR DESCRIPTION
## What
- Adds a feature flagged behaviour for using the orch session to attach the `authenticated` claim in the JAR sent to authentication instead of the shared session store
- Flag is turned on in dev, build and staging but not integration or production

## How to review
- Code review commit-by-commit
- Deployed Dev:
    - Run auth acceptance test against dev (sandpit) to ensure no regression - all passed

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

- Branches off: https://github.com/govuk-one-login/authentication-api/pull/5543, so must be merged first
