### PR TITLE
ATO-1230: Return uplift_required in userinfo response

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/entity/AuthUserInfoClaims.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/entity/AuthUserInfoClaims.java
@@ -15,7 +15,8 @@ public enum AuthUserInfoClaims {
     SALT("salt"),
     VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type"),
     CURRENT_CREDENTIAL_STRENGTH("current_credential_strength"),
-    NEW_ACCOUNT("new_account");
+    NEW_ACCOUNT("new_account"),
+    UPLIFT_REQUIRED("uplift_required");
 
     private final String value;
 

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -126,6 +126,11 @@ public class UserInfoService {
                     "current_credential_strength value: {}",
                     authSession.getCurrentCredentialStrength());
         }
+        if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.UPLIFT_REQUIRED.getValue())) {
+            userInfo.setClaim(
+                    AuthUserInfoClaims.UPLIFT_REQUIRED.getValue(), authSession.getUpliftRequired());
+            LOG.info("uplift_required value: {}", authSession.getUpliftRequired());
+        }
     }
 
     private static String bytesToBase64(ByteBuffer byteBuffer) {

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -54,6 +54,7 @@ public class UserInfoServiceTest {
     private static final String TEST_VERIFIED_MFA_METHOD_TYPE = MFAMethodType.EMAIL.getValue();
     private static final CredentialTrustLevel TEST_CURRENT_CREDENTIAL_STRENGTH =
             CredentialTrustLevel.MEDIUM_LEVEL;
+    private static final boolean TEST_UPLIFT_REQUIRED = true;
     private static final boolean TEST_IS_NEW_ACCOUNT = true;
     private static final long TEST_PASSWORD_RESET_TIME = 1710255380L;
     private static final UserProfile TEST_USER_PROFILE =
@@ -69,7 +70,8 @@ public class UserInfoServiceTest {
     private static final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withVerifiedMfaMethodType(TEST_VERIFIED_MFA_METHOD_TYPE)
-                    .withCurrentCredentialStrength(TEST_CURRENT_CREDENTIAL_STRENGTH);
+                    .withCurrentCredentialStrength(TEST_CURRENT_CREDENTIAL_STRENGTH)
+                    .withUpliftRequired(TEST_UPLIFT_REQUIRED);
 
     @BeforeEach
     public void setUp() {
@@ -96,7 +98,8 @@ public class UserInfoServiceTest {
             Boolean expectedPhoneNumberVerified,
             String expectedSalt,
             String expectedVerifiedMfaMethod,
-            CredentialTrustLevel expectedCurrentCredentialStrength) {
+            CredentialTrustLevel expectedCurrentCredentialStrength,
+            Boolean expectedUpliftRequired) {
         UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore, authSession);
 
         assertEquals(TEST_INTERNAL_COMMON_SUBJECT_ID, actual.getSubject().getValue());
@@ -115,6 +118,7 @@ public class UserInfoServiceTest {
         assertEquals(
                 expectedCurrentCredentialStrength, actual.getClaim("current_credential_strength"));
         assertEquals(TEST_PASSWORD_RESET_TIME, actual.getClaim("password_reset_time"));
+        assertEquals(expectedUpliftRequired, actual.getClaim("uplift_required"));
     }
 
     private static Stream<Arguments> provideTestData() {
@@ -124,6 +128,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         TEST_SUBJECT.getValue(),
+                        null,
                         null,
                         null,
                         null,
@@ -143,6 +148,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         null,
+                        null,
                         null),
                 Arguments.of(
                         getMockAccessTokenStore(
@@ -156,7 +162,8 @@ public class UserInfoServiceTest {
                                         "phone_number_verified",
                                         "salt",
                                         "verified_mfa_method_type",
-                                        "current_credential_strength")),
+                                        "current_credential_strength",
+                                        "uplift_required")),
                         TEST_LEGACY_SUBJECT_ID,
                         TEST_PUBLIC_SUBJECT_ID,
                         TEST_SUBJECT.getValue(),
@@ -166,7 +173,8 @@ public class UserInfoServiceTest {
                         TEST_PHONE_VERIFIED,
                         bytesToBase64(TEST_SALT),
                         TEST_VERIFIED_MFA_METHOD_TYPE,
-                        TEST_CURRENT_CREDENTIAL_STRENGTH));
+                        TEST_CURRENT_CREDENTIAL_STRENGTH,
+                        TEST_UPLIFT_REQUIRED));
     }
 
     private static AccessTokenStore getMockAccessTokenStore(List<String> claims) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -259,6 +259,14 @@ public class StartHandler
                             isBlockedForReauth,
                             isUserAuthenticatedWithValidProfile);
 
