### PR TITLE
ATO-1117: add user info to ipv callback handler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -543,6 +543,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
     private void setupUserProfileAndUserCredentials() {
         userStore.signUp(TEST_EMAIL_ADDRESS, "password", TEST_SUBJECT);
+        userStore.addVerifiedPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);
     }
 
     private void setupClientStore() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -15,7 +15,9 @@ import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,7 @@ import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.orchestration.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.IPVStubExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
@@ -47,6 +50,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +85,10 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     @RegisterExtension
     public static final OrchSessionExtension orchSessionExtension = new OrchSessionExtension();
 
+    @RegisterExtension
+    protected static final AuthenticationCallbackUserInfoStoreExtension userInfoStorageExtension =
+            new AuthenticationCallbackUserInfoStoreExtension(180);
+
     protected static final ConfigurationService configurationService =
             new IPVCallbackHandlerIntegrationTest.TestConfigurationService(
                     ipvStub,
@@ -94,7 +102,9 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     private static final String CLIENT_ID = "test-client-id";
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String REDIRECT_URI = "http://localhost/redirect";
+    private static final URI OIDC_BASE_URL = URI.create("https://base-url.com");
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
+    private static final String TEST_PHONE_NUMBER = "01234567890";
     private static final String SESSION_ID = "some-session-id";
     public static final String CLIENT_NAME = "test-client-name";
     public static final String CLIENT_SESSION_ID = "some-client-session-id";
@@ -104,6 +114,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     private static final String TEST_INTERNAL_SECTOR_ID = "test.com";
 
     private static byte[] salt;
+    private static String base64EncodedSalt;
     private static String internalCommonSubjectId;
 
     @BeforeEach
@@ -117,10 +128,12 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         setupClientStore();
 
         salt = userStore.addSalt(TEST_EMAIL_ADDRESS);
+        base64EncodedSalt = Base64.getEncoder().encodeToString(salt);
         internalCommonSubjectId =
                 calculatePairwiseIdentifier(TEST_SUBJECT.getValue(), TEST_INTERNAL_SECTOR_ID, salt);
 
         setupOrchSession(internalCommonSubjectId);
+        setupAuthUserInfoTable(internalCommonSubjectId, salt);
     }
 
     @Test
@@ -553,6 +566,25 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 new OrchSessionItem(SESSION_ID)
                         .withVerifiedMfaMethodType(MFAMethodType.AUTH_APP.getValue())
                         .withInternalCommonSubjectId(internalCommonSubjectId));
+    }
+
+    private void setupAuthUserInfoTable(String internalCommonSubjectId, byte[] salt) {
+        var userInfo =
+                new UserInfo(
+                        new JSONObject(
+                                Map.of(
+                                        "sub",
+                                        internalCommonSubjectId,
+                                        "email",
+                                        TEST_EMAIL_ADDRESS,
+                                        "phone_number",
+                                        TEST_PHONE_NUMBER,
+                                        "salt",
+                                        base64EncodedSalt,
+                                        "local_account_id",
+                                        TEST_SUBJECT.getValue())));
+
+        userInfoStorageExtension.addAuthenticationUserInfoData(internalCommonSubjectId, userInfo);
     }
 
     private void assertSessionUpdatedWhenReturnCodeRequestedAndPresent() throws Json.JsonException {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -10,6 +10,7 @@ import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.UserInfoRequest;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -26,6 +27,7 @@ import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.api.CommonFrontend;
 import uk.gov.di.orchestration.shared.api.OrchFrontend;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
+import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -57,9 +59,12 @@ import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.nimbusds.oauth2.sdk.OAuth2Error.ACCESS_DENIED_CODE;
 import static uk.gov.di.orchestration.shared.entity.ValidClaims.RETURN_CODE;
@@ -339,6 +344,43 @@ public class IPVCallbackHandler
             auditService.submitAuditEvent(
                     IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED, clientId, user);
 
+            // TODO: ATO-1117: temporary logs to check values are as expected
+            Optional<UserInfo> authUserInfo =
+                    getAuthUserInfo(
+                            authUserInfoStorageService, orchSession.getInternalCommonSubjectId());
+
+            if (authUserInfo.isEmpty()) {
+                LOG.info("authUserInfo not found");
+            } else {
+                LOG.info(
+                        "is email the same on authUserInfo as on session: {}",
+                        session.getEmailAddress().equals(authUserInfo.get().getEmailAddress()));
+                if (userProfile.getPhoneNumber() != null) {
+                    LOG.info(
+                            "is phone number the same on authUserInfo as on UserProfile: {}",
+                            userProfile
+                                    .getPhoneNumber()
+                                    .equals(authUserInfo.get().getPhoneNumber()));
+                }
+                var saltFromAuthUserInfo = authUserInfo.get().getStringClaim("salt");
+                var saltDecoded = Base64.getDecoder().decode(saltFromAuthUserInfo);
+                var saltBuffer = ByteBuffer.wrap(saltDecoded).asReadOnlyBuffer();
+                LOG.info(
+                        "is salt the same on authUserInfo as on UserProfile: {}",
+                        userProfile.getSalt().equals(saltBuffer));
+                LOG.info(
+                        "is subjectId the same on authUserInfo as on UserProfile: {}",
+                        userProfile
+                                .getSubjectID()
+                                .equals(
+                                        authUserInfo
+                                                .get()
+                                                .getClaim(
+                                                        AuthUserInfoClaims.LOCAL_ACCOUNT_ID
+                                                                .getValue())));
+            }
+            //
+
             var tokenResponse =
                     segmentedFunctionCall(
                             "getIpvToken",
@@ -482,6 +524,19 @@ public class IPVCallbackHandler
         } catch (UserNotFoundException e) {
             LOG.error(e.getMessage());
             throw new RuntimeException(e);
+        }
+    }
+
+    private static Optional<UserInfo> getAuthUserInfo(
+            AuthenticationUserInfoStorageService authUserInfoStorageService,
+            String internalCommonSubjectId) {
+        try {
+            return authUserInfoStorageService.getAuthenticationUserInfo(internalCommonSubjectId);
+        } catch (ParseException e) {
+            // TODO: ATO-1117: temporary logs. authUserInfo is not essential, so we don't want this
+            // to exit the lambda yet.
+            LOG.info("error parsing authUserInfo. Message: {}", e.getMessage());
+            return Optional.empty();
         }
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -284,24 +284,6 @@ public class IPVCallbackHandler
                             URI.create(configurationService.getInternalSectorURI()),
                             dynamoService.getOrGenerateSalt(userProfile));
 
