### PR TITLE
ATO-1097: Return auth_time in ID token

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -92,6 +92,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String DIFFERENT_CLIENT_ID = "different-test-id";
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
     private static final String REDIRECT_URI = "http://localhost/redirect";
+    private static final Long AUTH_TIME = NowHelper.now().toInstant().getEpochSecond() - 120L;
 
     @RegisterExtension
     public static final RpPublicKeyCacheExtension rpPublicKeyCacheExtension =
@@ -238,6 +239,12 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(200));
         JSONObject jsonResponse = JSONObjectUtils.parse(response.getBody());
+        var idTokenClaims =
+                OIDCTokenResponse.parse(jsonResponse)
+                        .getOIDCTokens()
+                        .getIDToken()
+                        .getJWTClaimsSet();
+
         assertNotNull(
                 TokenResponse.parse(jsonResponse)
                         .toSuccessResponse()
@@ -249,12 +256,9 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getTokens()
                         .getBearerAccessToken());
         assertThat(
-                OIDCTokenResponse.parse(jsonResponse)
-                        .getOIDCTokens()
-                        .getIDToken()
-                        .getJWTClaimsSet()
-                        .getSubject(),
+                idTokenClaims.getSubject(),
                 equalTo(userStore.getPublicSubjectIdForEmail(TEST_EMAIL)));
+        assertEquals(AUTH_TIME, idTokenClaims.getClaim("auth_time"));
 
         AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
@@ -273,8 +277,14 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         scope, Optional.empty(), Optional.empty(), Optional.of(CLIENT_ID));
 
         var response = makeTokenRequestWithPrivateKeyJWT(baseTokenRequest, keyPair.getPrivate());
+
         assertThat(response, hasStatus(200));
         JSONObject jsonResponse = JSONObjectUtils.parse(response.getBody());
+        var idTokenClaims =
+                OIDCTokenResponse.parse(jsonResponse)
+                        .getOIDCTokens()
+                        .getIDToken()
+                        .getJWTClaimsSet();
         assertNotNull(
                 TokenResponse.parse(jsonResponse)
                         .toSuccessResponse()
@@ -286,12 +296,9 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getTokens()
                         .getBearerAccessToken());
         assertThat(
-                OIDCTokenResponse.parse(jsonResponse)
-                        .getOIDCTokens()
-                        .getIDToken()
-                        .getJWTClaimsSet()
-                        .getSubject(),
+                idTokenClaims.getSubject(),
                 not(equalTo(userStore.getPublicSubjectIdForEmail(TEST_EMAIL))));
+        assertEquals(AUTH_TIME, idTokenClaims.getClaim("auth_time"));
 
         AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
@@ -611,7 +618,8 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 TEST_EMAIL,
                 generateAuthRequest(scope, vtr, oidcClaimsRequest).toParameters(),
                 vtrList,
-                "client-name");
+                "client-name",
+                AUTH_TIME);
         Map<String, List<String>> customParams = new HashMap<>();
         customParams.put(
                 "grant_type", Collections.singletonList(GrantType.AUTHORIZATION_CODE.getValue()));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -258,7 +258,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(
                 idTokenClaims.getSubject(),
                 equalTo(userStore.getPublicSubjectIdForEmail(TEST_EMAIL)));
-        assertEquals(AUTH_TIME, idTokenClaims.getClaim("auth_time"));
+        assertNull(idTokenClaims.getClaim("auth_time"));
 
         AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
@@ -298,7 +298,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(
                 idTokenClaims.getSubject(),
                 not(equalTo(userStore.getPublicSubjectIdForEmail(TEST_EMAIL))));
-        assertEquals(AUTH_TIME, idTokenClaims.getClaim("auth_time"));
+        assertNull(idTokenClaims.getClaim("auth_time"));
 
         AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -420,7 +420,8 @@ public class TokenHandler
                                             true,
                                             signingAlgorithm,
                                             authCodeExchangeData.getClientSessionId(),
-                                            vot));
+                                            vot,
+                                            null));
         } else {
             UserProfile userProfile =
                     dynamoService.getUserProfileByEmail(authCodeExchangeData.getEmail());
@@ -450,7 +451,8 @@ public class TokenHandler
                                             false,
                                             signingAlgorithm,
                                             authCodeExchangeData.getClientSessionId(),
-                                            vot));
+                                            vot,
+                                            authCodeExchangeData.getAuthTime()));
         }
         return tokenResponse;
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -50,6 +50,7 @@ import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
@@ -138,6 +139,7 @@ public class TokenHandlerTest {
     public static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final Nonce NONCE = new Nonce();
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
+    private static final Long AUTH_TIME = NowHelper.now().toInstant().getEpochSecond() - 120L;
 
     private final BearerAccessToken accessToken = new BearerAccessToken();
     private final RefreshToken refreshToken = new RefreshToken();
@@ -231,7 +233,8 @@ public class TokenHandlerTest {
                                                         authenticationRequest.toParameters(),
                                                         LocalDateTime.now(),
                                                         vtr,
-                                                        CLIENT_NAME))));
+                                                        CLIENT_NAME))
+                                        .setAuthTime(AUTH_TIME)));
         when(dynamoService.getUserProfileByEmail(eq(TEST_EMAIL))).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
