### PR TITLE
BAU: Use name instead of name_prefix in policies referenced by CT

### DIFF
--- a/ci/terraform/account-management/manually-delete-account.tf
+++ b/ci/terraform/account-management/manually-delete-account.tf
@@ -161,7 +161,7 @@ data "aws_iam_policy_document" "invoke_account_deletion_lambda" {
 
 resource "aws_iam_policy" "invoke_account_deletion_lambda" {
   count       = local.should_create_account_deletion_policy ? 1 : 0
-  name_prefix = "manual-account-deletion-user-policy"
+  name        = "manual-account-deletion-user-policy"
   path        = "/control-tower/am/"
   description = "Policy for use in Control Tower to be attached to the role assumed by support users to perform account deletions"
   policy      = data.aws_iam_policy_document.invoke_account_deletion_lambda.json

--- a/ci/terraform/shared/iam-ct.tf
+++ b/ci/terraform/shared/iam-ct.tf
@@ -60,7 +60,7 @@ locals {
 
 resource "aws_iam_policy" "client_registry_read_only" {
   count       = local.should_create_client_registry_policy ? 1 : 0
-  name_prefix = "client-registry-read-only-user-policy"
+  name        = "client-registry-read-only-user-policy"
   path        = "/control-tower/shared/"
   description = "Policy for use in Control Tower to be attached to the role assumed by support users to view the Client Registry"
   policy      = data.aws_iam_policy_document.client_registry_read_only.json


### PR DESCRIPTION
The name needs to be known exactly
