### PR TITLE
Ato 975/turn on current credential strength auth code setting

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -203,7 +203,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/e34095ae-a65b-4609-99b3-9c1f407eff73
       defaultProvisionedConcurrency: 1
       aisUriSecretId: ""
-      currentCredentialStrengthInOrchSession: false
+      currentCredentialStrengthInOrchSession: true
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       authApiId: "s4gj268zy6"
@@ -235,7 +235,7 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:172348255554:key/0e5c92f4-26a1-442d-a57b-87db810a40d1
       defaultProvisionedConcurrency: 3
       aisUriSecretId: ""
-      currentCredentialStrengthInOrchSession: false
+      currentCredentialStrengthInOrchSession: true
   ProvisionedConcurrency:
     staging:
       TrustmarkFunction: 1


### PR DESCRIPTION
## What

Turn on setting current credential strength in the orch session in Prod and Int.

This shouldn't affect any flows or behaviours.
