### PR TITLE
ATO-1117: check if rpPairwiseId is not blank

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -287,6 +287,10 @@ public class IPVCallbackHandler
 
             // TODO: ATO-1117: temp logging
             LOG.info(
+                    "is rpPairwiseId not blank on clientSession: {}",
+                    clientSession.getRpPairwiseId() != null
+                            && !clientSession.getRpPairwiseId().isBlank());
+            LOG.info(
                     "is rpPairwiseId the same on clientSession as calculated: {}",
                     rpPairwiseSubject.getValue().equals(clientSession.getRpPairwiseId()));
 


### PR DESCRIPTION
## What
We have discovered that in our new structure, it is possible for a user to have an undefined internalCommonSubjectId here. In this cases, it was because the user had skipped authenticationCallbackHandler. However, there were 2 cases where internalCommonSubjectId was defined and matched the calculated value, but rpPairwiseId didn't. With this log, I want to check if the values actually don't match, or if the value is just undefined.

The journey in question:
https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20%22persistent-session-id%22%3D%22NpetkOCgg3FVY_gsDotLanZ8pNo--1720278504017%22&earliest=-7d%40h&latest=now&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&sid=1736511865.615899

## How to review
1. Code Review