### PR TITLE
AUT-3906: Add cost allocation tags to authentication-api

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -10,6 +10,9 @@ module "account_management_api_authenticate_role" {
     aws_iam_policy.parameter_policy.arn,
     module.account_management_txma_audit.access_policy_arn
   ]
+  extra_tags = {
+    Service = "authenticate"
+  }
 }
 
 module "authenticate" {
@@ -59,6 +62,7 @@ module "authenticate" {
   account_alias         = data.aws_iam_account_alias.current.account_alias
   slack_event_topic_arn = data.aws_sns_topic.slack_events.arn
   dynatrace_secret      = local.dynatrace_secret
+
 
   depends_on = [module.account_management_api_authenticate_role]
 }

--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -10,6 +10,9 @@ module "account_management_api_authorizer_role" {
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     local.client_registry_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "authorizer"
+  }
 }
 
 locals {

--- a/ci/terraform/account-management/delete-account.tf
+++ b/ci/terraform/account-management/delete-account.tf
@@ -13,6 +13,9 @@ module "account_management_api_remove_account_role" {
     aws_iam_policy.dynamo_am_account_modifiers_delete_access_policy.arn,
     local.account_modifiers_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "delete-account"
+  }
 }
 
 module "delete_account" {

--- a/ci/terraform/account-management/manually-delete-account.tf
+++ b/ci/terraform/account-management/manually-delete-account.tf
@@ -15,6 +15,9 @@ module "account_management_manually_delete_account_role" {
     aws_iam_policy.permit_send_email_queue_policy.arn,
     aws_iam_policy.legacy_account_deletion_topic.arn
   ]
+  extra_tags = {
+    Service = "manually-delete-account"
+  }
 }
 
 resource "aws_lambda_function" "manually_delete_account_lambda" {

--- a/ci/terraform/account-management/send-otp-notification.tf
+++ b/ci/terraform/account-management/send-otp-notification.tf
@@ -16,6 +16,9 @@ module "account_management_api_send_notification_role" {
     local.email_check_results_encryption_policy_arn,
     aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
   ]
+  extra_tags = {
+    Service = "send-otp-notification"
+  }
 }
 
 module "send_otp_notification" {

--- a/ci/terraform/account-management/site.tf
+++ b/ci/terraform/account-management/site.tf
@@ -38,7 +38,12 @@ provider "aws" {
 
   default_tags {
     tags = {
-      environment = var.environment
+      Environment = var.environment
+      Owner       = "di-authentication@digital.cabinet-office.gov.uk"
+      Product     = "GOV.UK Sign In"
+      System      = "account-management-api"
+      # Don't set `Service` by default as it's not always applicable
+
       application = "account-management-api"
     }
   }

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -15,6 +15,9 @@ module "account_management_api_update_email_role" {
     local.user_profile_encryption_policy_arn,
     local.email_check_results_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "update-email"
+  }
 }
 
 module "update_email" {

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -13,6 +13,9 @@ module "account_management_api_update_password_role" {
     local.common_passwords_encryption_policy_arn,
     local.user_profile_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "update-password"
+  }
 }
 
 module "update_password" {

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -12,6 +12,9 @@ module "account_management_api_update_phone_number_role" {
     module.account_management_txma_audit.access_policy_arn,
     local.user_profile_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "update-phone-number"
+  }
 }
 
 module "update_phone_number" {

--- a/ci/terraform/auth-external-api/site.tf
+++ b/ci/terraform/auth-external-api/site.tf
@@ -22,7 +22,12 @@ provider "aws" {
 
   default_tags {
     tags = {
-      environment = var.environment
+      Environment = var.environment
+      Owner       = "di-authentication@digital.cabinet-office.gov.uk"
+      Product     = "GOV.UK Sign In"
+      System      = "auth-external-api"
+      # Don't set `Service` by default as it's not always applicable
+
       application = "auth-external-api"
     }
   }

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -16,6 +16,9 @@ module "auth_token_role" {
     aws_iam_policy.access_token_store_signing_key_kms_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn
   ]
+  extra_tags = {
+    Service = "auth-token"
+  }
 }
 
 module "auth_token" {

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -17,6 +17,9 @@ module "auth_userinfo_role" {
     aws_iam_policy.dynamo_auth_session_write_policy.arn,
     aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
+  extra_tags = {
+    Service = "auth-userinfo"
+  }
 }
 
 module "auth_userinfo" {

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -9,6 +9,9 @@ module "delivery_receipts_api_notify_callback_role" {
     aws_iam_policy.bulk_user_email_dynamo_encryption_key_kms_policy.arn,
     local.user_profile_encryption_policy_arn,
   ], local.deploy_bulk_email_users_count == 1 ? [aws_iam_policy.bulk_user_email_receipts_dynamo_write_access[0].arn, aws_iam_policy.bulk_user_email_receipts_user_profile_dynamo_read_access.arn] : [])
+  extra_tags = {
+    Service = "notify-callback"
+  }
 }
 
 module "notify_callback" {

--- a/ci/terraform/delivery-receipts/site.tf
+++ b/ci/terraform/delivery-receipts/site.tf
@@ -33,7 +33,12 @@ provider "aws" {
 
   default_tags {
     tags = {
-      environment = var.environment
+      Environment = var.environment
+      Owner       = "di-authentication@digital.cabinet-office.gov.uk"
+      Product     = "GOV.UK Sign In"
+      System      = "delivery-receipts-api"
+      # Don't set `Service` by default as it's not always applicable
+
       application = "delivery-receipts-api"
     }
   }

--- a/ci/terraform/interventions-api-stub/lambda.tf
+++ b/ci/terraform/interventions-api-stub/lambda.tf
@@ -4,6 +4,9 @@ module "account_interventions_stub_role" {
   role_name          = "account_interventions_stub-role"
   vpc_arn            = local.authentication_vpc_arn
   policies_to_attach = [aws_iam_policy.stub_interventions_dynamo_read_access.arn]
+  extra_tags = {
+    Service = "account-interventions-stub"
+  }
 }
 
 module "account_interventions_stub_lambda" {

--- a/ci/terraform/interventions-api-stub/site.tf
+++ b/ci/terraform/interventions-api-stub/site.tf
@@ -20,7 +20,12 @@ provider "aws" {
 
   default_tags {
     tags = {
-      environment = var.environment
+      Environment = var.environment
+      Owner       = "di-authentication@digital.cabinet-office.gov.uk"
+      Product     = "GOV.UK Sign In"
+      System      = "interventions-api-stub"
+      # Don't set `Service` by default as it's not always applicable
+
       application = "interventions-api-stub"
     }
   }

--- a/ci/terraform/modules/api-gateway/api-gateway.tf
+++ b/ci/terraform/modules/api-gateway/api-gateway.tf
@@ -1,3 +1,5 @@
+
+
 resource "aws_api_gateway_rest_api" "rest_api" {
   name = var.api_gateway_name
 
@@ -99,6 +101,8 @@ resource "aws_api_gateway_usage_plan" "api_usage_plan" {
     api_id = aws_api_gateway_rest_api.rest_api.id
     stage  = aws_api_gateway_stage.stage.stage_name
   }
+
+  tags = var.extra_tags
   # checkov:skip=CKV_AWS_120:We do not want API caching on this Lambda
 }
 
@@ -129,6 +133,8 @@ resource "aws_cloudwatch_log_group" "access_logs" {
   #checkov:skip=CKV_AWS_338:Cloudwatch logs do not need to be retained for a year, as they are shipped elsewhere (Splunk)
   retention_in_days = var.cloudwatch_log_retention
   kms_key_id        = var.cloudwatch_encryption_key_arn
+
+  tags = var.extra_tags
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "stage_access_log_subscription" {
@@ -148,6 +154,8 @@ resource "aws_cloudwatch_log_group" "execution_logs" {
   #checkov:skip=CKV_AWS_338:Cloudwatch logs do not need to be retained for a year, as they are shipped elsewhere (Splunk)
   retention_in_days = var.cloudwatch_log_retention
   kms_key_id        = var.cloudwatch_encryption_key_arn
+
+  tags = var.extra_tags
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "execution_log_subscription" {
@@ -177,6 +185,8 @@ resource "aws_cloudwatch_log_group" "waf_logs" {
   #checkov:skip=CKV_AWS_338:Cloudwatch logs do not need to be retained for a year, as they are shipped elsewhere (Splunk)
   retention_in_days = var.cloudwatch_log_retention
   kms_key_id        = var.cloudwatch_encryption_key_arn
+
+  tags = var.extra_tags
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "waf_log_subscription" {

--- a/ci/terraform/modules/endpoint-lambda/alerts.tf
+++ b/ci/terraform/modules/endpoint-lambda/alerts.tf
@@ -21,6 +21,8 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_cloudwatch_alarm" {
   threshold           = var.lambda_log_alarm_threshold
   alarm_description   = "${var.lambda_log_alarm_threshold} or more errors have occurred in the ${var.environment} ${var.endpoint_name} lambda.ACCOUNT: ${var.account_alias}"
   alarm_actions       = [var.slack_event_topic_arn]
+
+  tags = local.extra_tags
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_error_rate_cloudwatch_alarm" {
@@ -67,4 +69,6 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_rate_cloudwatch_alarm" {
     }
   }
   alarm_actions = [var.slack_event_topic_arn]
+
+  tags = local.extra_tags
 }

--- a/ci/terraform/modules/endpoint-lambda/lambda.tf
+++ b/ci/terraform/modules/endpoint-lambda/lambda.tf
@@ -42,12 +42,12 @@ resource "aws_lambda_function" "endpoint_lambda" {
     }
   }
 
-  tags = var.extra_tags
+  tags = local.extra_tags
 }
 
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
   name              = "/aws/lambda/${aws_lambda_function.endpoint_lambda.function_name}"
-  tags              = var.extra_tags
+  tags              = local.extra_tags
   kms_key_id        = var.cloudwatch_key_arn
   retention_in_days = var.cloudwatch_log_retention
 
@@ -110,6 +110,7 @@ resource "aws_appautoscaling_target" "lambda_target" {
   service_namespace  = "lambda"
 
   depends_on = [aws_lambda_provisioned_concurrency_config.endpoint_lambda_concurrency_config]
+  tags       = local.extra_tags
 }
 
 resource "aws_appautoscaling_policy" "provisioned-concurrency-policy" {

--- a/ci/terraform/modules/endpoint-lambda/variables.tf
+++ b/ci/terraform/modules/endpoint-lambda/variables.tf
@@ -74,6 +74,15 @@ variable "extra_tags" {
   description = "Extra tags to apply to resources"
 }
 
+locals {
+  extra_tags = merge(
+    var.extra_tags,
+    {
+      Service = var.endpoint_name
+    }
+  )
+}
+
 variable "cloudwatch_key_arn" {
   type        = string
   description = "The ARN of the KMS key to use log encryption"

--- a/ci/terraform/modules/endpoint-module/alerts.tf
+++ b/ci/terraform/modules/endpoint-module/alerts.tf
@@ -30,6 +30,8 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_cloudwatch_alarm" {
   threshold           = var.lambda_log_alarm_threshold
   alarm_description   = local.error_alarm_description
   alarm_actions       = [data.aws_sns_topic.slack_events.arn]
+
+  tags = local.extra_tags
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_error_rate_cloudwatch_alarm" {
@@ -76,6 +78,8 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_rate_cloudwatch_alarm" {
     }
   }
   alarm_actions = [data.aws_sns_topic.slack_events.arn]
+
+  tags = local.extra_tags
 }
 
 data "aws_sns_topic" "slack_events" {

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -34,7 +34,7 @@ resource "aws_lambda_function" "endpoint_lambda" {
 
   runtime = var.handler_runtime
 
-  tags = var.extra_tags
+  tags = local.extra_tags
 }
 
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
@@ -105,6 +105,7 @@ resource "aws_appautoscaling_target" "lambda_target" {
   service_namespace  = "lambda"
 
   depends_on = [aws_lambda_provisioned_concurrency_config.endpoint_lambda_concurrency_config]
+  tags       = local.extra_tags
 }
 
 resource "aws_appautoscaling_policy" "provisioned-concurrency-policy" {

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -117,6 +117,16 @@ variable "extra_tags" {
   description = "Extra tags to apply to resources"
 }
 
+locals {
+  extra_tags = merge(
+    var.extra_tags,
+    {
+      Service = var.endpoint_name
+    }
+  )
+}
+
+
 variable "authorizer_id" {
   type    = string
   default = null

--- a/ci/terraform/modules/txma-audit-queue/key.tf
+++ b/ci/terraform/modules/txma-audit-queue/key.tf
@@ -7,7 +7,7 @@ resource "aws_kms_key" "txma_audit_queue_encryption_key" {
 
   policy = data.aws_iam_policy_document.txma_audit_queue_encryption_key_access_policy.json
 
-  tags = var.extra_tags
+  tags = local.extra_tags
 }
 
 resource "aws_kms_alias" "txma_audit_queue_encryption_key_alias" {

--- a/ci/terraform/modules/txma-audit-queue/policy.tf
+++ b/ci/terraform/modules/txma-audit-queue/policy.tf
@@ -28,4 +28,6 @@ resource "aws_iam_policy" "txma_audit_queue_access_policy" {
   description = "IAM Policy for write access to the TxMA audit queue"
 
   policy = data.aws_iam_policy_document.txma_audit_queue_access_policy_document.json
+
+  tags = local.extra_tags
 }

--- a/ci/terraform/modules/txma-audit-queue/queue.tf
+++ b/ci/terraform/modules/txma-audit-queue/queue.tf
@@ -11,7 +11,7 @@ resource "aws_sqs_queue" "txma_audit_queue" {
     maxReceiveCount     = 3
   })
 
-  tags = var.extra_tags
+  tags = local.extra_tags
 }
 
 resource "aws_sqs_queue" "txma_audit_dead_letter_queue" {
@@ -22,7 +22,7 @@ resource "aws_sqs_queue" "txma_audit_dead_letter_queue" {
 
   message_retention_seconds = 604800
 
-  tags = var.extra_tags
+  tags = local.extra_tags
 }
 
 resource "aws_sqs_queue_policy" "txma_audit_queue_subscription" {

--- a/ci/terraform/modules/txma-audit-queue/variables.tf
+++ b/ci/terraform/modules/txma-audit-queue/variables.tf
@@ -17,3 +17,9 @@ variable "service_name" {
   type        = string
   description = "Name of the service that will be using these queues. Used for disambiguation"
 }
+
+locals {
+  extra_tags = merge(var.extra_tags, {
+    ServiceName = var.service_name
+  })
+}

--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -16,6 +16,9 @@ module "frontend_api_account_interventions_role" {
     ], local.deploy_ticf_cri_count == 1 ? [
     aws_iam_policy.ticf_cri_lambda_invocation_policy[0].arn,
   ] : [])
+  extra_tags = {
+    Service = "account-interventions"
+  }
 }
 
 module "account_interventions" {

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -17,6 +17,9 @@ module "frontend_api_account_recovery_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "account-recovery"
+  }
 }
 
 

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -15,6 +15,9 @@ module "oidc_auth_code_role" {
     local.user_credentials_encryption_policy_arn,
     local.user_profile_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "auth-code"
+  }
 }
 
 module "auth-code" {

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -20,6 +20,9 @@ module "frontend_api_orch_auth_code_role" {
     local.user_credentials_encryption_policy_arn,
     local.email_check_results_encryption_policy_arn,
   ]
+  extra_tags = {
+    Service = "orch-auth-code"
+  }
 }
 
 module "orch_auth_code" {

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -18,6 +18,9 @@ module "oidc_api_authentication_callback_role" {
     local.client_registry_encryption_policy_arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn
   ]
+  extra_tags = {
+    Service = "orchestration-redirect"
+  }
 }
 
 

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -20,6 +20,9 @@ module "oidc_authorize_role" {
     local.user_credentials_encryption_policy_arn,
     aws_iam_policy.oidc_token_kms_signing_policy.arn
   ]
+  extra_tags = {
+    Service = "authorize"
+  }
 }
 
 module "authorize" {

--- a/ci/terraform/oidc/authorizer-orch-frontend.tf
+++ b/ci/terraform/oidc/authorizer-orch-frontend.tf
@@ -3,6 +3,9 @@ module "orch_frontend_authorizer_role" {
   environment = var.environment
   role_name   = "orch-fe-authorizer-role"
   vpc_arn     = local.authentication_vpc_arn
+  extra_tags = {
+    Service = "orch-frontend-authorizer"
+  }
 }
 
 locals {
@@ -42,6 +45,9 @@ resource "aws_lambda_function" "orch_frontend_authorizer" {
     }
   }
   kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
+  tags = {
+    Service = "orch-frontend-authorizer"
+  }
 }
 
 resource "aws_iam_role" "orch_frontend_authorizer_invocation_role" {
@@ -49,6 +55,9 @@ resource "aws_iam_role" "orch_frontend_authorizer_invocation_role" {
   path = "/"
 
   assume_role_policy = data.aws_iam_policy_document.api_gateway_can_assume_policy.json
+  tags = {
+    Service = "orch-frontend-authorizer"
+  }
 }
 
 
@@ -107,6 +116,9 @@ resource "aws_appautoscaling_target" "orch_frontend_authorizer_lambda_target" {
   resource_id        = "function:${aws_lambda_function.orch_frontend_authorizer.function_name}:${aws_lambda_alias.orch_frontend_authorizer_alias.name}"
   scalable_dimension = "lambda:function:ProvisionedConcurrency"
   service_namespace  = "lambda"
+  tags = {
+    Service = "orch-frontend-authorizer"
+  }
 }
 
 resource "aws_appautoscaling_policy" "orch_frontend_authorizer_concurrency_policy" {
@@ -149,6 +161,9 @@ resource "aws_cloudwatch_metric_alarm" "lambda_authorizer_error_cloudwatch_alarm
   threshold           = local.alert_error_threshold
   alarm_description   = "${local.alert_error_threshold} or more errors have occurred in the ${var.environment} ${aws_lambda_function.orch_frontend_authorizer.function_name} lambda. ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
   alarm_actions       = [data.aws_sns_topic.slack_events.arn]
+  tags = {
+    Service = "orch-frontend-authorizer"
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_authorizer_error_rate_cloudwatch_alarm" {
@@ -194,4 +209,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_authorizer_error_rate_cloudwatch_
     }
   }
   alarm_actions = [data.aws_sns_topic.slack_events.arn]
+  tags = {
+    Service = "orch-frontend-authorizer"
+  }
 }

--- a/ci/terraform/oidc/backchannel-logout-request.tf
+++ b/ci/terraform/oidc/backchannel-logout-request.tf
@@ -7,6 +7,9 @@ module "backchannel_logout_request_role" {
     aws_iam_policy.oidc_token_kms_signing_policy.arn,
     aws_iam_policy.back_channel_logout_queue_read_access_policy.arn
   ]
+  extra_tags = {
+    Service = "backchannel-logout-request"
+  }
 }
 
 resource "aws_lambda_function" "backchannel_logout_request_lambda" {
@@ -33,6 +36,9 @@ resource "aws_lambda_function" "backchannel_logout_request_lambda" {
     })
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  tags = {
+    Service = "backchannel-logout-request"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "backchannel_logout_request_lambda_log_group" {
@@ -74,4 +80,7 @@ resource "aws_lambda_event_source_mapping" "backchannel_logout_lambda_sqs_mappin
     aws_sqs_queue.back_channel_logout_queue,
     aws_lambda_function.backchannel_logout_request_lambda
   ]
+  tags = {
+    Service = "backchannel-logout-request"
+  }
 }

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -15,6 +15,9 @@ module "frontend_api_check_email_fraud_block_role" {
     local.client_registry_encryption_policy_arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
   ]
+  extra_tags = {
+    Service = "check-email-fraud-block"
+  }
 }
 
 module "check_email_fraud_block" {

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -16,6 +16,9 @@ module "frontend_api_check_reauth_user_role" {
     aws_iam_policy.dynamo_authentication_attempt_read_policy.arn,
     aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn
   ]
+  extra_tags = {
+    Service = "check-reauth-user"
+  }
 }
 
 module "check_reauth_user" {

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -15,6 +15,9 @@ module "doc_app_callback_role" {
     module.oidc_txma_audit.access_policy_arn,
     local.doc_app_credential_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "doc-app-callback"
+  }
 }
 
 module "doc-app-callback" {

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -12,6 +12,9 @@ module "identity_progress_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
   ]
+  extra_tags = {
+    Service = "identity-progress"
+  }
 }
 
 module "identity_progress" {

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -22,6 +22,9 @@ module "ipv_callback_role" {
     local.user_profile_encryption_policy_arn,
     aws_iam_policy.spot_queue_write_access_policy.arn
   ]
+  extra_tags = {
+    Service = "ipv-callback"
+  }
 }
 
 module "ipv-callback" {

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -10,6 +10,9 @@ module "ipv_capacity_role" {
     aws_iam_policy.ipv_capacity_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
+  extra_tags = {
+    Service = "ipv-capacity"
+  }
 }
 
 module "ipv-capacity" {

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -9,6 +9,9 @@ module "oidc_jwks_role" {
     aws_iam_policy.doc_app_auth_kms_policy.arn,
     local.doc_app_credential_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "jwks.json"
+  }
 }
 
 module "jwks" {

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -25,6 +25,9 @@ module "frontend_api_login_role" {
   ]
   // The joint read/write policy above is required because we've reached the managed polices per role quota limit (20)
   // Ticket raised to request quota increase (ATO-1056)
+  extra_tags = {
+    Service = "login"
+  }
 }
 
 

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -16,6 +16,9 @@ module "oidc_logout_role" {
     local.user_credentials_encryption_policy_arn,
     aws_iam_policy.back_channel_logout_queue_write_access_policy.arn
   ]
+  extra_tags = {
+    Service = "logout"
+  }
 }
 
 module "logout" {

--- a/ci/terraform/oidc/mfa-reset-authorize.tf
+++ b/ci/terraform/oidc/mfa-reset-authorize.tf
@@ -13,6 +13,9 @@ module "mfa_reset_authorize_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
   ]
+  extra_tags = {
+    Service = "mfa-reset-authorize"
+  }
 }
 
 

--- a/ci/terraform/oidc/mfa-reset-jar-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-jar-jwk.tf
@@ -1,3 +1,7 @@
+locals {
+  reverification_jwk_json_endpoint_name = "reverification-jwk.json"
+}
+
 module "mfa_reset_jar_signing_jwk_role" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -7,12 +11,15 @@ module "mfa_reset_jar_signing_jwk_role" {
   policies_to_attach = [
     aws_iam_policy.mfa_reset_jar_kms_signing_jwk_policy.arn
   ]
+  extra_tags = {
+    Service = local.reverification_jwk_json_endpoint_name
+  }
 }
 
 module "mfa_reset_jar_signing_jwk" {
   source = "../modules/endpoint-module"
 
-  endpoint_name   = "reverification-jwk.json"
+  endpoint_name   = local.reverification_jwk_json_endpoint_name
   path_part       = "reverification-jwk.json"
   endpoint_method = ["GET"]
   environment     = var.environment

--- a/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
@@ -7,6 +7,9 @@ module "mfa_reset_storage_token_jwk_role" {
   policies_to_attach = [
     aws_iam_policy.mfa_reset_storage_token_kms_signing_policy.arn
   ]
+  extra_tags = {
+    Service = "mfa-reset-jwk.json"
+  }
 }
 
 module "mfa_reset_storage_token_jwk" {

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -15,6 +15,9 @@ module "frontend_api_mfa_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "mfa"
+  }
 }
 
 module "mfa" {

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -18,6 +18,9 @@ module "ipv_processing_identity_role" {
     local.identity_credentials_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "processing-identity"
+  }
 }
 
 module "ipv_processing_identity_role_with_orch_session_table_access" {

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -12,6 +12,9 @@ module "client_registry_role" {
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "register"
+  }
 }
 
 module "register" {

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -14,6 +14,9 @@ module "frontend_api_reset_password_request_role" {
     local.account_modifiers_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "reset-password-request"
+  }
 }
 
 module "reset-password-request" {

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -20,6 +20,9 @@ module "frontend_api_reset_password_role" {
     local.common_passwords_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "reset-password"
+  }
 }
 
 module "reset_password" {

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -12,6 +12,9 @@ module "reverification_result_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
   ]
+  extra_tags = {
+    Service = "reverification-result"
+  }
 }
 
 module "reverification_result" {

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -19,6 +19,9 @@ module "frontend_api_send_notification_role" {
     local.email_check_results_encryption_policy_arn,
     aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
   ]
+  extra_tags = {
+    Service = "send-notification"
+  }
 }
 
 module "send_notification" {

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -20,6 +20,9 @@ module "frontend_api_signup_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "signup"
+  }
 }
 
 module "signup" {

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -37,7 +37,12 @@ provider "aws" {
 
   default_tags {
     tags = {
-      environment = var.environment
+      Environment = var.environment
+      Owner       = "di-authentication@digital.cabinet-office.gov.uk"
+      Product     = "GOV.UK Sign In"
+      System      = "oidc-api"
+      # Don't set `Service` by default as it's not always applicable
+
       application = "oidc-api"
     }
   }

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -18,6 +18,9 @@ module "ipv_spot_response_role" {
   depends_on = [
     aws_iam_policy.spot_response_sqs_read_policy
   ]
+  extra_tags = {
+    Service = "spot-response"
+  }
 }
 
 data "aws_iam_policy_document" "spot_response_policy_document" {
@@ -58,6 +61,9 @@ resource "aws_iam_policy" "spot_response_sqs_read_policy" {
   policy      = data.aws_iam_policy_document.spot_response_policy_document.json
   path        = "/${var.environment}/sqs/"
   name_prefix = "spot-response-sqs-read-policy-policy"
+  tags = {
+    Service = "spot-response"
+  }
 }
 
 resource "aws_lambda_event_source_mapping" "spot_response_lambda_sqs_mapping" {
@@ -71,6 +77,9 @@ resource "aws_lambda_event_source_mapping" "spot_response_lambda_sqs_mapping" {
     aws_lambda_function.spot_response_lambda,
     aws_iam_policy.spot_response_sqs_read_policy
   ]
+  tags = {
+    Service = "spot-response"
+  }
 }
 
 resource "aws_lambda_function" "spot_response_lambda" {
@@ -103,6 +112,9 @@ resource "aws_lambda_function" "spot_response_lambda" {
     })
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  tags = {
+    Service = "spot-response"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "spot_response_lambda_log_group" {

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -19,6 +19,9 @@ module "frontend_api_start_role" {
     local.user_credentials_encryption_policy_arn,
     local.user_profile_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "start"
+  }
 }
 
 module "start" {

--- a/ci/terraform/oidc/storage-token-jwk.tf
+++ b/ci/terraform/oidc/storage-token-jwk.tf
@@ -7,6 +7,9 @@ module "oidc_storage_token_jwk_role" {
   policies_to_attach = [
     aws_iam_policy.storage_token_kms_signing_policy.arn
   ]
+  extra_tags = {
+    Service = "storage-token-jwk.json"
+  }
 }
 
 module "storage_token_jwk" {

--- a/ci/terraform/oidc/ticf-cri.tf
+++ b/ci/terraform/oidc/ticf-cri.tf
@@ -4,6 +4,9 @@ module "frontend_api_ticf_cri_role" {
   role_name   = "frontend-api-ticf-cri-role"
   vpc_arn     = local.authentication_vpc_arn
   count       = local.deploy_ticf_cri_count
+  extra_tags = {
+    Service = "ticf-cri"
+  }
 }
 
 resource "aws_lambda_function" "ticf_cri_lambda" {
@@ -42,6 +45,9 @@ resource "aws_lambda_function" "ticf_cri_lambda" {
     })
   }
   # checkov:skip=CKV_AWS_116:Adding a DLQ would not be useful as we're not adding a retry policy.
+  tags = {
+    Service = "ticf-cri"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "ticf_cri_lambda_log_group" {
@@ -50,6 +56,9 @@ resource "aws_cloudwatch_log_group" "ticf_cri_lambda_log_group" {
   name              = "/aws/lambda/${aws_lambda_function.ticf_cri_lambda[count.index].function_name}"
   kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   retention_in_days = var.cloudwatch_log_retention
+  tags = {
+    Service = "ticf-cri"
+  }
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "ticf_cri_lambda_log_subscription" {
@@ -71,6 +80,9 @@ resource "aws_iam_policy" "ticf_cri_lambda_invocation_policy" {
   description = "IAM policy managing lambda invocation access for the TICF CRI lambda."
 
   policy = data.aws_iam_policy_document.ticf_cri_lambda_invocation_policy_document[count.index].json
+  tags = {
+    Service = "ticf-cri"
+  }
 }
 
 resource "aws_lambda_alias" "ticf_cri_lambda_alias" {

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -1,3 +1,7 @@
+locals {
+  oidc_token_endpoint_name = "token"
+}
+
 module "oidc_token_role" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -16,6 +20,9 @@ module "oidc_token_role" {
     local.user_credentials_encryption_policy_arn,
     local.user_profile_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = local.oidc_token_endpoint_name
+  }
 }
 
 data "aws_iam_policy_document" "kms_signing_policy_document" {
@@ -40,12 +47,15 @@ resource "aws_iam_policy" "oidc_token_kms_signing_policy" {
   description = "IAM policy for managing KMS connection for a lambda which allows signing"
 
   policy = data.aws_iam_policy_document.kms_signing_policy_document.json
+  tags = {
+    Service = local.oidc_token_endpoint_name
+  }
 }
 
 module "token" {
   source = "../modules/endpoint-module"
 
-  endpoint_name   = "token"
+  endpoint_name   = local.oidc_token_endpoint_name
   path_part       = var.orch_token_enabled ? "token-auth" : "token"
   endpoint_method = ["POST"]
   environment     = var.environment

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -4,6 +4,9 @@ module "oidc_trustmarks_role" {
   role_name   = "oidc-trustmarks-role"
   environment = var.environment
   vpc_arn     = local.authentication_vpc_arn
+  extra_tags = {
+    Service = "trustmarks"
+  }
 }
 
 module "trustmarks" {

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -12,6 +12,9 @@ module "client_update_role" {
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "update-client-info"
+  }
 }
 
 module "update" {

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -16,6 +16,9 @@ module "frontend_api_update_profile_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "update-profile"
+  }
 }
 
 module "update_profile" {

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -17,6 +17,9 @@ module "frontend_api_user_exists_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "user-exists"
+  }
 }
 
 module "userexists" {

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -20,6 +20,9 @@ module "oidc_userinfo_role" {
     local.doc_app_credential_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "userinfo"
+  }
 }
 
 module "userinfo" {

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -23,6 +23,9 @@ module "frontend_api_verify_code_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
   ]
+  extra_tags = {
+    Service = "verify-code"
+  }
 }
 
 module "verify_code" {

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -23,6 +23,9 @@ module "frontend_api_verify_mfa_code_role" {
     local.user_credentials_encryption_policy_arn,
     local.experian_phone_check_sqs_queue_policy_arn
   ]
+  extra_tags = {
+    Service = "verify-mfa-code"
+  }
 }
 
 module "verify_mfa_code" {

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -1,15 +1,22 @@
+locals {
+  openid_configuration_endpoint_name = "openid-configuration"
+}
+
 module "openid_configuration_role" {
   source = "../modules/lambda-role"
 
   role_name   = "openid-configuration"
   environment = var.environment
   vpc_arn     = local.authentication_vpc_arn
+  extra_tags = {
+    Service = local.openid_configuration_endpoint_name
+  }
 }
 
 module "openid_configuration_discovery" {
   source = "../modules/endpoint-module"
 
-  endpoint_name   = "openid-configuration"
+  endpoint_name   = local.openid_configuration_endpoint_name
   path_part       = var.orch_openid_configuration_enabled ? "openid-configuration-auth" : "openid-configuration"
   endpoint_method = ["GET"]
   environment     = var.environment

--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -38,7 +38,12 @@ provider "aws" {
 
   default_tags {
     tags = {
-      environment = var.environment
+      Environment = var.environment
+      Owner       = "di-authentication@digital.cabinet-office.gov.uk"
+      Product     = "GOV.UK Sign In"
+      System      = "shared"
+      # Don't set `Service` by default as it's not always applicable
+
       application = "shared"
     }
   }
@@ -59,7 +64,12 @@ provider "aws" {
 
   default_tags {
     tags = {
-      environment = var.environment
+      Environment = var.environment
+      Owner       = "di-authentication@digital.cabinet-office.gov.uk"
+      Product     = "GOV.UK Sign In"
+      System      = "shared"
+      # Don't set `Service` by default as it's not always applicable
+
       application = "shared"
     }
   }

--- a/ci/terraform/test-services/delete-synthetics-user.tf
+++ b/ci/terraform/test-services/delete-synthetics-user.tf
@@ -1,3 +1,6 @@
+locals {
+  test_services_api_delete-synthetics_endpoint_name = "synthetics-user"
+}
 module "test_services_api_delete-synthetics-user_role" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -9,12 +12,15 @@ module "test_services_api_delete-synthetics-user_role" {
     aws_iam_policy.dynamo_test_services_user_delete_access_policy.arn,
     module.test_services_txma_audit.access_policy_arn,
   ]
+  extra_tags = {
+    Service = local.test_services_api_delete-synthetics_endpoint_name
+  }
 }
 
 module "delete-synthetics-user" {
   source = "../modules/endpoint-module"
 
-  endpoint_name   = "synthetics-user"
+  endpoint_name   = local.test_services_api_delete-synthetics_endpoint_name
   path_part       = "synthetics-user"
   endpoint_method = ["DELETE"]
   environment     = var.environment

--- a/ci/terraform/test-services/site.tf
+++ b/ci/terraform/test-services/site.tf
@@ -33,7 +33,12 @@ provider "aws" {
 
   default_tags {
     tags = {
-      environment = var.environment
+      Environment = var.environment
+      Owner       = "di-authentication@digital.cabinet-office.gov.uk"
+      Product     = "GOV.UK Sign In"
+      System      = "test-services-api"
+      # Don't set `Service` by default as it's not always applicable
+
       application = "test-services-api"
     }
   }

--- a/ci/terraform/ticf-cri-stub/lambda.tf
+++ b/ci/terraform/ticf-cri-stub/lambda.tf
@@ -4,6 +4,9 @@ module "ticf_cri_stub_role" {
   role_name          = "ticf_cri_stub-role"
   vpc_arn            = local.authentication_vpc_arn
   policies_to_attach = [aws_iam_policy.stub_ticf_cri_dynamo_read_access.arn]
+  extra_tags = {
+    Service = "ticf-cri-stub"
+  }
 }
 
 module "ticf_cri_stub_lambda" {

--- a/ci/terraform/ticf-cri-stub/site.tf
+++ b/ci/terraform/ticf-cri-stub/site.tf
@@ -20,7 +20,12 @@ provider "aws" {
 
   default_tags {
     tags = {
-      environment = var.environment
+      Environment = var.environment
+      Owner       = "di-authentication@digital.cabinet-office.gov.uk"
+      Product     = "GOV.UK Sign In"
+      System      = "ticf-cri-stub"
+      # Don't set `Service` by default as it's not always applicable
+
       application = "ticf-cri-stub"
     }
   }

--- a/ci/terraform/utils/site.tf
+++ b/ci/terraform/utils/site.tf
@@ -31,7 +31,12 @@ provider "aws" {
 
   default_tags {
     tags = {
-      environment = var.environment
+      Environment = var.environment
+      Owner       = "di-authentication@digital.cabinet-office.gov.uk"
+      Product     = "GOV.UK Sign In"
+      System      = "utils"
+      # Don't set `Service` by default as it's not always applicable
+
       application = "utils"
     }
   }

--- a/deploy-dev.sh
+++ b/deploy-dev.sh
@@ -12,6 +12,7 @@ Usage:
 
 Options:
     -b, --build                 run gradle and buildZip tasks before applying the Terraform configuration. (default: true)
+    --no-build                  do not run gradle and buildZip tasks before applying the Terraform configuration. (default: false)
     -p, --prompt                prompt for confirmation before applying the Terraform configuration. (default: false)
     -c, --clean                 run gradle clean before build. (default: false)
     --shell                     start a shell in the Terraform configuration directory. (does not automatically apply) (default: false)
@@ -58,6 +59,7 @@ AUTO_APPROVE="-auto-approve"
 while (($#)); do
   case $1 in
     -b | --build) O_BUILD=1 ;;
+    --no-build) O_BUILD=0 ;;
     -p | --prompt) AUTO_APPROVE="" ;;
     -c | --clean) O_CLEAN="clean" ;;
     --shell) O_SHELL=1 ;;


### PR DESCRIPTION
## What

Add Cost Allocation tags to all components

I've updated the `default_tags` block on the providers to the following:
```
  default_tags {
    tags = {
      Environment = var.environment
      Owner       = "di-orchestration@digital.cabinet-office.gov.uk" / "di-authentication@digital.cabinet-office.gov.uk"
      Product     = "GOV.UK Sign In"
      System      = "${terraform-module-name}"

      application = "${terraform-module-name}"
    }
  }
```

This means that all the resources created by this terraform will now be correctly labeled and easily identified through the cost explorer, so we can better gauge what's costing what.

Note: `environment` => `Environment`. I would have left the two, but labels are case sensitive except for one specific instance, so it's easier to just keep one of these, otherwise we get flip-flopping resources.

## How to review

1. Deploy to a dev environment
2. Check some arbitrary resources have the expected tags