### PR TITLE
AUT-1933: Upgrade `jetty` to 12.0.15

### DIFF
--- a/orchestration-shared-test/build.gradle
+++ b/orchestration-shared-test/build.gradle
@@ -19,7 +19,7 @@ dependencies {
             configurations.ssm,
             configurations.cloudwatch,
             configurations.pact_provider,
-            "org.eclipse.jetty:jetty-server:11.0.18",
+            "org.eclipse.jetty:jetty-server:12.0.15",
             "com.google.code.gson:gson:2.10.1"
 
     implementation project(":orchestration-shared")

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/httpstub/HttpStub.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/httpstub/HttpStub.java
@@ -1,22 +1,23 @@
 package uk.gov.di.orchestration.sharedtest.httpstub;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import uk.gov.di.orchestration.sharedtest.exceptions.Unchecked;
 
 import java.io.File;
-import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.security.KeyStore;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 class HttpStub {
 
@@ -157,25 +158,25 @@ class HttpStub {
         return recordedRequests;
     }
 
-    private class Handler extends AbstractHandler {
+    private class Handler extends org.eclipse.jetty.server.Handler.Abstract {
+
         @Override
-        public void handle(
-                String target,
-                Request baseRequest,
-                HttpServletRequest request,
-                HttpServletResponse response)
-                throws IOException, ServletException {
-            recordedRequests.add(new RecordedRequest(baseRequest));
+        public boolean handle(Request request, Response response, Callback callback)
+                throws Exception {
+            recordedRequests.add(new RecordedRequest(request));
 
             RegisteredResponse registeredResponse =
-                    registeredResponses.get(baseRequest.getRequestURI());
+                    registeredResponses.get(request.getHttpURI().getPath());
 
             if (registeredResponse != null) {
                 response.setStatus(registeredResponse.getStatus());
-                response.setContentType(registeredResponse.getContentType());
-                response.getWriter().append(registeredResponse.getBody());
-                baseRequest.setHandled(true);
+                response.getHeaders()
+                        .put(HttpHeader.CONTENT_TYPE, registeredResponse.getContentType());
+                ByteBuffer content = UTF_8.encode(registeredResponse.getBody());
+                response.write(true, content, callback);
+                callback.succeeded();
             }
+            return true;
         }
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/httpstub/RecordedRequest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/httpstub/RecordedRequest.java
@@ -1,17 +1,18 @@
 package uk.gov.di.orchestration.sharedtest.httpstub;
 
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.io.content.ContentSourceInputStream;
 import org.eclipse.jetty.server.Request;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 
 public class RecordedRequest {
     private final String requestURI;
-    private final Map<String, List<String>> headers;
     private final String querystring;
     private final String method;
     private final String url;
@@ -19,11 +20,11 @@ public class RecordedRequest {
 
     public RecordedRequest(Request request) {
         this.method = request.getMethod();
-        this.requestURI = request.getRequestURI();
-        this.querystring = request.getQueryString();
-        this.headers = getHeaders(request);
+        this.requestURI = request.getHttpURI().getPath();
+        this.querystring = request.getHttpURI().getQuery();
         this.entity = readEntity(request);
-        this.url = request.getRequestURL().toString();
+        HttpURI httpURI = HttpURI.build(request.getHttpURI()).query(null);
+        this.url = httpURI.asString();
     }
 
     public String getQuerystring() {
@@ -46,24 +47,13 @@ public class RecordedRequest {
         return url;
     }
 
-    public String getHeader(String name) {
-        List<String> values = headers.get(name.toLowerCase());
-        return values == null ? null : values.get(0);
-    }
-
     private static String readEntity(Request request) {
-        try (BufferedReader in = request.getReader()) {
-            return in.lines().collect(Collectors.joining());
+        try (InputStream stream = new ContentSourceInputStream(request)) {
+            InputStreamReader in = new InputStreamReader(stream, StandardCharsets.UTF_8);
+            BufferedReader reader = new BufferedReader(in);
+            return reader.lines().collect(Collectors.joining());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private static Map<String, List<String>> getHeaders(Request request) {
-        return Collections.list(request.getHeaderNames()).stream()
-                .collect(
-                        Collectors.toUnmodifiableMap(
-                                String::toLowerCase,
-                                n -> List.copyOf(Collections.list(request.getHeaders(n)))));
     }
 }

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -18,7 +18,7 @@ dependencies {
             configurations.sqs,
             configurations.ssm,
             configurations.cloudwatch,
-            "org.eclipse.jetty:jetty-server:11.0.18",
+            "org.eclipse.jetty:jetty-server:12.0.15",
             "com.google.code.gson:gson:2.10.1"
 
     implementation project(":shared")

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/RecordedRequest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/RecordedRequest.java
@@ -1,17 +1,18 @@
 package uk.gov.di.authentication.sharedtest.httpstub;
 
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.io.content.ContentSourceInputStream;
 import org.eclipse.jetty.server.Request;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 
 public class RecordedRequest {
     private final String requestURI;
-    private final Map<String, List<String>> headers;
     private final String querystring;
     private final String method;
     private final String url;
@@ -19,11 +20,11 @@ public class RecordedRequest {
 
     public RecordedRequest(Request request) {
         this.method = request.getMethod();
-        this.requestURI = request.getRequestURI();
-        this.querystring = request.getQueryString();
-        this.headers = getHeaders(request);
+        this.requestURI = request.getHttpURI().getPath();
+        this.querystring = request.getHttpURI().getQuery();
         this.entity = readEntity(request);
-        this.url = request.getRequestURL().toString();
+        HttpURI httpURI = HttpURI.build(request.getHttpURI()).query(null);
+        this.url = httpURI.asString();
     }
 
     public String getQuerystring() {
@@ -46,24 +47,13 @@ public class RecordedRequest {
         return url;
     }
 
-    public String getHeader(String name) {
-        List<String> values = headers.get(name.toLowerCase());
-        return values == null ? null : values.get(0);
-    }
-
     private static String readEntity(Request request) {
-        try (BufferedReader in = request.getReader()) {
-            return in.lines().collect(Collectors.joining());
+        try (InputStream stream = new ContentSourceInputStream(request)) {
+            InputStreamReader in = new InputStreamReader(stream, StandardCharsets.UTF_8);
+            BufferedReader reader = new BufferedReader(in);
+            return reader.lines().collect(Collectors.joining());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private static Map<String, List<String>> getHeaders(Request request) {
-        return Collections.list(request.getHeaderNames()).stream()
-                .collect(
-                        Collectors.toUnmodifiableMap(
-                                String::toLowerCase,
-                                n -> List.copyOf(Collections.list(request.getHeaders(n)))));
     }
 }


### PR DESCRIPTION
## What

This involves changing some implementation details for methods that have been removed with the bump.

Also took the opportunity to simplify `RecordedRequest` as it contained methods and properties that were not used.

This change is duplicated across auth and orch `shared-test` packages.

## How to review

1. Code Review
2. See tests pass

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.
