### PR TITLE
Ato 975/setting current credential strength orch session

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -261,7 +261,7 @@ public class IPVCallbackHelper {
                 isTestJourney);
 
         authCodeResponseService.saveSession(
-                false, sessionService, session, orchSessionService, orchSession);
+                false, sessionService, session, orchSessionService, orchSession, clientSession);
         return authenticationResponse;
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -277,9 +277,13 @@ public class AuthCodeHandler
                     clientID.getValue(),
                     clientSession.getClientName(),
                     isTestJourney);
-
             authCodeResponseService.saveSession(
-                    docAppJourney, sessionService, session, orchSessionService, orchSession);
+                    docAppJourney,
+                    sessionService,
+                    session,
+                    orchSessionService,
+                    orchSession,
+                    clientSession);
 
             LOG.info("Generating successful auth code response");
             return generateApiGatewayProxyResponse(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -530,6 +530,13 @@ public class AuthenticationCallbackHandler
                             orchSession.withCurrentCredentialStrength(
                                     lowestRequestedCredentialTrustLevel));
                 }
+                // ATO-975 logging to make sure there are no differences in production
+                LOG.info(
+                        "Shared session current credential strength: {}",
+                        userSession.getCurrentCredentialStrength());
+                LOG.info(
+                        "Orch session current credential strength: {}",
+                        orchSession.getCurrentCredentialStrength());
                 cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
                 cloudwatchMetricsService.incrementSignInByClient(
                         orchAccountState, clientId, clientSession.getClientName(), isTestJourney);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -521,6 +521,15 @@ public class AuthenticationCallbackHandler
                                 clientRedirectURI, authCode, null, null, state, null, responseMode);
 
                 sessionService.storeOrUpdateSession(userSession);
+                CredentialTrustLevel currentCredentialStrength =
+                        orchSession.getCurrentCredentialStrength();
+                if (isNull(currentCredentialStrength)
+                        || lowestRequestedCredentialTrustLevel.compareTo(currentCredentialStrength)
+                                > 0) {
+                    orchSessionService.updateSession(
+                            orchSession.withCurrentCredentialStrength(
+                                    lowestRequestedCredentialTrustLevel));
+                }
                 cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
                 cloudwatchMetricsService.incrementSignInByClient(
                         orchAccountState, clientId, clientSession.getClientName(), isTestJourney);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -189,14 +189,26 @@ class AuthCodeHandlerTest {
                             return null;
                         })
                 .when(authCodeResponseService)
-                .saveSession(true, sessionService, session, orchSessionService, orchSession);
+                .saveSession(
+                        true,
+                        sessionService,
+                        session,
+                        orchSessionService,
+                        orchSession,
+                        clientSession);
         doAnswer(
                         (i) -> {
                             session.setAuthenticated(true).setNewAccount(EXISTING);
                             return null;
                         })
                 .when(authCodeResponseService)
