### PR TITLE
BAU: Refactor Auth session setting in Start handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -209,8 +209,7 @@ public class StartHandler
                     Optional.ofNullable(startRequest.previousSessionId());
             CredentialTrustLevel currentCredentialStrength =
                     startRequest.currentCredentialStrength();
-            authSessionService.addOrUpdateSessionId(
-                    previousSessionId, session.getSessionId(), currentCredentialStrength);
+            authSessionService.addOrUpdateSessionId(previousSessionId, session.getSessionId());
 
             var clientSessionId =
                     getHeaderValueFromHeaders(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ClientStartInfo;
@@ -30,9 +31,11 @@ import uk.gov.di.authentication.frontendapi.entity.StartResponse;
 import uk.gov.di.authentication.frontendapi.entity.UserStartInfo;
 import uk.gov.di.authentication.frontendapi.services.StartService;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CountType;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
@@ -61,6 +64,7 @@ import java.util.stream.Stream;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -586,6 +590,35 @@ class StartHandlerTest {
         verifyNoInteractions(auditService);
     }
 
+    @Test
+    void shouldSetCurrentCredentialStrengthInAuthSession() throws ParseException {
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, false, null, false);
+        usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
+        usingValidClientSession();
+        usingValidSession();
+
+        var body =
+                format(
+                        """
+               { "rp-pairwise-id-for-reauth": %s,
+               "previous-govuk-signin-journey-id": %s,
+                "authenticated": %s,
+                "current-credential-strength": %s}
+                """,
+                        TEST_RP_PAIRWISE_ID,
+                        TEST_PREVIOUS_SIGN_IN_JOURNEY_ID,
+                        true,
+                        CredentialTrustLevel.MEDIUM_LEVEL);
+        var event = apiRequestEventWithHeadersAndBody(headersWithReauthenticate("true"), body);
+        handler.handleRequest(event, context);
+
+        var authSessionCaptor = ArgumentCaptor.forClass(AuthSessionItem.class);
+        verify(authSessionService, times(1)).updateSession(authSessionCaptor.capture());
+        assertEquals(
+                CredentialTrustLevel.MEDIUM_LEVEL,
+                authSessionCaptor.getAllValues().get(0).getCurrentCredentialStrength());
+    }
+
     private String makeRequestBodyWithAuthenticatedField(boolean authenticated) {
         return String.format("{\"authenticated\": %s}", authenticated);
     }
@@ -611,6 +644,8 @@ class StartHandlerTest {
         when(startService.createNewSessionWithExistingIdAndClientSession(
                         session, CLIENT_SESSION_ID))
                 .thenReturn(session);
+        when(authSessionService.getSession(SESSION_ID))
+                .thenReturn(Optional.ofNullable(new AuthSessionItem().withSessionId(SESSION_ID)));
     }
 
     private void usingInvalidSession() {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -72,7 +72,7 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
     }
 
     public void addSession(Optional<String> previousSessionId, String sessionId) {
-        authSessionService.addOrUpdateSessionId(previousSessionId, sessionId, null);
+        authSessionService.addOrUpdateSessionId(previousSessionId, sessionId);
     }
 
     public void updateSession(AuthSessionItem sessionItem) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.exceptions.AuthSessionException;
 import uk.gov.di.authentication.shared.helpers.InputSanitiser;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -40,10 +39,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
         this.configurationService = configurationService;
     }
 
-    public void addOrUpdateSessionId(
-            Optional<String> previousSessionId,
-            String newSessionId,
-            CredentialTrustLevel currentCredentialStrength) {
+    public void addOrUpdateSessionId(Optional<String> previousSessionId, String newSessionId) {
         try {
             Optional<AuthSessionItem> oldItem = Optional.empty();
             if (previousSessionId.isPresent()) {
@@ -54,7 +50,6 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                 AuthSessionItem newItem =
                         oldItem.get()
                                 .withSessionId(newSessionId)
-                                .withCurrentCredentialStrength(currentCredentialStrength)
                                 .withTimeToLive(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()
@@ -70,7 +65,6 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                         new AuthSessionItem()
                                 .withSessionId(newSessionId)
                                 .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
-                                .withCurrentCredentialStrength(currentCredentialStrength)
                                 .withTimeToLive(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -8,7 +8,6 @@ import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.exceptions.AuthSessionException;
 
 import java.time.Instant;
@@ -73,7 +72,7 @@ class AuthSessionServiceTest {
 
     @Test
     void shouldAddNewSessionWhenNoPreviousSessionGiven() {
-        authSessionService.addOrUpdateSessionId(Optional.empty(), NEW_SESSION_ID, null);
+        authSessionService.addOrUpdateSessionId(Optional.empty(), NEW_SESSION_ID);
 
         ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
         verify(table).putItem(captor.capture());
@@ -87,7 +86,7 @@ class AuthSessionServiceTest {
     void shouldAddNewSessionWhenNoPreviousSessionExists() {
         withNoSession();
 
-        authSessionService.addOrUpdateSessionId(Optional.of(SESSION_ID), NEW_SESSION_ID, null);
+        authSessionService.addOrUpdateSessionId(Optional.of(SESSION_ID), NEW_SESSION_ID);
 
         ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
         verify(table).putItem(captor.capture());
@@ -101,7 +100,7 @@ class AuthSessionServiceTest {
     void shouldPutAndDeleteSessionWhenUpdatingSessionId() {
         AuthSessionItem existingSession = withValidSession();
 
-        authSessionService.addOrUpdateSessionId(Optional.of(SESSION_ID), NEW_SESSION_ID, null);
+        authSessionService.addOrUpdateSessionId(Optional.of(SESSION_ID), NEW_SESSION_ID);
 
         ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
         verify(table).putItem(captor.capture());
@@ -110,36 +109,6 @@ class AuthSessionServiceTest {
         assertThat(updatedItem.getSessionId(), is(NEW_SESSION_ID));
         assertTrue(updatedItem.getTimeToLive() > Instant.now().getEpochSecond());
         verify(table).deleteItem(existingSession);
-    }
-
-    @Test
-    void shouldIncludeTheCurrentCredentialStrengthWhenUpdating() {
-        withValidSession();
-
-        authSessionService.addOrUpdateSessionId(
-                Optional.of(SESSION_ID), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL);
-
-        ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
-        verify(table).putItem(captor.capture());
-        AuthSessionItem savedItem = captor.getValue();
-
-        assertThat(savedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertThat(savedItem.getCurrentCredentialStrength(), is(CredentialTrustLevel.MEDIUM_LEVEL));
-    }
-
-    @Test
-    void shouldIncludeTheCurrentCredentialStrengthWhenNewSession() {
-        withNoSession();
-
-        authSessionService.addOrUpdateSessionId(
-                Optional.empty(), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL);
-
-        ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
-        verify(table).putItem(captor.capture());
-        AuthSessionItem savedItem = captor.getValue();
-
-        assertThat(savedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertThat(savedItem.getCurrentCredentialStrength(), is(CredentialTrustLevel.MEDIUM_LEVEL));
     }
 
     @Test


### PR DESCRIPTION
## What
The `addOrUpdateSessionId` method is specifically for updating the sessionId of the Auth session. Instead the Auth session is built with certain fields (including currentCredentialStrength) and then updated in Dynamo later in the handler.

## Testing

- [x] currentCredentialStrength still set properly in sandpit-auth-session table
