### PR TITLE
ATO-1310: enable max_age for stub-build-acceptance-test client

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -73,7 +73,7 @@ stub_rp_clients = [
     ]
     one_login_service = false
     service_type      = "MANDATORY"
-    max_age_enabled   = false
+    max_age_enabled   = true
   },
   {
     client_name           = "relying-party-micro-stub-build-acceptance-test"


### PR DESCRIPTION
## What
Enable `max_age` for `relying-party-stub-build-acceptance-test` client. This is so that we can test the scenario that when the client has a `max_age_enabled`, and the user attempts to log in with an expired `max_age`, they are logged out. 

PR on orchestration-acceptance-tests here: https://github.com/govuk-one-login/orchestration-acceptance-tests/pull/53

## How to review
1. Code Review