### PR TITLE
BAU: Fix remote_state assume_role configuration

### DIFF
--- a/ci/terraform/account-management/core.tf
+++ b/ci/terraform/account-management/core.tf
@@ -1,10 +1,11 @@
 data "terraform_remote_state" "core" {
   backend = "s3"
   config = {
-    bucket                      = var.common_state_bucket
-    key                         = "${var.environment}-core-terraform.tfstate"
-    role_arn                    = var.deployer_role_arn
-    region                      = var.aws_region
+    bucket      = var.common_state_bucket
+    key         = "${var.environment}-core-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
+
     endpoint                    = var.use_localstack ? "http://localhost:45678" : null
     iam_endpoint                = var.use_localstack ? "http://localhost:45678" : null
     sts_endpoint                = var.use_localstack ? "http://localhost:45678" : null

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -1,10 +1,11 @@
 data "terraform_remote_state" "shared" {
   backend = "s3"
   config = {
-    bucket                      = var.common_state_bucket
-    key                         = "${var.environment}-shared-terraform.tfstate"
-    role_arn                    = var.deployer_role_arn
-    region                      = var.aws_region
+    bucket      = var.common_state_bucket
+    key         = "${var.environment}-shared-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
+
     endpoint                    = var.use_localstack ? "http://localhost:45678" : null
     iam_endpoint                = var.use_localstack ? "http://localhost:45678" : null
     sts_endpoint                = var.use_localstack ? "http://localhost:45678" : null

--- a/ci/terraform/auth-external-api/shared.tf
+++ b/ci/terraform/auth-external-api/shared.tf
@@ -1,10 +1,11 @@
 data "terraform_remote_state" "shared" {
   backend = "s3"
   config = {
-    bucket                      = var.shared_state_bucket
-    key                         = "${var.environment}-shared-terraform.tfstate"
-    role_arn                    = var.deployer_role_arn
-    region                      = var.aws_region
+    bucket      = var.shared_state_bucket
+    key         = "${var.environment}-shared-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
+
     endpoint                    = null
     iam_endpoint                = null
     sts_endpoint                = null

--- a/ci/terraform/delivery-receipts/core.tf
+++ b/ci/terraform/delivery-receipts/core.tf
@@ -1,10 +1,11 @@
 data "terraform_remote_state" "core" {
   backend = "s3"
   config = {
-    bucket                      = var.common_state_bucket
-    key                         = "${var.environment}-core-terraform.tfstate"
-    role_arn                    = var.deployer_role_arn
-    region                      = var.aws_region
+    bucket      = var.common_state_bucket
+    key         = "${var.environment}-core-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
+
     endpoint                    = var.use_localstack ? "http://localhost:45678" : null
     iam_endpoint                = var.use_localstack ? "http://localhost:45678" : null
     sts_endpoint                = var.use_localstack ? "http://localhost:45678" : null

--- a/ci/terraform/delivery-receipts/shared.tf
+++ b/ci/terraform/delivery-receipts/shared.tf
@@ -1,10 +1,11 @@
 data "terraform_remote_state" "shared" {
   backend = "s3"
   config = {
-    bucket                      = var.common_state_bucket
-    key                         = "${var.environment}-shared-terraform.tfstate"
-    role_arn                    = var.deployer_role_arn
-    region                      = var.aws_region
+    bucket      = var.common_state_bucket
+    key         = "${var.environment}-shared-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
+
     endpoint                    = var.use_localstack ? "http://localhost:45678" : null
     iam_endpoint                = var.use_localstack ? "http://localhost:45678" : null
     sts_endpoint                = var.use_localstack ? "http://localhost:45678" : null

--- a/ci/terraform/interventions-api-stub/shared.tf
+++ b/ci/terraform/interventions-api-stub/shared.tf
@@ -1,10 +1,11 @@
 data "terraform_remote_state" "shared" {
   backend = "s3"
   config = {
-    bucket                      = var.shared_state_bucket
-    key                         = "${var.environment}-shared-terraform.tfstate"
-    role_arn                    = var.deployer_role_arn
-    region                      = var.aws_region
+    bucket      = var.shared_state_bucket
+    key         = "${var.environment}-shared-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
+
     endpoint                    = null
     iam_endpoint                = null
     sts_endpoint                = null

--- a/ci/terraform/modules/dns/dns.tf
+++ b/ci/terraform/modules/dns/dns.tf
@@ -2,10 +2,10 @@ data "terraform_remote_state" "dns" {
   count   = var.is_localstack || var.is_sandpit ? 0 : 1
   backend = "s3"
   config = {
-    bucket   = var.dns_state_bucket
-    key      = var.dns_state_key
-    role_arn = var.dns_state_role
-    region   = var.aws_region
+    bucket      = var.dns_state_bucket
+    key         = var.dns_state_key
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
   }
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -1,10 +1,11 @@
 data "terraform_remote_state" "shared" {
   backend = "s3"
   config = {
-    bucket                      = var.shared_state_bucket
-    key                         = "${var.environment}-shared-terraform.tfstate"
-    role_arn                    = var.deployer_role_arn
-    region                      = var.aws_region
+    bucket      = var.shared_state_bucket
+    key         = "${var.environment}-shared-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
+
     endpoint                    = var.use_localstack ? "http://localhost:45678" : null
     iam_endpoint                = var.use_localstack ? "http://localhost:45678" : null
     sts_endpoint                = var.use_localstack ? "http://localhost:45678" : null
@@ -17,10 +18,11 @@ data "terraform_remote_state" "shared" {
 data "terraform_remote_state" "auth-ext-api" {
   backend = "s3"
   config = {
-    bucket                      = var.shared_state_bucket
-    key                         = "${var.environment}-auth-external-api-terraform.tfstate"
-    role_arn                    = var.deployer_role_arn
-    region                      = var.aws_region
+    bucket      = var.shared_state_bucket
+    key         = "${var.environment}-auth-external-api-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
+
     endpoint                    = var.use_localstack ? "http://localhost:45678" : null
     iam_endpoint                = var.use_localstack ? "http://localhost:45678" : null
     sts_endpoint                = var.use_localstack ? "http://localhost:45678" : null
@@ -33,10 +35,10 @@ data "terraform_remote_state" "auth-ext-api" {
 data "terraform_remote_state" "contra" {
   backend = "s3"
   config = {
-    bucket   = var.contra_state_bucket
-    key      = "${var.environment}-experian-phone-check-terraform.tfstate"
-    role_arn = var.deployer_role_arn
-    region   = var.aws_region
+    bucket      = var.contra_state_bucket
+    key         = "${var.environment}-experian-phone-check-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
   }
 }
 

--- a/ci/terraform/shared/core.tf
+++ b/ci/terraform/shared/core.tf
@@ -1,10 +1,11 @@
 data "terraform_remote_state" "core" {
   backend = "s3"
   config = {
-    bucket                      = var.common_state_bucket
-    key                         = "${var.environment}-core-terraform.tfstate"
-    role_arn                    = var.deployer_role_arn
-    region                      = var.aws_region
+    bucket      = var.common_state_bucket
+    key         = "${var.environment}-core-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
+
     endpoint                    = var.use_localstack ? "http://localhost:45678" : null
     iam_endpoint                = var.use_localstack ? "http://localhost:45678" : null
     sts_endpoint                = var.use_localstack ? "http://localhost:45678" : null

--- a/ci/terraform/test-services/shared.tf
+++ b/ci/terraform/test-services/shared.tf
@@ -1,10 +1,11 @@
 data "terraform_remote_state" "shared" {
   backend = "s3"
   config = {
-    bucket                      = var.shared_state_bucket
-    key                         = "${var.environment}-shared-terraform.tfstate"
-    role_arn                    = var.deployer_role_arn
-    region                      = var.aws_region
+    bucket      = var.shared_state_bucket
+    key         = "${var.environment}-shared-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
+
     endpoint                    = var.use_localstack ? "http://localhost:45678" : null
     iam_endpoint                = var.use_localstack ? "http://localhost:45678" : null
     sts_endpoint                = var.use_localstack ? "http://localhost:45678" : null

--- a/ci/terraform/ticf-cri-stub/shared.tf
+++ b/ci/terraform/ticf-cri-stub/shared.tf
@@ -1,10 +1,11 @@
 data "terraform_remote_state" "shared" {
   backend = "s3"
   config = {
-    bucket                      = var.shared_state_bucket
-    key                         = "${var.environment}-shared-terraform.tfstate"
-    role_arn                    = var.deployer_role_arn
-    region                      = var.aws_region
+    bucket      = var.shared_state_bucket
+    key         = "${var.environment}-shared-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
+
     endpoint                    = null
     iam_endpoint                = null
     sts_endpoint                = null

--- a/ci/terraform/utils/shared.tf
+++ b/ci/terraform/utils/shared.tf
@@ -1,10 +1,10 @@
 data "terraform_remote_state" "shared" {
   backend = "s3"
   config = {
-    bucket   = var.shared_state_bucket
-    key      = "${var.environment}-shared-terraform.tfstate"
-    role_arn = var.deployer_role_arn
-    region   = var.aws_region
+    bucket      = var.shared_state_bucket
+    key         = "${var.environment}-shared-terraform.tfstate"
+    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
+    region      = var.aws_region
   }
 }
 


### PR DESCRIPTION
## What

This was missed when upgrading the providers. If `role_arn` is null,
`terraform_remote_state` will fail to initialise.

This fixes that by conditionally building the object value for the
`assume_role` property.

## How to review

- Code Review
- Maybe attempt to deploy to a dev environment locally?
