### PR TITLE
AUT-3904: Turn on calls to ticf in build

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -9,6 +9,7 @@ shared_state_bucket                  = "digital-identity-dev-tfstate"
 test_clients_enabled                 = true
 internal_sector_uri                  = "https://identity.build.account.gov.uk"
 ipv_api_enabled                      = true
+call_ticf_cri                        = true
 
 # lockout config
 lockout_duration                          = 60


### PR DESCRIPTION
This is a preparatory step before turning the calls on in production, which will follow subsequently. In build we call the ticf stub.

