### PR TITLE
AUT-3900: Downgrading TICF CRI timeout logging level

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -63,7 +63,7 @@ public class TicfCriHandler implements RequestHandler<TICFCRIRequest, Void> {
                             environmentForMetrics,
                             Map.entry("StatusCode", String.valueOf(statusCode))));
         } catch (HttpTimeoutException e) {
-            LOG.error(
+            LOG.warn(
                     format(
                             "Request to TICF CRI timed out with timeout set to %d",
                             configurationService.getTicfCriServiceCallTimeout()));


### PR DESCRIPTION
## What

As an error it raises several alerts, which gets noisy fast. We don't yet need alerting on timeouts, so disabling by changing the level to warn.

## How to review

1. Code Review
