### PR TITLE
BAU: Refactor Auth session setting in Start handler (2nd attempt)

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -9,6 +9,7 @@ shared_state_bucket                  = "digital-identity-dev-tfstate"
 test_clients_enabled                 = true
 internal_sector_uri                  = "https://identity.build.account.gov.uk"
 ipv_api_enabled                      = true
+start_session_refactor_enabled       = true
 
 # lockout config
 lockout_duration                          = 60

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -17,6 +17,7 @@ send_storage_token_to_ipv_enabled           = true
 call_ticf_cri                               = true
 support_reauth_signout_enabled              = true
 authentication_attempts_service_enabled     = true
+start_session_refactor_enabled              = true
 auth_frontend_public_encryption_key         = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs41htFRe62BIfwQZ0OCT

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -18,6 +18,7 @@ call_ticf_cri                           = true
 ticf_cri_service_call_timeout           = 10000
 support_reauth_signout_enabled          = true
 authentication_attempts_service_enabled = true
+start_session_refactor_enabled          = true
 
 orch_account_id                       = "590183975515"
 is_orch_stubbed                       = false

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -41,6 +41,7 @@ module "start" {
     IDENTITY_ENABLED                        = var.ipv_api_enabled
     INTERNAl_SECTOR_URI                     = var.internal_sector_uri
     AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED = var.authentication_attempts_service_enabled
+    START_SESSION_REFACTOR_ENABLED          = var.start_session_refactor_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.StartHandler::handleRequest"
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -746,6 +746,12 @@ variable "ipv_authorization_public_key" {
   description = "Public key for IPV"
 }
 
+variable "start_session_refactor_enabled" {
+  description = "Flag to enable a refactor of session setting in start handler"
+  type        = bool
+  default     = false
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -209,8 +209,12 @@ public class StartHandler
                     Optional.ofNullable(startRequest.previousSessionId());
             CredentialTrustLevel currentCredentialStrength =
                     startRequest.currentCredentialStrength();
-            authSessionService.addOrUpdateSessionId(
-                    previousSessionId, session.getSessionId(), currentCredentialStrength);
+            if (configurationService.isStartSessionRefactorEnabled()) {
+                authSessionService.addOrUpdateSessionId(previousSessionId, session.getSessionId());
+            } else {
+                authSessionService.addOrUpdateSessionId(
+                        previousSessionId, session.getSessionId(), currentCredentialStrength);
+            }
 
             var clientSessionId =
                     getHeaderValueFromHeaders(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ClientStartInfo;
@@ -30,9 +31,11 @@ import uk.gov.di.authentication.frontendapi.entity.StartResponse;
 import uk.gov.di.authentication.frontendapi.entity.UserStartInfo;
 import uk.gov.di.authentication.frontendapi.services.StartService;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CountType;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
@@ -61,6 +64,7 @@ import java.util.stream.Stream;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -586,6 +590,36 @@ class StartHandlerTest {
         verifyNoInteractions(auditService);
     }
 
+    @Test
+    void shouldSetCurrentCredentialStrengthInAuthSession() throws ParseException {
+        when(configurationService.isStartSessionRefactorEnabled()).thenReturn(true);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, false, null, false);
+        usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
+        usingValidClientSession();
+        usingValidSession();
+
+        var body =
+                format(
+                        """
+               { "rp-pairwise-id-for-reauth": %s,
+               "previous-govuk-signin-journey-id": %s,
+                "authenticated": %s,
+                "current-credential-strength": %s}
+                """,
+                        TEST_RP_PAIRWISE_ID,
+                        TEST_PREVIOUS_SIGN_IN_JOURNEY_ID,
+                        true,
+                        CredentialTrustLevel.MEDIUM_LEVEL);
+        var event = apiRequestEventWithHeadersAndBody(headersWithReauthenticate("true"), body);
+        handler.handleRequest(event, context);
+
+        var authSessionCaptor = ArgumentCaptor.forClass(AuthSessionItem.class);
+        verify(authSessionService, times(1)).updateSession(authSessionCaptor.capture());
+        assertEquals(
+                CredentialTrustLevel.MEDIUM_LEVEL,
+                authSessionCaptor.getAllValues().get(0).getCurrentCredentialStrength());
+    }
+
     private String makeRequestBodyWithAuthenticatedField(boolean authenticated) {
         return String.format("{\"authenticated\": %s}", authenticated);
     }
@@ -611,6 +645,8 @@ class StartHandlerTest {
         when(startService.createNewSessionWithExistingIdAndClientSession(
                         session, CLIENT_SESSION_ID))
                 .thenReturn(session);
+        when(authSessionService.getSession(SESSION_ID))
+                .thenReturn(Optional.ofNullable(new AuthSessionItem().withSessionId(SESSION_ID)));
     }
 
     private void usingInvalidSession() {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -72,7 +72,7 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
     }
 
     public void addSession(Optional<String> previousSessionId, String sessionId) {
-        authSessionService.addOrUpdateSessionId(previousSessionId, sessionId, null);
+        authSessionService.addOrUpdateSessionId(previousSessionId, sessionId);
     }
 
     public void updateSession(AuthSessionItem sessionItem) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -509,6 +509,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return List.of("build", "staging", "integration", "production").contains(getEnvironment());
     }
 
+    public boolean isStartSessionRefactorEnabled() {
+        return System.getenv()
+                .getOrDefault("START_SESSION_REFACTOR_ENABLED", FEATURE_SWITCH_OFF)
+                .equals(FEATURE_SWITCH_ON);
+    }
+
     private Map<String, String> getSsmRedisParameters() {
         if (ssmRedisParameters == null) {
             var getParametersRequest =

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -73,7 +73,7 @@ class AuthSessionServiceTest {
 
     @Test
     void shouldAddNewSessionWhenNoPreviousSessionGiven() {
-        authSessionService.addOrUpdateSessionId(Optional.empty(), NEW_SESSION_ID, null);
+        authSessionService.addOrUpdateSessionId(Optional.empty(), NEW_SESSION_ID);
 
         ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
         verify(table).putItem(captor.capture());
@@ -87,7 +87,7 @@ class AuthSessionServiceTest {
     void shouldAddNewSessionWhenNoPreviousSessionExists() {
         withNoSession();
 
-        authSessionService.addOrUpdateSessionId(Optional.of(SESSION_ID), NEW_SESSION_ID, null);
+        authSessionService.addOrUpdateSessionId(Optional.of(SESSION_ID), NEW_SESSION_ID);
 
         ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
         verify(table).putItem(captor.capture());
@@ -101,7 +101,7 @@ class AuthSessionServiceTest {
     void shouldPutAndDeleteSessionWhenUpdatingSessionId() {
         AuthSessionItem existingSession = withValidSession();
 
-        authSessionService.addOrUpdateSessionId(Optional.of(SESSION_ID), NEW_SESSION_ID, null);
+        authSessionService.addOrUpdateSessionId(Optional.of(SESSION_ID), NEW_SESSION_ID);
 
         ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
         verify(table).putItem(captor.capture());


### PR DESCRIPTION
_This is a second attempt at deploying as [the previous](https://github.com/govuk-one-login/authentication-api/pull/5561) was reverted_

## What
The `addOrUpdateSessionId` method is specifically for updating the sessionId of the Auth session. Instead the Auth session is built with certain fields (including currentCredentialStrength) and then updated in Dynamo later in the handler.

Feature flag implementation as the previous deploy caused errors in StartHandler in prod.

## Testing

- [x] currentCredentialStrength still set properly in sandpit-auth-session table
