### PR TITLE
BAU: Update pre-commit hooks to latest versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: 🏗️ Set up Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -9,7 +9,7 @@ repos:
       - id: check-executables-have-shebangs
 
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v1.11.1
+    rev: v1.22.3
     hooks:
       - id: cfn-python-lint
         exclude: ^(ci|.github)/.*|docker-compose.*|.pre-commit-config.yaml|orchestration-canary-alarms.template.yaml|.*.approved.json|checkov-policies.*|.terraform-docs.yml$
@@ -21,25 +21,25 @@ repos:
       - id: gradle-spotless-apply
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.1
+    rev: v1.96.3
     hooks:
       - id: terraform_fmt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 1ee2e387938ec90ec10a64f85fc0b4be527ade6a # v0.5.5
+    rev: v0.8.6
     hooks:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: a23f6b85d0fdd5bb9d564e2579e678033debbdff # v0.10.0.1 # pragma: allowlist secret
+    rev: v0.10.0.1
     hooks:
       - id: shellcheck
         exclude: ./gradlew|./pre-commit.sh
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.0
+    rev: v1.7.6
     hooks:
       - id: actionlint
 


### PR DESCRIPTION
## What

Upgrade pre-commit hooks.

antonbabenko/pre-commit-terraform no longer ships `terraform`, so we
now need to use `hashicorp/setup-terraform` to install it.

## How to review

Code review
