### PR TITLE
BAU: Rename AuthSessionService method to better reflect its usage

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -205,12 +205,10 @@ public class StartHandler
             Optional<String> maybeInternalCommonSubjectIdentifier =
                     Optional.ofNullable(session.getInternalCommonSubjectIdentifier());
 
-            Optional<String> previousSessionId =
-                    Optional.ofNullable(startRequest.previousSessionId());
-            CredentialTrustLevel currentCredentialStrength =
-                    startRequest.currentCredentialStrength();
             authSessionService.updateSessionIncludingSessionId(
-                    previousSessionId, session.getSessionId(), currentCredentialStrength);
+                    Optional.ofNullable(startRequest.previousSessionId()),
+                    session.getSessionId(),
+                    startRequest.currentCredentialStrength());
 
             var clientSessionId =
                     getHeaderValueFromHeaders(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -209,7 +209,7 @@ public class StartHandler
                     Optional.ofNullable(startRequest.previousSessionId());
             CredentialTrustLevel currentCredentialStrength =
                     startRequest.currentCredentialStrength();
-            authSessionService.addOrUpdateSessionId(
+            authSessionService.updateSessionIncludingSessionId(
                     previousSessionId, session.getSessionId(), currentCredentialStrength);
 
             var clientSessionId =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -72,7 +72,7 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
     }
 
     public void addSession(Optional<String> previousSessionId, String sessionId) {
-        authSessionService.addOrUpdateSessionId(previousSessionId, sessionId, null);
+        authSessionService.updateSessionIncludingSessionId(previousSessionId, sessionId, null);
     }
 
     public void updateSession(AuthSessionItem sessionItem) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -40,7 +40,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
         this.configurationService = configurationService;
     }
 
-    public void addOrUpdateSessionId(
+    public void updateSessionIncludingSessionId(
             Optional<String> previousSessionId,
             String newSessionId,
             CredentialTrustLevel currentCredentialStrength) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -73,7 +73,7 @@ class AuthSessionServiceTest {
 
     @Test
     void shouldAddNewSessionWhenNoPreviousSessionGiven() {
-        authSessionService.addOrUpdateSessionId(Optional.empty(), NEW_SESSION_ID, null);
+        authSessionService.updateSessionIncludingSessionId(Optional.empty(), NEW_SESSION_ID, null);
 
         ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
         verify(table).putItem(captor.capture());
@@ -87,7 +87,8 @@ class AuthSessionServiceTest {
     void shouldAddNewSessionWhenNoPreviousSessionExists() {
         withNoSession();
 
-        authSessionService.addOrUpdateSessionId(Optional.of(SESSION_ID), NEW_SESSION_ID, null);
+        authSessionService.updateSessionIncludingSessionId(
+                Optional.of(SESSION_ID), NEW_SESSION_ID, null);
 
         ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
         verify(table).putItem(captor.capture());
@@ -101,7 +102,8 @@ class AuthSessionServiceTest {
     void shouldPutAndDeleteSessionWhenUpdatingSessionId() {
         AuthSessionItem existingSession = withValidSession();
 
-        authSessionService.addOrUpdateSessionId(Optional.of(SESSION_ID), NEW_SESSION_ID, null);
+        authSessionService.updateSessionIncludingSessionId(
+                Optional.of(SESSION_ID), NEW_SESSION_ID, null);
 
         ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
         verify(table).putItem(captor.capture());
@@ -116,7 +118,7 @@ class AuthSessionServiceTest {
     void shouldIncludeTheCurrentCredentialStrengthWhenUpdating() {
         withValidSession();
 
-        authSessionService.addOrUpdateSessionId(
+        authSessionService.updateSessionIncludingSessionId(
                 Optional.of(SESSION_ID), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL);
 
         ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
@@ -131,7 +133,7 @@ class AuthSessionServiceTest {
     void shouldIncludeTheCurrentCredentialStrengthWhenNewSession() {
         withNoSession();
 
-        authSessionService.addOrUpdateSessionId(
+        authSessionService.updateSessionIncludingSessionId(
                 Optional.empty(), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL);
 
         ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);


### PR DESCRIPTION
## What
1. The method was named as if it was just updating the sessionId, but it actually updates currentCrendentialStrength too, so it has been renamed for clarity.
2. Remove unnecessary variable declarations.