### PR TITLE
BAU: Initialise cloudwatch metrics service in access token service constructor

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenService.java
@@ -33,6 +33,7 @@ public class AccessTokenService extends BaseDynamoService<AccessTokenStore> {
         super(AccessTokenStore.class, "access-token-store", configurationService);
         this.timeToExist = configurationService.getAccessTokenExpiry();
         this.configurationService = configurationService;
+        this.cloudwatchMetricsService = new CloudwatchMetricsService();
     }
 
     public AccessTokenService(


### PR DESCRIPTION
When we added the cloudwatch metrics service to this class ([here](https://github.com/govuk-one-login/authentication-api/pull/5090/files#diff-a7e7ff7cedcd463c93c40cd203dbd387c691f3b0c10e64496f1021040d94c3d2)), we did not initialise it in all constructors. This constructor is being used by the token handler in the auth external api, meaning that when the access token service was being used by this lambda it was unable to increment the relevant counter and was raising an error in logs
