### PR TITLE
ATO-1268: Dependabot ignore `com.nimbusds:oauth2-oidc-sdk`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: daily
       time: "03:00"
     open-pull-requests-limit: 100
+    ignore:
+      - dependency-name: "com.nimbusds:oauth2-oidc-sdk"
     groups:
       gradle-security-updates:
         applies-to: security-updates


### PR DESCRIPTION
## What

The latest versions of `com.nimbusds:oauth2-oidc-sdk` introduce many changes that need to be comprehensively evaluated for impact internally and RPs.

ATO-1268 tracks this work.

We do not want Dependabot to be raising PRs to update this dependency until ATO-1268 is complete.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.