### PR TITLE
AUT-3900: Logging tweaks to TICF CRI handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -54,9 +54,7 @@ public class TicfCriHandler implements RequestHandler<TICFCRIRequest, Void> {
             var response = sendRequest(input);
             var statusCode = String.valueOf(response.statusCode());
             var logMessage =
-                    format(
-                            "Response received from TICF CRI Service with status %s and body %s",
-                            statusCode, response.body());
+                    format("Response received from TICF CRI Service with status %s", statusCode);
             LOG.info(logMessage);
             cloudwatchMetricsService.incrementCounter(
                     "TicfCriResponseReceived",

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -64,8 +64,7 @@ public class TicfCriHandler implements RequestHandler<TICFCRIRequest, Void> {
                     format(
                             "Request to TICF CRI timed out with timeout set to %d",
                             configurationService.getTicfCriServiceCallTimeout());
-            logAndSendMetricsForInterventionsError(
-                    errorDescription, "TicfCriServiceTimeout", false);
+            logAndSendMetricsForInterventionsError(errorDescription, "TicfCriServiceTimeout", true);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             var errorDescription = format("Error occurred in the TICF CRI Handler: %s", e);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -60,29 +60,23 @@ public class TicfCriHandler implements RequestHandler<TICFCRIRequest, Void> {
                     "TicfCriResponseReceived",
                     Map.ofEntries(environmentForMetrics, Map.entry("StatusCode", statusCode)));
         } catch (HttpTimeoutException e) {
-            var errorDescription =
+            LOG.error(
                     format(
                             "Request to TICF CRI timed out with timeout set to %d",
-                            configurationService.getTicfCriServiceCallTimeout());
-            logAndSendMetricsForInterventionsError(errorDescription, "TicfCriServiceTimeout", true);
+                            configurationService.getTicfCriServiceCallTimeout()));
+            sendMetricsForInterventionsError("TicfCriServiceTimeout");
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            var errorDescription = format("Error occurred in the TICF CRI Handler: %s", e);
-            logAndSendMetricsForInterventionsError(errorDescription, "TicfCriServiceError", true);
+            LOG.error(format("Error occurred in the TICF CRI Handler: %s", e));
+            sendMetricsForInterventionsError("TicfCriServiceError");
         } catch (IOException e) {
-            var errorDescription = format("Error occurred in the TICF CRI Handler: %s", e);
-            logAndSendMetricsForInterventionsError(errorDescription, "TicfCriServiceError", true);
+            LOG.error(format("Error occurred in the TICF CRI Handler: %s", e));
+            sendMetricsForInterventionsError("TicfCriServiceError");
         }
         return null;
     }
 
