### PR TITLE
ATO-1243: Add a strongly consistent read retry when getting Auth sessions from DynamoDB

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -212,6 +212,13 @@ public class StartHandler
             authSessionService.addOrUpdateSessionId(
                     previousSessionId, session.getSessionId(), currentCredentialStrength);
 
+            // For testing only, remove in ATO-1244
+            var testSession = authSessionService.getSession(session.getSessionId());
+            if (testSession.isEmpty()) {
+                LOG.info("Auth session is still not found even after strongly consistent read");
+            }
+            //
+
             var clientSessionId =
                     getHeaderValueFromHeaders(
                             input.getHeaders(),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
@@ -53,6 +54,15 @@ public class BaseDynamoService<T> {
         return Optional.ofNullable(
                 dynamoTable.getItem(
                         Key.builder().partitionValue(partition).sortValue(sortKey).build()));
+    }
+
+    public Optional<T> getWithStronglyConsistentRead(String partition) {
+        GetItemEnhancedRequest request =
+                GetItemEnhancedRequest.builder()
+                        .key(k -> k.partitionValue(partition))
+                        .consistentRead(true)
+                        .build();
+        return Optional.ofNullable(dynamoTable.getItem(request));
     }
 
     public void delete(String partition) {


### PR DESCRIPTION
## What
Add a retry when when getting Orch and Auth sessions from DynamoDB which uses [strongly consistent read](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html). Strongly consistent read "returns a response with the most up-to-date data, reflecting the updates from all prior write operations that were successful".

This change is introduced as a result of an [incident](https://gds.slack.com/archives/C02HCLREVV5/p1732264067902419) which took place whereby in a small percentage (~0.4%) of cases, sessions were not being retrieved from DynamoDB shortly after they were written. By using strongly consistent read we can guarantee that the session will be retrieved if it's in the DB.

Note that strongly consistent read is twice as expensive as eventually consistent read (the default) which is why it's only used on the retry.

## Testing

- Going to deploy to prod and use the temp logging to check that strongly consistent read works for the ~0.4% of journeys that previously failed at that point 
