### PR TITLE
ATO-1229: Set `UpliftRequired` in Auth session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -259,6 +259,13 @@ public class StartHandler
                             isBlockedForReauth,
                             isUserAuthenticatedWithValidProfile);
 
+            var authSession = authSessionService.getSession(session.getSessionId());
+            authSession.ifPresent(
+                    authSessionItem ->
+                            authSessionService.updateSession(
+                                    authSessionItem.withUpliftRequired(
+                                            userStartInfo.isUpliftRequired())));
+
             if (userStartInfo.isDocCheckingAppUser()) {
                 var docAppSubjectId =
                         DocAppSubjectIdHelper.calculateDocAppSubjectId(


### PR DESCRIPTION
## What

When uplift is required, set it in the Auth session. This value will be passed to Orch in the userinfo response.

## Testing

- [x] uplift and non-uplift journey in dev sets value appropriately
