### PR TITLE
AUT-3909: remove lambda provisioned from dev account

### DIFF
--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -38,7 +38,7 @@ enable_api_gateway_execution_request_tracing = true
 spot_enabled                                 = false
 
 lambda_max_concurrency = 0
-lambda_min_concurrency = 1
+lambda_min_concurrency = 0
 endpoint_memory_size   = 1536
 
 

--- a/ci/terraform/oidc/dev-overrides.tfvars
+++ b/ci/terraform/oidc/dev-overrides.tfvars
@@ -48,6 +48,6 @@ performance_tuning = {
   }
 }
 lambda_max_concurrency = 0
-lambda_min_concurrency = 1
+lambda_min_concurrency = 0
 endpoint_memory_size   = 1536
 scaling_trigger        = 0.6

--- a/ci/terraform/ticf-cri-stub/authdev1.tfvars
+++ b/ci/terraform/ticf-cri-stub/authdev1.tfvars
@@ -1,2 +1,5 @@
 environment         = "authdev1"
 shared_state_bucket = "di-auth-development-tfstate"
+
+lambda_max_concurrency = 0
+lambda_min_concurrency = 0

--- a/ci/terraform/ticf-cri-stub/authdev2.tfvars
+++ b/ci/terraform/ticf-cri-stub/authdev2.tfvars
@@ -1,2 +1,5 @@
 environment         = "authdev2"
 shared_state_bucket = "di-auth-development-tfstate"
+
+lambda_max_concurrency = 0
+lambda_min_concurrency = 0

--- a/ci/terraform/ticf-cri-stub/dev.tfvars
+++ b/ci/terraform/ticf-cri-stub/dev.tfvars
@@ -1,3 +1,6 @@
 ticf_cri_stub_release_zip_file = "./artifacts/ticf-cri-stub.zip"
 logging_endpoint_arns          = []
 shared_state_bucket            = "di-auth-development-tfstate"
+
+lambda_max_concurrency = 0
+lambda_min_concurrency = 0

--- a/ci/terraform/utils/authdev1.tfvars
+++ b/ci/terraform/utils/authdev1.tfvars
@@ -15,3 +15,5 @@ performance_tuning = {
     timeout = 300
   }
 }
+
+email_check_results_writer_provisioned_concurrency = 0

--- a/ci/terraform/utils/authdev2.tfvars
+++ b/ci/terraform/utils/authdev2.tfvars
@@ -15,3 +15,5 @@ performance_tuning = {
     timeout = 300
   }
 }
+
+email_check_results_writer_provisioned_concurrency = 0

--- a/ci/terraform/utils/dev.tfvars
+++ b/ci/terraform/utils/dev.tfvars
@@ -17,3 +17,5 @@ bulk_user_email_email_sending_enabled = false
 bulk_user_email_batch_query_limit     = 25
 bulk_user_email_max_batch_count       = 100
 bulk_user_email_batch_pause_duration  = 0
+
+email_check_results_writer_provisioned_concurrency = 0


### PR DESCRIPTION
## What
[AUT-3909]
remove lambda provisioned from dev account 
we are incurring total **USD 1,664.66** monthly for lambda  , which includes only concurrency cost in DEV account ( di-auth-development ) , concurrency is not required in non performance dev account 

## How to review

1. Code Review
2. Deploy to sandpit with `./deploy-authdevs -p`



[AUT-3909]: https://govukverify.atlassian.net/browse/AUT-3909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