### PR TITLE
ATO-983: AuthSession Get InternalCommonSubjectId - VerifyCodeHander /…

### DIFF
--- a/ci/terraform/auth-external-api/authdev1.tfvars
+++ b/ci/terraform/auth-external-api/authdev1.tfvars
@@ -10,3 +10,5 @@ endpoint_memory_size   = 1536
 orch_client_id                       = "orchestrationAuth"
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENB3csRUIdoaTHNn079Jl7JpiXzxF0p2ZIddCErxtIhGMTTqtbQZJCPesSKUVE/DQbpIko3mLoisuFgmQfFouCw=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM0ZehmrdDd89uYEFMTakbS7JgwCGXK7CAYMcVvy1pP5yV4O2mnDjYmvjZpvio2ctgOPxDuBb38QP1HD9WAOR2w=="
+
+use_auth_session_ics_id = true

--- a/ci/terraform/auth-external-api/authdev2.tfvars
+++ b/ci/terraform/auth-external-api/authdev2.tfvars
@@ -10,3 +10,5 @@ endpoint_memory_size   = 1536
 orch_client_id                       = "orchestrationAuth"
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/Yz722IDLN1mPqkPTihkwAkp/rUmBhnWynwAkE/YZlskX+N7VmwIjupla7O6hczlIOqkmPdQ1ayDqI8yY2QOiw=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwe8ey1GnTbH6E69EJFUkt4WQc1KltJwzOYNWUmK/+GxooRp+j9i9KWQ0WlV4gVI0iQkHY3ZKq+RWk94tSDHbyQ=="
+
+use_auth_session_ics_id = true

--- a/ci/terraform/auth-external-api/build.tfvars
+++ b/ci/terraform/auth-external-api/build.tfvars
@@ -13,3 +13,5 @@ orch_client_id                       = "orchestrationAuth"
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPrCBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmzWAucozlF6eykmgikXj2kI03O7VWwuA51+3Ak+stF2dddC60WXEKhrFumKBUnE5GhJNg4v0iN948Mwl+vz5Xw=="
 orch_api_vpc_endpoint_id             = "vpce-0867442e4d95fb43e"
+
+use_auth_session_ics_id = true

--- a/ci/terraform/auth-external-api/dev.tfvars
+++ b/ci/terraform/auth-external-api/dev.tfvars
@@ -9,3 +9,5 @@ scaling_trigger          = 0.6
 orch_client_id                       = "orchestrationAuth"
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHzG8IFx1jE1+Ul44jQk96efPknCXVxWS4PqLrKfR/31UQovFQLfyxA46uiMOvr7+0hRwFX1fQhagsIK+dfB5PA=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1P2vcnCdqx+MDwMTrJy47tV5ryTfkRaZYTpLsfCpC79ZgKSYEBcguuOUP4DvJpyHomBEnxeUs7s5KRgyMQjY4g=="
+
+use_auth_session_ics_id = true

--- a/ci/terraform/auth-external-api/integration.tfvars
+++ b/ci/terraform/auth-external-api/integration.tfvars
@@ -12,3 +12,5 @@ scaling_trigger        = 0.6
 orch_client_id                  = "orchestrationAuth"
 orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzzwKLypUL89WVaeTbfBZu0Fws8T7ppx89XLVfgXIoCs2P//N5qdghvzgNIgVehQ7CkzyorO/lnRlWPfjCG4Oxw=="
 orch_api_vpc_endpoint_id        = "vpce-0704b783d794cea52"
+
+use_auth_session_ics_id = true

--- a/ci/terraform/auth-external-api/sandpit.tfvars
+++ b/ci/terraform/auth-external-api/sandpit.tfvars
@@ -10,3 +10,5 @@ endpoint_memory_size   = 1536
 orch_client_id                  = "orchestrationAuth"
 orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5Px78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ=="
 orch_api_vpc_endpoint_id        = "vpce-0028f62dad635589a"
+
+use_auth_session_ics_id = true

--- a/ci/terraform/auth-external-api/staging.tfvars
+++ b/ci/terraform/auth-external-api/staging.tfvars
@@ -13,3 +13,5 @@ orch_client_id                       = "orchestrationAuth"
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5PP1PZmhiuHR57ZEfZXARt9/uiG+KKF+S7us4zEEEmEXZFR1H+kWP5RrLHQy9esxsul9X7V4pygDTY1I6QbMGg=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEw3VqLzY6ZFWmqruOpvMpPH8PWuQQ1zSWSgFy2sngA1GKybC0zuZluGHfZMnr/BGo+teQzbDCekLijPvlozXY1g=="
 orch_api_vpc_endpoint_id             = "vpce-0a81481bcd8257f5e"
