### PR TITLE
Aut 3903/invoke ticf via alias

### DIFF
--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -40,7 +40,7 @@ module "account_interventions" {
     ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
     ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED = var.account_intervention_service_action_enabled
     ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled
-    TICF_CRI_LAMBDA_NAME                        = local.deploy_ticf_cri_count == 1 ? aws_lambda_function.ticf_cri_lambda[0].function_name : null
+    TICF_CRI_LAMBDA_NAME                        = local.deploy_ticf_cri_count == 1 ? aws_lambda_alias.ticf_cri_lambda_alias[0].arn : null
     INVOKE_TICF_CRI_LAMBDA                      = var.call_ticf_cri
   }
 

--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -40,7 +40,7 @@ module "account_interventions" {
     ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
     ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED = var.account_intervention_service_action_enabled
     ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled
-    TICF_CRI_LAMBDA_NAME                        = local.deploy_ticf_cri_count == 1 ? aws_lambda_alias.ticf_cri_lambda_alias[0].arn : null
+    TICF_CRI_LAMBDA_IDENTIFIER                  = local.deploy_ticf_cri_count == 1 ? aws_lambda_alias.ticf_cri_lambda_alias[0].arn : null
     INVOKE_TICF_CRI_LAMBDA                      = var.call_ticf_cri
   }
 

--- a/ci/terraform/oidc/ticf-cri.tf
+++ b/ci/terraform/oidc/ticf-cri.tf
@@ -73,6 +73,14 @@ resource "aws_iam_policy" "ticf_cri_lambda_invocation_policy" {
   policy = data.aws_iam_policy_document.ticf_cri_lambda_invocation_policy_document[count.index].json
 }
 
+resource "aws_lambda_alias" "ticf_cri_lambda_alias" {
+  count            = local.deploy_ticf_cri_count
+  name             = "${var.environment}-ticf-cri-lambda-active"
+  description      = "Alias pointing at active version of Lambda"
+  function_name    = aws_lambda_function.ticf_cri_lambda[0].arn
+  function_version = aws_lambda_function.ticf_cri_lambda[0].version
+}
+
 data "aws_iam_policy_document" "ticf_cri_lambda_invocation_policy_document" {
   count = local.deploy_ticf_cri_count
   statement {
@@ -84,7 +92,7 @@ data "aws_iam_policy_document" "ticf_cri_lambda_invocation_policy_document" {
     ]
 
     resources = [
-      aws_lambda_function.ticf_cri_lambda[0].arn,
+      aws_lambda_alias.ticf_cri_lambda_alias[0].arn,
     ]
   }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -238,7 +238,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             return;
         }
 
-        lambdaInvoker.invokeAsyncWithPayload(payload, configurationService.getTicfCRILambdaName());
+        lambdaInvoker.invokeAsyncWithPayload(
+                payload, configurationService.getTicfCRILambdaIdentifier());
     }
 
     private AccountInterventionsResponse getAccountInterventionsResponse(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -219,8 +219,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("BULK_USER_EMAIL_AUDIENCE_LOADER_LAMBDA_NAME", "");
     }
 
-    public String getTicfCRILambdaName() {
-        return System.getenv().getOrDefault("TICF_CRI_LAMBDA_NAME", "");
+    public String getTicfCRILambdaIdentifier() {
+        return System.getenv().getOrDefault("TICF_CRI_LAMBDA_IDENTIFIER", "");
     }
 
     public boolean isInvokeTicfCRILambdaEnabled() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -197,7 +197,7 @@ class ConfigurationServiceTest {
 
     @Test
     void getTicfCRILambdaNameShouldDefault() {
-        assertEquals("", configurationService.getTicfCRILambdaName());
+        assertEquals("", configurationService.getTicfCRILambdaIdentifier());
     }
 
     @Test


### PR DESCRIPTION
## What

Invokes the TICF lambda via an alias rather than directly by name. Updates the policy to ensure that the lambda cannot be invoked by name.

This brings us in line with a programme-wide drive to invoke via aliases: see [here](https://govukverify.atlassian.net/browse/PROBLEM-130) for details.

## How to review

1. Code Review
1. Deploy to a dev env.
1. Run through a sign-in journey in that environment. In a normal sign-in journey, the TICF lambda is invoked directly by the account interventions lambda. So to check this works correctly you should a) see that the TICF lambda has been successfully invoked, and b) that there are no error logs in the account interventions lambda related to not being able to invoke the TICF lambda. (Note that even if it wasn't able to invoke, there would be no difference in the user journey since we invoke it in a fire-and-forget, safe way)
1. If you wanted, to test that the policy does not allow invoking the lambda directly anymore, you could change the `TICF_CRI_LAMBDA_IDENTIFIER` env variable in account-interventions.tf back to the value it had previously (aws_lambda_alias.ticf_cri_lambda_alias[0].arn) and see that the call does now error in the account interventions lambda.