@@ -244,7 +247,8 @@ public class TokenHandlerTest {
                         false,
                         JWSAlgorithm.ES256,
                         CLIENT_SESSION_ID,
-                        lowestLevelVtr.retrieveVectorOfTrustForToken()))
+                        lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                        AUTH_TIME))
                 .thenReturn(tokenResponse);
 
         APIGatewayProxyResponseEvent result =
@@ -308,7 +312,8 @@ public class TokenHandlerTest {
                                                         authenticationRequest.toParameters(),
                                                         LocalDateTime.now(),
                                                         vtr,
-                                                        CLIENT_NAME))));
+                                                        CLIENT_NAME))
+                                        .setAuthTime(AUTH_TIME)));
         when(dynamoService.getUserProfileByEmail(eq(TEST_EMAIL))).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
@@ -321,7 +326,8 @@ public class TokenHandlerTest {
                         false,
                         JWSAlgorithm.RS256,
                         CLIENT_SESSION_ID,
-                        lowestLevelVtr.retrieveVectorOfTrustForToken()))
+                        lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                        AUTH_TIME))
                 .thenReturn(tokenResponse);
 
         APIGatewayProxyResponseEvent result =
@@ -603,7 +609,8 @@ public class TokenHandlerTest {
                                                         generateAuthRequest().toParameters(),
                                                         LocalDateTime.now(),
                                                         List.of(mock(VectorOfTrust.class)),
-                                                        CLIENT_NAME))));
+                                                        CLIENT_NAME))
+                                        .setAuthTime(AUTH_TIME)));
 
         APIGatewayProxyResponseEvent result =
                 generateApiGatewayRequest(
@@ -675,7 +682,8 @@ public class TokenHandlerTest {
                         true,
                         JWSAlgorithm.ES256,
                         CLIENT_SESSION_ID,
-                        lowestLevelVtr.retrieveVectorOfTrustForToken()))
+                        lowestLevelVtr.retrieveVectorOfTrustForToken(),
+                        null))
                 .thenReturn(tokenResponse);
 
         var result =

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -346,5 +346,10 @@ public class IntegrationTest {
         public boolean supportMaxAgeEnabled() {
             return true;
         }
+
+        @Override
+        public boolean isReturnAuthTimeInIdTokenEnabled() {
+            return false;
+        }
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -186,7 +186,8 @@ public class RedisExtension
             String email,
             Map<String, List<String>> authRequest,
             List<VectorOfTrust> vtrList,
-            String clientName)
+            String clientName,
+            Long authTime)
             throws Json.JsonException {
         var clientSession =
                 new ClientSession(authRequest, LocalDateTime.now(), vtrList, clientName);
@@ -196,8 +197,10 @@ public class RedisExtension
                         new AuthCodeExchangeData()
                                 .setClientSessionId(clientSessionId)
                                 .setEmail(email)
-                                .setClientSession(clientSession)),
+                                .setClientSession(clientSession)
+                                .setAuthTime(authTime)),
                 300);
+
         redis.saveWithExpiry(
                 CLIENT_SESSION_PREFIX.concat(clientSessionId),
                 objectMapper.writeValueAsString(clientSession),

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -413,6 +413,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("USE_ORCH_SESSION_FOR_AUTHENTICATED_CLAIM");
     }
 