-                .saveSession(false, sessionService, session, orchSessionService, orchSession);
+                .saveSession(
+                        false,
+                        sessionService,
+                        session,
+                        orchSessionService,
+                        orchSession,
+                        clientSession);
     }
 
     private static Stream<Arguments> upliftTestParameters() {
@@ -296,7 +308,8 @@ class AuthCodeHandlerTest {
                         eq(sessionService),
                         eq(session),
                         eq(orchSessionService),
-                        eq(orchSession));
+                        eq(orchSession),
+                        eq(clientSession));
 
         var expectedRpPairwiseId =
                 ClientSubjectHelper.calculatePairwiseIdentifier(
@@ -411,7 +424,8 @@ class AuthCodeHandlerTest {
                         eq(sessionService),
                         eq(session),
                         any(OrchSessionService.class),
-                        any(OrchSessionItem.class));
+                        any(OrchSessionItem.class),
+                        eq(clientSession));
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTH_CODE_ISSUED,
@@ -643,7 +657,8 @@ class AuthCodeHandlerTest {
                         eq(sessionService),
                         eq(session),
                         any(OrchSessionService.class),
-                        any(OrchSessionItem.class));
+                        any(OrchSessionItem.class),
+                        eq(clientSession));
     }
 
     private AuthenticationRequest generateValidSessionAndAuthRequest(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -14,6 +14,7 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
     public static final String ATTRIBUTE_AUTHENTICATED = "Authenticated";
     public static final String ATTRIBUTE_AUTH_TIME = "AuthTime";
+    public static final String ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH = "CurrentCredentialStrength";
 
     public enum AccountState {
         NEW,
@@ -30,6 +31,7 @@ public class OrchSessionItem {
     private AccountState isNewAccount;
     private String internalCommonSubjectId;
     private Long authTime;
+    private CredentialTrustLevel currentCredentialStrength;
 
     public OrchSessionItem() {}
 
@@ -148,6 +150,21 @@ public class OrchSessionItem {
 
     public OrchSessionItem withAuthTime(Long authTime) {
         this.authTime = authTime;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH)
+    public CredentialTrustLevel getCurrentCredentialStrength() {
+        return this.currentCredentialStrength;
+    }
+
+    public void setCurrentCredentialStrength(CredentialTrustLevel currentCredentialStrength) {
+        this.currentCredentialStrength = currentCredentialStrength;
+    }
+
+    public OrchSessionItem withCurrentCredentialStrength(
+            CredentialTrustLevel currentCredentialStrength) {
+        this.currentCredentialStrength = currentCredentialStrength;
         return this;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static java.util.Objects.isNull;
 import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING;
 import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING_DOC_APP_JOURNEY;
 
@@ -121,7 +122,11 @@ public class AuthCodeResponseGenerationService {
             SessionService sessionService,
             Session session,
             OrchSessionService orchSessionService,
-            OrchSessionItem orchSession) {
+            OrchSessionItem orchSession,
+            ClientSession clientSession) {
+
+        setCurrentCredentialStrength(orchSession, clientSession);
+
         if (docAppJourney) {
             sessionService.storeOrUpdateSession(session.setNewAccount(EXISTING_DOC_APP_JOURNEY));
             orchSessionService.updateSession(
@@ -134,6 +139,18 @@ public class AuthCodeResponseGenerationService {
                     orchSession
                             .withAuthenticated(true)
                             .withAccountState(OrchSessionItem.AccountState.EXISTING));
+        }
+    }
+
+    private void setCurrentCredentialStrength(
+            OrchSessionItem orchSession, ClientSession clientSession) {
+        CredentialTrustLevel lowestRequestedCredentialTrustLevel =
+                VectorOfTrust.getLowestCredentialTrustLevel(clientSession.getVtrList());
+        CredentialTrustLevel currentCredentialStrength = orchSession.getCurrentCredentialStrength();
+
+        if (isNull(currentCredentialStrength)
+                || lowestRequestedCredentialTrustLevel.compareTo(currentCredentialStrength) > 0) {
+            orchSession.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
         }
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -140,6 +140,12 @@ public class AuthCodeResponseGenerationService {
                             .withAuthenticated(true)
                             .withAccountState(OrchSessionItem.AccountState.EXISTING));
         }
+        LOG.info(
+                "Shared session current credential strength: {}",
+                session.getCurrentCredentialStrength());
+        LOG.info(
+                "Orch session current credential strength: {}",
+                orchSession.getCurrentCredentialStrength());
     }
 
     private void setCurrentCredentialStrength(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -148,8 +148,10 @@ public class AuthCodeResponseGenerationService {
                 VectorOfTrust.getLowestCredentialTrustLevel(clientSession.getVtrList());
         CredentialTrustLevel currentCredentialStrength = orchSession.getCurrentCredentialStrength();
 
-        if (isNull(currentCredentialStrength)
-                || lowestRequestedCredentialTrustLevel.compareTo(currentCredentialStrength) > 0) {
+        if (configurationService.isCurrentCredentialStrengthInOrchSessionEnabled()
+                && (isNull(currentCredentialStrength)
+                        || lowestRequestedCredentialTrustLevel.compareTo(currentCredentialStrength)
+                                > 0)) {
             orchSession.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
         }
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -401,6 +401,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("STORAGE_TOKEN_SIGNING_KEY_ALIAS");
     }
 
+    public boolean isCurrentCredentialStrengthInOrchSessionEnabled() {
+        return getFlagOrFalse("CURRENT_CREDENTIAL_STRENGTH_IN_ORCH_SESSION");
+    }
+
     public Optional<String> getIPVCapacity() {
         try {
             var request =

--- a/template.yaml
+++ b/template.yaml
@@ -107,6 +107,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/8bc4e01c-466b-4663-9c60-c29d5e9f2fcf
       defaultProvisionedConcurrency: 0
       aisUriSecretId: 6b29b810-e509-4354-9d75-934d0f154d07
+      currentCredentialStrengthInOrchSession: true
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "6of9f4amvg"
@@ -138,6 +139,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/5fdfad8b-ca31-4afc-a948-59fd498c0f3c
       defaultProvisionedConcurrency: 1
       aisUriSecretId: fd6ef1f1-7d31-40ca-978d-2180199141d8
+      currentCredentialStrengthInOrchSession: true
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "1rvwudxmbk"
@@ -169,6 +171,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:758531536632:key/3d990d7b-0042-4115-8263-e6b472d84cc2
       defaultProvisionedConcurrency: 3
       aisUriSecretId: 2b9a3315-50e9-4970-87e6-b354cc4a2484
+      currentCredentialStrengthInOrchSession: true
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "k2skqhxed6"
@@ -200,6 +203,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/e34095ae-a65b-4609-99b3-9c1f407eff73
       defaultProvisionedConcurrency: 1
       aisUriSecretId: ""
+      currentCredentialStrengthInOrchSession: false
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       authApiId: "s4gj268zy6"
@@ -231,6 +235,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:172348255554:key/0e5c92f4-26a1-442d-a57b-87db810a40d1
       defaultProvisionedConcurrency: 3
       aisUriSecretId: ""
+      currentCredentialStrengthInOrchSession: false
   ProvisionedConcurrency:
     staging:
       TrustmarkFunction: 1
@@ -2753,6 +2758,12 @@ Resources:
                   !Ref Environment,
                   serviceDomain,
                 ]
+          CURRENT_CREDENTIAL_STRENGTH_IN_ORCH_SESSION:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              currentCredentialStrengthInOrchSession,
+            ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy


### PR DESCRIPTION
## What

Creating the current credential strength value in Orch session.
 - Setting it the lowest requested credential trust
 - Added a check on the orch to see if the currentCredential strength in the session is less than the lowest requested credential strength and if so update.

Included the getters of the orch session since they are just used for comparison.

Feature flagged in AuthCode to test in staging

Tested in Dev 
Acceptance test past 

## How to review

Check commit messages to make sure they make sense. Tried to record the reason for implementing the logic. 
Make sure no logic is missing from the shared session.