### PR TITLE
AUT-3929: Warn when metrics would fail validation

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/metrics/MetricValidationWarningLogger.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/metrics/MetricValidationWarningLogger.java
@@ -1,0 +1,158 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ *   Modifications made:
+ *   - GDS (2024-12): Rather than throwing errors, this logs warnings should
+ *     validation of a metric, dimension or namespace fail
+ */
+
+package uk.gov.di.orchestration.metrics;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
+
+public class MetricValidationWarningLogger {
+    private static final Logger LOG = LogManager.getLogger(MetricValidationWarningLogger.class);
+
+    public static final short MAX_DIMENSION_NAME_LENGTH = 250;
+    public static final short MAX_DIMENSION_VALUE_LENGTH = 1024;
+    public static final short MAX_METRIC_NAME_LENGTH = 1024;
+    public static final short MAX_NAMESPACE_LENGTH = 256;
+    public static final String VALID_NAMESPACE_REGEX = "^[a-zA-Z0-9._#:/-]+$";
+
+    private MetricValidationWarningLogger() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static void validateDimensionSet(String dimensionName, String dimensionValue) {
+
+        if (dimensionName == null || dimensionName.trim().isEmpty()) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension name cannot be empty {}",
+                    getStackTrace());
+            return;
+        }
+
+        if (dimensionValue == null || dimensionValue.trim().isEmpty()) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension value cannot be empty {}",
+                    getStackTrace());
+            return;
+        }
+
+        if (dimensionName.length() > MAX_DIMENSION_NAME_LENGTH) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension name exceeds maximum length of {}: {} {}",
+                    MAX_DIMENSION_NAME_LENGTH,
+                    dimensionName,
+                    getStackTrace());
+        }
+
+        if (dimensionValue.length() > MAX_DIMENSION_VALUE_LENGTH) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension value exceeds maximum length of {}}: {} {}",
+                    MAX_DIMENSION_VALUE_LENGTH,
+                    dimensionValue,
+                    getStackTrace());
+        }
+
+        if (!StringUtils.isAsciiPrintable(dimensionName)) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension name has invalid characters: {} {}",
+                    dimensionName,
+                    getStackTrace());
+        }
+
+        if (!StringUtils.isAsciiPrintable(dimensionValue)) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension value has invalid characters: {} {}",
+                    dimensionValue,
+                    getStackTrace());
+        }
+
+        if (dimensionName.startsWith(":")) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension name cannot start with ':' {}",
+                    getStackTrace());
+        }
+    }
+
+    public static void validateMetric(String name, double value, Unit unit) {
+        if (name == null || name.trim().isEmpty()) {
+            LOG.warn(
+                    "Would throw InvalidMetricException. Metric name {} must include at least one non-whitespace character {}",
+                    name,
+                    getStackTrace());
+            return;
+        }
+
+        if (name.length() > MAX_METRIC_NAME_LENGTH) {
+            LOG.warn(
+                    "Would throw InvalidMetricException. Metric name exceeds maximum length of {}: {} {}",
+                    MAX_METRIC_NAME_LENGTH,
+                    name,
+                    getStackTrace());
+        }
+
+        if (!Double.isFinite(value)) {
+            LOG.warn(
+                    "Would throw InvalidMetricException. Metric value is not a number {}",
+                    getStackTrace());
+        }
+
+        if (unit == null) {
+            LOG.warn(
+                    "Would throw InvalidMetricException. Metric unit cannot be null {}",
+                    getStackTrace());
+        }
+    }
+
+    public static void validateNamespace(String namespace) {
+        if (namespace == null || namespace.trim().isEmpty()) {
+            LOG.warn(
+                    "Would throw InvalidNamespaceException. Namespace must include at least one non-whitespace character {}",
+                    getStackTrace());
+            return;
+        }
+
+        if (namespace.length() > MAX_NAMESPACE_LENGTH) {
+            LOG.warn(
+                    "Would throw InvalidNamespaceException. Namespace exceeds maximum length of {}: {} {}",
+                    MAX_NAMESPACE_LENGTH,
+                    namespace,
+                    getStackTrace());
+        }
+
+        if (!namespace.matches(VALID_NAMESPACE_REGEX)) {
+            LOG.warn(
+                    "Would throw InvalidNamespaceException. Namespace contains invalid characters: {} {}",
+                    namespace,
+                    getStackTrace());
+        }
+    }
+
+    public static String getStackTrace() {
+        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+
+        StringBuilder stackTraceString = new StringBuilder();
+        for (StackTraceElement element : stackTrace) {
+            stackTraceString.append("\n").append(element);
+        }
+
+        return stackTraceString.toString();
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CloudwatchMetricsService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CloudwatchMetricsService.java
@@ -3,6 +3,7 @@ package uk.gov.di.orchestration.shared.services;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
+import uk.gov.di.orchestration.metrics.MetricValidationWarningLogger;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 
@@ -37,11 +38,17 @@ public class CloudwatchMetricsService {
                     var metrics = new MetricsLogger();
                     var dimensionsSet = new DimensionSet();
 
+                    String namespace = "Authentication";
                     dimensions.forEach(dimensionsSet::addDimension);
+                    Unit unit = Unit.NONE;
 
-                    metrics.setNamespace("Authentication");
+                    MetricValidationWarningLogger.validateNamespace(namespace);
+                    MetricValidationWarningLogger.validateMetric(name, value, unit);
+                    dimensions.forEach(MetricValidationWarningLogger::validateDimensionSet);
+
+                    metrics.setNamespace(namespace);
                     metrics.putDimensions(dimensionsSet);
-                    metrics.putMetric(name, value, Unit.NONE);
+                    metrics.putMetric(name, value, unit);
                     metrics.flush();
                 });
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -4,6 +4,7 @@ import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.metrics.MetricValidationWarningLogger;
 
 import java.util.Map;
 
