### PR TITLE
ATO-1230: Include uplift_required in userinfo response

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -131,6 +131,11 @@ public class UserInfoService {
                     "current_credential_strength value: {}",
                     authSession.getCurrentCredentialStrength());
         }
+        if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.UPLIFT_REQUIRED.getValue())) {
+            userInfo.setClaim(
+                    AuthUserInfoClaims.UPLIFT_REQUIRED.getValue(), authSession.getUpliftRequired());
+            LOG.info("uplift_required value: {}", authSession.getUpliftRequired());
+        }
     }
 
     private static String bytesToBase64(ByteBuffer byteBuffer) {

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -54,6 +54,7 @@ public class UserInfoServiceTest {
     private static final String TEST_VERIFIED_MFA_METHOD_TYPE = MFAMethodType.EMAIL.getValue();
     private static final CredentialTrustLevel TEST_CURRENT_CREDENTIAL_STRENGTH =
             CredentialTrustLevel.MEDIUM_LEVEL;
+    private static final boolean TEST_UPLIFT_REQUIRED = true;
     private static final boolean TEST_IS_NEW_ACCOUNT = true;
     private static final long TEST_PASSWORD_RESET_TIME = 1710255380L;
     private static final UserProfile TEST_USER_PROFILE =
@@ -69,7 +70,8 @@ public class UserInfoServiceTest {
     private static final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withVerifiedMfaMethodType(TEST_VERIFIED_MFA_METHOD_TYPE)
-                    .withCurrentCredentialStrength(TEST_CURRENT_CREDENTIAL_STRENGTH);
+                    .withCurrentCredentialStrength(TEST_CURRENT_CREDENTIAL_STRENGTH)
+                    .withUpliftRequired(TEST_UPLIFT_REQUIRED);
 
     @BeforeEach
     public void setUp() {
@@ -96,7 +98,8 @@ public class UserInfoServiceTest {
             Boolean expectedPhoneNumberVerified,
             String expectedSalt,
             String expectedVerifiedMfaMethod,
-            CredentialTrustLevel expectedCurrentCredentialStrength) {
+            CredentialTrustLevel expectedCurrentCredentialStrength,
+            Boolean expectedUpliftRequired) {
         UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore, authSession);
 
         assertEquals(TEST_INTERNAL_COMMON_SUBJECT_ID, actual.getSubject().getValue());
@@ -115,6 +118,7 @@ public class UserInfoServiceTest {
         assertEquals(
                 expectedCurrentCredentialStrength, actual.getClaim("current_credential_strength"));
         assertEquals(TEST_PASSWORD_RESET_TIME, actual.getClaim("password_reset_time"));
+        assertEquals(expectedUpliftRequired, actual.getClaim("uplift_required"));
     }
 
     private static Stream<Arguments> provideTestData() {
@@ -124,6 +128,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         TEST_SUBJECT.getValue(),
+                        null,
                         null,
                         null,
                         null,
@@ -143,6 +148,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         null,
+                        null,
                         null),
                 Arguments.of(
                         getMockAccessTokenStore(
@@ -156,7 +162,8 @@ public class UserInfoServiceTest {
                                         "phone_number_verified",
                                         "salt",
                                         "verified_mfa_method_type",
-                                        "current_credential_strength")),
+                                        "current_credential_strength",
+                                        "uplift_required")),
                         TEST_LEGACY_SUBJECT_ID,
                         TEST_PUBLIC_SUBJECT_ID,
                         TEST_SUBJECT.getValue(),
@@ -166,7 +173,8 @@ public class UserInfoServiceTest {
                         TEST_PHONE_VERIFIED,
                         bytesToBase64(TEST_SALT),
                         TEST_VERIFIED_MFA_METHOD_TYPE,
-                        TEST_CURRENT_CREDENTIAL_STRENGTH));
+                        TEST_CURRENT_CREDENTIAL_STRENGTH,
+                        TEST_UPLIFT_REQUIRED));
     }
 
     private static AccessTokenStore getMockAccessTokenStore(List<String> claims) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -129,6 +129,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
         assertNull(userInfoResponse.getClaim("salt"));
         assertNull(userInfoResponse.getClaim("verified_mfa_method_type"));
         assertNull(userInfoResponse.getClaim("current_credential_strength"));
+        assertNull(userInfoResponse.getClaim("uplift_required"));
 
         assertThat(
                 authSessionExtension.getSession(TEST_SESSION_ID).get().getIsNewAccount(),
@@ -172,7 +173,8 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                 List.of(
                         OIDCScopeValue.EMAIL.getValue(),
                         AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
-                        AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue()),
+                        AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue(),
+                        AuthUserInfoClaims.UPLIFT_REQUIRED.getValue()),
                 true);
         withAuthSessionNewAccount();
 
@@ -195,6 +197,8 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                 userInfoResponse.getClaim(
                         AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue()),
                 equalTo("MEDIUM_LEVEL"));
+        assertTrue(
+                (Boolean) userInfoResponse.getClaim(AuthUserInfoClaims.UPLIFT_REQUIRED.getValue()));
     }
 
     @Test
@@ -332,6 +336,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                         .get()
                         .withAccountState(AuthSessionItem.AccountState.NEW)
                         .withVerifiedMfaMethodType(MFAMethodType.AUTH_APP.getValue())
-                        .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL));
+                        .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL)
+                        .withUpliftRequired(true));
     }
 }


### PR DESCRIPTION
## What

Include uplift_required in userinfo response if Orch have requested it (Orch will [always request it](https://github.com/govuk-one-login/authentication-api/pull/5558)). 
If true, Orch will set auth time in the Orch session

## Sandpit testing

- [x] userinfo response includes `uplift_required=false` on a no-2FA journey
- [x] Then without logging out, `uplift_required=true` on a 2FA journey
- [x] Auth acceptance tests