+
+use_auth_session_ics_id = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -746,6 +746,12 @@ variable "ipv_authorization_public_key" {
   description = "Public key for IPV"
 }
 
+variable "use_auth_session_ics_id" {
+  type        = bool
+  default     = false
+  description = "Feature flag to enable reading the internal common subject id from Auth session instead of session."
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -53,6 +53,7 @@ module "verify_code" {
     SUPPORT_REAUTH_SIGNOUT_ENABLED           = var.support_reauth_signout_enabled
     REAUTH_ENTER_SMS_CODE_COUNT_TTL          = var.reauth_enter_sms_code_count_ttl
     AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED  = var.authentication_attempts_service_enabled
+    USE_AUTH_SESSION_ICS_ID                  = var.use_auth_session_ics_id
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest"
 

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -54,6 +54,7 @@ module "verify_mfa_code" {
     SUPPORT_REAUTH_SIGNOUT_ENABLED          = var.support_reauth_signout_enabled
     AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED = var.authentication_attempts_service_enabled
     REAUTH_ENTER_AUTH_APP_CODE_COUNT_TTL    = var.reauth_enter_auth_app_code_count_ttl
+    USE_AUTH_SESSION_ICS_ID                 = var.use_auth_session_ics_id
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler::handleRequest"
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
@@ -28,14 +28,26 @@ public class SessionHelper {
                 userContext.getUserProfile().isPresent()
                         ? userContext.getUserProfile().get()
                         : authenticationService.getUserProfileByEmail(session.getEmailAddress());
-        var internalCommonSubjectId =
-                session.getInternalCommonSubjectIdentifier() != null
-                        ? session.getInternalCommonSubjectIdentifier()
-                        : ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                                        userProfile,
-                                        configurationService.getInternalSectorUri(),
-                                        authenticationService)
-                                .getValue();
+        String internalCommonSubjectId;
+        if (configurationService.getUseAuthSessionInternalCommonSubjectId()) {
+            internalCommonSubjectId =
+                    authSession.getInternalCommonSubjectId() != null
+                            ? authSession.getInternalCommonSubjectId()
+                            : ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                                            userProfile,
+                                            configurationService.getInternalSectorUri(),
+                                            authenticationService)
+                                    .getValue();
+        } else {
+            internalCommonSubjectId =
+                    session.getInternalCommonSubjectIdentifier() != null
+                            ? session.getInternalCommonSubjectIdentifier()
+                            : ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                                            userProfile,
+                                            configurationService.getInternalSectorUri(),
+                                            authenticationService)
+                                    .getValue();
+        }
         LOG.info("Setting internal common subject identifier in user session");
         session.setInternalCommonSubjectIdentifier(internalCommonSubjectId);
         sessionService.storeOrUpdateSession(session);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -160,13 +160,15 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             VerifyMfaCodeRequest codeRequest,
             UserContext userContext) {
 
-        Optional<AuthSessionItem> authSession =
+        Optional<AuthSessionItem> authSessionOptional =
                 authSessionService.getSessionFromRequestHeaders(input.getHeaders());
-        if (authSession.isEmpty()) {
+        if (authSessionOptional.isEmpty()) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
-        } else {
-            attachAuthSessionIdToLogs(authSession.get());
         }
+
+        var authSession = authSessionOptional.get();
+
+        attachAuthSessionIdToLogs(authSession);
 
         var journeyType = codeRequest.getJourneyType();
         Optional<UserProfile> userProfileMaybe = userContext.getUserProfile();
@@ -183,7 +185,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
-                        userContext.getSession().getInternalCommonSubjectIdentifier(),
+                        configurationService.getUseAuthSessionInternalCommonSubjectId()
+                                ? authSession.getInternalCommonSubjectId()
+                                : userContext.getSession().getInternalCommonSubjectIdentifier(),
                         userContext.getSession().getEmailAddress(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
@@ -208,7 +212,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     codeRequest,
                     userContext,
                     subjectID,
-                    authSession.get(),
+                    authSession,
                     maybeRpPairwiseId,
                     client);
         } catch (Exception e) {
@@ -318,6 +322,10 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
         var errorResponseMaybe = mfaCodeProcessor.validateCode();
 
+        var internalCommonSubjectId =
+                configurationService.getUseAuthSessionInternalCommonSubjectId()
+                        ? authSession.getInternalCommonSubjectId()
+                        : session.getInternalCommonSubjectIdentifier();
         if (errorResponseMaybe.isPresent()) {
             var errorResponse = errorResponseMaybe.get();
             if (errorResponse.equals(ErrorResponse.ERROR_1041)) {
@@ -347,7 +355,13 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             }
         } else {
             processSuccessfulCodeSession(
-                    session, input, subjectId, codeRequest, mfaCodeProcessor, maybeRpPairwiseId);
+                    internalCommonSubjectId,
+                    session,
+                    input,
+                    subjectId,
+                    codeRequest,
+                    mfaCodeProcessor,
+                    maybeRpPairwiseId);
         }
 
         var auditableEvent =
