### PR TITLE
ATO-1255: Update sandpit client reg entry to have MaxAgeEnabled=true

### DIFF
--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -29,6 +29,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
   {
     // this client may or may not work. It's needed for the SSM parameter generation though, so this could be classed as a dummy entry.
@@ -54,6 +55,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
 ]
 

--- a/ci/terraform/shared/authdev2.tfvars
+++ b/ci/terraform/shared/authdev2.tfvars
@@ -28,6 +28,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
   {
     // this client may or may not work. It's needed for the SSM parameter generation though, so this could be classed as a dummy entry.
@@ -53,6 +54,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
 ]
 

--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -22,6 +22,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
   {
     client_name           = "relying-party-stub-build-app"
@@ -45,6 +46,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
   {
     client_name           = "relying-party-stub-build-acceptance-test"
@@ -71,6 +73,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
   {
     client_name           = "relying-party-micro-stub-build-acceptance-test"
@@ -95,6 +98,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
   {
     # New client for Secure pipeline Migration
@@ -121,5 +125,6 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
 ]

--- a/ci/terraform/shared/dev-stub-clients.tfvars
+++ b/ci/terraform/shared/dev-stub-clients.tfvars
@@ -22,6 +22,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
   {
     client_name           = "relying-party-stub-dev-app"
@@ -46,5 +47,6 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
 ]

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -19,6 +19,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
   {
     client_name           = "relying-party-stub-integration-app"
@@ -38,5 +39,6 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
 ]

--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -19,6 +19,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
   {
     client_name           = "relying-party-stub-production-app"
@@ -38,5 +39,6 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
 ]

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -28,6 +28,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = true
   },
   {
     client_name           = "relying-party-stub-sandpit-app"
@@ -52,6 +53,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
 ]
 

--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -20,6 +20,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
   {
     client_name           = "relying-party-stub-staging-app"
@@ -39,6 +40,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
   {
     client_name           = "relying-party-stub-staging-perf-test"
@@ -60,5 +62,6 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
+    max_age_enabled   = false
   },
 ]

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -128,5 +128,8 @@ resource "aws_dynamodb_table_item" "stub_relying_party_client" {
         }
       ]
     }
+    MaxAgeEnabled = {
+      BOOL = each.value.max_age_enabled
+    }
   })
 }

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -89,7 +89,7 @@ variable "logging_endpoint_arns" {
 
 variable "stub_rp_clients" {
   default     = []
-  type        = list(object({ client_name : string, at_client : bool, sector_identifier_uri : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, one_login_service : bool, service_type : string }))
+  type        = list(object({ client_name : string, at_client : bool, sector_identifier_uri : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, one_login_service : bool, service_type : string, max_age_enabled : bool }))
   description = "The details of RP clients to provision in the Client table"
   validation {
     condition     = length(var.stub_rp_clients) > 0


### PR DESCRIPTION
_second attempt after the first PR (https://github.com/govuk-one-login/authentication-api/pull/5609) was reverted_
## What

Update sandpit client reg entry to have MaxAgeEnabled=true. This will allow testing of the max age initiative in dev / sandpit without always having to manually update the client reg entry.
