### PR TITLE
ATO-1134: add prefix for orch resources env variable

### DIFF
--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -77,6 +77,7 @@ module "processing-identity" {
     OIDC_API_BASE_URL                           = local.api_base_url
     JAVA_TOOL_OPTIONS                           = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 '--add-reads=jdk.jfr=ALL-UNNAMED'"
     IS_DESTROY_ORCH_SESSION_ON_SIGN_OUT_ENABLED = var.is_destroy_orch_session_on_sign_out_enabled
+    ORCH_DYNAMO_ARN_PREFIX                      = "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-"
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.ProcessingIdentityHandler::handleRequest"
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/TableNameHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/TableNameHelper.java
@@ -1,0 +1,21 @@
+package uk.gov.di.orchestration.shared.helpers;
+
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+
+import java.util.Optional;
+
+public class TableNameHelper {
+
+    private TableNameHelper() {}
+
+    public static String getFullTableName(
+            String tableName,
+            ConfigurationService configurationService,
+            boolean isTableInOrchAccount) {
+        Optional<String> authDynamoArnPrefix = configurationService.getDynamoArnPrefix();
+        if (authDynamoArnPrefix.isPresent() && !isTableInOrchAccount) {
+            return authDynamoArnPrefix.get() + tableName;
+        }
+        return configurationService.getEnvironment() + "-" + tableName;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/TableNameHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/TableNameHelper.java
@@ -13,8 +13,11 @@ public class TableNameHelper {
             ConfigurationService configurationService,
             boolean isTableInOrchAccount) {
         Optional<String> authDynamoArnPrefix = configurationService.getDynamoArnPrefix();
+        Optional<String> orchDynamoArnPrefix = configurationService.getOrchDynamoArnPrefix();
         if (authDynamoArnPrefix.isPresent() && !isTableInOrchAccount) {
             return authDynamoArnPrefix.get() + tableName;
+        } else if (orchDynamoArnPrefix.isPresent() && isTableInOrchAccount) {
+            return orchDynamoArnPrefix.get() + tableName;
         }
         return configurationService.getEnvironment() + "-" + tableName;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import uk.gov.di.orchestration.shared.helpers.TableNameHelper;
 
 import java.util.Optional;
 
@@ -30,12 +31,8 @@ public class BaseDynamoService<T> {
             ConfigurationService configurationService,
             boolean isTableInOrchAccount) {
 
-        var tableName = table;
-        if (configurationService.getDynamoArnPrefix().isPresent() && !isTableInOrchAccount) {
-            tableName = configurationService.getDynamoArnPrefix().get() + tableName;
-        } else {
-            tableName = configurationService.getEnvironment() + "-" + tableName;
-        }
+        var tableName =
+                TableNameHelper.getFullTableName(table, configurationService, isTableInOrchAccount);
 
         client = createDynamoClient(configurationService);
         var enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -196,6 +196,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Optional.ofNullable(System.getenv("DYNAMO_ARN_PREFIX"));
     }
 
+    public Optional<String> getOrchDynamoArnPrefix() {
+        return Optional.ofNullable(System.getenv("ORCH_DYNAMO_ARN_PREFIX"));
+    }
+
     public Optional<String> getDynamoEndpointURI() {
         return Optional.ofNullable(System.getenv("DYNAMO_ENDPOINT"));
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/TableNameHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/TableNameHelperTest.java
@@ -1,0 +1,37 @@
+package uk.gov.di.orchestration.shared.helpers;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TableNameHelperTest {
+    private static final String TEST_AUTH_DYNAMO_ARN_PREFIX =
+            "arn:aws:dynamodb:eu-west-2:12345:table/test-";
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+    @Test
+    void shouldReturnTableArnForAuthTableWhenCalledInOrchAccount() {
+        when(configurationService.getDynamoArnPrefix())
+                .thenReturn(Optional.of(TEST_AUTH_DYNAMO_ARN_PREFIX));
+
+        String fullTableName =
+                TableNameHelper.getFullTableName("auth-table", configurationService, false);
+
+        assertEquals(TEST_AUTH_DYNAMO_ARN_PREFIX + "auth-table", fullTableName);
+    }
+
+    @Test
+    void shouldReturnTableNameIfNoPrefixDefined() {
+        when(configurationService.getEnvironment()).thenReturn("dev");
+
+        String fullTableName =
+                TableNameHelper.getFullTableName("local-table", configurationService, false);
+
+        assertEquals("dev-local-table", fullTableName);
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/TableNameHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/TableNameHelperTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.when;
 class TableNameHelperTest {
     private static final String TEST_AUTH_DYNAMO_ARN_PREFIX =
             "arn:aws:dynamodb:eu-west-2:12345:table/test-";
+    private static final String TEST_ORCH_DYNAMO_ARN_PREFIX =
+            "arn:aws:dynamodb:eu-west-2:56789:table/test-";
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
 
     @Test
@@ -23,6 +25,17 @@ class TableNameHelperTest {
                 TableNameHelper.getFullTableName("auth-table", configurationService, false);
 
         assertEquals(TEST_AUTH_DYNAMO_ARN_PREFIX + "auth-table", fullTableName);
+    }
+
+    @Test
+    void shouldReturnTableArnForOrchTableWhenCalledInAuthAccount() {
+        when(configurationService.getOrchDynamoArnPrefix())
+                .thenReturn(Optional.of(TEST_ORCH_DYNAMO_ARN_PREFIX));
+
+        String fullTableName =
+                TableNameHelper.getFullTableName("orch-table", configurationService, true);
+
+        assertEquals(TEST_ORCH_DYNAMO_ARN_PREFIX + "orch-table", fullTableName);
     }
 
     @Test


### PR DESCRIPTION
## What
- Pulls out the table name definition into a helper
- Defines a new table name for when in an auth account accessing an orch table (this should only be for ProcessingIdentityHandler)

This updates code that is only turned on up to staging.

## How to review
1. Code Review