-            // TODO: ATO-1117: temp logging
-            LOG.info(
-                    "is rpPairwiseId not blank on clientSession: {}",
-                    clientSession.getRpPairwiseId() != null
-                            && !clientSession.getRpPairwiseId().isBlank());
-            LOG.info(
-                    "is rpPairwiseId the same on clientSession as calculated: {}",
-                    rpPairwiseSubject.getValue().equals(clientSession.getRpPairwiseId()));
-
-            LOG.info(
-                    "is internalCommonSubjectId not blank on orchSession: {}",
-                    orchSession.getInternalCommonSubjectId() != null
-                            && !orchSession.getInternalCommonSubjectId().isBlank());
-            LOG.info(
-                    "is internalCommonSubjectId the same on orchSession as calculated: {}",
-                    internalPairwiseSubjectId.equals(orchSession.getInternalCommonSubjectId()));
-            //
-
             var ipAddress = IpAddressHelper.extractIpAddress(input);
             var user =
                     TxmaAuditUser.user()

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -41,6 +41,7 @@ import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -82,6 +83,7 @@ public class IPVCallbackHandler
     private final IPVTokenService ipvTokenService;
     private final SessionService sessionService;
     private final OrchSessionService orchSessionService;
+    private final AuthenticationUserInfoStorageService authUserInfoStorageService;
     private final DynamoService dynamoService;
     private final ClientSessionService clientSessionService;
     private final DynamoClientService dynamoClientService;
@@ -104,6 +106,7 @@ public class IPVCallbackHandler
             IPVTokenService ipvTokenService,
             SessionService sessionService,
             OrchSessionService orchSessionService,
+            AuthenticationUserInfoStorageService authUserInfoStorageService,
             DynamoService dynamoService,
             ClientSessionService clientSessionService,
             DynamoClientService dynamoClientService,
@@ -119,6 +122,7 @@ public class IPVCallbackHandler
         this.ipvTokenService = ipvTokenService;
         this.sessionService = sessionService;
         this.orchSessionService = orchSessionService;
+        this.authUserInfoStorageService = authUserInfoStorageService;
         this.dynamoService = dynamoService;
         this.clientSessionService = clientSessionService;
         this.dynamoClientService = dynamoClientService;
@@ -142,6 +146,8 @@ public class IPVCallbackHandler
         this.ipvTokenService = new IPVTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
+        this.authUserInfoStorageService =
+                new AuthenticationUserInfoStorageService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);
@@ -168,6 +174,8 @@ public class IPVCallbackHandler
         this.ipvTokenService = new IPVTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService, redis);
         this.orchSessionService = new OrchSessionService(configurationService);
