### PR TITLE
ATO-1100: copy client sessions

### DIFF
--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -47,6 +47,12 @@ public class RedisExtension
         return session.getSessionId();
     }
 
+    public Session addSession(Session session) throws Json.JsonException {
+        redis.saveWithExpiry(
+                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        return session;
+    }
+
     public void setVerifiedMfaMethodType(String sessionId, MFAMethodType mfaMethodType)
             throws Json.JsonException {
         var session = objectMapper.readValue(redis.getValue(sessionId), Session.class);

--- a/template.yaml
+++ b/template.yaml
@@ -1853,6 +1853,10 @@ Resources:
             - IsDestroySessionOnSignOutEnabled
             - true
             - false
+          SUPPORT_MAX_AGE_ENABLED: !If
+            - SupportMaxAgeEnabled
+            - true
+            - false
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy


### PR DESCRIPTION
## What: 

- Adds max age handling to the authentication callback handler behind a feature flag
- This adds handling for the case in which the internalCommonSubjectIds match (ie we return the same user) after a max age journey
- This involves re-attatching the client sessions to their shared session 
- We also remove the previous session id from their session as this prevents subsequent journeys from having the same check the same check - we only want to do this if they have been on a max age journey

## How to review
- Code review commit-by-commit
- Deploy to dev and test:
- A journey without max age (establish an existing session)
- A journey forcing max age re-auth (max_age =0) 
- Observe logging around same user signed in 
- Do the same as above but sign in as different user
## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs: 
- Branches off of https://github.com/govuk-one-login/authentication-api/pull/5608 so must be merged first