### PR TITLE
ATO-1113: Send backchannel logouts if different user post `max_age`

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -827,8 +827,7 @@ public class AuthenticationCallbackHandler
         } else {
             LOG.info(
                     "Previous OrchSession InternalCommonSubjectId does not match Auth UserInfo response");
-            // TODO: ATO-1101: Send backchannel logouts + audit events
-
+            logoutService.handleMaxAgeLogout(previousSharedSession.get());
         }
         currentOrchSession.setPreviousSessionId(null);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -214,6 +214,11 @@ public class LogoutService {
                 Optional.empty());
     }
 
+    public void handleMaxAgeLogout(Session previousSession) {
+        destroySessions(previousSession);
+        cloudwatchMetricsService.incrementLogout(Optional.empty());
+    }
+
     private void sendAuditEvent(
             TxmaAuditUser auditUser,
             LogoutReason logoutReason,

--- a/template.yaml
+++ b/template.yaml
@@ -1745,6 +1745,7 @@ Resources:
                   authEnvironment,
                 ]
           ACCOUNT_INTERVENTIONS_ERROR_METRIC_NAME: "AISException"
+          BACK_CHANNEL_LOGOUT_QUEUE_URI: !GetAtt BackChannelLogoutQueue.QueueUrl
           CREDENTIAL_STORE_URI: !Sub
             - https://credential-store.${ServiceDomain}
             - ServiceDomain:


### PR DESCRIPTION
## What
- Sends backchannel logout notifications if the internalCommonSubject Id does not match the previous session after a max_age reauthentication
- Also removes the previous shared session and orch session as these no longer have any value
- Future work will include sending audit events 
- All changes are behind the MAX_AGE_ENABLED feature flag 


## How to review: 
- Code review commit-by-commit 
- Deploy to dev
   - Run through a normal journey followed by a max_age re-authentication as same user
   -  Run through a normal journey followed by a max_age re-authentication as with different users

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
