### PR TITLE
Ato 1280/save auth time in auth code exchange data

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -208,7 +208,10 @@ public class IPVCallbackHelper {
                 () -> saveIdentityClaimsToDynamo(rpPairwiseSubject, userIdentityUserInfo));
         var authCode =
                 authorisationCodeService.generateAndSaveAuthorisationCode(
-                        clientSessionId, userProfile.getEmail(), clientSession);
+                        clientSessionId,
+                        userProfile.getEmail(),
+                        clientSession,
+                        orchSession.getAuthTime());
         var authenticationResponse =
                 new AuthenticationSuccessResponse(
                         authRequest.getRedirectionURI(),

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -171,7 +171,7 @@ class IPVCallbackHelperTest {
                         new AccountIntervention(
                                 new AccountInterventionState(false, true, false, false)));
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        anyString(), anyString(), any(ClientSession.class)))
+                        anyString(), anyString(), any(ClientSession.class), any(Long.class)))
                 .thenReturn(AUTH_CODE);
 
         when(oidcAPI.trustmarkURI()).thenReturn(OIDC_TRUSTMARK_URI);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -391,6 +391,9 @@ public class AuthCodeHandler
             orchSession.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
         }
         return authorisationCodeService.generateAndSaveAuthorisationCode(
-                clientSessionId, session.getEmailAddress(), clientSession);
+                clientSessionId,
+                session.getEmailAddress(),
+                clientSession,
+                orchSession.getAuthTime());
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -533,7 +533,10 @@ public class AuthenticationCallbackHandler
 
                 var authCode =
                         authorisationCodeService.generateAndSaveAuthorisationCode(
-                                clientSessionId, userInfo.getEmailAddress(), clientSession);
+                                clientSessionId,
+                                userInfo.getEmailAddress(),
+                                clientSession,
+                                orchSession.getAuthTime());
 
                 var authenticationResponse =
                         new AuthenticationSuccessResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -140,7 +140,9 @@ class AuthCodeHandlerTest {
 
     private final Session session = new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID);
     private final OrchSessionItem orchSession =
-            new OrchSessionItem(SESSION_ID).withAccountState(OrchSessionItem.AccountState.NEW);
+            new OrchSessionItem(SESSION_ID)
+                    .withAccountState(OrchSessionItem.AccountState.NEW)
+                    .withAuthTime(12345L);
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =
@@ -272,7 +274,7 @@ class AuthCodeHandlerTest {
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        CLIENT_SESSION_ID, EMAIL, clientSession))
+                        eq(CLIENT_SESSION_ID), eq(EMAIL), eq(clientSession), any(Long.class)))
                 .thenReturn(authorizationCode);
         when(orchestrationAuthorizationService.generateSuccessfulAuthResponse(
                         any(AuthenticationRequest.class),
@@ -371,7 +373,7 @@ class AuthCodeHandlerTest {
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        CLIENT_SESSION_ID, null, clientSession))
+                        eq(CLIENT_SESSION_ID), eq(null), eq(clientSession), any(Long.class)))
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(
                         eq(orchSession),
@@ -608,7 +610,7 @@ class AuthCodeHandlerTest {
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        CLIENT_SESSION_ID, null, clientSession))
+                        eq(CLIENT_SESSION_ID), eq(null), eq(clientSession), any(Long.class)))
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(
                         eq(orchSession),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -138,7 +138,10 @@ class AuthenticationCallbackHandlerTest {
                         new AccountIntervention(
                                 new AccountInterventionState(false, false, false, false)));
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        CLIENT_SESSION_ID, TEST_EMAIL_ADDRESS, clientSession))
+                        eq(CLIENT_SESSION_ID),
+                        eq(TEST_EMAIL_ADDRESS),
+                        eq(clientSession),
+                        any(Long.class)))
                 .thenReturn(AUTH_CODE_RP_TO_ORCH);
         when(cookieHelper.parseSessionCookie(anyMap())).thenCallRealMethod();
         when(UNSUCCESSFUL_TOKEN_RESPONSE.indicatesSuccess()).thenReturn(false);
@@ -468,7 +471,10 @@ class AuthenticationCallbackHandlerTest {
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(mediumRequestSession));
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        CLIENT_SESSION_ID, TEST_EMAIL_ADDRESS, mediumRequestSession))
+                        eq(CLIENT_SESSION_ID),
+                        eq(TEST_EMAIL_ADDRESS),
+                        eq(mediumRequestSession),
+                        any(Long.class)))
                 .thenReturn(AUTH_CODE_RP_TO_ORCH);
         usingValidClient();
 
