### PR TITLE
ATO-1331: Set browserSessionId on orch session in docapp journey

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -514,7 +514,9 @@ public class AuthorisationHandler
         OrchSessionItem orchSession;
         String newSessionId = session.getSessionId();
         if (orchSessionOptional.isEmpty()) {
-            orchSession = new OrchSessionItem(newSessionId);
+            orchSession =
+                    new OrchSessionItem(newSessionId)
+                            .withBrowserSessionId(session.getBrowserSessionId());
             LOG.info("Created new Orch session");
         } else {
             String previousOrchSessionId = orchSessionOptional.get().getSessionId();


### PR DESCRIPTION
## What
- The DocApp journey is currently not deleting sessions once the journey finishes. 
- This is leading to the auth journey reusing DocApp journeys, which do not generate browserSessionIds for orch sessions. 
- This is a temporary fix.
