### PR TITLE
ATO-1104: Temporarily disable TTL configuration

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -698,7 +698,7 @@ resource "aws_dynamodb_table" "auth_session_table" {
 
   ttl {
     attribute_name = "TimeToLive"
-    enabled        = true
+    enabled        = false
   }
 
   point_in_time_recovery {


### PR DESCRIPTION
## What: 

To be able to modify the `attribute_name` field we firstly need to disable[1] the TTL configuration first to then be able to enable the renamed attribute, which we will set to the existing attribute `ttl`.

The plan: 
1) Merge this PR, this will disable the TTL config. Any changes merged before step 2 is merged will fail at the deploy shared module stage.  (This PR)
2) [Merge the PR which comments out](https://github.com/govuk-one-login/authentication-api/pull/5576) the ttl config block. Deploying this will result in a no-op update to the shared module but allow subsequent deployments to succeed. (Tested in sandpit)
3) After an hour, merge the [PR re-enabling the ttl config with the renamed attribute](https://github.com/govuk-one-login/authentication-api/pull/5439)


> [!NOTE]  
>  Once this is merged, we must wait at least one hour before merging the subsequent PR, which will re-enable the TTL config with a new attribute. This is due to the underlying way dynamoDB works[2]


[1] - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-timetolivespecification.html
[2] - https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTimeToLive.html#API_UpdateTimeToLive_RequestSyntax:~:text=It%20can%20take%20up%20to%20one%20hour%20for%20the%20change%20to%20fully%20process.%20Any%20additional%20UpdateTimeToLive%20calls%20for%20the%20same%20table%20during%20this%20one%20hour%20duration%20result%20in%20a%20ValidationException.

## How to review

- Code review the commit
- Deploy Sandpit
- Deploy the changes in order, waiting the required amount of time between them

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs: 
- PR which comments out config: https://github.com/govuk-one-login/authentication-api/pull/5576
- PR which re-enables this: https://github.com/govuk-one-login/authentication-api/pull/5439