-    private void logAndSendMetricsForInterventionsError(
-            String errorDescription, String metric, Boolean raiseErrorLog) {
-        if (Boolean.TRUE.equals(raiseErrorLog)) {
-            LOG.error(errorDescription);
-        } else {
-            LOG.warn(errorDescription);
-        }
+    private void sendMetricsForInterventionsError(String metric) {
         cloudwatchMetricsService.incrementCounter(
                 metric, Map.of("Environment", configurationService.getEnvironment()));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
@@ -99,7 +99,7 @@ class TicfCriHandlerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {200, 404, 500})
+    @MethodSource("statusCodes")
     void sendsMetricsBasedOnTheHttpStatusCode(Integer statusCode)
             throws IOException, InterruptedException {
         var ticfRequest =
@@ -116,6 +116,10 @@ class TicfCriHandlerTest {
                         Map.ofEntries(
                                 Map.entry("Environment", "test-environment"),
                                 Map.entry("StatusCode", statusCode.toString())));
+    }
+
+    private static List<Arguments> statusCodes() {
+        return List.of(Arguments.of(200), Arguments.of(404), Arguments.of(500));
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
@@ -2,8 +2,10 @@ package uk.gov.di.authentication.frontendapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.google.gson.JsonArray;
+import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -14,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,11 +32,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.entity.TICFCRIRequest.basicTicfCriRequest;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withLevelAndMessageContaining;
 
 class TicfCriHandlerTest {
 
@@ -53,6 +59,10 @@ class TicfCriHandlerTest {
     private AutoCloseable mocks;
     private static final Map<String, String> METRICS_CONTEXT =
             Map.of("Environment", "test-environment");
+
+    @RegisterExtension
+    private final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(TicfCriHandler.class);
 
     @BeforeEach
     void setUp() {
@@ -100,7 +110,7 @@ class TicfCriHandlerTest {
 
     @ParameterizedTest
     @MethodSource("statusCodes")
-    void sendsMetricsBasedOnTheHttpStatusCode(Integer statusCode)
+    void sendsMetricsAndLogsBasedOnTheHttpStatusCode(Integer statusCode, Level expectedLogLevel)
             throws IOException, InterruptedException {
         var ticfRequest =
                 basicTicfCriRequest(
@@ -116,15 +126,26 @@ class TicfCriHandlerTest {
                         Map.ofEntries(
                                 Map.entry("Environment", "test-environment"),
                                 Map.entry("StatusCode", statusCode.toString())));
+        assertThat(
+                logging.events(),
+                hasItem(
+                        withLevelAndMessageContaining(
+                                expectedLogLevel,
+                                format(
+                                        "Response received from TICF CRI Service with status %d",
+                                        statusCode))));
     }
 
     private static List<Arguments> statusCodes() {
-        return List.of(Arguments.of(200), Arguments.of(404), Arguments.of(500));
+        return List.of(
+                Arguments.of(200, Level.INFO),
+                Arguments.of(404, Level.ERROR),
+                Arguments.of(500, Level.INFO));
     }
 
     @ParameterizedTest
     @MethodSource("exceptions")
-    void testIncrementsMetricWhenAnExceptionOccurs(Exception e, String metricName)
+    void testIncrementsMetricAndSendsLogsWhenAnExceptionOccurs(Exception e, String metricName)
             throws Exception {
         when(httpClient.send(any(), any())).thenThrow(e);
 
@@ -134,6 +155,9 @@ class TicfCriHandlerTest {
                 context);
 
         verify(cloudwatchMetricsService).incrementCounter(metricName, METRICS_CONTEXT);
+        assertThat(
+                logging.events(),
+                hasItem(withLevelAndMessageContaining(Level.ERROR, format(e.getMessage()))));
     }
 
     private static List<Arguments> exceptions() {
@@ -142,8 +166,7 @@ class TicfCriHandlerTest {
                 Arguments.of(
                         new InterruptedException("an Interrputed exception"),
                         "TicfCriServiceError"),
-                Arguments.of(
-                        new HttpTimeoutException("request timed out"), "TicfCriServiceTimeout"));
+                Arguments.of(new HttpTimeoutException("timed out"), "TicfCriServiceTimeout"));
     }
 
     private JsonArray jsonArrayFrom(List<String> elements) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.sharedtest.logging;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.ObjectMessage;
 import org.hamcrest.Description;
@@ -77,6 +78,28 @@ public class LogEventMatcher {
             @Override
             protected boolean matchesSafely(LogEvent item) {
                 var message = item.getMessage().getFormattedMessage();
+
+                return Arrays.stream(values).anyMatch(message::contains);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(
+                        "a log event with message containing [" + Arrays.asList(values) + "]");
+            }
+        };
+    }
+
+    public static Matcher<LogEvent> withLevelAndMessageContaining(Level level, String... values) {
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            protected boolean matchesSafely(LogEvent item) {
+                var message = item.getMessage().getFormattedMessage();
+
+                if (!item.getLevel().equals(level)) {
+                    return false;
+                }
 
                 return Arrays.stream(values).anyMatch(message::contains);
             }


### PR DESCRIPTION
## What

### Do not log TICF CRI response body
We want to prevent potentially leaking sensitive information should the TICF CRI API response change in the future


### Treat TICF CRI service timeouts and returning 4xx statuses as errors
Using our existing alerts infrastructure, should several timeouts or 4xx responses happen in a window we should be told about it.

We get the alerts by treating a timeout as an error to log.


## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
