### PR TITLE
AUT-3900: Add runbook link to TICF CRI handler alerts

### DIFF
--- a/ci/terraform/modules/endpoint-lambda/README.md
+++ b/ci/terraform/modules/endpoint-lambda/README.md
@@ -79,6 +79,7 @@ No modules.
 | <a name="input_logging_endpoint_enabled"></a> [logging\_endpoint\_enabled](#input\_logging\_endpoint\_enabled) | Whether the Lambda should ship its logs to the `logging_endpoint_arn` | `bool` | `false` | no |
 | <a name="input_max_provisioned_concurrency"></a> [max\_provisioned\_concurrency](#input\_max\_provisioned\_concurrency) | n/a | `number` | `5` | no |
 | <a name="input_provisioned_concurrency"></a> [provisioned\_concurrency](#input\_provisioned\_concurrency) | n/a | `number` | `0` | no |
+| <a name="input_runbook_link"></a> [runbook\_link](#input\_runbook\_link) | A link that is appended to alarm descriptions that should open a page describing how to triage and handle the alarm | `string` | `""` | no |
 | <a name="input_scaling_trigger"></a> [scaling\_trigger](#input\_scaling\_trigger) | n/a | `number` | `0.7` | no |
 | <a name="input_snapstart"></a> [snapstart](#input\_snapstart) | n/a | `bool` | `false` | no |
 | <a name="input_wait_for_alias_timeout"></a> [wait\_for\_alias\_timeout](#input\_wait\_for\_alias\_timeout) | The number of seconds to wait for the alias to be created | `number` | `300` | no |

--- a/ci/terraform/modules/endpoint-lambda/alerts.tf
+++ b/ci/terraform/modules/endpoint-lambda/alerts.tf
@@ -1,3 +1,10 @@
+locals {
+  base_error_alarm_description      = "${var.lambda_log_alarm_threshold} or more errors have occurred in the ${var.environment} ${var.endpoint_name} lambda.ACCOUNT: ${var.account_alias}"
+  error_alarm_description           = var.runbook_link == "" ? local.base_error_alarm_description : "${local.base_error_alarm_description}. Runbook: ${var.runbook_link}"
+  base_error_rate_alarm_description = "Lambda error rate of ${var.lambda_log_alarm_error_rate_threshold} has been reached in the ${var.environment} ${var.endpoint_name} lambda.ACCOUNT: ${var.account_alias}"
+  error_rate_alarm_description      = var.runbook_link == "" ? local.base_error_rate_alarm_description : "${local.base_error_rate_alarm_description}. Runbook: ${var.runbook_link}"
+}
+
 resource "aws_cloudwatch_log_metric_filter" "lambda_error_metric_filter" {
   name           = replace("${var.environment}-${var.endpoint_name}-errors", ".", "")
   pattern        = "{($.level = \"ERROR\")}"
@@ -19,7 +26,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_cloudwatch_alarm" {
   period              = "3600"
   statistic           = "Sum"
   threshold           = var.lambda_log_alarm_threshold
-  alarm_description   = "${var.lambda_log_alarm_threshold} or more errors have occurred in the ${var.environment} ${var.endpoint_name} lambda.ACCOUNT: ${var.account_alias}"
+  alarm_description   = local.error_alarm_description
   alarm_actions       = [var.slack_event_topic_arn]
 
   tags = local.extra_tags
@@ -31,7 +38,8 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_rate_cloudwatch_alarm" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   threshold           = var.lambda_log_alarm_error_rate_threshold
-  alarm_description   = "Lambda error rate of ${var.lambda_log_alarm_error_rate_threshold} has been reached in the ${var.environment} ${var.endpoint_name} lambda.ACCOUNT: ${var.account_alias}"
+
+  alarm_description = local.error_rate_alarm_description
 
   metric_query {
     id          = "e1"

--- a/ci/terraform/modules/endpoint-lambda/variables.tf
+++ b/ci/terraform/modules/endpoint-lambda/variables.tf
@@ -173,3 +173,9 @@ variable "wait_for_alias_timeout" {
   description = "The number of seconds to wait for the alias to be created"
   default     = 300
 }
+
+variable "runbook_link" {
+  type        = string
+  description = "A link that is appended to alarm descriptions that should open a page describing how to triage and handle the alarm"
+  default     = ""
+}

--- a/ci/terraform/oidc/ticf-cri.tf
+++ b/ci/terraform/oidc/ticf-cri.tf
@@ -21,6 +21,7 @@ module "ticf_cri_lambda" {
   source = "../modules/endpoint-lambda"
 
   endpoint_name = "ticf-cri"
+  runbook_link  = "https://govukverify.atlassian.net/l/cp/UzdQFFH1"
 
   environment = var.environment
 


### PR DESCRIPTION
## What

### Add runbook link support to `endpoint-lambda`
Like 1e50cc8f75ab5e7f22bddcbb45bedae6e8eb4a60, add support for appending runbook links to CloudWatch Alarm descriptions.

### Add runbook link to TICFCRIHandler alarms
This link holds a page that will help triage and resolve alarms related to the TICF CRI handler.

![Screenshot 2024-12-10 at 11 32 49](https://github.com/user-attachments/assets/ba04060d-3429-43e5-8414-393a57498bd9)

## How to review

1. Code Review
