### PR TITLE
AUT-3954: Move Authdev1 env to run on Shared VPC

### DIFF
--- a/ci/terraform/account-management/authdev1.tfvars
+++ b/ci/terraform/account-management/authdev1.tfvars
@@ -1,5 +1,7 @@
 environment         = "authdev1"
 common_state_bucket = "di-auth-development-tfstate"
+redis_node_size     = "cache.t2.micro"
+vpc_environment     = "dev"
 
 logging_endpoint_enabled = false
 logging_endpoint_arns    = []

--- a/ci/terraform/auth-external-api/authdev1.tfvars
+++ b/ci/terraform/auth-external-api/authdev1.tfvars
@@ -1,5 +1,6 @@
 environment         = "authdev1"
 shared_state_bucket = "di-auth-development-tfstate"
+vpc_environment     = "dev"
 
 logging_endpoint_arns  = []
 internal_sector_uri    = "https://identity.authdev1.sandpit.account.gov.uk"

--- a/ci/terraform/delivery-receipts/authdev1.tfvars
+++ b/ci/terraform/delivery-receipts/authdev1.tfvars
@@ -1,5 +1,6 @@
 environment         = "authdev1"
 common_state_bucket = "di-auth-development-tfstate"
+vpc_environment     = "dev"
 
 logging_endpoint_enabled = false
 logging_endpoint_arns    = []

--- a/ci/terraform/interventions-api-stub/authdev1.tfvars
+++ b/ci/terraform/interventions-api-stub/authdev1.tfvars
@@ -1,2 +1,3 @@
 environment         = "authdev1"
 shared_state_bucket = "di-auth-development-tfstate"
+vpc_environment     = "dev"

--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -2,6 +2,7 @@ environment         = "authdev1"
 common_state_bucket = "di-auth-development-tfstate"
 redis_node_size     = "cache.t2.micro"
 password_pepper     = "fake-pepper"
+vpc_environment     = "dev"
 
 enable_api_gateway_execution_request_tracing = true
 di_tools_signing_profile_version_arn         = "arn:aws:signer:eu-west-2:706615647326:/signing-profiles/di_auth_lambda_signing_20220214175605677200000001/ZPqg7ZUgCP"

--- a/ci/terraform/test-services/authdev1.tfvars
+++ b/ci/terraform/test-services/authdev1.tfvars
@@ -1,5 +1,6 @@
 environment         = "authdev1"
 shared_state_bucket = "di-auth-development-tfstate"
+vpc_environment     = "dev"
 
 synthetics_users = "any.user@digital.cabinet-office.gov.uk"
 

--- a/ci/terraform/test-services/authdev2.tfvars
+++ b/ci/terraform/test-services/authdev2.tfvars
@@ -1,5 +1,6 @@
 environment         = "authdev2"
 shared_state_bucket = "di-auth-development-tfstate"
+vpc_environment     = "dev"
 
 synthetics_users = "any.user@digital.cabinet-office.gov.uk"
 

--- a/ci/terraform/test-services/variables.tf
+++ b/ci/terraform/test-services/variables.tf
@@ -87,3 +87,9 @@ variable "txma_account_id" {
   default = ""
   type    = string
 }
+
+variable "vpc_environment" {
+  description = "The name of the environment this environment is sharing the VPC , this var is only for Authdevs env and must be overide using Authdevs.tfvars, default value should be null always."
+  type        = string
+  default     = null
+}

--- a/ci/terraform/ticf-cri-stub/authdev1.tfvars
+++ b/ci/terraform/ticf-cri-stub/authdev1.tfvars
@@ -1,5 +1,6 @@
 environment         = "authdev1"
 shared_state_bucket = "di-auth-development-tfstate"
+vpc_environment     = "dev"
 
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0


### PR DESCRIPTION
## What

[AUT-3954] Migrate Authdev1 to run  shared Dev VPC

## How to review

Code Review
Deploy to authdev2 with `./deploy-authdevs.sh -p


[AUT-3954]: https://govukverify.atlassian.net/browse/AUT-3954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