### PR TITLE
ATO-1099: Update session when max age has expired

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -140,6 +140,21 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
                             redirectURI,
                             state));
         }
+        if (!client.getMaxAgeEnabled() && authRequest.getMaxAge() != -1) {
+            LOG.warn(
+                    "Max age present in auth request but not enabled for client. Client ID: {}",
+                    client.getClientID());
+        }
+        if (authRequest.getMaxAge() < -1) {
+            LOG.warn("Max age is negative in query params");
+            return Optional.of(
+                    new AuthRequestError(
+                            new ErrorObject(
+                                    OAuth2Error.INVALID_REQUEST_CODE,
+                                    "Max age is negative in query params"),
+                            redirectURI,
+                            state));
+        }
         return Optional.empty();
     }
 

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -341,5 +341,10 @@ public class IntegrationTest {
         public boolean isDestroyOrchSessionOnSignOutEnabled() {
             return true;
         }
+
+        @Override
+        public boolean supportMaxAgeEnabled() {
+            return true;
+        }
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/ClientStoreExtension.java
@@ -121,7 +121,43 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 clientType,
                 emptyList(),
                 jarValidationRequired,
-                clientLoCs);
+                clientLoCs,
+                false);
+    }
+
+    public void registerClient(
+            String clientID,
+            String clientName,
+            List<String> redirectUris,
+            List<String> contacts,
+            List<String> scopes,
+            String publicKey,
+            List<String> postLogoutRedirectUris,
+            String backChannelLogoutUri,
+            String serviceType,
+            String sectorIdentifierUri,
+            String subjectType,
+            ClientType clientType,
+            boolean jarValidationRequired,
+            List<String> clientLoCs,
+            boolean maxAgeEnabled) {
+        registerClient(
+                clientID,
+                clientName,
+                redirectUris,
+                contacts,
+                scopes,
+                publicKey,
+                postLogoutRedirectUris,
+                backChannelLogoutUri,
+                serviceType,
+                sectorIdentifierUri,
+                subjectType,
+                clientType,
+                emptyList(),
+                jarValidationRequired,
+                clientLoCs,
+                maxAgeEnabled);
     }
 
     public void registerClient(
@@ -180,7 +216,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
             ClientType clientType,
             List<String> claims,
             boolean jarValidationRequired,
-            List<String> clientLoCs) {
+            List<String> clientLoCs,
+            boolean maxAgeEnabled) {
         dynamoClientService.addClient(
                 clientID,
                 clientName,
@@ -204,7 +241,7 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 null,
                 clientLoCs,
                 Channel.WEB.getValue(),
-                false);
+                maxAgeEnabled);
     }
 
     public void registerClient(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -190,4 +190,8 @@ public class Session {
             codeRequestCountMap.put(requestType, 0);
         }
     }
+
+    public void resetClientSessions() {
+        this.clientSessions = new ArrayList<>();
+    }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -53,6 +53,22 @@ public class Session {
         initializeCodeRequestMap();
     }
 
+    public Session(Session session) {
+        this.sessionId = session.sessionId;
+        this.clientSessions = session.clientSessions;
+        this.isNewAccount = session.isNewAccount;
+        this.processingIdentityAttempts = session.processingIdentityAttempts;
+        this.codeRequestCountMap = session.codeRequestCountMap;
+        this.browserSessionId = session.browserSessionId;
+        this.authenticated = session.authenticated;
+        this.currentCredentialStrength = session.currentCredentialStrength;
+        this.emailAddress = session.emailAddress;
+        this.internalCommonSubjectIdentifier = session.internalCommonSubjectIdentifier;
+        this.retryCount = session.retryCount;
+        this.verifiedMfaMethodType = session.verifiedMfaMethodType;
+        initializeCodeRequestMap();
+    }
+
     public String getSessionId() {
         return sessionId;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -366,6 +366,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("SESSION_EXPIRY", "3600"));
     }
 
+    public boolean supportMaxAgeEnabled() {
+        return getFlagOrFalse("SUPPORT_MAX_AGE_ENABLED");
+    }
+
     public String getStorageTokenClaimName() {
         return System.getenv()
                 .getOrDefault(

--- a/template.yaml
+++ b/template.yaml
@@ -73,6 +73,12 @@ Conditions:
       !Equals [staging, !Ref Environment],
     ]
   IsIntegration: !Equals [!Ref Environment, integration]
+  SupportMaxAgeEnabled:
+    !Or [
+      !Equals [dev, !Ref Environment],
+      !Equals [build, !Ref Environment],
+      !Equals [staging, !Ref Environment],
+    ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -2359,6 +2365,10 @@ Resources:
               !Ref Environment,
               getAuthenticatedFromOrchSession,
             ]
+          SUPPORT_MAX_AGE_ENABLED: !If
+            - SupportMaxAgeEnabled
+            - true
+            - false
 
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy


### PR DESCRIPTION
## What
There is a specific set of updates required to the Orch session in relation to max age when all the following conditions are true:
- There is an existing Orch session
- Max age is enabled for the client
- Max age has expired

The updates to the Orch session are:
- Update the session ID of the existing (previous) Orch session. The session ID is updated as a security measure. Note that the previous session is not deleted (contrary to the non max age session update journey) because it is required after Authentication. The value of internalCommonSubjectIdentifier from the previous session will be compared against the value in the userinfo response, to confirm that the reauthenticated user is the same as the original user. Also the TTL of the previous session is bumped to ensure it is accessible after Authentication.
- Update the existing Orch session with authenticated=false (to force reauthentication) and add the new session ID for the previous session (to query ICSI from the previous session as described above).

Implementation has been feature flagged.

## Testing
Successfully run through the following journeys in dev, with both query parameter and request object requests:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