+    public boolean isReturnAuthTimeInIdTokenEnabled() {
+        return getFlagOrFalse("RETURN_AUTH_TIME_IN_ID_TOKEN_ENABLED");
+    }
+
     public Optional<String> getIPVCapacity() {
         try {
             var request =

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -92,7 +92,8 @@ public class TokenService {
             boolean isDocAppJourney,
             JWSAlgorithm signingAlgorithm,
             String journeyId,
-            String vot) {
+            String vot,
+            Long authTime) {
         List<String> scopesForToken = authRequestScopes.toStringList();
         AccessToken accessToken =
                 segmentedFunctionCall(
@@ -124,7 +125,8 @@ public class TokenService {
                                         vot,
                                         isDocAppJourney,
                                         signingAlgorithm,
-                                        journeyId));
+                                        journeyId,
+                                        authTime));
         if (scopesForToken.contains(OIDCScopeValue.OFFLINE_ACCESS.getValue())) {
             RefreshToken refreshToken =
                     segmentedFunctionCall(
@@ -225,7 +227,8 @@ public class TokenService {
             String vot,
             boolean isDocAppJourney,
             JWSAlgorithm signingAlgorithm,
-            String journeyId) {
+            String journeyId,
+            Long authTime) {
 
         LOG.info("Generating IdToken");
         URI trustMarkUri = oidcApi.trustmarkURI();
@@ -246,6 +249,7 @@ public class TokenService {
             idTokenClaims.setClaim("vot", vot);
         }
         idTokenClaims.setClaim("vtm", trustMarkUri.toString());
+        idTokenClaims.setClaim("auth_time", authTime);
 
         try {
             return generateSignedJwtUsingExternalKey(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -249,7 +249,9 @@ public class TokenService {
             idTokenClaims.setClaim("vot", vot);
         }
         idTokenClaims.setClaim("vtm", trustMarkUri.toString());
-        idTokenClaims.setClaim("auth_time", authTime);
+        if (configService.isReturnAuthTimeInIdTokenEnabled()) {
+            idTokenClaims.setClaim("auth_time", authTime);
+        }
 
         try {
             return generateSignedJwtUsingExternalKey(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -247,11 +247,11 @@ public class TokenService {
         idTokenClaims.putAll(additionalTokenClaims);
         if (!isDocAppJourney) {
             idTokenClaims.setClaim("vot", vot);
+            if (configService.isReturnAuthTimeInIdTokenEnabled()) {
+                idTokenClaims.setClaim("auth_time", authTime);
+            }
         }
         idTokenClaims.setClaim("vtm", trustMarkUri.toString());
-        if (configService.isReturnAuthTimeInIdTokenEnabled()) {
-            idTokenClaims.setClaim("auth_time", authTime);
-        }
 
         try {
             return generateSignedJwtUsingExternalKey(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
@@ -120,6 +120,7 @@ class TokenServiceTest {
             "eyJraWQiOiIxZDUwNGFlY2UyOThhMTRkNzRlZTBhMDJiNjc0MGI0MzcyYTFmYWI0MjA2Nzc4ZTQ4NmJhNzI3NzBmZjRiZWI4IiwiYWxnIjoiRVMyNTYifQ.";
     private static final String CREDENTIAL_STORE_URI = "https://credential-store.account.gov.uk";
     private static final String IPV_AUDIENCE = "https://identity.test.account.gov.uk";
+    private static final Long AUTH_TIME = NowHelper.now().toInstant().getEpochSecond() - 120L;
 
     private static final Json objectMapper = SerializationService.getInstance();
 
@@ -166,7 +167,8 @@ class TokenServiceTest {
                         false,
                         JWSAlgorithm.ES256,
                         JOURNEY_ID,
-                        VOT);
+                        VOT,
+                        AUTH_TIME);
 
         assertSuccessfulTokenResponse(tokenResponse);
 
@@ -237,7 +239,8 @@ class TokenServiceTest {
                         false,
                         JWSAlgorithm.ES256,
                         JOURNEY_ID,
-                        VOT);
+                        VOT,
+                        AUTH_TIME);
 
         assertSuccessfulTokenResponse(tokenResponse);
 
@@ -302,7 +305,8 @@ class TokenServiceTest {
                         false,
                         JWSAlgorithm.ES256,
                         JOURNEY_ID,
-                        VOT);
+                        VOT,
+                        AUTH_TIME);
 
         assertSuccessfulTokenResponse(tokenResponse);
 
@@ -329,7 +333,8 @@ class TokenServiceTest {
                         false,
                         JWSAlgorithm.ES256,
                         JOURNEY_ID,
-                        VOT);
+                        VOT,
+                        AUTH_TIME);
 
         var parsedAccessToken =
                 SignedJWT.parse(tokenResponse.getOIDCTokens().getAccessToken().getValue())
@@ -578,5 +583,8 @@ class TokenServiceTest {
         assertThat(
                 tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getStringClaim("sid"),
                 is(JOURNEY_ID));
+        assertThat(
+                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaim("auth_time"),
+                is(AUTH_TIME));
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
@@ -579,12 +579,10 @@ class TokenServiceTest {
                                         JWSAlgorithm.ES256,
                                         null)
                                 .toString()));
-
         assertThat(
                 tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getStringClaim("sid"),
                 is(JOURNEY_ID));
-        assertThat(
-                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaim("auth_time"),
-                is(AUTH_TIME));
+        assertNull(
+                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaim("auth_time"));
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -72,6 +72,13 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
     ]
+  IsReturnAuthTimeInIdTokenEnabled:
+    !Or [
+      !Equals [dev, !Ref Environment],
+      !Equals [build, !Ref Environment],
+      !Equals [staging, !Ref Environment],
+      !Equals [integration, !Ref Environment],
+    ]
   IsIntegration: !Equals [!Ref Environment, integration]
   SupportMaxAgeEnabled:
     !Or [
@@ -1339,6 +1346,10 @@ Resources:
                 ]
           FETCH_RP_PUBLIC_KEY_FROM_JWKS_ENABLED: !If
             - EnableFetchJwks
+            - true
+            - false
+          RETURN_AUTH_TIME_IN_ID_TOKEN_ENABLED: !If
+            - IsReturnAuthTimeInIdTokenEnabled
             - true
             - false
 


### PR DESCRIPTION
## What

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. The claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request).

Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