@@ -40,11 +41,17 @@ public class CloudwatchMetricsService {
                     var metrics = new MetricsLogger();
                     var dimensionsSet = new DimensionSet();
 
+                    String namespace = "Authentication";
                     dimensions.forEach(dimensionsSet::addDimension);
+                    Unit unit = Unit.NONE;
 
-                    metrics.setNamespace("Authentication");
+                    MetricValidationWarningLogger.validateNamespace(namespace);
+                    MetricValidationWarningLogger.validateMetric(name, value, unit);
+                    dimensions.forEach(MetricValidationWarningLogger::validateDimensionSet);
+
+                    metrics.setNamespace(namespace);
                     metrics.putDimensions(dimensionsSet);
-                    metrics.putMetric(name, value, Unit.NONE);
+                    metrics.putMetric(name, value, unit);
                     metrics.flush();
                 });
     }

--- a/shared/src/main/java/uk/gov/di/metrics/MetricValidationWarningLogger.java
+++ b/shared/src/main/java/uk/gov/di/metrics/MetricValidationWarningLogger.java
@@ -1,0 +1,158 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ *   Modifications made:
+ *   - GDS (2024-12): Rather than throwing errors, this logs warnings should
+ *     validation of a metric, dimension or namespace fail
+ */
+
+package uk.gov.di.metrics;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
+
+public class MetricValidationWarningLogger {
+    private static final Logger LOG = LogManager.getLogger(MetricValidationWarningLogger.class);
+
+    public static final short MAX_DIMENSION_NAME_LENGTH = 250;
+    public static final short MAX_DIMENSION_VALUE_LENGTH = 1024;
+    public static final short MAX_METRIC_NAME_LENGTH = 1024;
+    public static final short MAX_NAMESPACE_LENGTH = 256;
+    public static final String VALID_NAMESPACE_REGEX = "^[a-zA-Z0-9._#:/-]+$";
+
+    private MetricValidationWarningLogger() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static void validateDimensionSet(String dimensionName, String dimensionValue) {
+
+        if (dimensionName == null || dimensionName.trim().isEmpty()) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension name cannot be empty {}",
+                    getStackTrace());
+            return;
+        }
+
+        if (dimensionValue == null || dimensionValue.trim().isEmpty()) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension value cannot be empty {}",
+                    getStackTrace());
+            return;
+        }
+
+        if (dimensionName.length() > MAX_DIMENSION_NAME_LENGTH) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension name exceeds maximum length of {}: {} {}",
+                    MAX_DIMENSION_NAME_LENGTH,
+                    dimensionName,
+                    getStackTrace());
+        }
+
+        if (dimensionValue.length() > MAX_DIMENSION_VALUE_LENGTH) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension value exceeds maximum length of {}}: {} {}",
+                    MAX_DIMENSION_VALUE_LENGTH,
+                    dimensionValue,
+                    getStackTrace());
+        }
+
+        if (!StringUtils.isAsciiPrintable(dimensionName)) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension name has invalid characters: {} {}",
+                    dimensionName,
+                    getStackTrace());
+        }
+
+        if (!StringUtils.isAsciiPrintable(dimensionValue)) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension value has invalid characters: {} {}",
+                    dimensionValue,
+                    getStackTrace());
+        }
+
+        if (dimensionName.startsWith(":")) {
+            LOG.warn(
+                    "Would throw InvalidDimensionException. Dimension name cannot start with ':' {}",
+                    getStackTrace());
+        }
+    }
+
+    public static void validateMetric(String name, double value, Unit unit) {
+        if (name == null || name.trim().isEmpty()) {
+            LOG.warn(
+                    "Would throw InvalidMetricException. Metric name {} must include at least one non-whitespace character {}",
+                    name,
+                    getStackTrace());
+            return;
+        }
+
+        if (name.length() > MAX_METRIC_NAME_LENGTH) {
+            LOG.warn(
+                    "Would throw InvalidMetricException. Metric name exceeds maximum length of {}: {} {}",
+                    MAX_METRIC_NAME_LENGTH,
+                    name,
+                    getStackTrace());
+        }
+
+        if (!Double.isFinite(value)) {
+            LOG.warn(
+                    "Would throw InvalidMetricException. Metric value is not a number {}",
+                    getStackTrace());
+        }
+
+        if (unit == null) {
+            LOG.warn(
+                    "Would throw InvalidMetricException. Metric unit cannot be null {}",
+                    getStackTrace());
+        }
+    }
+
+    public static void validateNamespace(String namespace) {
+        if (namespace == null || namespace.trim().isEmpty()) {
+            LOG.warn(
+                    "Would throw InvalidNamespaceException. Namespace must include at least one non-whitespace character {}",
+                    getStackTrace());
+            return;
+        }
+
+        if (namespace.length() > MAX_NAMESPACE_LENGTH) {
+            LOG.warn(
+                    "Would throw InvalidNamespaceException. Namespace exceeds maximum length of {}: {} {}",
+                    MAX_NAMESPACE_LENGTH,
+                    namespace,
+                    getStackTrace());
+        }
+
+        if (!namespace.matches(VALID_NAMESPACE_REGEX)) {
+            LOG.warn(
+                    "Would throw InvalidNamespaceException. Namespace contains invalid characters: {} {}",
+                    namespace,
+                    getStackTrace());
+        }
+    }
+
+    public static String getStackTrace() {
+        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+
+        StringBuilder stackTraceString = new StringBuilder();
+        for (StackTraceElement element : stackTrace) {
+            stackTraceString.append("\n").append(element);
+        }
+
+        return stackTraceString.toString();
+    }
+}


### PR DESCRIPTION
## What

The version bump of `aws-embedded-metrics` from v2 to v4 [1] introduces validation of metrics that thow errors on failure.

This commit brings in the same validation methods implemented by AWS [2] but instead of throwing an error it logs a warning with stacktrace.

The intention is to let this run in environments for a time period and assess any warnings logged before continuing with the version bump. The data gathered will help us make the nessessary modifications across orch and auth.

This would be reverted when we upgrade the library.

[1]: https://github.com/govuk-one-login/authentication-api/pull/4993
[2]: https://github.com/awslabs/aws-embedded-metrics-java/pull/119/files#diff-95ba60790f295fcb1d765c68bd8876c4722e13ef3fd5a34c6965b5fe1b393786R1

## How to review

1. Code Review
2. Run the `doesThrowWhenAisReturns500AndAbortFlagIsOnWithIdentity` test from `integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java` and see the following warning in the logs `Would throw InvalidMetricException. Metric name  must include at least one non-whitespace character...`

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.
