### PR TITLE
ATO-1134: turn on destroy orch session on logout in prod

### DIFF
--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -55,4 +55,4 @@ orch_authentication_callback_enabled        = true
 orch_logout_enabled                         = true
 auth_spot_response_disabled                 = true
 orch_storage_token_jwk_enabled              = true
-is_destroy_orch_session_on_sign_out_enabled = false
+is_destroy_orch_session_on_sign_out_enabled = true

--- a/template.yaml
+++ b/template.yaml
@@ -72,6 +72,7 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
       !Equals [integration, !Ref Environment],
+      !Equals [production, !Ref Environment],
     ]
   IsReturnAuthTimeInIdTokenEnabled:
     !Or [


### PR DESCRIPTION
## What
Turns on the feature flag `is_destroy_orch_session_on_sign_out_enabled` in production.

This was successfully tested in staging and in integration, so it is safe to turn this on in production.

## How to review
1. Code Review