@@ -1046,9 +1052,10 @@ class AuthenticationCallbackHandlerTest {
         ClientSession clientSessionWithCredentialTrustLevel =
                 createClientSession(credentialTrustLevel);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        CLIENT_SESSION_ID,
-                        TEST_EMAIL_ADDRESS,
-                        clientSessionWithCredentialTrustLevel))
+                        eq(CLIENT_SESSION_ID),
+                        eq(TEST_EMAIL_ADDRESS),
+                        eq(clientSessionWithCredentialTrustLevel),
+                        any(Long.class)))
                 .thenReturn(AUTH_CODE_RP_TO_ORCH);
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(clientSessionWithCredentialTrustLevel));

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthCodeExchangeData.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthCodeExchangeData.java
@@ -15,6 +15,10 @@ public class AuthCodeExchangeData {
     @SerializedName("clientSession")
     private ClientSession clientSession;
 
+    @Expose
+    @SerializedName("authTime")
+    private Long authTime;
+
     public String getClientSessionId() {
         return clientSessionId;
     }
@@ -39,6 +43,15 @@ public class AuthCodeExchangeData {
 
     public AuthCodeExchangeData setClientSession(ClientSession clientSession) {
         this.clientSession = clientSession;
+        return this;
+    }
+
+    public Long getAuthTime() {
+        return authTime;
+    }
+
+    public AuthCodeExchangeData setAuthTime(Long authTime) {
+        this.authTime = authTime;
         return this;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
@@ -41,6 +41,11 @@ public class AuthorisationCodeService {
 
     public AuthorizationCode generateAndSaveAuthorisationCode(
             String clientSessionId, String email, ClientSession clientSession) {
+        return generateAndSaveAuthorisationCode(clientSessionId, email, clientSession, null);
+    }
+
+    public AuthorizationCode generateAndSaveAuthorisationCode(
+            String clientSessionId, String email, ClientSession clientSession, Long authTime) {
         LOG.info("Generating and saving AuthorisationCode");
         AuthorizationCode authorizationCode = new AuthorizationCode();
         try {
@@ -50,7 +55,8 @@ public class AuthorisationCodeService {
                             new AuthCodeExchangeData()
                                     .setEmail(email)
                                     .setClientSessionId(clientSessionId)
-                                    .setClientSession(clientSession)),
+                                    .setClientSession(clientSession)
+                                    .setAuthTime(authTime)),
                     authorisationCodeExpiry);
             return authorizationCode;
         } catch (JsonException e) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
@@ -1,0 +1,58 @@
+package uk.gov.di.orchestration.shared.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
+import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.serialization.Json;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AuthorisationCodeServiceTest {
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final RedisConnectionService redisConnectionService =
+            mock(RedisConnectionService.class);
+    private final Json objectMapper = SerializationService.getInstance();
+    private AuthorisationCodeService authCodeService;
+
+    @BeforeEach
+    void setup() {
+        when(configurationService.getAuthCodeExpiry()).thenReturn(123L);
+        authCodeService =
+                new AuthorisationCodeService(
+                        configurationService, redisConnectionService, objectMapper);
+    }
+
+    @Test
+    void shouldSaveToRedisWhenGeneratingAuthCode() throws Json.JsonException {
+        ClientSession clientSession =
+                new ClientSession(Map.of(), LocalDateTime.now(), List.of(), "test-client");
+
+        authCodeService.generateAndSaveAuthorisationCode(
+                "test-client-session", "test@email.com", clientSession);
+
+        AuthCodeExchangeData expectedExchangeData =
+                new AuthCodeExchangeData()
+                        .setClientSessionId("test-client-session")
+                        .setEmail("test@email.com")
+                        .setClientSession(clientSession);
+        String expectedJson = objectMapper.writeValueAsString(expectedExchangeData);
+        verify(redisConnectionService)
+                .saveWithExpiry(startsWith("auth-code-"), eq(expectedJson), eq(123L));
+    }
+
+    @Test
+    void shouldPrefixAuthCodeWhenLoadingFromRedis() {
+        authCodeService.getExchangeDataForCode("test");
+
+        verify(redisConnectionService).popValue("auth-code-test");
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
@@ -37,13 +37,14 @@ class AuthorisationCodeServiceTest {
                 new ClientSession(Map.of(), LocalDateTime.now(), List.of(), "test-client");
 
         authCodeService.generateAndSaveAuthorisationCode(
-                "test-client-session", "test@email.com", clientSession);
+                "test-client-session", "test@email.com", clientSession, 12345L);
 
         AuthCodeExchangeData expectedExchangeData =
                 new AuthCodeExchangeData()
                         .setClientSessionId("test-client-session")
                         .setEmail("test@email.com")
-                        .setClientSession(clientSession);
+                        .setClientSession(clientSession)
+                        .setAuthTime(12345L);
         String expectedJson = objectMapper.writeValueAsString(expectedExchangeData);
         verify(redisConnectionService)
                 .saveWithExpiry(startsWith("auth-code-"), eq(expectedJson), eq(123L));


### PR DESCRIPTION
## What
Worked on with: @cearl1
- Updates the AuthCodeExchageData to include the auth time from the session, as the token request is a server-to-server interaction and therefore does not have access to the user's session.
- This is added in all cases we generate an authorisation code, except the doc app journey. This is because we do not want to return an `auth_time` claim in the ID token for doc app. 

## How to review
 - Code review commit-by-commit
 - Deployed to dev:
   - Ran through a journey - all fine
## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->
- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
