### PR TITLE
ATO-1329: add claim validation to request object

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
@@ -106,7 +106,7 @@ public class RequestObjectToAuthRequestHelper {
         }
     }
 
-    private static OIDCClaimsRequest parseOidcClaims(JWTClaimsSet claimsSet) {
+    public static OIDCClaimsRequest parseOidcClaims(JWTClaimsSet claimsSet) {
         var stringClaim = claimsSet.getClaim("claims").toString();
         if (stringClaim == null || stringClaim.isEmpty()) {
             throw new IllegalArgumentException("Claims must not be null or empty");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -416,11 +416,6 @@ public class AuthorisationHandler
         if (DocAppUserHelper.isDocCheckingAppUser(
                 authRequest.toParameters(), Optional.of(client))) {
 
-            // ATO-1328: Revert once we have collected enough logs
-            LOG.info(
-                    "Claims are attached to DocApp request: {}",
-                    Objects.nonNull(authRequest.getOIDCClaims()));
-
             return handleDocAppJourney(
                     session,
                     orchSessionOptional,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -1,16 +1,20 @@
 package uk.gov.di.authentication.oidc.validators;
 
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
+import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
 import uk.gov.di.authentication.oidc.services.IPVCapacityService;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -51,5 +55,42 @@ public abstract class BaseAuthorizeValidator {
         } else {
             LOG.warn(logMessage);
         }
+    }
+
+    protected boolean areClaimsValid(
+            OIDCClaimsRequest claimsRequest, ClientRegistry clientRegistry) {
+        if (claimsRequest == null || claimsRequest.getUserInfoClaimsRequest() == null) {
+            LOG.info("No claims present in auth request");
+            return true;
+        }
+        List<String> claimNames =
+                claimsRequest.getUserInfoClaimsRequest().getEntries().stream()
+                        .map(ClaimsSetRequest.Entry::getClaimName)
+                        .toList();
+
+        boolean containsUnsupportedClaims =
+                claimNames.stream()
+                        .anyMatch(
+                                claim ->
+                                        ValidClaims.getAllValidClaims().stream()
+                                                .noneMatch(t -> t.equals(claim)));
+        if (containsUnsupportedClaims) {
+            logErrorInProdElseWarn(
+                    String.format(
+                            "Claims have been requested which are not yet supported. Claims in request: %s",
+                            claimsRequest.toJSONString()));
+            return false;
+        }
+
+        boolean hasUnsupportedClaims = !clientRegistry.getClaims().containsAll(claimNames);
+        if (hasUnsupportedClaims) {
+            logErrorInProdElseWarn(
+                    String.format(
+                            "Claims have been requested which this client is not supported to request. Claims in request: %s",
+                            claimsRequest.toJSONString()));
+            return false;
+        }
+        LOG.info("Claims are present AND valid in auth request");
+        return true;
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -4,12 +4,9 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
-import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
-import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
 import uk.gov.di.authentication.oidc.services.IPVCapacityService;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
-import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
@@ -175,42 +172,6 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
                             scopes));
             return false;
         }
-        return true;
-    }
-
-    private boolean areClaimsValid(OIDCClaimsRequest claimsRequest, ClientRegistry clientRegistry) {
-        if (claimsRequest == null || claimsRequest.getUserInfoClaimsRequest() == null) {
-            LOG.info("No claims present in auth request");
-            return true;
-        }
-        List<String> claimNames =
-                claimsRequest.getUserInfoClaimsRequest().getEntries().stream()
-                        .map(ClaimsSetRequest.Entry::getClaimName)
-                        .toList();
-
-        boolean containsUnsupportedClaims =
-                claimNames.stream()
-                        .anyMatch(
-                                claim ->
-                                        ValidClaims.getAllValidClaims().stream()
-                                                .noneMatch(t -> t.equals(claim)));
-        if (containsUnsupportedClaims) {
-            logErrorInProdElseWarn(
-                    String.format(
-                            "Claims have been requested which are not yet supported. Claims in request: %s",
-                            claimsRequest.toJSONString()));
-            return false;
-        }
-
-        boolean hasUnsupportedClaims = !clientRegistry.getClaims().containsAll(claimNames);
-        if (hasUnsupportedClaims) {
-            logErrorInProdElseWarn(
-                    String.format(
-                            "Claims have been requested which this client is not supported to request. Claims in request: %s",
-                            claimsRequest.toJSONString()));
-            return false;
-        }
-        LOG.info("Claims are present AND valid in auth request");
         return true;
     }
 }


### PR DESCRIPTION
## What: 
- Adds claim validation to the request object flow, meaning requested claims are now validated against the clients configuration.

## How to review: 
- Code review commit-by-commit
- Deployed to dev and tested the following cases using the stub:
  - Checked with valid claims -> As usual 
  - Removed a claim from the client config and requested it -> got expected invalid claims error
  - Made a request object request with no claims -> As usual  


## Related PRs:
- Deployed alongside this: https://github.com/govuk-one-login/relying-party-stub/pull/417 to ensure the claims were properly formatted when testing. Preferably we should merge this PR after that one, to ensure the stub stays fully working 
