### PR TITLE
ATO-1248: Add AuthSession To UserContext

### DIFF
--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -15,7 +15,8 @@ module "frontend_api_account_interventions_role" {
     module.oidc_txma_audit.access_policy_arn,
     ], local.deploy_ticf_cri_count == 1 ? [
     aws_iam_policy.ticf_cri_lambda_invocation_policy[0].arn,
-  ] : [])
+    ] : [],
+  [aws_iam_policy.dynamo_auth_session_read_policy.arn])
 }
 
 module "account_interventions" {

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -15,7 +15,8 @@ module "frontend_api_account_recovery_role" {
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -19,6 +19,7 @@ module "frontend_api_orch_auth_code_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     local.email_check_results_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -14,6 +14,7 @@ module "frontend_api_check_email_fraud_block_role" {
     aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
     local.client_registry_encryption_policy_arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -14,7 +14,8 @@ module "frontend_api_check_reauth_user_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_authentication_attempt_write_policy.arn,
     aws_iam_policy.dynamo_authentication_attempt_read_policy.arn,
-    aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn
+    aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/mfa-reset-authorize.tf
+++ b/ci/terraform/oidc/mfa-reset-authorize.tf
@@ -12,6 +12,7 @@ module "mfa_reset_authorize_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -13,7 +13,8 @@ module "frontend_api_mfa_role" {
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -12,7 +12,8 @@ module "frontend_api_reset_password_request_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -18,7 +18,8 @@ module "frontend_api_reset_password_role" {
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.common_passwords_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -11,6 +11,7 @@ module "reverification_result_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -18,6 +18,7 @@ module "frontend_api_send_notification_role" {
     local.pending_email_check_queue_access_policy_arn,
     local.email_check_results_encryption_policy_arn,
     aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -14,7 +14,8 @@ module "frontend_api_update_profile_role" {
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
   ]
 }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -96,6 +97,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
     protected AccountInterventionsHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
@@ -108,6 +110,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                 AccountInterventionsRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -37,6 +38,7 @@ public class AccountRecoveryHandler extends BaseFrontendHandler<AccountRecoveryR
     protected AccountRecoveryHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
@@ -46,6 +48,7 @@ public class AccountRecoveryHandler extends BaseFrontendHandler<AccountRecoveryR
                 AccountRecoveryRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -52,6 +53,7 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
             DynamoAuthCodeService dynamoAuthCodeService,
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
@@ -61,6 +63,7 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                 AuthCodeRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -43,6 +44,7 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
     protected CheckEmailFraudBlockHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
@@ -52,6 +54,7 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
                 CheckEmailFraudBlockRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -24,6 +24,7 @@ import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.ReauthAuthenticationAttemptsHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -62,6 +63,7 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
     public CheckReAuthUserHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
@@ -72,6 +74,7 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                 CheckReauthUserRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -52,7 +52,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
     private final AuditService auditService;
     private final CodeStorageService codeStorageService;
-    private final AuthSessionService authSessionService;
 
     public CheckUserExistsHandler(
             ConfigurationService configurationService,
@@ -67,12 +66,12 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                 CheckUserExistsRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);
         this.auditService = auditService;
         this.codeStorageService = codeStorageService;
-        this.authSessionService = authSessionService;
     }
 
     public CheckUserExistsHandler() {
@@ -83,7 +82,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
         super(CheckUserExistsRequest.class, configurationService);
         this.auditService = new AuditService(configurationService);
         this.codeStorageService = new CodeStorageService(configurationService);
-        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     public CheckUserExistsHandler(
@@ -91,7 +89,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
         super(CheckUserExistsRequest.class, configurationService, redis);
         this.auditService = new AuditService(configurationService);
         this.codeStorageService = new CodeStorageService(configurationService, redis);
-        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -84,7 +84,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final CommonPasswordsService commonPasswordsService;
     private final AuthenticationAttemptsService authenticationAttemptsService;
-    private final AuthSessionService authSessionService;
 
     public LoginHandler(
             ConfigurationService configurationService,
@@ -103,6 +102,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                 LoginRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService,
@@ -113,7 +113,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.commonPasswordsService = commonPasswordsService;
         this.authenticationAttemptsService = authenticationAttemptsService;
-        this.authSessionService = authSessionService;
     }
 
     public LoginHandler(ConfigurationService configurationService) {
@@ -127,7 +126,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.commonPasswordsService = new CommonPasswordsService(configurationService);
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
-        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     public LoginHandler(ConfigurationService configurationService, RedisConnectionService redis) {
@@ -141,7 +139,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.commonPasswordsService = new CommonPasswordsService(configurationService);
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
-        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     public LoginHandler() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.authentication.shared.helpers.TestClientHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -67,6 +68,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
     public MfaHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             CodeGeneratorService codeGeneratorService,
             CodeStorageService codeStorageService,
             ClientSessionService clientSessionService,
@@ -78,6 +80,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                 MfaRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -45,6 +46,7 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
     public MfaResetAuthorizeHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
@@ -55,6 +57,7 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
                 MfaResetRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -27,6 +27,7 @@ import uk.gov.di.authentication.shared.helpers.TestClientHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -70,6 +71,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             CodeStorageService codeStorageService,
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuditService auditService,
@@ -80,6 +82,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                 ResetPasswordCompletionRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.shared.helpers.TestClientHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -62,6 +63,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
     public ResetPasswordRequestHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
@@ -73,6 +75,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                 ResetPasswordRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -41,6 +42,7 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
     public ReverificationResultHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
@@ -50,6 +52,7 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
                 ReverificationResultRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -27,6 +27,7 @@ import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -89,6 +90,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
     public SendNotificationHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
@@ -102,6 +104,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                 SendNotificationRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -47,7 +47,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
     private final AuditService auditService;
     private final CommonPasswordsService commonPasswordsService;
     private final PasswordValidator passwordValidator;
-    private final AuthSessionService authSessionService;
 
     public SignUpHandler(
             ConfigurationService configurationService,
@@ -63,13 +62,13 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                 SignupRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);
         this.auditService = auditService;
         this.commonPasswordsService = commonPasswordsService;
         this.passwordValidator = passwordValidator;
-        this.authSessionService = authSessionService;
     }
 
     public SignUpHandler() {
@@ -81,7 +80,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
         this.auditService = new AuditService(configurationService);
         this.commonPasswordsService = new CommonPasswordsService(configurationService);
         this.passwordValidator = new PasswordValidator(commonPasswordsService);
-        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     public SignUpHandler(ConfigurationService configurationService, RedisConnectionService redis) {
@@ -89,7 +87,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
         this.auditService = new AuditService(configurationService);
         this.commonPasswordsService = new CommonPasswordsService(configurationService);
         this.passwordValidator = new PasswordValidator(commonPasswordsService);
-        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -133,6 +133,7 @@ public class StartHandler
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
         LOG.info("Start request received");
+
         var session = sessionService.getSessionFromRequestHeaders(input.getHeaders()).orElse(null);
         if (Objects.isNull(session)) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
@@ -140,6 +141,7 @@ public class StartHandler
             attachSessionIdToLogs(session);
             LOG.info("Start session retrieved");
         }
+
         attachLogFieldToLogs(
                 PERSISTENT_SESSION_ID, extractPersistentIdFromHeaders(input.getHeaders()));
 
@@ -174,7 +176,8 @@ public class StartHandler
                                         configurationService.getHeadersCaseInsensitive()));
             }
 
-            var userContext = startService.buildUserContext(session, clientSession.get());
+            var userContext =
+                    startService.buildUserContext(session, Optional.empty(), clientSession.get());
 
             attachLogFieldToLogs(
                     CLIENT_ID,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.shared.helpers.LogLineHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -46,6 +47,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
     protected UpdateProfileHandler(
             AuthenticationService authenticationService,
             SessionService sessionService,
+            AuthSessionService authSessionService,
             ClientSessionService clientSessionService,
             ConfigurationService configurationService,
             AuditService auditService,
@@ -54,6 +56,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 UpdateProfileRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -80,7 +80,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final DynamoAccountModifiersService accountModifiersService;
     private final AuthenticationAttemptsService authenticationAttemptsService;
-    private final AuthSessionService authSessionService;
 
     protected VerifyCodeHandler(
             ConfigurationService configurationService,
@@ -98,6 +97,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 VerifyCodeRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);
@@ -106,7 +106,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.accountModifiersService = accountModifiersService;
         this.authenticationAttemptsService = authenticationAttemptsService;
-        this.authSessionService = authSessionService;
     }
 
     public VerifyCodeHandler() {
@@ -121,7 +120,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.accountModifiersService = new DynamoAccountModifiersService(configurationService);
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
-        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     public VerifyCodeHandler(
@@ -133,7 +131,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.accountModifiersService = new DynamoAccountModifiersService(configurationService);
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
-        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -79,7 +79,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
     private final MfaCodeProcessorFactory mfaCodeProcessorFactory;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final AuthenticationAttemptsService authenticationAttemptsService;
-    private final AuthSessionService authSessionService;
 
     public VerifyMfaCodeHandler(
             ConfigurationService configurationService,
@@ -97,6 +96,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 VerifyMfaCodeRequest.class,
                 configurationService,
                 sessionService,
+                authSessionService,
                 clientSessionService,
                 clientService,
                 authenticationService);
@@ -105,7 +105,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.mfaCodeProcessorFactory = mfaCodeProcessorFactory;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.authenticationAttemptsService = authenticationAttemptsService;
-        this.authSessionService = authSessionService;
     }
 
     public VerifyMfaCodeHandler() {
@@ -126,7 +125,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
-        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     public VerifyMfaCodeHandler(
@@ -144,7 +142,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
-        this.authSessionService = new AuthSessionService(configurationService);
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -10,6 +10,7 @@ import uk.gov.di.authentication.frontendapi.entity.ClientStartInfo;
 import uk.gov.di.authentication.frontendapi.entity.UserStartInfo;
 import uk.gov.di.authentication.shared.conditions.DocAppUserHelper;
 import uk.gov.di.authentication.shared.conditions.IdentityHelper;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
@@ -65,8 +66,9 @@ public class StartService {
         return session;
     }
 
-    public UserContext buildUserContext(Session session, ClientSession clientSession) {
-        var builder = UserContext.builder(session).withClientSession(clientSession);
+    public UserContext buildUserContext(
+            Session session, Optional<AuthSessionItem> authSession, ClientSession clientSession) {
+        var builder = UserContext.builder(session, authSession).withClientSession(clientSession);
         UserContext userContext;
         try {
             var clientId =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.frontendapi.entity.Intervention;
 import uk.gov.di.authentication.frontendapi.entity.State;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.frontendapi.services.AccountInterventionsService;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -37,6 +38,7 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -101,6 +103,7 @@ class AccountInterventionsHandlerTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -118,6 +121,7 @@ class AccountInterventionsHandlerTest {
                     .setEmailAddress(EMAIL)
                     .setSessionId(SESSION_ID)
                     .setInternalCommonSubjectIdentifier(TEST_INTERNAL_SUBJECT_ID);
+    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
 
     private static final AuditContext AUDIT_CONTEXT =
             new AuditContext(
@@ -137,6 +141,8 @@ class AccountInterventionsHandlerTest {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));
+        when(authSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(authSession));
         UserProfile userProfile = generateUserProfile();
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
@@ -161,6 +167,7 @@ class AccountInterventionsHandlerTest {
                 new AccountInterventionsHandler(
                         configurationService,
                         sessionService,
+                        authSessionService,
                         clientSessionService,
                         clientService,
                         authenticationService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
@@ -5,11 +5,13 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -49,6 +51,7 @@ class AccountRecoveryHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final DynamoAccountModifiersService dynamoAccountModifiersService =
             mock(DynamoAccountModifiersService.class);
@@ -60,6 +63,7 @@ class AccountRecoveryHandlerTest {
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT_ID.getValue(), "test.account.gov.uk", SALT);
     private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
 
     private final AuditContext auditContext =
             new AuditContext(
@@ -84,6 +88,7 @@ class AccountRecoveryHandlerTest {
                 new AccountRecoveryHandler(
                         configurationService,
                         sessionService,
+                        authSessionService,
                         clientSessionService,
                         clientService,
                         authenticationService,
@@ -144,6 +149,8 @@ class AccountRecoveryHandlerTest {
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));
+        when(authSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(authSession));
     }
 
     private UserProfile generateUserProfile() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mockito;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CountType;
@@ -27,6 +28,7 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -90,12 +92,14 @@ class AuthenticationAuthCodeHandlerTest {
     private final DynamoAuthCodeService dynamoAuthCodeService = mock(DynamoAuthCodeService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
     private Session session;
+    private AuthSessionItem authSession;
     private final AuditService auditService = mock(AuditService.class);
     private final ClientSession clientSession = mock(ClientSession.class);
 
@@ -114,6 +118,7 @@ class AuthenticationAuthCodeHandlerTest {
     @BeforeEach
     void setUp() throws Json.JsonException {
         session = new Session(SESSION_ID).setEmailAddress(CommonTestVariables.EMAIL);
+        authSession = new AuthSessionItem().withSessionId(SESSION_ID);
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(clientSession));
@@ -122,6 +127,9 @@ class AuthenticationAuthCodeHandlerTest {
                 .thenReturn(Optional.of(new ClientRegistry().withClientID(CLIENT_ID)));
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));
+        when(authSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(authSession));
+
         UserProfile userProfile = generateUserProfile();
         when(authenticationService.getUserProfileByEmailMaybe(CommonTestVariables.EMAIL))
                 .thenReturn(Optional.of(userProfile));
@@ -131,6 +139,7 @@ class AuthenticationAuthCodeHandlerTest {
                         dynamoAuthCodeService,
                         configurationService,
                         sessionService,
+                        authSessionService,
                         clientSessionService,
                         clientService,
                         authenticationService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
@@ -23,6 +23,7 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -66,6 +67,7 @@ class CheckEmailFraudBlockHandlerTest {
     private static ClientSessionService clientSessionServiceMock;
     private static DynamoEmailCheckResultService dbMock;
     private static SessionService sessionServiceMock;
+    private static AuthSessionService authSessionServiceMock;
     private static ClientRegistry clientRegistry;
     private static UserContext userContext;
 
@@ -81,6 +83,7 @@ class CheckEmailFraudBlockHandlerTest {
         configurationServiceMock = mock(ConfigurationService.class);
         authenticationServiceMock = mock(AuthenticationService.class);
         sessionServiceMock = mock(SessionService.class);
+        authSessionServiceMock = mock(AuthSessionService.class);
         clientSessionServiceMock = mock(ClientSessionService.class);
         clientRegistry = mock(ClientRegistry.class);
         userContext = mock(UserContext.class);
@@ -105,6 +108,7 @@ class CheckEmailFraudBlockHandlerTest {
                 new CheckEmailFraudBlockHandler(
                         configurationServiceMock,
                         sessionServiceMock,
+                        authSessionServiceMock,
                         clientSessionServiceMock,
                         clientServiceMock,
                         authenticationServiceMock,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -58,6 +59,7 @@ class CheckReAuthUserHandlerTest {
     private final AuditService auditService = mock(AuditService.class);
     private final Context context = mock(Context.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final AuthenticationAttemptsService authenticationAttemptsService =
@@ -153,6 +155,7 @@ class CheckReAuthUserHandlerTest {
                 new CheckReAuthUserHandler(
                         configurationService,
                         sessionService,
+                        authSessionService,
                         clientSessionService,
                         clientService,
                         authenticationService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -134,6 +134,7 @@ class CheckUserExistsHandlerTest {
         when(codeStorageService.isBlockedForEmail(any(), any())).thenReturn(false);
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
         when(session.getSessionId()).thenReturn(SESSION_ID);
+        when(authSession.getSessionId()).thenReturn(SESSION_ID);
 
         handler =
                 new CheckUserExistsHandler(
@@ -153,7 +154,6 @@ class CheckUserExistsHandlerTest {
         @BeforeEach
         void setup() {
             usingValidSession();
-            authSessionExists();
             var userProfile =
                     generateUserProfile().withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER);
             setupUserProfileAndClient(Optional.of(userProfile));
@@ -292,7 +292,6 @@ class CheckUserExistsHandlerTest {
     @Test
     void shouldReturn200IfUserDoesNotExist() throws Json.JsonException {
         usingValidSession();
-        authSessionExists();
 
         setupUserProfileAndClient(Optional.empty());
 
@@ -353,6 +352,7 @@ class CheckUserExistsHandlerTest {
     void shouldReturn400IfAuthSessionExpired() {
         usingValidSession();
         authSessionMissing();
+
         setupClient();
 
         var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
@@ -364,10 +364,7 @@ class CheckUserExistsHandlerTest {
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));
-    }
-
-    private void authSessionExists() {
-        when(authSessionService.getSessionFromRequestHeaders(any()))
+        when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
@@ -14,8 +14,10 @@ import uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException;
 import uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.frontendapi.services.IPVReverificationService;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -58,8 +60,10 @@ class MfaResetAuthorizeHandlerTest {
     private static final ClientService clientService = mock(ClientService.class);
     private static final Context context = mock(Context.class);
     private static final SessionService sessionService = mock(SessionService.class);
+    private static final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private static final UserContext userContext = mock(UserContext.class);
     private static final Session session = mock(Session.class);
+    private static final AuthSessionItem authSession = mock(AuthSessionItem.class);
     private static final AuditService auditService = mock(AuditService.class);
     private static final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
@@ -87,6 +91,9 @@ class MfaResetAuthorizeHandlerTest {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));
         when(session.getSessionId()).thenReturn(SESSION_ID);
+        when(authSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(authSession));
+        when(authSession.getSessionId()).thenReturn(SESSION_ID);
     }
 
     @BeforeEach
@@ -95,6 +102,7 @@ class MfaResetAuthorizeHandlerTest {
                 new MfaResetAuthorizeHandler(
                         configurationService,
                         sessionService,
+                        authSessionService,
                         clientSessionService,
                         clientService,
                         authenticationService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
@@ -10,9 +10,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.services.ReverificationResultService;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulReverificationResponseException;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -50,6 +52,7 @@ class ReverificationResultHandlerTest {
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -57,12 +60,15 @@ class ReverificationResultHandlerTest {
             mock(ReverificationResultService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
 
     @BeforeEach
     void setUp() throws URISyntaxException {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));
+        when(authSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(authSession));
         when(configurationService.getIPVBackendURI())
                 .thenReturn(new URI("https://api.identity.account.gov.uk/token"));
 
@@ -70,6 +76,7 @@ class ReverificationResultHandlerTest {
                 new ReverificationResultHandler(
                         configurationService,
                         sessionService,
+                        authSessionService,
                         clientSessionService,
                         clientService,
                         authenticationService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mockito;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
@@ -38,6 +39,7 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -116,6 +118,7 @@ class SendNotificationHandlerTest {
     private final AwsSqsClient emailSqsClient = mock(AwsSqsClient.class);
     private final AwsSqsClient pendingEmailCheckSqsClient = mock(AwsSqsClient.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
@@ -140,6 +143,7 @@ class SendNotificationHandlerTest {
             new Session(SESSION_ID)
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
 
     private final AuditContext auditContext =
             new AuditContext(
@@ -157,6 +161,7 @@ class SendNotificationHandlerTest {
             new SendNotificationHandler(
                     configurationService,
                     sessionService,
+                    authSessionService,
                     clientSessionService,
                     clientService,
                     authenticationService,
@@ -1063,6 +1068,8 @@ class SendNotificationHandlerTest {
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));
+        when(authSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(authSession));
     }
 
     private void usingValidClientSession(String clientId) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -581,7 +581,8 @@ class StartHandlerTest {
     @Test
     void shouldReturn400WhenBuildClientStartInfoThrowsException()
             throws ParseException, Json.JsonException {
-        when(startService.buildUserContext(session, clientSession)).thenReturn(userContext);
+        when(startService.buildUserContext(session, Optional.empty(), clientSession))
+                .thenReturn(userContext);
         when(startService.buildClientStartInfo(userContext))
                 .thenThrow(new ParseException("Unable to parse authentication request"));
         usingValidClientSession();
@@ -702,7 +703,7 @@ class StartHandlerTest {
     private void usingStartServiceThatReturns(
             UserContext userContext, ClientStartInfo clientStartInfo, UserStartInfo userStartInfo)
             throws ParseException {
-        when(startService.buildUserContext(eq(session), any())).thenReturn(userContext);
+        when(startService.buildUserContext(eq(session), any(), any())).thenReturn(userContext);
         when(startService.buildClientStartInfo(userContext)).thenReturn(clientStartInfo);
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -26,6 +27,7 @@ import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -84,6 +86,7 @@ class UpdateProfileHandlerTest {
     private UpdateProfileHandler handler;
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
@@ -96,6 +99,7 @@ class UpdateProfileHandlerTest {
             new Session(SESSION_ID)
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
 
     private final AuditContext auditContextWithAllUserInfo =
             new AuditContext(
@@ -146,6 +150,7 @@ class UpdateProfileHandlerTest {
                 new UpdateProfileHandler(
                         authenticationService,
                         sessionService,
+                        authSessionService,
                         clientSessionService,
                         configurationService,
                         auditService,
@@ -257,6 +262,8 @@ class UpdateProfileHandlerTest {
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));
+        when(authSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(authSession));
     }
 
     private void usingValidClientSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ClientType;
@@ -68,6 +69,8 @@ class StartServiceTest {
     private static final ClientID CLIENT_ID = new ClientID("client-id");
     private static final String CLIENT_NAME = "test-client";
     private static final Session SESSION = new Session("a-session-id").setEmailAddress(EMAIL);
+    private static final AuthSessionItem AUTH_SESSION =
+            new AuthSessionItem().withSessionId("a-session-id");
     private static final Scope SCOPES =
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
     private static final String AUDIENCE = "oidc-audience";
@@ -144,7 +147,8 @@ class StartServiceTest {
                         LocalDateTime.now(),
                         mock(VectorOfTrust.class),
                         CLIENT_NAME);
-        var userContext = startService.buildUserContext(SESSION, clientSession);
+        var userContext =
+                startService.buildUserContext(SESSION, Optional.of(AUTH_SESSION), clientSession);
 
         assertThat(userContext.getSession(), equalTo(SESSION));
         assertThat(userContext.getClientSession(), equalTo(clientSession));
@@ -661,7 +665,8 @@ class StartServiceTest {
                         .withClientType(clientType.getValue())
                         .withIdentityVerificationSupported(identityVerificationSupport)
                         .withOneLoginService(oneLoginService);
-        return UserContext.builder(SESSION.setAuthenticated(isAuthenticated))
+        return UserContext.builder(
+                        SESSION.setAuthenticated(isAuthenticated), Optional.of(AUTH_SESSION))
                 .withClientSession(clientSession)
                 .withClient(clientRegistry)
                 .withUserCredentials(userCredentials)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -142,6 +142,7 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
                         "clientName");
 
         redis.createClientSession("client-session-id", clientSession);
+        authSessionStore.addSession(Optional.empty(), sessionId);
 
         headers.put("Session-Id", sessionId);
         headers.put(CLIENT_SESSION_ID_HEADER, "client-session-id");

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
@@ -63,6 +63,7 @@ public class AccountRecoveryIntegrationTest extends ApiGatewayHandlerIntegration
         accountModifiersStore.setAccountRecoveryBlock(internalCommonSubjectId);
         redis.addEmailToSession(sessionId, EMAIL);
         redis.createClientSession(CLIENT_SESSION_ID, createClientSession());
+        authSessionStore.addSession(Optional.empty(), sessionId);
         Map<String, String> headers = new HashMap<>();
         headers.put("Session-Id", sessionId);
         headers.put("X-API-Key", FRONTEND_API_KEY);
@@ -82,6 +83,7 @@ public class AccountRecoveryIntegrationTest extends ApiGatewayHandlerIntegration
         userStore.signUp(EMAIL, "password-1", SUBJECT);
         redis.addEmailToSession(sessionId, EMAIL);
         redis.createClientSession(CLIENT_SESSION_ID, createClientSession());
+        authSessionStore.addSession(Optional.empty(), sessionId);
 
         Map<String, String> headers = new HashMap<>();
         headers.put("Session-Id", sessionId);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -127,6 +127,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         Map<String, String> headers = new HashMap<>();
         // TODO: Not appropriate place to do this.
         var sessionId = redis.createSession();
+        authSessionStore.addSession(Optional.empty(), sessionId);
         redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         headers.put("Session-Id", sessionId);
         headers.put(TXMA_AUDIT_ENCODED_HEADER, ENCODED_DEVICE_INFORMATION);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
@@ -61,6 +61,7 @@ public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegr
     void shouldReturnCorrectStatusBasedOnDbResult() throws Json.JsonException {
         userStore.signUp(EMAIL, "password-1", SUBJECT);
         var sessionId = redis.createSession();
+        authSessionStore.addSession(Optional.empty(), sessionId);
         dynamoEmailCheckResultService.saveEmailCheckResult(
                 EMAIL, EmailCheckResultStatus.ALLOW, unixTimePlusNDays(), "test-reference");
         redis.addEmailToSession(sessionId, EMAIL);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
@@ -95,6 +95,7 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
     void setup() throws Json.JsonException {
 
         var sessionId = redis.createAuthenticatedSessionWithEmail(TEST_EMAIL);
+        authSessionStore.addSession(Optional.empty(), sessionId);
         requestHeaders = createHeaders(sessionId);
         redis.createClientSession(CLIENT_SESSION_ID, createClientSession());
         handler = new CheckReAuthUserHandler(CONFIGURATION_SERVICE, redisConnectionService);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
@@ -49,6 +49,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String mockPreviouslyIssuedPhoneCode =
                 redis.generateAndSavePhoneNumberCode(USER_EMAIL, 900L);
 
+        authSessionStore.addSession(Optional.empty(), SESSION_ID);
+
         var response =
                 makeRequest(
                         Optional.of(new MfaRequest(USER_EMAIL, true)),
@@ -67,6 +69,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenNotResendingVerifyPhoneCode() {
+        authSessionStore.addSession(Optional.empty(), SESSION_ID);
+
         var response =
                 makeRequest(
                         Optional.of(new MfaRequest(USER_EMAIL, false)),
@@ -84,6 +88,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenResettingPassword() {
+        authSessionStore.addSession(Optional.empty(), SESSION_ID);
         var response =
                 makeRequest(
                         Optional.of(
@@ -104,6 +109,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenReauthenticating()
             throws Json.JsonException {
         var authenticatedSessionId = redis.createAuthenticatedSessionWithEmail(USER_EMAIL);
+        authSessionStore.addSession(Optional.empty(), authenticatedSessionId);
 
         var response =
                 makeRequest(
@@ -125,6 +131,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldReturn400WhenRequestingACodeForReauthenticationWhichBreachesTheMaxThreshold()
             throws Json.JsonException {
         var authenticatedSessionId = redis.createAuthenticatedSessionWithEmail(USER_EMAIL);
+        authSessionStore.addSession(Optional.empty(), authenticatedSessionId);
 
         aUserHasEnteredAnOTPIncorrectlyTheMaximumAllowedTimes(authenticatedSessionId);
 
@@ -154,6 +161,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn400WhenInvalidMFAJourneyCombination() throws Json.JsonException {
         var authenticatedSessionId = redis.createAuthenticatedSessionWithEmail(USER_EMAIL);
+        authSessionStore.addSession(Optional.empty(), authenticatedSessionId);
 
         var response =
                 makeRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -50,6 +50,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     @Test
     void shouldUpdatePasswordAndReturn204() throws Json.JsonException {
         var sessionId = redis.createSession();
+        authSessionStore.addSession(Optional.empty(), sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
@@ -74,6 +75,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     void shouldUpdatePasswordSendSMSAndWriteToAccountModifiersTableWhenUserHasVerifiedPhoneNumber()
             throws Json.JsonException {
         var sessionId = redis.createSession();
+        authSessionStore.addSession(Optional.empty(), sessionId);
         var phoneNumber = "+441234567890";
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
@@ -109,6 +111,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     @Test
     void shouldReturn400ForRequestWithCommonPassword() throws Json.JsonException {
         var sessionId = redis.createSession();
+        authSessionStore.addSession(Optional.empty(), sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
@@ -128,6 +131,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     void shouldSendForcedResetJourneyAuditEventWhenForcedPasswordResetIsTrue()
             throws Json.JsonException {
         var sessionId = redis.createSession();
+        authSessionStore.addSession(Optional.empty(), sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
@@ -159,6 +163,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     void shouldUpdatePasswordAndWriteToAccountModifiersTableWithIfUserHasVerifiedPhoneNumber(
             boolean phoneNumberVerified) throws Json.JsonException {
         var sessionId = redis.createSession();
+        authSessionStore.addSession(Optional.empty(), sessionId);
         var phoneNumber = "+441234567890";
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         userStore.setPhoneNumberAndVerificationStatus(
@@ -209,6 +214,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     void shouldUpdatePasswordAndWriteToAccountRecoveryTableWithIfUserHasVerifiedAuthApp(
             boolean authAppVerified) throws Json.JsonException {
         var sessionId = redis.createSession();
+        authSessionStore.addSession(Optional.empty(), sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
         userStore.addMfaMethod(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -50,6 +50,7 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         String sessionId = redis.createSession();
         String persistentSessionId = "test-persistent-id";
         redis.addEmailToSession(sessionId, email);
+        authSessionStore.addSession(Optional.empty(), sessionId);
         var clientSessionId = IdGenerator.generate();
         setUpClientSession(email, clientSessionId, CLIENT_ID, CLIENT_NAME, REDIRECT_URI);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
@@ -29,6 +29,7 @@ class SendNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new SendNotificationHandler(
                         TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
         SESSION_ID = redis.createUnauthenticatedSessionWithEmail(USER_EMAIL);
+        authSessionStore.addSession(Optional.empty(), SESSION_ID);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -46,6 +46,7 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
     void shouldCallUpdateProfileToApproveTermsAndConditionsAndReturn204()
             throws Json.JsonException {
         String sessionId = redis.createSession();
+        authSessionStore.addSession(Optional.empty(), sessionId);
         String clientSessionId = IdGenerator.generate();
         setUpTest(sessionId, clientSessionId);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.state;
 
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -11,6 +12,7 @@ import java.util.Optional;
 
 public class UserContext {
     private final Session session;
+    private final Optional<AuthSessionItem> authSession;
     private final Optional<UserProfile> userProfile;
     private final Optional<UserCredentials> userCredentials;
     private final boolean userAuthenticated;
@@ -22,6 +24,7 @@ public class UserContext {
 
     protected UserContext(
             Session session,
+            Optional<AuthSessionItem> authSession,
             Optional<UserProfile> userProfile,
             Optional<UserCredentials> userCredentials,
             boolean userAuthenticated,
@@ -31,6 +34,7 @@ public class UserContext {
             String clientSessionId,
             String txmaAuditEncoded) {
         this.session = session;
+        this.authSession = authSession;
         this.userProfile = userProfile;
         this.userCredentials = userCredentials;
         this.userAuthenticated = userAuthenticated;
@@ -43,6 +47,10 @@ public class UserContext {
 
     public Session getSession() {
         return session;
+    }
+
+    public AuthSessionItem getAuthSession() {
+        return authSession.orElseThrow(() -> new RuntimeException("Auth session not set."));
     }
 
     public Optional<UserProfile> getUserProfile() {
@@ -85,12 +93,13 @@ public class UserContext {
         return txmaAuditEncoded;
     }
 
-    public static Builder builder(Session session) {
-        return new Builder(session);
+    public static Builder builder(Session session, Optional<AuthSessionItem> authSession) {
+        return new Builder(session, authSession);
     }
 
     public static class Builder {
         private Session session;
+        private Optional<AuthSessionItem> authSession;
         private Optional<UserProfile> userProfile = Optional.empty();
         private Optional<UserCredentials> userCredentials = Optional.empty();
         private boolean userAuthenticated = false;
@@ -100,8 +109,9 @@ public class UserContext {
         private String clientSessionId;
         private String txmaAuditEncoded;
 
-        protected Builder(Session session) {
+        protected Builder(Session session, Optional<AuthSessionItem> authSession) {
             this.session = session;
+            this.authSession = authSession;
         }
 
         public Builder withUserProfile(UserProfile userProfile) {
@@ -155,6 +165,7 @@ public class UserContext {
         public UserContext build() {
             return new UserContext(
                     session,
+                    authSession,
                     userProfile,
                     userCredentials,
                     userAuthenticated,

--- a/shared/src/test/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelperTest.java
@@ -17,6 +17,7 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ClientType;
@@ -41,6 +42,8 @@ class DocAppUserHelperTest {
     private static final ClientID CLIENT_ID = new ClientID("client-id");
     private static final String CLIENT_NAME = "test-client";
     private static final Session SESSION = new Session("a-session-id");
+    private static final AuthSessionItem AUTH_SESSION =
+            new AuthSessionItem().withSessionId("a-session-id");
     private static final String AUDIENCE = "oidc-audience";
     private static final Scope VALID_SCOPE =
             new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);
@@ -185,7 +188,7 @@ class DocAppUserHelperTest {
                         .withClientName(CLIENT_NAME)
                         .withCookieConsentShared(false)
                         .withClientType(clientType.getValue());
-        return UserContext.builder(SESSION)
+        return UserContext.builder(SESSION, Optional.of(AUTH_SESSION))
                 .withClientSession(clientSession)
                 .withClient(clientRegistry)
                 .build();

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
@@ -14,6 +15,7 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.everyItem;
@@ -135,8 +137,10 @@ class TestClientHelperTest {
                         .withClientName("some-client")
                         .withTestClient(isTestClient)
                         .withTestClientEmailAllowlist(allowedEmails);
+        var sessionId = IdGenerator.generate();
         return UserContext.builder(
-                        new Session(IdGenerator.generate()).setEmailAddress(TEST_EMAIL_ADDRESS))
+                        new Session(sessionId).setEmailAddress(TEST_EMAIL_ADDRESS),
+                        Optional.of(new AuthSessionItem().withSessionId(sessionId)))
                 .withClient(clientRegistry)
                 .build();
     }


### PR DESCRIPTION
## What
Added `AuthSession` to `UserContext`. The old `Session` lives on the `UserContext` so this will help us switch over to the `AuthSession` with less refactoring.

## How to review

Code Review

## Notes
The auth session has been added as an optional field for the time being. This is related to how the auth session is currently initialised/updated in the start handler where the user context is used to construct one of the inputs. With a bit of refactoring we should be able to make it non-optional once the start handler is no longer dependant on the session.