### PR TITLE
ATO-1328: Add logging to check if docApp contains claims

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -415,6 +415,12 @@ public class AuthorisationHandler
 
         if (DocAppUserHelper.isDocCheckingAppUser(
                 authRequest.toParameters(), Optional.of(client))) {
+
+            // ATO-1328: Revert once we have collected enough logs
+            LOG.info(
+                    "Claims are attached to DocApp request: {}",
+                    Objects.nonNull(authRequest.getOIDCClaims()));
+
             return handleDocAppJourney(
                     session,
                     orchSessionOptional,


### PR DESCRIPTION
## What:

- Adds logging to check whether the doc-app request contains claims. We're not expecting this to contain claims so this logging will help us confirm whether our assumptions are true.

## How to review:
- Code review commit-by-commit
