### PR TITLE
ATO-975: move setting the current credential strength in identity journey

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -261,7 +261,7 @@ public class IPVCallbackHelper {
                 isTestJourney);
 
         authCodeResponseService.saveSession(
-                false, sessionService, session, orchSessionService, orchSession, clientSession);
+                false, sessionService, session, orchSessionService, orchSession);
         return authenticationResponse;
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -278,12 +278,7 @@ public class AuthCodeHandler
                     clientSession.getClientName(),
                     isTestJourney);
             authCodeResponseService.saveSession(
-                    docAppJourney,
-                    sessionService,
-                    session,
-                    orchSessionService,
-                    orchSession,
-                    clientSession);
+                    docAppJourney, sessionService, session, orchSessionService, orchSession);
 
             LOG.info("Generating successful auth code response");
             return generateApiGatewayProxyResponse(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import static java.util.Objects.isNull;
 import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING;
 import static uk.gov.di.orchestration.shared.entity.Session.AccountState.EXISTING_DOC_APP_JOURNEY;
 
@@ -122,10 +121,7 @@ public class AuthCodeResponseGenerationService {
             SessionService sessionService,
             Session session,
             OrchSessionService orchSessionService,
-            OrchSessionItem orchSession,
-            ClientSession clientSession) {
-
-        setCurrentCredentialStrength(orchSession, clientSession);
+            OrchSessionItem orchSession) {
 
         if (docAppJourney) {
             sessionService.storeOrUpdateSession(session.setNewAccount(EXISTING_DOC_APP_JOURNEY));
@@ -152,19 +148,5 @@ public class AuthCodeResponseGenerationService {
                 Objects.equals(
                         session.getCurrentCredentialStrength(),
                         orchSession.getCurrentCredentialStrength()));
-    }
-
-    private void setCurrentCredentialStrength(
-            OrchSessionItem orchSession, ClientSession clientSession) {
-        CredentialTrustLevel lowestRequestedCredentialTrustLevel =
-                VectorOfTrust.getLowestCredentialTrustLevel(clientSession.getVtrList());
-        CredentialTrustLevel currentCredentialStrength = orchSession.getCurrentCredentialStrength();
-
-        if (configurationService.isCurrentCredentialStrengthInOrchSessionEnabled()
-                && (isNull(currentCredentialStrength)
-                        || lowestRequestedCredentialTrustLevel.compareTo(currentCredentialStrength)
-                                > 0)) {
-            orchSession.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
-        }
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
@@ -1,12 +1,7 @@
 package uk.gov.di.orchestration.shared.services;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
@@ -18,14 +13,10 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.shared.entity.MFAMethodType.AUTH_APP;
@@ -98,7 +89,7 @@ class AuthCodeResponseGenerationServiceTest {
     @Test
     void saveSessionUpdatesNonDocAppSessionWithAuthenticatedAndAccountState() {
         authCodeResponseGenerationService.saveSession(
-                false, sessionService, session, orchSessionService, orchSession, clientSession);
+                false, sessionService, session, orchSessionService, orchSession);
 
         verify(sessionService)
                 .storeOrUpdateSession(
@@ -119,7 +110,7 @@ class AuthCodeResponseGenerationServiceTest {
     @Test
     void saveSessionUpdatesDocAppSessionWithDocAppState() {
         authCodeResponseGenerationService.saveSession(
-                true, sessionService, session, orchSessionService, orchSession, clientSession);
+                true, sessionService, session, orchSessionService, orchSession);
 
         verify(sessionService)
                 .storeOrUpdateSession(
@@ -134,93 +125,5 @@ class AuthCodeResponseGenerationServiceTest {
                                         s.getIsNewAccount()
                                                 == OrchSessionItem.AccountState
                                                         .EXISTING_DOC_APP_JOURNEY));
-    }
-
-    @Nested
-    class CurrentCredentialStrength {
-
-        @BeforeEach
-        void setup() {
-            when(configurationService.isCurrentCredentialStrengthInOrchSessionEnabled())
-                    .thenReturn(true);
-        }
-
-        @Test
-        void
-                shouldSaveSessionWithCurrentCredentialStrengthWhenIsCurrentCredentialStrengthInOrchSessionFlagEnabled() {
-            authCodeResponseGenerationService.saveSession(
-                    true, sessionService, session, orchSessionService, orchSession, clientSession);
-            var orchSessionCaptor = ArgumentCaptor.forClass(OrchSessionItem.class);
-            verify(orchSessionService, times(1)).updateSession(orchSessionCaptor.capture());
-            assertThat(
-                    orchSessionCaptor.getAllValues().get(0).getCurrentCredentialStrength(),
-                    equalTo(lowestCredentialTrustLevel));
-        }
-
-        private static Stream<Arguments> currentCredentialStrengthParams() {
-            return Stream.of(
-                    Arguments.of( // 1
-                            null,
-                            CredentialTrustLevel.MEDIUM_LEVEL,
-                            CredentialTrustLevel.MEDIUM_LEVEL),
-                    Arguments.of( // 2
-                            CredentialTrustLevel.LOW_LEVEL,
-                            CredentialTrustLevel.MEDIUM_LEVEL,
-                            CredentialTrustLevel.MEDIUM_LEVEL),
-                    Arguments.of( // 3
-                            CredentialTrustLevel.MEDIUM_LEVEL,
-                            CredentialTrustLevel.MEDIUM_LEVEL,
-                            CredentialTrustLevel.MEDIUM_LEVEL),
-                    Arguments.of( // 4
-                            null, CredentialTrustLevel.LOW_LEVEL, CredentialTrustLevel.LOW_LEVEL),
-                    Arguments.of( // 5
-                            CredentialTrustLevel.LOW_LEVEL,
-                            CredentialTrustLevel.LOW_LEVEL,
-                            CredentialTrustLevel.LOW_LEVEL),
-                    Arguments.of( // 6
-                            CredentialTrustLevel.MEDIUM_LEVEL,
-                            CredentialTrustLevel.LOW_LEVEL,
-                            CredentialTrustLevel.MEDIUM_LEVEL));
-        }
-
-        @ParameterizedTest
-        @MethodSource("currentCredentialStrengthParams")
-        void shouldSaveSesionWithCurrentCredentialStrengthWhenSessionValuesAreCorrect(
-                CredentialTrustLevel orchSessionCurrentCredentialStrength,
-                CredentialTrustLevel credentialTrustLevel,
-                CredentialTrustLevel correctCurrentCredentialStrengthSet) {
-            var clientSessionWithCredentialTrust =
-                    createSessionWithCredentialTrust(credentialTrustLevel);
-            var orchSessionWithCurentCredentialStrength =
-                    new OrchSessionItem(SESSION_ID)
-                            .withAccountState(NEW)
-                            .withVerifiedMfaMethodType(AUTH_APP.toString())
-                            .withCurrentCredentialStrength(orchSessionCurrentCredentialStrength);
-
-            authCodeResponseGenerationService.saveSession(
-                    true,
-                    sessionService,
-                    session,
-                    orchSessionService,
-                    orchSessionWithCurentCredentialStrength,
-                    clientSessionWithCredentialTrust);
-            var orchSessionCaptor = ArgumentCaptor.forClass(OrchSessionItem.class);
-            verify(orchSessionService, times(1)).updateSession(orchSessionCaptor.capture());
-            assertThat(
-                    orchSessionCaptor.getAllValues().get(0).getCurrentCredentialStrength(),
-                    equalTo(correctCurrentCredentialStrengthSet));
-        }
-
-        private ClientSession createSessionWithCredentialTrust(
-                CredentialTrustLevel credentialTrustLevel) {
-            return clientSession =
-                    new ClientSession(
-                            new HashMap<>(),
-                            LocalDateTime.MIN,
-                            List.of(
-                                    VectorOfTrust.of(
-                                            credentialTrustLevel, LevelOfConfidence.LOW_LEVEL)),
-                            CLIENT_NAME);
-        }
     }
 }


### PR DESCRIPTION
## What

Move current credential strength setting from service to the auth code lambda as it was also setting it in the ipvCallback lambda, which the shared session does not do.