### PR TITLE
ATO-975: update uplift to use the current credetial strength from the start request.

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -205,12 +205,16 @@ public class StartHandler
             Optional<String> maybeInternalCommonSubjectIdentifier =
                     Optional.ofNullable(session.getInternalCommonSubjectIdentifier());
 
-            boolean upliftRequired = startService.isUpliftRequired(userContext);
+            CredentialTrustLevel currentCredentialStrength =
+                    startRequest.currentCredentialStrength();
+
+            boolean upliftRequired =
+                    startService.isUpliftRequired(userContext, currentCredentialStrength);
 
             authSessionService.addOrUpdateSessionIncludingSessionId(
                     Optional.ofNullable(startRequest.previousSessionId()),
                     session.getSessionId(),
-                    startRequest.currentCredentialStrength(),
+                    currentCredentialStrength,
                     upliftRequired);
 
             var clientSessionId =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -12,6 +12,7 @@ import uk.gov.di.authentication.shared.conditions.DocAppUserHelper;
 import uk.gov.di.authentication.shared.conditions.IdentityHelper;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -224,19 +225,17 @@ public class StartService {
                 .isEmpty();
     }
 
-    public boolean isUpliftRequired(UserContext userContext) {
+    public boolean isUpliftRequired(
+            UserContext userContext, CredentialTrustLevel currentCredentialStrength) {
         if (DocAppUserHelper.isDocCheckingAppUser(userContext)
-                || Objects.isNull(userContext.getSession().getCurrentCredentialStrength())) {
+                || Objects.isNull(currentCredentialStrength)) {
             return false;
         }
-        return (userContext
-                        .getSession()
-                        .getCurrentCredentialStrength()
-                        .compareTo(
-                                userContext
-                                        .getClientSession()
-                                        .getEffectiveVectorOfTrust()
-                                        .getCredentialTrustLevel())
+        return (currentCredentialStrength.compareTo(
+                        userContext
+                                .getClientSession()
+                                .getEffectiveVectorOfTrust()
+                                .getCredentialTrustLevel())
                 < 0);
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -462,12 +462,9 @@ class StartServiceTest {
                         Optional.of(userProfile),
                         Optional.of(userCredentials),
                         false);
-        userContext
-                .getSession()
-                .setCurrentCredentialStrength(credentialTrustLevel)
-                .setEmailAddress(EMAIL);
+        userContext.getSession().setEmailAddress(EMAIL);
 
-        var upliftRequired = startService.isUpliftRequired(userContext);
+        var upliftRequired = startService.isUpliftRequired(userContext, credentialTrustLevel);
         var userStartInfo =
                 startService.buildUserStartInfo(
                         userContext,


### PR DESCRIPTION
##What

Pass the current credential strength from the start request instead of using the userContext.

This will be the final change to allow all the current credential strength be moved to split sessions.

Tested in sandpit
Auth Acceptance tests pass
Tested it deploys to authDev