### PR TITLE
ATO-1332: Use browserSessionId in OrchSessionItem if feature flag enabled

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1995,8 +1995,13 @@ class AuthorisationHandlerTest {
                                         .withBrowserSessionId(NEW_BROWSER_SESSION_ID));
             }
 
-            @Test
-            void shouldCreateNewSessionWithNewBSIDWhenNeitherSessionNorBSIDCookiePresent() {
+            @ParameterizedTest(
+                    name = "With useBrowserSessionIdStoredInOrchSession feature flag = {0}")
+            @ValueSource(booleans = {true, false})
+            void shouldCreateNewSessionWithNewBSIDWhenNeitherSessionNorBSIDCookiePresent(
+                    boolean useBrowserSessionIdStoredInOrchSession) {
+                when(configService.isUseBrowserSessionIdStoredInOrchSessionEnabled())
+                        .thenReturn(useBrowserSessionIdStoredInOrchSession);
                 withExistingSession(null);
                 withExistingOrchSession(null);
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
@@ -2026,8 +2031,13 @@ class AuthorisationHandlerTest {
                                 pair("new_authentication_required", false));
             }
 
-            @Test
-            void shouldCreateNewSessionWithNewBSIDWhenNoSessionButCookieBSIDPresent() {
+            @ParameterizedTest(
+                    name = "With useBrowserSessionIdStoredInOrchSession feature flag = {0}")
+            @ValueSource(booleans = {true, false})
+            void shouldCreateNewSessionWithNewBSIDWhenNoSessionButCookieBSIDPresent(
+                    boolean useBrowserSessionIdStoredInOrchSession) {
+                when(configService.isUseBrowserSessionIdStoredInOrchSessionEnabled())
+                        .thenReturn(useBrowserSessionIdStoredInOrchSession);
                 withExistingSession(null);
                 withExistingOrchSession(null);
                 APIGatewayProxyResponseEvent response =
@@ -2058,8 +2068,13 @@ class AuthorisationHandlerTest {
                                 pair("new_authentication_required", false));
             }
 
-            @Test
-            void shouldCreateNewSessionWhenSessionHasBSIDButCookieDoesNot() {
+            @ParameterizedTest(
+                    name = "With useBrowserSessionIdStoredInOrchSession feature flag = {0}")
+            @ValueSource(booleans = {true, false})
+            void shouldCreateNewSessionWhenSessionHasBSIDButCookieDoesNot(
+                    boolean useBrowserSessionIdStoredInOrchSession) {
+                when(configService.isUseBrowserSessionIdStoredInOrchSessionEnabled())
+                        .thenReturn(useBrowserSessionIdStoredInOrchSession);
                 withExistingSession(session.withBrowserSessionId(BROWSER_SESSION_ID));
                 withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
@@ -2089,8 +2104,13 @@ class AuthorisationHandlerTest {
                                 pair("new_authentication_required", true));
             }
 
-            @Test
-            void shouldUseExistingSessionWithNoBSIDEvenWhenBSIDCookiePresent() {
+            @ParameterizedTest(
+                    name = "With useBrowserSessionIdStoredInOrchSession feature flag = {0}")
+            @ValueSource(booleans = {true, false})
+            void shouldUseExistingSessionWithNoBSIDEvenWhenBSIDCookiePresent(
+                    boolean useBrowserSessionIdStoredInOrchSession) {
+                when(configService.isUseBrowserSessionIdStoredInOrchSessionEnabled())
+                        .thenReturn(useBrowserSessionIdStoredInOrchSession);
                 withExistingSession(session.withBrowserSessionId(null));
                 withExistingOrchSession(orchSession.withBrowserSessionId(null));
                 var response = makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
@@ -2125,8 +2145,13 @@ class AuthorisationHandlerTest {
                                 pair("new_authentication_required", false));
             }
 
-            @Test
-            void shouldUseExistingSessionWhenBSIDsMatch() {
+            @ParameterizedTest(
+                    name = "With useBrowserSessionIdStoredInOrchSession feature flag = {0}")
+            @ValueSource(booleans = {true, false})
+            void shouldUseExistingSessionWhenSessionBSIDMatchesBSIDInCookie(
+                    boolean useBrowserSessionIdStoredInOrchSession) {
+                when(configService.isUseBrowserSessionIdStoredInOrchSessionEnabled())
+                        .thenReturn(useBrowserSessionIdStoredInOrchSession);
                 withExistingSession(session.withBrowserSessionId(BROWSER_SESSION_ID));
                 withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
                 APIGatewayProxyResponseEvent response =
@@ -2157,8 +2182,13 @@ class AuthorisationHandlerTest {
                                 pair("new_authentication_required", false));
             }
 
-            @Test
-            void shouldCreateNewSessionWhenSessionAndCookieBSIDDoNotMatch() {
+            @ParameterizedTest(
+                    name = "With useBrowserSessionIdStoredInOrchSession feature flag = {0}")
+            @ValueSource(booleans = {true, false})
+            void shouldCreateNewSessionWhenSessionAndCookieBSIDDoNotMatch(
+                    boolean useBrowserSessionIdStoredInOrchSession) {
+                when(configService.isUseBrowserSessionIdStoredInOrchSessionEnabled())
+                        .thenReturn(useBrowserSessionIdStoredInOrchSession);
                 withExistingSession(session.withBrowserSessionId(BROWSER_SESSION_ID));
                 withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
                 APIGatewayProxyResponseEvent response =

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -417,6 +417,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("RETURN_AUTH_TIME_IN_ID_TOKEN_ENABLED");
     }
 
+    public boolean isUseBrowserSessionIdStoredInOrchSessionEnabled() {
+        return getFlagOrFalse("USE_BROWSERSESSIONID_STORED_IN_ORCH_SESSION");
+    }
+
     public Optional<String> getIPVCapacity() {
         try {
             var request =

--- a/template.yaml
+++ b/template.yaml
@@ -86,6 +86,8 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
     ]
+  UseBrowserSessionIdStoredInOrchSession:
+    !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]]
 
 Mappings:
   EnvironmentConfiguration:
@@ -2382,6 +2384,10 @@ Resources:
             ]
           SUPPORT_MAX_AGE_ENABLED: !If
             - SupportMaxAgeEnabled
+            - true
+            - false
+          USE_BROWSERSESSIONID_STORED_IN_ORCH_SESSION: !If
+            - UseBrowserSessionIdStoredInOrchSession
             - true
             - false
 


### PR DESCRIPTION
## What

- Added new feature flag: `USE_BROWSERSESSIONID_STORED_IN_ORCH_SESSION`
  - If enabled, the browserSessionId from the previous orch session will be used in the auth journey (if present).
  - If disabled, the browserSessionId from the previous shared session will be used in the auth journey (if present).
- Only enabled for dev and build environments.