### PR TITLE
ATO-1117: add temporary logging to verify values

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -285,6 +285,20 @@ public class IPVCallbackHandler
                             URI.create(configurationService.getInternalSectorURI()),
                             dynamoService.getOrGenerateSalt(userProfile));
 
+            // TODO: ATO-1117: temp logging
+            LOG.info(
+                    "is rpPairwiseId the same on clientSession as calculated: {}",
+                    rpPairwiseSubject.getValue().equals(clientSession.getRpPairwiseId()));
+
+            LOG.info(
+                    "is internalCommonSubjectId not blank on orchSession: {}",
+                    orchSession.getInternalCommonSubjectId() != null
+                            && !orchSession.getInternalCommonSubjectId().isBlank());
+            LOG.info(
+                    "is internalCommonSubjectId the same on orchSession as calculated: {}",
+                    internalPairwiseSubjectId.equals(orchSession.getInternalCommonSubjectId()));
+            //
+
             var ipAddress = IpAddressHelper.extractIpAddress(input);
             var user =
                     TxmaAuditUser.user()


### PR DESCRIPTION
## What
In a previous PR, I had assumed orchSession.getInternalCommonSubjectId() would be a defined string, but it seems this is not the case. When I tried to use it to get from the dynamodb table, it threw the error Supplied AttributeValue is empty a few times in 4 hours. Here, I add a small subset of the logs I added there to see what is going on.

## How to review
1. Code Review