### PR TITLE
ATO-1259: add rpPairwiseId to client session

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -402,9 +402,12 @@ public class AuthenticationCallbackHandler
 
                 userSession.setAuthenticated(true);
                 orchSession.setAuthenticated(true);
+                clientSession.setRpPairwiseId(
+                        userInfo.getStringClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue()));
 
                 sessionService.storeOrUpdateSession(userSession);
                 orchSessionService.updateSession(orchSession);
+                clientSessionService.updateStoredClientSession(clientSessionId, clientSession);
 
                 var docAppJourney = isDocCheckingAppUserWithSubjectId(clientSession);
                 Map<String, String> dimensions =

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -383,6 +383,10 @@ public class AuthenticationCallbackHandler
                 LOG.info(
                         "is uplift_required attached to auth-external-api userinfo response: {}",
                         userInfo.getClaim(AuthUserInfoClaims.UPLIFT_REQUIRED.getValue()) != null);
+                LOG.info(
+                        "is rpPairwiseId attached to auth-external-api userinfo response: {}",
+                        userInfo.getStringClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue())
+                                != null);
                 //
 
                 Boolean newAccount =

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -148,6 +148,8 @@ class AuthenticationCallbackHandlerTest {
         when(USER_INFO.getSubject()).thenReturn(new Subject(TEST_INTERNAL_COMMON_SUBJECT_ID));
         when(USER_INFO.getClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue(), String.class))
                 .thenReturn(RP_PAIRWISE_ID.getValue());
+        when(USER_INFO.getStringClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue()))
+                .thenReturn(RP_PAIRWISE_ID.getValue());
         when(USER_INFO.getPhoneNumber()).thenReturn("1234");
         when(USER_INFO.getClaim(
                         AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(), String.class))
@@ -272,6 +274,7 @@ class AuthenticationCallbackHandlerTest {
                         eq(pair("authCode", AUTH_CODE_RP_TO_ORCH.getValue())),
                         eq(pair("nonce", RP_NONCE.getValue())));
         assertOrchSessionUpdated();
+        assertClientSessionUpdated();
     }
 
     @Test
@@ -1030,6 +1033,13 @@ class AuthenticationCallbackHandlerTest {
         assertThat(
                 orchSessionCaptor.getAllValues().get(0).getCurrentCredentialStrength(),
                 equalTo(lowestCredentialTrustLevel));
+    }
+
+    private void assertClientSessionUpdated() {
+        var clientSessionCaptor = ArgumentCaptor.forClass(ClientSession.class);
+        verify(clientSessionService, times(1))
+                .updateStoredClientSession(any(), clientSessionCaptor.capture());
+        assertEquals(RP_PAIRWISE_ID.getValue(), clientSessionCaptor.getValue().getRpPairwiseId());
     }
 
     private void clientSessionWithCredentialTrustValue(CredentialTrustLevel credentialTrustLevel) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
@@ -25,6 +25,8 @@ public class ClientSession {
 
     @Expose private List<VectorOfTrust> vtrList;
 
+    @Expose private String rpPairwiseId;
+
     @Expose private Subject docAppSubjectId;
 
     @Expose private String clientName;
@@ -62,6 +64,15 @@ public class ClientSession {
 
     public List<VectorOfTrust> getVtrList() {
         return vtrList;
+    }
+
+    public String getRpPairwiseId() {
+        return rpPairwiseId;
+    }
+
+    public ClientSession setRpPairwiseId(String rpPairwiseId) {
+        this.rpPairwiseId = rpPairwiseId;
+        return this;
     }
 
     public Subject getDocAppSubjectId() {


### PR DESCRIPTION
## What
Adds rpPairwiseId to the client session in the authentication callback handler. There is a one-to-one mapping of rpPairwiseId to ClientSession, and we can always get the clientSession via the clientSessionId in the request cookies.

By defining it here, we gain a number of benefits:
- Calculate once, use many times. Currently, it is calcuated in lots of places.
- By calculating once, we define one name for this particular value, and remove opportunities for naming it differently when calculated.
- We don’t need to get subject, sector uri and salt everytime we want to get rpPairwiseId.
- We won’t have to be getting salt from the authUserInfo table - we can just use it immediately in the authenticationCallbackHandler, set it in the client session and use that.. This means we avoid the fiddliness of ByteBuffers (converting to a byte[] takes 3 lines of code, and incorrectly reading results in side effects).

This will also be the implementation of the new migrated ClientSession table. By doing this work here, we ready the codebase for this migration too.

## How to review
1. Code Review