@@ -358,7 +372,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
-                        session.getInternalCommonSubjectIdentifier(),
+                        internalCommonSubjectId,
                         session.getEmailAddress(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
@@ -432,6 +446,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
     }
 
     private void processSuccessfulCodeSession(
+            String internalCommonSubjectId,
             Session session,
             APIGatewayProxyRequestEvent input,
             String subjectId,
@@ -451,7 +466,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         }
         mfaCodeProcessor.processSuccessfulCodeRequest(
                 IpAddressHelper.extractIpAddress(input),
-                extractPersistentIdFromHeaders(input.getHeaders()));
+                extractPersistentIdFromHeaders(input.getHeaders()),
+                internalCommonSubjectId);
     }
 
     private FrontendAuditableEvent errorResponseAsFrontendAuditableEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -110,7 +110,8 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
     }
 
     @Override
-    public void processSuccessfulCodeRequest(String ipAddress, String persistentSessionId) {
+    public void processSuccessfulCodeRequest(
+            String ipAddress, String persistentSessionId, String internalCommonSubjectId) {
         switch (codeRequest.getJourneyType()) {
             case REGISTRATION:
                 dynamoService.setAuthAppAndAccountVerified(
@@ -121,6 +122,7 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
                         AuditService.UNKNOWN,
                         ipAddress,
                         persistentSessionId,
+                        internalCommonSubjectId,
                         false);
                 break;
             case ACCOUNT_RECOVERY:
@@ -132,11 +134,13 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
                         AuditService.UNKNOWN,
                         ipAddress,
                         persistentSessionId,
+                        internalCommonSubjectId,
                         true);
                 break;
             case SIGN_IN:
             case PASSWORD_RESET_MFA:
-                clearAccountRecoveryBlockIfPresent(AUTH_APP, ipAddress, persistentSessionId);
+                clearAccountRecoveryBlockIfPresent(
+                        AUTH_APP, ipAddress, persistentSessionId, internalCommonSubjectId);
         }
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
@@ -67,12 +67,13 @@ public abstract class MfaCodeProcessor {
             String phoneNumber,
             String ipAddress,
             String persistentSessionId,
+            String internalCommonSubjectId,
             boolean accountRecovery) {
 
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
-                        userContext.getSession().getInternalCommonSubjectIdentifier(),
+                        internalCommonSubjectId,
                         emailAddress,
                         ipAddress,
                         phoneNumber,
@@ -86,18 +87,19 @@ public abstract class MfaCodeProcessor {
     }
 
     void clearAccountRecoveryBlockIfPresent(
-            MFAMethodType mfaMethodType, String ipAddress, String persistentSessionId) {
+            MFAMethodType mfaMethodType,
+            String ipAddress,
+            String persistentSessionId,
+            String internalCommonSubjectId) {
         var accountRecoveryBlockPresent =
-                accountModifiersService.isAccountRecoveryBlockPresent(
-                        userContext.getSession().getInternalCommonSubjectIdentifier());
+                accountModifiersService.isAccountRecoveryBlockPresent(internalCommonSubjectId);
         if (accountRecoveryBlockPresent) {
             LOG.info("AccountRecovery block is present. Removing block");
-            accountModifiersService.removeAccountRecoveryBlockIfPresent(
-                    userContext.getSession().getInternalCommonSubjectIdentifier());
+            accountModifiersService.removeAccountRecoveryBlockIfPresent(internalCommonSubjectId);
             var auditContext =
                     auditContextFromUserContext(
                             userContext,
-                            userContext.getSession().getInternalCommonSubjectIdentifier(),
+                            internalCommonSubjectId,
                             emailAddress,
                             ipAddress,
                             AuditService.UNKNOWN,
@@ -111,5 +113,6 @@ public abstract class MfaCodeProcessor {
 
     public abstract Optional<ErrorResponse> validateCode();
 
-    public abstract void processSuccessfulCodeRequest(String ipAddress, String persistentSessionId);
+    public abstract void processSuccessfulCodeRequest(
+            String ipAddress, String persistentSessionId, String internalCommonSubjectId);
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -128,13 +128,13 @@ class VerifyCodeHandlerTest {
     private final UserProfile userProfile = mock(UserProfile.class);
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(TEST_SUBJECT_ID, SECTOR_HOST, SALT);
-    private final Session session =
-            new Session(SESSION_ID)
-                    .setEmailAddress(EMAIL)
-                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
     private final Session testSession =
             new Session("test-client-session-id").setEmailAddress(TEST_CLIENT_EMAIL);
-    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withInternalCommonSubjectId(expectedCommonSubject);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
@@ -230,6 +230,7 @@ class VerifyCodeHandlerTest {
         when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
+        when(configurationService.getUseAuthSessionInternalCommonSubjectId()).thenReturn(true);
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -128,7 +128,10 @@ class VerifyMfaCodeHandlerTest {
             new Session(SESSION_ID)
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(expectedCommonSubject);
-    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withInternalCommonSubjectId(expectedCommonSubject);
     private final Json objectMapper = SerializationService.getInstance();
     public VerifyMfaCodeHandler handler;
 
@@ -189,6 +192,7 @@ class VerifyMfaCodeHandlerTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(MAX_RETRIES);
         when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
         when(configurationService.getMaxEmailReAuthRetries()).thenReturn(MAX_RETRIES);
+        when(configurationService.getUseAuthSessionInternalCommonSubjectId()).thenReturn(true);
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(clientSession));
         when(authSessionService.getSessionFromRequestHeaders(any()))

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -251,7 +251,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(
                 authSession.getCurrentCredentialStrength(),
                 equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
-        verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
+        verify(authAppCodeProcessor)
+                .processSuccessfulCodeRequest(anyString(), anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
@@ -338,7 +339,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(
                 authSession.getCurrentCredentialStrength(),
                 equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
-        verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
+        verify(authAppCodeProcessor)
+                .processSuccessfulCodeRequest(anyString(), anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
@@ -384,7 +386,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(
                 authSession.getCurrentCredentialStrength(),
                 equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
-        verify(phoneNumberCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
+        verify(phoneNumberCodeProcessor)
+                .processSuccessfulCodeRequest(anyString(), anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
@@ -430,7 +433,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(
                 authSession.getCurrentCredentialStrength(),
                 equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
-        verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
+        verify(authAppCodeProcessor)
+                .processSuccessfulCodeRequest(anyString(), anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
@@ -476,7 +480,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(
                 authSession.getCurrentCredentialStrength(),
                 equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
-        verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
+        verify(authAppCodeProcessor)
+                .processSuccessfulCodeRequest(anyString(), anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -68,14 +68,15 @@ class PhoneNumberCodeProcessorTest {
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final String SESSION_ID = "a-session-id";
     private static final String IP_ADDRESS = "123.123.123.123";
-    private static final String INTERNAL_SUB_ID = "urn:fdc:gov.uk:2022:" + IdGenerator.generate();
+    private static final String INTERNAL_COMMON_SUBJECT_ID =
+            "urn:fdc:gov.uk:2022:" + IdGenerator.generate();
     private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
     private static final AuditContext AUDIT_CONTEXT =
             new AuditContext(
                     CLIENT_ID,
                     CLIENT_SESSION_ID,
                     SESSION_ID,
-                    INTERNAL_SUB_ID,
+                    INTERNAL_COMMON_SUBJECT_ID,
                     CommonTestVariables.EMAIL,
                     IP_ADDRESS,
                     CommonTestVariables.UK_MOBILE_NUMBER,
@@ -256,7 +257,8 @@ class PhoneNumberCodeProcessorTest {
                         CommonTestVariables.UK_MOBILE_NUMBER),
                 CodeRequestType.SMS_REGISTRATION);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_COMMON_SUBJECT_ID);
 
         verify(authenticationService)
                 .updatePhoneNumberAndAccountVerifiedStatus(
@@ -284,7 +286,8 @@ class PhoneNumberCodeProcessorTest {
                         CommonTestVariables.UK_MOBILE_NUMBER),
                 CodeRequestType.SMS_ACCOUNT_RECOVERY);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_COMMON_SUBJECT_ID);
 
         verify(authenticationService)
                 .setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(
@@ -306,7 +309,8 @@ class PhoneNumberCodeProcessorTest {
                 new VerifyMfaCodeRequest(MFAMethodType.SMS, VALID_CODE, JourneyType.SIGN_IN),
                 CodeRequestType.SMS_REGISTRATION);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_COMMON_SUBJECT_ID);
 
         verifyNoInteractions(authenticationService);
         verifyNoInteractions(auditService);
@@ -324,7 +328,8 @@ class PhoneNumberCodeProcessorTest {
                         CommonTestVariables.UK_MOBILE_NUMBER),
                 CodeRequestType.SMS_REGISTRATION);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_COMMON_SUBJECT_ID);
 
         verify(sqsClient)
                 .send(
@@ -335,7 +340,7 @@ class PhoneNumberCodeProcessorTest {
                                                 CommonTestVariables.UK_MOBILE_NUMBER,
                                                 true,
                                                 journeyType,
-                                                INTERNAL_SUB_ID)));
+                                                INTERNAL_COMMON_SUBJECT_ID)));
     }
 
     @Test
@@ -351,7 +356,8 @@ class PhoneNumberCodeProcessorTest {
                 CodeRequestType.SMS_ACCOUNT_RECOVERY);
         when(userProfile.getPhoneNumber()).thenReturn(CommonTestVariables.UK_MOBILE_NUMBER);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_COMMON_SUBJECT_ID);
 
         verifyNoInteractions(sqsClient);
     }
@@ -367,7 +373,8 @@ class PhoneNumberCodeProcessorTest {
                         CommonTestVariables.UK_MOBILE_NUMBER),
                 CodeRequestType.SMS_REGISTRATION);
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_COMMON_SUBJECT_ID);
 
         verifyNoInteractions(sqsClient);
     }
@@ -384,7 +391,8 @@ class PhoneNumberCodeProcessorTest {
         when(clientRegistry.isSmokeTest()).thenReturn(true);
         when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
 
-        phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
+        phoneNumberCodeProcessor.processSuccessfulCodeRequest(
+                IP_ADDRESS, PERSISTENT_ID, INTERNAL_COMMON_SUBJECT_ID);
 
         verifyNoInteractions(sqsClient);
     }
@@ -393,7 +401,7 @@ class PhoneNumberCodeProcessorTest {
         var differentPhoneNumber = CommonTestVariables.UK_MOBILE_NUMBER.replace("789", "987");
         when(session.getEmailAddress()).thenReturn(CommonTestVariables.EMAIL);
         when(session.getSessionId()).thenReturn(SESSION_ID);
-        when(session.getInternalCommonSubjectIdentifier()).thenReturn(INTERNAL_SUB_ID);
+        when(session.getInternalCommonSubjectIdentifier()).thenReturn(INTERNAL_COMMON_SUBJECT_ID);
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(userContext.getClientId()).thenReturn(CLIENT_ID);
         when(userContext.getSession()).thenReturn(session);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -338,5 +338,10 @@ public abstract class HandlerIntegrationTest<Q, S> {
         public String getFrontendBaseUrl() {
             return "http://localhost:3000/reset-password?code=";
         }
+
+        @Override
+        public boolean getUseAuthSessionInternalCommonSubjectId() {
+            return true;
+        }
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -159,15 +159,6 @@ public class RedisExtension
                 3600);
     }
 
-    public void addInternalCommonSubjectIdToSession(
-            String sessionId, String internalCommonSubjectId) throws Json.JsonException {
-        var session =
-                objectMapper
-                        .readValue(redis.getValue(sessionId), Session.class)
-                        .setInternalCommonSubjectIdentifier(internalCommonSubjectId);
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
-    }
-
     public void addEmailToSession(String sessionId, String emailAddress) throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.setEmailAddress(emailAddress);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -678,4 +678,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     public String getIPVAuthorisationClientId() {
         return System.getenv().getOrDefault("IPV_AUTHORISATION_CLIENT_ID", "");
     }
+
+    public boolean getUseAuthSessionInternalCommonSubjectId() {
+        return System.getenv()
+                .getOrDefault("USE_AUTH_SESSION_ICS_ID", FEATURE_SWITCH_OFF)
+                .equals(FEATURE_SWITCH_ON);
+    }
 }


### PR DESCRIPTION
… VerifyMfaCodeHandler - Introduce Feature Flag

Read internal common subject identifier from auth session in VerifyCodeHander / VerifyMfaCodeHandler (disabled for production)

Tested in sandpit including acceptance tests.