### PR TITLE
BAU: reinstate global dependency workflows

### DIFF
--- a/.github/workflows/dependency-review-on-pr.yml
+++ b/.github/workflows/dependency-review-on-pr.yml
@@ -2,14 +2,6 @@ name: Dependency review for pull requests
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/dependency-review-on-pr.yml"
-      # Ensure these are synchronized with the paths in the check-changed-files job
-      - "**/src/**"
-      - "**/*.java"
-      - "**/*.gradle"
-      - "**/*.properties"
-      - "gradle*"
 
 permissions:
   contents: write

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -4,13 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      # Ensure these are synchronized with the paths in the check-changed-files job
-      - "**/src/**"
-      - "**/*.java"
-      - "**/*.gradle"
-      - "**/*.properties"
-      - "gradle*"
 
 permissions:
   contents: write


### PR DESCRIPTION
## What

These were switched to be java-only checks, but this is bad behaviour: it's not just java files which can be scanned, and this makes the dependency graph weird and can cause spurious workflow failures

## How to review

Code review
