### PR TITLE
ATO-1134: turn on destroy orch session on logout in integration

### DIFF
--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -59,4 +59,4 @@ orch_logout_enabled                         = true
 auth_spot_response_disabled                 = true
 orch_register_enabled                       = true
 orch_storage_token_jwk_enabled              = true
-is_destroy_orch_session_on_sign_out_enabled = false
+is_destroy_orch_session_on_sign_out_enabled = true

--- a/template.yaml
+++ b/template.yaml
@@ -71,6 +71,7 @@ Conditions:
       !Equals [dev, !Ref Environment],
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
+      !Equals [integration, !Ref Environment],
     ]
   IsIntegration: !Equals [!Ref Environment, integration]
 


### PR DESCRIPTION
### Wider context of change
Turns on destroying the orch sesion in integration. This was tested successfully in integration, but I the spinner page was broken. While the logs suggest the orch session was deleted, I want to see that the error isn't cascaded down and missed because of the broken page.

### What’s changed
Integration added to feature flag

### Manual testing
Tested in staging, now I want to manually test it in integration

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required. 
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
