### PR TITLE
ATO-1255: Update sandpit client reg entry to have MaxAgeEnabled=true

### DIFF
--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -28,6 +28,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = true
   },
   {
     client_name           = "relying-party-stub-sandpit-app"

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -128,5 +128,8 @@ resource "aws_dynamodb_table_item" "stub_relying_party_client" {
         }
       ]
     }
+    MaxAgeEnabled = {
+      BOOL = each.value.max_age_enabled
+    }
   })
 }

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -89,7 +89,7 @@ variable "logging_endpoint_arns" {
 
 variable "stub_rp_clients" {
   default     = []
-  type        = list(object({ client_name : string, at_client : bool, sector_identifier_uri : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, one_login_service : bool, service_type : string }))
+  type        = list(object({ client_name : string, at_client : bool, sector_identifier_uri : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, one_login_service : bool, service_type : string, max_age_enabled : bool }))
   description = "The details of RP clients to provision in the Client table"
   validation {
     condition     = length(var.stub_rp_clients) > 0


### PR DESCRIPTION
## What

Update sandpit client reg entry to have MaxAgeEnabled=true. This will allow testing of the max age initiative in dev / sandpit without always having to manually update the client reg entry.
