### PR TITLE
ATO-975: switch getter from shared session to orch session in authorize

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -781,7 +781,7 @@ public class AuthorisationHandler
                                         : session.isAuthenticated())
                         .claim(
                                 "current_credential_strength",
-                                session.getCurrentCredentialStrength());
+                                orchSession.getCurrentCredentialStrength());
 
         previousSessionId.ifPresent(id -> claimsBuilder.claim("previous_session_id", id));
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -515,9 +515,9 @@ class AuthorisationHandlerTest {
         @Test
         void shouldPassCurrentCredentialStrengthClaimToAuthFromSession() {
             var currentCredentialStrength = CredentialTrustLevel.MEDIUM_LEVEL;
-            withExistingSession(
-                    new Session(NEW_SESSION_ID)
-                            .setCurrentCredentialStrength(currentCredentialStrength));
+            withExistingOrchSession(
+                    new OrchSessionItem(NEW_SESSION_ID)
+                            .withCurrentCredentialStrength(currentCredentialStrength));
 
             var requestParams =
                     buildRequestParams(


### PR DESCRIPTION
## What

When passing the current credential strength to auth use the value from the orch session instead of the shared session.