### PR TITLE
ATO-1252: Refactor Orch session setting in AuthorisationHandler

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -669,12 +669,15 @@ public class AuthorisationHandler
                                         .getEpochSecond());
         orchSessionService.addSession(updatedOrchSession);
         orchSessionService.deleteSession(existingOrchSession.getSessionId());
-        LOG.info("Updated existing Orch session");
+        LOG.info(
+                "Updated existing Orch session ID from {} to {}",
+                existingOrchSession.getSessionId(),
+                newSessionId);
     }
 
-    private void createNewOrchSession(String newSessionId) {
-        orchSessionService.addSession(new OrchSessionItem(newSessionId));
-        LOG.info("Created new Orch session");
+    private void createNewOrchSession(String sessionId) {
+        orchSessionService.addSession(new OrchSessionItem(sessionId));
+        LOG.info("Created new Orch session with session ID: {}", sessionId);
     }
 
     private APIGatewayProxyResponseEvent generateAuthRedirect(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -648,10 +648,8 @@ class AuthorisationHandlerTest {
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
             verify(sessionService).storeOrUpdateSession(eq(session));
-            verify(orchSessionService)
-                    .addOrUpdateSessionId(
-                            Optional.of(orchSession.getSessionId()), session.getSessionId());
-            verify(orchSessionService).updateSession(orchSession);
+            verify(orchSessionService).addSession(any());
+            verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
             inOrder.verify(auditService)
@@ -722,10 +720,8 @@ class AuthorisationHandlerTest {
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
             verify(sessionService).storeOrUpdateSession(eq(session));
-            verify(orchSessionService)
-                    .addOrUpdateSessionId(
-                            Optional.of(orchSession.getSessionId()), session.getSessionId());
-            verify(orchSessionService).updateSession(orchSession);
+            verify(orchSessionService).addSession(any());
+            verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
             inOrder.verify(auditService)
@@ -766,10 +762,8 @@ class AuthorisationHandlerTest {
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
             verify(sessionService).storeOrUpdateSession(session);
-            verify(orchSessionService)
-                    .addOrUpdateSessionId(
-                            Optional.of(orchSession.getSessionId()), session.getSessionId());
-            verify(orchSessionService).updateSession(orchSession);
+            verify(orchSessionService).addSession(any());
+            verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
             verifyAuthorisationRequestParsedAuditEvent(
@@ -815,10 +809,8 @@ class AuthorisationHandlerTest {
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
             verify(sessionService).storeOrUpdateSession(eq(session));
-            verify(orchSessionService)
-                    .addOrUpdateSessionId(
-                            Optional.of(orchSession.getSessionId()), session.getSessionId());
-            verify(orchSessionService).updateSession(orchSession);
+            verify(orchSessionService).addSession(any());
+            verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
             inOrder.verify(auditService)
@@ -2206,6 +2198,7 @@ class AuthorisationHandlerTest {
         @Test
         void shouldUpdateOrchSessionWhenThereIsAnExistingSession() throws JOSEException {
             withExistingSession(session);
+            when(orchSessionService.addOrUpdateSessionId(any(), any())).thenReturn(orchSession);
 
             makeDocAppHandlerRequest();
 
@@ -2599,7 +2592,6 @@ class AuthorisationHandlerTest {
         when(sessionService.getSessionFromSessionCookie(any())).thenReturn(Optional.of(session));
         when(orchSessionService.getSessionFromSessionCookie(any()))
                 .thenReturn(Optional.of(orchSession));
-        when(orchSessionService.addOrUpdateSessionId(any(), any())).thenReturn(orchSession);
     }
 
     private void withNoSession() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -40,6 +40,18 @@ public class OrchSessionItem {
         this.isNewAccount = AccountState.UNKNOWN;
     }
 
+    public OrchSessionItem(OrchSessionItem orchSessionItem) {
+        this.sessionId = orchSessionItem.sessionId;
+        this.previousSessionId = orchSessionItem.previousSessionId;
+        this.timeToLive = orchSessionItem.timeToLive;
+        this.verifiedMfaMethodType = orchSessionItem.verifiedMfaMethodType;
+        this.isAuthenticated = orchSessionItem.isAuthenticated;
+        this.isNewAccount = orchSessionItem.isNewAccount;
+        this.internalCommonSubjectId = orchSessionItem.internalCommonSubjectId;
+        this.authTime = orchSessionItem.authTime;
+        this.currentCredentialStrength = orchSessionItem.currentCredentialStrength;
+    }
+
     @DynamoDbPartitionKey
     @DynamoDbAttribute(ATTRIBUTE_SESSION_ID)
     public String getSessionId() {


### PR DESCRIPTION
## What

Refactor session setting in AuthorisationHandler

Modifying the Orch session for the max_age initiative (https://github.com/govuk-one-login/authentication-api/pull/5589/commits/97db69292517a83df7b444df43efc0fe69863d28) was becoming very cumbersome and the code was becoming unreadable and difficult to maintain. With this refactor, it is easier to:
- Understand how the Orch session is set 
- Modify the Orch session in future

I've deliberately not touched the Doc App journey to keep changes to a minimum, but as the journeys are similar a similar pattern can be applied there.

Each commit explains the refactoring done.