+        this.authUserInfoStorageService =
+                new AuthenticationUserInfoStorageService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService, redis);
         this.dynamoClientService = new DynamoClientService(configurationService);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -66,6 +66,7 @@ import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.AwsSqsClient;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -123,6 +124,8 @@ class IPVCallbackHandlerTest {
     private final IPVTokenService ipvTokenService = mock(IPVTokenService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
+    private final AuthenticationUserInfoStorageService authUserInfoStorageService =
+            mock(AuthenticationUserInfoStorageService.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
     private final CookieHelper cookieHelper = mock(CookieHelper.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
@@ -269,6 +272,7 @@ class IPVCallbackHandlerTest {
                         ipvTokenService,
                         sessionService,
                         orchSessionService,
+                        authUserInfoStorageService,
                         dynamoService,
                         clientSessionService,
                         dynamoClientService,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -117,7 +117,6 @@ import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMes
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVCallbackHandlerTest {
-    private static final Subject SUBJECT = new Subject();
     private final Context context = mock(Context.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final IPVAuthorisationService responseService = mock(IPVAuthorisationService.class);
@@ -167,7 +166,7 @@ class IPVCallbackHandlerTest {
                     new VectorOfTrust(CredentialTrustLevel.LOW_LEVEL),
                     new VectorOfTrust(CredentialTrustLevel.MEDIUM_LEVEL));
     private IPVCallbackHandler handler;
-    private final byte[] salt =
+    private static final byte[] salt =
             "Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw=".getBytes(StandardCharsets.UTF_8);
     private final String redirectUriErrorMessage = "redirect_uri param must be provided";
     private final URI accessDeniedURI =
@@ -179,9 +178,11 @@ class IPVCallbackHandlerTest {
                     .toURI();
     private final ClientRegistry clientRegistry = generateClientRegistryNoClaims();
     private final UserProfile userProfile = generateUserProfile();
-    private final String expectedCommonSubject =
+
+    private static final Subject TEST_SUBJECT = new Subject();
+    private static final String TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER =
             ClientSubjectHelper.calculatePairwiseIdentifier(
-                    SUBJECT.getValue(), "test.account.gov.uk", salt);
+                    TEST_SUBJECT.getValue(), "test.account.gov.uk", salt);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =
@@ -190,7 +191,7 @@ class IPVCallbackHandlerTest {
     private final Session session =
             new Session(SESSION_ID)
                     .setEmailAddress(TEST_EMAIL_ADDRESS)
-                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
+                    .setInternalCommonSubjectIdentifier(TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER);
 
     private final OrchSessionItem orchSession = new OrchSessionItem(SESSION_ID);
 
@@ -1013,7 +1014,7 @@ class IPVCallbackHandlerTest {
                 .withPhoneNumber("012345678902")
                 .withPhoneNumberVerified(true)
                 .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
-                .withSubjectID(SUBJECT.getValue());
+                .withSubjectID(TEST_SUBJECT.getValue());
     }
 
     private static ClientRegistry generateClientRegistryNoClaims() {
@@ -1057,7 +1058,7 @@ class IPVCallbackHandlerTest {
                         TxmaAuditUser.user()
                                 .withGovukSigninJourneyId(CLIENT_SESSION_ID)
                                 .withSessionId(SESSION_ID)
-                                .withUserId(expectedCommonSubject)
+                                .withUserId(TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER)
                                 .withEmail(TEST_EMAIL_ADDRESS)
                                 .withPhone(userProfile.getPhoneNumber())
                                 .withPersistentSessionId(PERSISTENT_SESSION_ID));


### PR DESCRIPTION
This was previously merged here https://github.com/govuk-one-login/authentication-api/pull/5491, but it caused some errors. I've investigated it here https://github.com/govuk-one-login/authentication-api/pull/5716 and here https://github.com/govuk-one-login/authentication-api/pull/5730 and have discovered the issue, and importantly _why_ it happens. It is not a problem with our code - is it the new structure we have, combined with users trying to access parts of the journey they shouldn't be. The second to last commit fixes the issue, and the final commit removes the investigation logs.

## What
Adds authUserInfo to the IPVCallbackHandler. Read access has been added here https://github.com/govuk-one-login/authentication-api/pull/5475.

I first want to verify that authUserInfo is both defined, and that the values are as expected. This PR therefore just adds some logging to compare the values used in this handler and the corresponding values in the orchSession and the authUserInfo table entry.

## How to review
1. Code Review