### PR TITLE
BAU: fix cross account errors in auth dev

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -733,6 +733,7 @@ data "aws_iam_policy_document" "dynamo_auth_session_read_write_policy_document" 
 }
 
 data "aws_iam_policy_document" "dynamo_orch_session_encryption_key_cross_account_decrypt_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
   statement {
     sid    = "AllowOrchSessionEncryptionKeyCrossAccountDecryptAccess"
     effect = "Allow"
@@ -744,8 +745,14 @@ data "aws_iam_policy_document" "dynamo_orch_session_encryption_key_cross_account
     ]
   }
 }
+moved {
+  from = data.aws_iam_policy_document.dynamo_orch_session_encryption_key_cross_account_decrypt_policy_document
+  to   = data.aws_iam_policy_document.dynamo_orch_session_encryption_key_cross_account_decrypt_policy_document[0]
+}
 
 data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_access_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+
   statement {
     sid    = "AllowOrchSessionCrossAccountReadAccess"
     effect = "Allow"
@@ -758,8 +765,13 @@ data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_access_po
     ]
   }
 }
+moved {
+  from = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_access_policy_document
+  to   = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_access_policy_document[0]
+}
 
 data "aws_iam_policy_document" "dynamo_orch_session_cross_account_delete_access_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
   statement {
     sid    = "AllowOrchSessionCrossAccountDeleteAccess"
     effect = "Allow"
@@ -770,6 +782,10 @@ data "aws_iam_policy_document" "dynamo_orch_session_cross_account_delete_access_
       "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Orch-Session",
     ]
   }
+}
+moved {
+  from = data.aws_iam_policy_document.dynamo_orch_session_cross_account_delete_access_policy_document
+  to   = data.aws_iam_policy_document.dynamo_orch_session_cross_account_delete_access_policy_document[0]
 }
 
 resource "aws_iam_policy" "dynamo_client_registry_write_access_policy" {
@@ -999,25 +1015,43 @@ resource "aws_iam_policy" "dynamo_auth_session_delete_policy" {
 }
 
 resource "aws_iam_policy" "dynamo_orch_session_encryption_key_cross_account_decrypt_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
   name_prefix = "dynamo-orch-session-encryption-key-cross-account-decrypt-policy"
   path        = "/${var.environment}/oidc-shared/"
   description = "IAM policy for managing decrypt and describe permissions to the orch session table's KMS encryption key"
 
-  policy = data.aws_iam_policy_document.dynamo_orch_session_encryption_key_cross_account_decrypt_policy_document.json
+  policy = data.aws_iam_policy_document.dynamo_orch_session_encryption_key_cross_account_decrypt_policy_document[count.index].json
+}
+moved {
+  from = aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_decrypt_policy
+  to   = aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_decrypt_policy[0]
 }
 
 resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_access_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
   name_prefix = "dynamo-orch-session-cross-account-read-policy"
   path        = "/${var.environment}/oidc-shared/"
   description = "IAM policy for managing read permissions to the orch session table"
 
-  policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_access_policy_document.json
+  policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_access_policy_document[count.index].json
+}
+moved {
+  from = aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy
+  to   = aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0]
 }
 
 resource "aws_iam_policy" "dynamo_orch_session_cross_account_delete_access_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
   name_prefix = "dynamo-orch-session-cross-account-delete-policy"
   path        = "/${var.environment}/oidc-shared/"
   description = "IAM policy for managing delete permissions to the orch session table"
 
-  policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_delete_access_policy_document.json
+  policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_delete_access_policy_document[count.index].json
+}
+moved {
+  from = aws_iam_policy.dynamo_orch_session_cross_account_delete_access_policy
+  to   = aws_iam_policy.dynamo_orch_session_cross_account_delete_access_policy[0]
 }

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -21,6 +21,8 @@ module "ipv_processing_identity_role" {
 }
 
 module "ipv_processing_identity_role_with_orch_session_table_access" {
+  count = var.is_orch_stubbed ? 0 : 1
+
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "ipv-processing-identity-role-with-orch-session-access"
@@ -39,10 +41,14 @@ module "ipv_processing_identity_role_with_orch_session_table_access" {
     local.client_registry_encryption_policy_arn,
     local.identity_credentials_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
-    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_decrypt_policy.arn,
-    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy.arn,
-    aws_iam_policy.dynamo_orch_session_cross_account_delete_access_policy.arn
+    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_decrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_delete_access_policy[0].arn
   ]
+}
+moved {
+  from = module.ipv_processing_identity_role_with_orch_session_table_access
+  to   = module.ipv_processing_identity_role_with_orch_session_table_access[0]
 }
 
 module "processing-identity" {
@@ -93,7 +99,7 @@ module "processing-identity" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = var.is_orch_stubbed ? module.ipv_processing_identity_role.arn : module.ipv_processing_identity_role_with_orch_session_table_access.arn
+  lambda_role_arn                        = var.is_orch_stubbed ? module.ipv_processing_identity_role.arn : module.ipv_processing_identity_role_with_orch_session_table_access[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -692,7 +692,7 @@ variable "orch_account_id" {
 }
 
 variable "is_orch_stubbed" {
-  type    = string
+  type    = bool
   default = false
 }
 


### PR DESCRIPTION
## What
Conditionally create and add the IAM policies for accessing the orch session table based on `is_orch_stubbed`.

For `authdev1`, `authdev2` and `dev`, orch is stubbed, so these environments don't need access to the orch session table. Currently however, the policies and roles enabling access are still being created, even if they're never used. However, there is some validation occurring on these policies and roles which are failing, because for example there isn't an encryption key arn (it defaults to an empty string).

## How to review
1. Code Review
2. Tested the deployment for environments with `is_orch_stubbed == false`:
  i. deploy edsandpit from main
  ii. deployed sandpit from BAU/fix-cross-account-errors-in-auth-dev
  iii. observed that the roles policies were moved, but none were destroyed nor added. This means the role persists, with no downtime
3. Tested the deployment for environments with `is_orch_stubbed == true`:
  i. set `is_orch_stubbed` to `true` in sandpit and removed the `orch_environment` and `orch_session_table_encryption_key_arn` variables (ie the same state `authdev1`, `authdev2` and `dev` are in)
  ii. deployed sandpit from BAU/fix-cross-account-errors-in-auth-dev
  iii. observed that the deployment succeeds