+            if (userStartInfo.isUpliftRequired()) {
+                var authSession = authSessionService.getSession(session.getSessionId());
+                authSession.ifPresent(
+                        authSessionItem ->
+                                authSessionService.updateSession(
+                                        authSessionItem.withUpliftRequired(true)));
+            }
+
             if (userStartInfo.isDocCheckingAppUser()) {
                 var docAppSubjectId =
                         DocAppSubjectIdHelper.calculateDocAppSubjectId(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ClientStartInfo;
@@ -30,6 +32,7 @@ import uk.gov.di.authentication.frontendapi.entity.StartResponse;
 import uk.gov.di.authentication.frontendapi.entity.UserStartInfo;
 import uk.gov.di.authentication.frontendapi.services.StartService;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CountType;
@@ -586,6 +589,32 @@ class StartHandlerTest {
         verifyNoInteractions(auditService);
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetOrNotSetUpliftRequiredInAuthSession(boolean upliftRequired)
+            throws ParseException {
+        var userStartInfo =
+                new UserStartInfo(upliftRequired, false, true, null, null, false, null, false);
+        usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
+        usingValidClientSession();
+        usingValidSession();
+
+        var event =
+                apiRequestEventWithHeadersAndBody(
+                        VALID_HEADERS, makeRequestBodyWithAuthenticatedField(true));
+        handler.handleRequest(event, context);
+
+        var authSessionCaptor = ArgumentCaptor.forClass(AuthSessionItem.class);
+        if (upliftRequired) {
+            verify(authSessionService, times(1)).updateSession(authSessionCaptor.capture());
+            assertTrue(authSessionCaptor.getAllValues().get(0).getUpliftRequired());
+            assertTrue(authSessionService.getSession(SESSION_ID).get().getUpliftRequired());
+        } else {
+            verify(authSessionService, times(0)).updateSession(authSessionCaptor.capture());
+            assertFalse(authSessionService.getSession(SESSION_ID).get().getUpliftRequired());
+        }
+    }
+
     private String makeRequestBodyWithAuthenticatedField(boolean authenticated) {
         return String.format("{\"authenticated\": %s}", authenticated);
     }
@@ -611,6 +640,8 @@ class StartHandlerTest {
         when(startService.createNewSessionWithExistingIdAndClientSession(
                         session, CLIENT_SESSION_ID))
                 .thenReturn(session);
+        when(authSessionService.getSession(SESSION_ID))
+                .thenReturn(Optional.ofNullable(new AuthSessionItem().withSessionId(SESSION_ID)));
     }
 
     private void usingInvalidSession() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -129,6 +129,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
         assertNull(userInfoResponse.getClaim("salt"));
         assertNull(userInfoResponse.getClaim("verified_mfa_method_type"));
         assertNull(userInfoResponse.getClaim("current_credential_strength"));
+        assertNull(userInfoResponse.getClaim("uplift_required"));
 
         assertThat(
                 authSessionExtension.getSession(TEST_SESSION_ID).get().getIsNewAccount(),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -12,6 +12,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH = "currentCredentialStrength";
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
+    public static final String ATTRIBUTE_UPLIFT_REQUIRED = "UpliftRequired";
 
     public enum AccountState {
         NEW,
@@ -26,6 +27,7 @@ public class AuthSessionItem {
     private AccountState isNewAccount;
     private CredentialTrustLevel currentCredentialStrength;
     private String internalCommonSubjectId;
+    private boolean upliftRequired;
 
     public AuthSessionItem() {}
 
@@ -112,6 +114,20 @@ public class AuthSessionItem {
     public AuthSessionItem withCurrentCredentialStrength(
             CredentialTrustLevel currentCredentialStrength) {
         this.currentCredentialStrength = currentCredentialStrength;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_UPLIFT_REQUIRED)
+    public boolean getUpliftRequired() {
+        return this.upliftRequired;
+    }
+
+    public void setUpliftRequired(boolean upliftRequired) {
+        this.upliftRequired = upliftRequired;
+    }
+
+    public AuthSessionItem withUpliftRequired(boolean upliftRequired) {
+        this.upliftRequired = upliftRequired;
         return this;
     }
 }


### PR DESCRIPTION
## What

Include uplift_required in userinfo response if Orch have requested it (Orch will [always request it](https://github.com/govuk-one-login/authentication-api/pull/5558)). 
If true, Orch will set auth time in the Orch session

## Testing

- [x] in sandpit, userinfo response includes `uplift_required=false` on a no-2FA journey. Then without logging out, `uplift_required=true` on a 2FA journey