### PR TITLE
Aut 3902/add provisioned concurrency

### DIFF
--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -43,7 +43,7 @@ module "account_interventions" {
     ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
     ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED = var.account_intervention_service_action_enabled
     ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled
-    TICF_CRI_LAMBDA_IDENTIFIER                  = local.deploy_ticf_cri_count == 1 ? aws_lambda_alias.ticf_cri_lambda_alias[0].arn : null
+    TICF_CRI_LAMBDA_IDENTIFIER                  = local.deploy_ticf_cri_count == 1 ? module.ticf_cri_lambda[0].endpoint_lambda_alias.arn : null
     INVOKE_TICF_CRI_LAMBDA                      = var.call_ticf_cri
   }
 

--- a/ci/terraform/oidc/dynatrace.tf
+++ b/ci/terraform/oidc/dynatrace.tf
@@ -1,0 +1,13 @@
+locals {
+  dynatrace_production_secret    = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables"
+  dynatrace_nonproduction_secret = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
+
+  dynatrace_secret = jsondecode(data.aws_secretsmanager_secret_version.dynatrace_secret.secret_string)
+}
+
+data "aws_secretsmanager_secret" "dynatrace_secret" {
+  arn = var.environment == "production" ? local.dynatrace_production_secret : local.dynatrace_nonproduction_secret
+}
+data "aws_secretsmanager_secret_version" "dynatrace_secret" {
+  secret_id = data.aws_secretsmanager_secret.dynatrace_secret.id
+}


### PR DESCRIPTION
## What

Add provisioned concurrency and scaling policy for ticf lambda.

This involved migrating the lambda to use the shared endpoint module.

Also adds dynatrace layer for OIDC.


## How to review

1. Code Review
1. Deploy to sandpit
1. Check performance parameters have been successfully applied

## Related PRs

Relies on https://github.com/govuk-one-login/authentication-api/pull/5624 being merged first [**DONE**]
