### PR TITLE
ATO-975: remove feature flag for current credential strength in AuthCode

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -386,10 +386,8 @@ public class AuthCodeHandler
         }
         CredentialTrustLevel currentCredentialStrength = orchSession.getCurrentCredentialStrength();
 
-        if (configurationService.isCurrentCredentialStrengthInOrchSessionEnabled()
-                && (isNull(currentCredentialStrength)
-                        || lowestRequestedCredentialTrustLevel.compareTo(currentCredentialStrength)
-                                > 0)) {
+        if (isNull(currentCredentialStrength)
+                || lowestRequestedCredentialTrustLevel.compareTo(currentCredentialStrength) > 0) {
             orchSession.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
         }
         return authorisationCodeService.generateAndSaveAuthorisationCode(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -178,8 +178,6 @@ class AuthCodeHandlerTest {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(configurationService.getEnvironment()).thenReturn("unit-test");
         when(configurationService.getInternalSectorURI()).thenReturn(INTERNAL_SECTOR_URI);
-        when(configurationService.isCurrentCredentialStrengthInOrchSessionEnabled())
-                .thenReturn(true);
         when(authCodeResponseService.getSubjectId(session)).thenReturn(SUBJECT.getValue());
         when(authCodeResponseService.getRpPairwiseId(session, CLIENT_ID, dynamoClientService))
                 .thenReturn(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -405,10 +405,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("USE_ORCH_SESSION_FOR_AUTHENTICATED_CLAIM");
     }
 
-    public boolean isCurrentCredentialStrengthInOrchSessionEnabled() {
-        return getFlagOrFalse("CURRENT_CREDENTIAL_STRENGTH_IN_ORCH_SESSION");
-    }
-
     public Optional<String> getIPVCapacity() {
         try {
             var request =

--- a/template.yaml
+++ b/template.yaml
@@ -108,7 +108,6 @@ Mappings:
       defaultProvisionedConcurrency: 0
       aisUriSecretId: 6b29b810-e509-4354-9d75-934d0f154d07
       getAuthenticatedFromOrchSession: true
-      currentCredentialStrengthInOrchSession: true
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       authApiId: "6of9f4amvg"
@@ -140,7 +139,6 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/5fdfad8b-ca31-4afc-a948-59fd498c0f3c
       defaultProvisionedConcurrency: 1
       aisUriSecretId: fd6ef1f1-7d31-40ca-978d-2180199141d8
-      currentCredentialStrengthInOrchSession: true
       getAuthenticatedFromOrchSession: true
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -173,7 +171,6 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:758531536632:key/3d990d7b-0042-4115-8263-e6b472d84cc2
       defaultProvisionedConcurrency: 3
       aisUriSecretId: 2b9a3315-50e9-4970-87e6-b354cc4a2484
-      currentCredentialStrengthInOrchSession: true
       getAuthenticatedFromOrchSession: true
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -206,7 +203,6 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:761723964695:key/e34095ae-a65b-4609-99b3-9c1f407eff73
       defaultProvisionedConcurrency: 1
       aisUriSecretId: ""
-      currentCredentialStrengthInOrchSession: true
       getAuthenticatedFromOrchSession: true
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -239,7 +235,6 @@ Mappings:
       authenticationCallbackUserinfoKeyArn: arn:aws:kms:eu-west-2:172348255554:key/0e5c92f4-26a1-442d-a57b-87db810a40d1
       defaultProvisionedConcurrency: 3
       aisUriSecretId: ""
-      currentCredentialStrengthInOrchSession: true
       getAuthenticatedFromOrchSession: true
   ProvisionedConcurrency:
     staging:
@@ -2769,12 +2764,6 @@ Resources:
                   !Ref Environment,
                   serviceDomain,
                 ]
-          CURRENT_CREDENTIAL_STRENGTH_IN_ORCH_SESSION:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              currentCredentialStrengthInOrchSession,
-            ]
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy


### PR DESCRIPTION
Removing feature flag that was used for testing the authCode in staging.