### PR TITLE
ATO-1245: refactor session setting in start

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -226,16 +226,16 @@ public class StartService {
     }
 
     public boolean isUpliftRequired(
-            UserContext userContext, CredentialTrustLevel currentCredentialStrength) {
-        if (DocAppUserHelper.isDocCheckingAppUser(userContext)
+            ClientSession clientSession,
+            ClientRegistry client,
+            CredentialTrustLevel currentCredentialStrength) {
+        if (DocAppUserHelper.isDocCheckingAppUser(
+                        clientSession.getAuthRequestParams(), Optional.of(client))
                 || Objects.isNull(currentCredentialStrength)) {
             return false;
         }
         return (currentCredentialStrength.compareTo(
-                        userContext
-                                .getClientSession()
-                                .getEffectiveVectorOfTrust()
-                                .getCredentialTrustLevel())
+                        clientSession.getEffectiveVectorOfTrust().getCredentialTrustLevel())
                 < 0);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -32,6 +32,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static java.util.function.Predicate.not;
 import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.COOKIE_CONSENT;
 import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.GA;
@@ -243,7 +244,12 @@ public class StartService {
         return clientService
                 .getClient(clientID)
                 .map(ClientRegistry::isCookieConsentShared)
-                .orElseThrow(() -> new ClientNotFoundException(clientID));
+                .orElseThrow(
+                        () ->
+                                new ClientNotFoundException(
+                                        format(
+                                                "Could not find client for clientID: %s",
+                                                clientID)));
     }
 
     private boolean validCookieConsentValueIsPresent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -30,6 +30,7 @@ import uk.gov.di.authentication.frontendapi.entity.StartResponse;
 import uk.gov.di.authentication.frontendapi.entity.UserStartInfo;
 import uk.gov.di.authentication.frontendapi.services.StartService;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CountType;
@@ -149,6 +150,7 @@ class StartHandlerTest {
         when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
         when(userContext.getClientSession()).thenReturn(clientSession);
         when(clientRegistry.getClientID()).thenReturn(TEST_CLIENT_ID);
+        when(authSessionService.generateNewAuthSession(anyString())).thenCallRealMethod();
         handler =
                 new StartHandler(
                         clientSessionService,
@@ -625,6 +627,8 @@ class StartHandlerTest {
         when(startService.createNewSessionWithExistingIdAndClientSession(
                         session, CLIENT_SESSION_ID))
                 .thenReturn(session);
+        when(authSessionService.getUpdatedPreviousSessionOrCreateNew(any(), any(), any()))
+                .thenReturn(new AuthSessionItem().withSessionId(SESSION_ID));
     }
 
     private void usingInvalidSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -451,6 +451,8 @@ class StartServiceTest {
             UserProfile userProfile,
             UserCredentials userCredentials,
             MFAMethodType expectedMfaMethodType) {
+        var clientRegistry =
+                generateClientRegistry(REDIRECT_URI.toString(), CLIENT_ID.getValue(), false);
         var userContext =
                 buildUserContext(
                         vtr,
@@ -464,7 +466,9 @@ class StartServiceTest {
                         false);
         userContext.getSession().setEmailAddress(EMAIL);
 
-        var upliftRequired = startService.isUpliftRequired(userContext, credentialTrustLevel);
+        var upliftRequired =
+                startService.isUpliftRequired(
+                        userContext.getClientSession(), clientRegistry, credentialTrustLevel);
         var userStartInfo =
                 startService.buildUserStartInfo(
                         userContext,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -329,7 +329,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
     }
 
     private void withAuthSessionNewAccount() {
-        authSessionExtension.addSession(Optional.empty(), TEST_SESSION_ID);
+        authSessionExtension.addSession(TEST_SESSION_ID);
         authSessionExtension.updateSession(
                 authSessionExtension
                         .getSession(TEST_SESSION_ID)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -62,7 +62,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             MFAMethodType mfaMethodType) throws JsonException {
         var emailAddress = "joe.bloggs+1@digital.cabinet-office.gov.uk";
         var sessionId = redis.createSession();
-        authSessionStore.addSession(Optional.empty(), sessionId);
+        authSessionStore.addSession(sessionId);
         var clientSessionId = IdGenerator.generate();
         userStore.signUp(emailAddress, "password-1");
 
@@ -107,7 +107,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var emailAddress = "joe.bloggs+1@digital.cabinet-office.gov.uk";
 
         String sessionId = redis.createUnauthenticatedSessionWithEmail(emailAddress);
-        authSessionStore.addSession(Optional.empty(), sessionId);
+        authSessionStore.addSession(sessionId);
         var codeRequestType =
                 CodeRequestType.getCodeRequestType(MFAMethodType.AUTH_APP, JourneyType.SIGN_IN);
 
@@ -153,7 +153,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             throws JsonException {
         String emailAddress = "joe.bloggs+2@digital.cabinet-office.gov.uk";
         String sessionId = redis.createSession();
-        authSessionStore.addSession(Optional.empty(), sessionId);
+        authSessionStore.addSession(sessionId);
         var clientSessionId = IdGenerator.generate();
         setUpClientSession(emailAddress, clientSessionId, CLIENT_ID, CLIENT_NAME, REDIRECT_URI);
         BaseFrontendRequest request = new CheckUserExistsRequest(emailAddress);
@@ -181,7 +181,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             throws JsonException {
         String emailAddress = "joe.bloggs+2@digital.cabinet-office.gov.uk";
         String sessionId = redis.createUnauthenticatedSessionWithEmail(emailAddress);
-        authSessionStore.addSession(Optional.empty(), sessionId);
+        authSessionStore.addSession(sessionId);
         redis.blockMfaCodesForEmail(
                 emailAddress,
                 CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.PASSWORD_RESET);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -108,7 +108,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var password = "password-1";
         var sessionId = IdGenerator.generate();
         redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
-        authSessionExtension.addSession(Optional.empty(), sessionId);
+        authSessionExtension.addSession(sessionId);
 
         userStore.signUp(email, password);
         userStore.updateTermsAndConditions(email, termsAndConditionsVersion);
@@ -192,7 +192,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var password = "password-1";
         var sessionId = IdGenerator.generate();
         redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
-        authSessionExtension.addSession(Optional.empty(), sessionId);
+        authSessionExtension.addSession(sessionId);
 
         userStore.signUp(email, password);
         userStore.updateTermsAndConditions(email, CURRENT_TERMS_AND_CONDITIONS);
@@ -221,7 +221,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         var sessionId = IdGenerator.generate();
         redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
-        authSessionExtension.addSession(Optional.empty(), sessionId);
+        authSessionExtension.addSession(sessionId);
         redis.createClientSession(
                 CLIENT_SESSION_ID, CLIENT_NAME, basicAuthRequestBuilder.build().toParameters());
         var headers = validHeadersWithSessionId(sessionId);
@@ -242,7 +242,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         userStore.signUp(email, "wrong-password");
         var sessionId = IdGenerator.generate();
         redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
-        authSessionExtension.addSession(Optional.empty(), sessionId);
+        authSessionExtension.addSession(sessionId);
         var headers = validHeadersWithSessionId(sessionId);
 
         redis.createClientSession(
@@ -278,7 +278,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         userStore.signUp(email, "wrong-password");
         var sessionId = IdGenerator.generate();
         redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
-        authSessionExtension.addSession(Optional.empty(), sessionId);
+        authSessionExtension.addSession(sessionId);
         var headers = validHeadersWithSessionId(sessionId);
 
         redis.createClientSession(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -167,6 +167,6 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     private void withAuthSession() {
-        authSessionExtension.addSession(Optional.empty(), SESSION_ID);
+        authSessionExtension.addSession(SESSION_ID);
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -382,7 +382,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         @Test
         void shouldReplaceSessionInDynamoWhenPreviousSessionIsProvidedInRequestBody() {
-            authSessionExtension.addSession(Optional.empty(), PREVIOUS_SESSION_ID);
+            authSessionExtension.addSession(PREVIOUS_SESSION_ID);
             assertThat(
                     authSessionExtension.getSession(PREVIOUS_SESSION_ID).isPresent(),
                     equalTo(true));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -80,7 +80,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         REAUTH_SIGNOUT_AND_TXMA_ENABLED_CONFIGUARION_SERVICE,
                         redisConnectionService);
         this.sessionId = redis.createSession();
-        authSessionExtension.addSession(Optional.empty(), this.sessionId);
+        authSessionExtension.addSession(this.sessionId);
         txmaAuditQueue.clear();
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -107,7 +107,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         txmaAuditQueue.clear();
 
         this.sessionId = redis.createSession();
-        authSessionExtension.addSession(Optional.empty(), this.sessionId);
+        authSessionExtension.addSession(this.sessionId);
         redis.addInternalCommonSubjectIdToSession(this.sessionId, internalCommonSubjectId);
         setUpTest(sessionId, withScope());
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.services;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 
 import java.util.Map;
@@ -10,6 +11,9 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 
 class AuthSessionServiceIntegrationTest {
@@ -20,8 +24,8 @@ class AuthSessionServiceIntegrationTest {
     protected static final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
 
     @Test
-    void shouldAddNewSessionWithExpectedDefaultValuesWhenNoPreviousSessionIdProvided() {
-        withSession();
+    void shouldAddNewSessionWithExpectedDefaultValues() {
+        withStoredSession(SESSION_ID);
 
         Optional<AuthSessionItem> retrievedSession = authSessionExtension.getSession(SESSION_ID);
 
@@ -33,40 +37,43 @@ class AuthSessionServiceIntegrationTest {
     }
 
     @Test
-    void shouldReplaceSessionWhenPreviousSessionIdGivenAndExists() {
-        withPreviousSession();
-        withUpdatedPreviousSession();
+    void shouldReturnUpdatedSessionWhenItExistsAndDeletePrevious() {
+        withStoredSession(PREVIOUS_SESSION_ID);
 
-        Optional<AuthSessionItem> retrievedPreviousSession =
-                authSessionExtension.getSession(PREVIOUS_SESSION_ID);
-        Optional<AuthSessionItem> retrievedSession = authSessionExtension.getSession(SESSION_ID);
+        AuthSessionItem previousSession =
+                authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.of(PREVIOUS_SESSION_ID),
+                        SESSION_ID,
+                        CredentialTrustLevel.MEDIUM_LEVEL);
+        var previousSessionItem = authSessionExtension.getSession(PREVIOUS_SESSION_ID);
 
-        assertThat(retrievedPreviousSession.isPresent(), equalTo(false));
-        assertThat(retrievedSession.isPresent(), equalTo(true));
-        assertThat(retrievedSession.get().getSessionId(), equalTo(SESSION_ID));
+        assertTrue(previousSessionItem.isEmpty());
+        assertThat(previousSession.getSessionId(), is(SESSION_ID));
+        assertThat(
+                previousSession.getCurrentCredentialStrength(),
+                is(CredentialTrustLevel.MEDIUM_LEVEL));
     }
 
     @Test
-    void shouldAddSessionWhenPreviousSessionIdGivenAndDoesNotExist() {
-        withUpdatedPreviousSession();
+    void shouldReturnNewSessionWhenPreviousDoesNotExist() {
+        var previousSessionItem = authSessionExtension.getSession(PREVIOUS_SESSION_ID);
 
-        Optional<AuthSessionItem> retrievedPreviousSession =
-                authSessionExtension.getSession(PREVIOUS_SESSION_ID);
-        Optional<AuthSessionItem> retrievedSession = authSessionExtension.getSession(SESSION_ID);
+        assertTrue(previousSessionItem.isEmpty());
 
-        assertThat(retrievedPreviousSession.isPresent(), equalTo(false));
-        assertThat(retrievedSession.isPresent(), equalTo(true));
-        assertThat(retrievedSession.get().getSessionId(), equalTo(SESSION_ID));
-        assertThat(
-                retrievedSession.get().getIsNewAccount(),
-                equalTo(AuthSessionItem.AccountState.UNKNOWN));
+        AuthSessionItem previousSession =
+                authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.of(PREVIOUS_SESSION_ID),
+                        SESSION_ID,
+                        CredentialTrustLevel.MEDIUM_LEVEL);
+        assertThat(previousSession.getSessionId(), is(SESSION_ID));
+        assertEquals(
+                CredentialTrustLevel.MEDIUM_LEVEL, previousSession.getCurrentCredentialStrength());
     }
 
     @Test
     void shouldStoreAnUpdatedSession() {
-        withSession();
+        var session = withStoredSession(SESSION_ID);
 
-        var session = authSessionExtension.getSession(SESSION_ID).get();
         session.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
         authSessionExtension.updateSession(session);
         var updatedSession = authSessionExtension.getSession(SESSION_ID).get();
@@ -75,29 +82,32 @@ class AuthSessionServiceIntegrationTest {
     }
 
     @Test
-    void shouldRetainAPreviousSessionsValuesWhenSessionIdIsUpdated() {
-        withPreviousSession();
+    void shouldReturnAPreviousSessionWithRetainedValues() {
+        var previousSession = withStoredSession(PREVIOUS_SESSION_ID);
 
-        var previousSession = authSessionExtension.getSession(PREVIOUS_SESSION_ID).get();
         previousSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
         authSessionExtension.updateSession(previousSession);
-        withUpdatedPreviousSession();
 
-        Optional<AuthSessionItem> retrievedPreviousSession =
-                authSessionExtension.getSession(PREVIOUS_SESSION_ID);
-        Optional<AuthSessionItem> retrievedSession = authSessionExtension.getSession(SESSION_ID);
+        AuthSessionItem retrievedSession =
+                authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.of(PREVIOUS_SESSION_ID),
+                        SESSION_ID,
+                        CredentialTrustLevel.MEDIUM_LEVEL);
+        var retrievedPreviousSession = authSessionExtension.getSession(PREVIOUS_SESSION_ID);
 
-        assertThat(retrievedPreviousSession.isPresent(), equalTo(false));
-        assertThat(retrievedSession.isPresent(), equalTo(true));
-        assertThat(retrievedSession.get().getSessionId(), equalTo(SESSION_ID));
+        assertTrue(retrievedPreviousSession.isEmpty());
+        assertThat(retrievedSession.getSessionId(), equalTo(SESSION_ID));
         assertThat(
-                retrievedSession.get().getIsNewAccount(),
-                equalTo(AuthSessionItem.AccountState.EXISTING));
+                retrievedSession.getIsNewAccount(), equalTo(AuthSessionItem.AccountState.EXISTING));
+
+        assertThat(
+                retrievedSession.getCurrentCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
     }
 
     @Test
     void shouldGetSessionFromRequestHeaders() {
-        withSession();
+        withStoredSession(SESSION_ID);
 
         var headersWithSessionId = Map.of(SESSION_ID_HEADER, SESSION_ID);
         Optional<AuthSessionItem> retrievedSession =
@@ -106,15 +116,8 @@ class AuthSessionServiceIntegrationTest {
         assertThat(retrievedSession.get().getSessionId(), equalTo(SESSION_ID));
     }
 
-    private void withSession() {
-        authSessionExtension.addSession(Optional.empty(), SESSION_ID);
-    }
-
-    private void withPreviousSession() {
-        authSessionExtension.addSession(Optional.empty(), PREVIOUS_SESSION_ID);
-    }
-
-    private void withUpdatedPreviousSession() {
-        authSessionExtension.addSession(Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
+    private AuthSessionItem withStoredSession(String sessionId) {
+        authSessionExtension.addSession(sessionId);
+        return authSessionExtension.getSession(sessionId).get();
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -76,6 +76,10 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
                 previousSessionId, sessionId, null, false);
     }
 
+    public void addSession(String sessionId) {
+        authSessionService.addSession(authSessionService.generateNewAuthSession(sessionId));
+    }
+
     public void updateSession(AuthSessionItem sessionItem) {
         authSessionService.updateSession(sessionItem);
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
@@ -71,13 +72,16 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
         return authSessionService.getSession(sessionId);
     }
 
-    public void addSession(Optional<String> previousSessionId, String sessionId) {
-        authSessionService.addOrUpdateSessionIncludingSessionId(
-                previousSessionId, sessionId, null, false);
-    }
-
     public void addSession(String sessionId) {
         authSessionService.addSession(authSessionService.generateNewAuthSession(sessionId));
+    }
+
+    public AuthSessionItem getUpdatedPreviousSessionOrCreateNew(
+            Optional<String> previousSessionId,
+            String sessionId,
+            CredentialTrustLevel credentialTrustLevel) {
+        return authSessionService.getUpdatedPreviousSessionOrCreateNew(
+                previousSessionId, sessionId, credentialTrustLevel);
     }
 
     public void updateSession(AuthSessionItem sessionItem) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientNotFoundException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientNotFoundException.java
@@ -6,8 +6,8 @@ import static java.lang.String.format;
 
 public class ClientNotFoundException extends Exception {
 
-    public ClientNotFoundException(String clientID) {
-        super(format("No Client found for ClientID: %s", clientID));
+    public ClientNotFoundException(String message) {
+        super(message);
     }
 
     public ClientNotFoundException(Session session) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -40,6 +40,16 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
         this.configurationService = configurationService;
     }
 
+    public AuthSessionItem generateNewAuthSession(String sessionId) {
+        return new AuthSessionItem()
+                .withSessionId(sessionId)
+                .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
+                .withTimeToLive(
+                        NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
+                                .toInstant()
+                                .getEpochSecond());
+    }
+
     public void addOrUpdateSessionIncludingSessionId(
             Optional<String> previousSessionId,
             String newSessionId,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -50,6 +50,15 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                                 .getEpochSecond());
     }
 
+    public void addSession(AuthSessionItem authSessionItem) {
+        try {
+            put(authSessionItem);
+        } catch (Exception e) {
+            logAndThrowAuthSessionException(
+                    "Failed to add auth session item to table", authSessionItem.getSessionId(), e);
+        }
+    }
+
     public void addOrUpdateSessionIncludingSessionId(
             Optional<String> previousSessionId,
             String newSessionId,

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.shared.services;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -50,6 +49,7 @@ class AuthSessionServiceTest {
         var session = authSessionService.generateNewAuthSession(SESSION_ID);
         assertEquals(SESSION_ID, session.getSessionId());
         assertEquals(AuthSessionItem.AccountState.UNKNOWN, session.getIsNewAccount());
+        assertTrue(session.getTimeToLive() > Instant.now().getEpochSecond());
     }
 
     @Test
@@ -79,46 +79,44 @@ class AuthSessionServiceTest {
     }
 
     @Test
-    void shouldAddNewSessionWhenNoPreviousSessionGiven() {
-        authSessionService.addOrUpdateSessionIncludingSessionId(
-                Optional.empty(), NEW_SESSION_ID, null, false);
-
-        ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
-        verify(table).putItem(captor.capture());
-        AuthSessionItem savedItem = captor.getValue();
-
-        assertThat(savedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertTrue(savedItem.getTimeToLive() > Instant.now().getEpochSecond());
-    }
-
-    @Test
-    void shouldAddNewSessionWhenNoPreviousSessionExists() {
+    void shouldReturnNewSessionWhenPreviousSessionIdNotProvided() {
         withNoSession();
 
-        authSessionService.addOrUpdateSessionIncludingSessionId(
-                Optional.of(SESSION_ID), NEW_SESSION_ID, null, false);
+        var newSession =
+                authSessionService.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.empty(), NEW_SESSION_ID, null);
 
-        ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
-        verify(table).putItem(captor.capture());
-        AuthSessionItem savedItem = captor.getValue();
-
-        assertThat(savedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertTrue(savedItem.getTimeToLive() > Instant.now().getEpochSecond());
+        verifyNoInteractions(dynamoDbClient);
+        assertEquals(NEW_SESSION_ID, newSession.getSessionId());
+        assertTrue(newSession.getTimeToLive() > Instant.now().getEpochSecond());
     }
 
     @Test
-    void shouldPutAndDeleteSessionWhenUpdatingSessionId() {
+    void shouldReturnNewSessionWhenPreviousDoesNotExist() {
+        withNoSession();
+
+        var newSession =
+                authSessionService.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.of(SESSION_ID), NEW_SESSION_ID, null);
+
+        verifyNoInteractions(dynamoDbClient);
+        assertEquals(NEW_SESSION_ID, newSession.getSessionId());
+        assertTrue(newSession.getTimeToLive() > Instant.now().getEpochSecond());
+    }
+
+    @Test
+    void shouldDeleteSessionWhenUpdatingSessionId() {
         AuthSessionItem existingSession = withValidSession();
 
-        authSessionService.addOrUpdateSessionIncludingSessionId(
-                Optional.of(SESSION_ID), NEW_SESSION_ID, null, false);
+        var updatedSession =
+                authSessionService.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.of(SESSION_ID), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL);
 
-        ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
-        verify(table).putItem(captor.capture());
-        AuthSessionItem updatedItem = captor.getValue();
-
-        assertThat(updatedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertTrue(updatedItem.getTimeToLive() > Instant.now().getEpochSecond());
+        assertThat(updatedSession.getSessionId(), is(NEW_SESSION_ID));
+        assertTrue(updatedSession.getTimeToLive() > Instant.now().getEpochSecond());
+        // We call get() twice, once to check the item is present and then once when we go to
+        // delete the item
+        verify(table, times(2)).getItem(Key.builder().partitionValue(SESSION_ID).build());
         verify(table).deleteItem(existingSession);
     }
 
@@ -126,32 +124,26 @@ class AuthSessionServiceTest {
     void shouldAddFieldsToSessionWhenUpdating() {
         withValidSession();
 
-        authSessionService.addOrUpdateSessionIncludingSessionId(
-                Optional.of(SESSION_ID), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL, true);
+        var authSession =
+                authSessionService.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.of(SESSION_ID), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL);
 
-        ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
-        verify(table).putItem(captor.capture());
-        AuthSessionItem savedItem = captor.getValue();
-
-        assertThat(savedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertThat(savedItem.getCurrentCredentialStrength(), is(CredentialTrustLevel.MEDIUM_LEVEL));
-        assertTrue(savedItem.getUpliftRequired());
+        assertThat(authSession.getSessionId(), is(NEW_SESSION_ID));
+        assertThat(
+                authSession.getCurrentCredentialStrength(), is(CredentialTrustLevel.MEDIUM_LEVEL));
     }
 
     @Test
-    void shouldAddFieldsToSessionWhenNewSession() {
+    void shouldReturnNewSessionWithCredentialTrustWhenNoPreviousSessionPresent() {
         withNoSession();
 
-        authSessionService.addOrUpdateSessionIncludingSessionId(
-                Optional.empty(), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL, false);
+        var authSession =
+                authSessionService.getUpdatedPreviousSessionOrCreateNew(
+                        Optional.empty(), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL);
 
-        ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
-        verify(table).putItem(captor.capture());
-        AuthSessionItem savedItem = captor.getValue();
-
-        assertThat(savedItem.getSessionId(), is(NEW_SESSION_ID));
-        assertThat(savedItem.getCurrentCredentialStrength(), is(CredentialTrustLevel.MEDIUM_LEVEL));
-        assertFalse(savedItem.getUpliftRequired());
+        assertThat(authSession.getSessionId(), is(NEW_SESSION_ID));
+        assertThat(
+                authSession.getCurrentCredentialStrength(), is(CredentialTrustLevel.MEDIUM_LEVEL));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -46,6 +46,13 @@ class AuthSessionServiceTest {
     }
 
     @Test
+    void generatesANewSessionWithExpectedDefaults() {
+        var session = authSessionService.generateNewAuthSession(SESSION_ID);
+        assertEquals(SESSION_ID, session.getSessionId());
+        assertEquals(AuthSessionItem.AccountState.UNKNOWN, session.getIsNewAccount());
+    }
+
+    @Test
     void getSessionReturnsSessionWithValidTtl() {
         withValidSession();
         var session = authSessionService.getSession(SESSION_ID);


### PR DESCRIPTION
## What: 

- Refactors how the session is setup in the StartHandler to remove the use of `addOrUpdateSessionIncludingSessionId` 
- Replaces its usage in the StartHandler with `getUpdatedPreviousSessionOrReturnNew` and removes it's usage in the integration tests.
## How to review

- Code review commit-by-commit
-  Deploy to dev env (sandpit)
   - Run auth acceptance tests against changes (passed)

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
