### PR TITLE
ATO-1096: Add auth time to Orch session

### DIFF
--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthExternalApiStubExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthExternalApiStubExtension.java
@@ -38,7 +38,7 @@ public class AuthExternalApiStubExtension extends HttpStubExtension {
         register("/userinfo", 200, "application/json", userInfo.toJSONString());
     }
 
-    public void init(Subject subjectId, Long passwordResetTime) {
+    public void init(Subject subjectId, Long passwordResetTime, boolean upliftRequired) {
         register(
                 "/token",
                 200,
@@ -56,6 +56,7 @@ public class AuthExternalApiStubExtension extends HttpStubExtension {
         userInfo.setClaim("new_account", true);
         userInfo.setClaim("verified_mfa_method_type", MFAMethodType.AUTH_APP.getValue());
         userInfo.setClaim("password_reset_time", passwordResetTime);
+        userInfo.setClaim("uplift_required", upliftRequired);
         register("/userinfo", 200, "application/json", userInfo.toJSONString());
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -13,6 +13,7 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "IsNewAccount";
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
     public static final String ATTRIBUTE_AUTHENTICATED = "Authenticated";
+    public static final String ATTRIBUTE_AUTH_TIME = "AuthTime";
 
     public enum AccountState {
         NEW,
@@ -28,6 +29,7 @@ public class OrchSessionItem {
     private boolean isAuthenticated;
     private AccountState isNewAccount;
     private String internalCommonSubjectId;
+    private Long authTime;
 
     public OrchSessionItem() {}
 
@@ -132,6 +134,20 @@ public class OrchSessionItem {
 
     public OrchSessionItem withAuthenticated(boolean authenticated) {
         this.isAuthenticated = authenticated;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_AUTH_TIME)
+    public Long getAuthTime() {
+        return authTime;
+    }
+
+    public void setAuthTime(Long authTime) {
+        this.authTime = authTime;
+    }
+
+    public OrchSessionItem withAuthTime(Long authTime) {
+        this.authTime = authTime;
         return this;
     }
 }


### PR DESCRIPTION
## What

As part of the max_age initiative, Orch are to begin setting `authTime` in the Orch session. This needs to happen in two situations:

1. When the user is authenticated (ie. when the `authenticated` session field goes from `false` to `true`).

2. When the user has had their credential strength uplifted (eg. from LOW to MEDIUM), which happens when a user with an existing session authenticates with a higher trust level on a second journey. This information is [passed as a claim ("uplift_required")](https://github.com/govuk-one-login/authentication-api/pull/5580) to Orch in the Auth userinfo response.

## Dev testing
- 1st journey 2FA
- [x] upliftRequired = false, authenticated = false
- [x] auth time set in Orch session
- 2nd journey 2FA
- [x] upliftRequired = false, authenticated = true
- [x] not set auth time in Orch session
---
- 1st journey no-MFA
- [x] upliftRequired = false, authenticated = false
- [x] auth time set in Orch session
- 2nd journey 2FA
- [x] upliftRequired = true, authenticated = true
- [x] auth time set in Orch session


