### PR TITLE
ATO-1147: swap roles over in production

### DIFF
--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -92,7 +92,7 @@ module "processing-identity" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = var.environment == "production" || var.is_orch_stubbed ? module.ipv_processing_identity_role.arn : module.ipv_processing_identity_role_with_orch_session_table_access.arn
+  lambda_role_arn                        = var.is_orch_stubbed ? module.ipv_processing_identity_role.arn : module.ipv_processing_identity_role_with_orch_session_table_access.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention


### PR DESCRIPTION
## What
We have already swapped them over on all other environments without issue here https://github.com/govuk-one-login/authentication-api/pull/5548, so here, we swap the role on production too.

## How to review
1. Code Review