### PR TITLE
BAU: fix integer max age in request object

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
@@ -79,6 +79,11 @@ public class RequestObjectToAuthRequestHelper {
             if (Objects.nonNull(jwtClaimsSet.getClaim("nonce"))) {
                 builder.nonce(Nonce.parse(jwtClaimsSet.getStringClaim("nonce")));
             }
+
+            if (Objects.nonNull(jwtClaimsSet.getClaim("max_age"))) {
+                builder.maxAge(getMaxAge(jwtClaimsSet));
+            }
+
             return builder.build();
         } catch (ParseException | com.nimbusds.oauth2.sdk.ParseException | Json.JsonException e) {
             LOG.error("Parse exception thrown whilst converting RequestObject to Auth Request", e);
@@ -116,6 +121,23 @@ public class RequestObjectToAuthRequestHelper {
             return parseClaimsAsJson(claimsSet);
         } catch (java.text.ParseException e) {
             return parseClaimsAsString(claimsSet);
+        }
+    }
+
+    private static Integer getMaxAge(JWTClaimsSet claimsSet) {
+        try {
+            return claimsSet.getIntegerClaim("max_age");
+        } catch (java.text.ParseException e) {
+            return parseStringMaxAge(claimsSet);
+        }
+    }
+
+    private static Integer parseStringMaxAge(JWTClaimsSet claimsSet) {
+        try {
+            var stringMaxAge = claimsSet.getStringClaim("max_age");
+            return Integer.parseInt(stringMaxAge);
+        } catch (java.text.ParseException e) {
+            throw new IllegalArgumentException("Max age claim is could not be parsed to integer");
         }
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -774,37 +774,19 @@ public class AuthorisationHandler
         return newSession;
     }
 
-    private Optional<Long> getMaxAge(AuthenticationRequest authRequest) {
-        int maxAgeParam;
-        try {
-            if (Objects.isNull(authRequest.getRequestObject())) {
-                maxAgeParam = authRequest.getMaxAge();
-                // Nimbus returns -1 if max age parameter is not present
-                if (maxAgeParam == -1) {
-                    return Optional.empty();
-                }
-            } else {
-                String maxAgeClaim =
-                        authRequest.getRequestObject().getJWTClaimsSet().getStringClaim("max_age");
-                if (Objects.isNull(maxAgeClaim)) {
-                    return Optional.empty();
-                }
-                maxAgeParam = Integer.parseInt(maxAgeClaim);
-            }
-            if (maxAgeParam < 0) {
-                LOG.error("Max age parameter is negative in auth request");
-                return Optional.empty();
-            }
-            return Optional.of((long) maxAgeParam);
-        } catch (Exception e) {
-            LOG.error(
-                    "Failed to parse max age param from auth request, assuming no max age parameter. Error: {}",
-                    e.getMessage());
+    private Optional<Integer> getMaxAge(AuthenticationRequest authRequest) {
+        // We call getMaxAge on both query params and request objects as
+        // we've persisted the value to the top level when calling
+        // RequestObjectToAuthRequestHelper.transform
+        var maxAge = authRequest.getMaxAge();
+
+        if (maxAge == -1) {
+            // Nimbus returns -1 for no max_age parameter
             return Optional.empty();
-        }
+        } else return Optional.of(maxAge);
     }
 
-    private boolean maxAgeExpired(Long authTime, Optional<Long> maxAge, long timeNow) {
+    private boolean maxAgeExpired(Long authTime, Optional<Integer> maxAge, long timeNow) {
         if (maxAge.isEmpty()) return false;
         if (authTime == null) {
             LOG.error(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
@@ -229,6 +229,62 @@ class RequestObjectToAuthRequestHelperTest {
     }
 
     @Test
+    void shouldConvertRequestObjectToAuthRequestWhenMaxAgeClaimPresentAsString()
+            throws JOSEException {
+        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
+        var jwtClaimsSet = getClaimsSetBuilder(scope).claim("max_age", "123").build();
+        var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
+        var authRequest =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                new Scope(OIDCScopeValue.OPENID),
+                                CLIENT_ID,
+                                null)
+                        .requestObject(signedJWT)
+                        .build();
+
+        var transformedAuthRequest = RequestObjectToAuthRequestHelper.transform(authRequest);
+
+        assertThat(transformedAuthRequest.getState(), equalTo(STATE));
+        assertThat(transformedAuthRequest.getNonce(), equalTo(NONCE));
+        assertThat(transformedAuthRequest.getRedirectionURI(), equalTo(REDIRECT_URI));
+        assertThat(transformedAuthRequest.getScope(), equalTo(scope));
+        assertThat(transformedAuthRequest.getClientID(), equalTo(CLIENT_ID));
+        assertThat(transformedAuthRequest.getResponseType(), equalTo(ResponseType.CODE));
+        assertThat(transformedAuthRequest.getRequestObject(), equalTo(signedJWT));
+        assertThat(transformedAuthRequest.getMaxAge(), equalTo(123));
+    }
+
+    @Test
+    void shouldConvertRequestObjectToAuthRequestWhenMaxAgeClaimPresentAsInteger()
+            throws JOSEException {
+        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
+        var jwtClaimsSet = getClaimsSetBuilder(scope).claim("max_age", 123).build();
+        var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
+        var authRequest =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                new Scope(OIDCScopeValue.OPENID),
+                                CLIENT_ID,
+                                null)
+                        .requestObject(signedJWT)
+                        .build();
+
+        var transformedAuthRequest = RequestObjectToAuthRequestHelper.transform(authRequest);
+
+        assertThat(transformedAuthRequest.getState(), equalTo(STATE));
+        assertThat(transformedAuthRequest.getNonce(), equalTo(NONCE));
+        assertThat(transformedAuthRequest.getRedirectionURI(), equalTo(REDIRECT_URI));
+        assertThat(transformedAuthRequest.getScope(), equalTo(scope));
+        assertThat(transformedAuthRequest.getClientID(), equalTo(CLIENT_ID));
+        assertThat(transformedAuthRequest.getResponseType(), equalTo(ResponseType.CODE));
+        assertThat(transformedAuthRequest.getRequestObject(), equalTo(signedJWT));
+        assertThat(transformedAuthRequest.getMaxAge(), equalTo(123));
+    }
+
+    @Test
     void shouldReturnAuthRequestWhenNoRequestObjectIsPresent() {
         Scope scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.PHONE);
         var authRequest =

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -2660,8 +2660,6 @@ class AuthorisationHandlerTest {
                     arguments(recentAuthTime - 1000, "800", true),
                     arguments(recentAuthTime - 1000, "1800", false),
                     arguments(recentAuthTime, "-1", false),
-                    arguments(recentAuthTime, "-12345", false),
-                    arguments(recentAuthTime, "-12345", false),
                     arguments(null, "1800", false),
                     arguments(99999999999L, "1800", false),
                     arguments(-123L, "1800", false));


### PR DESCRIPTION
### Wider context of change:

As part of the max_age feature, RPs can provide the `max_age` claim in the request object. Our previous code assumed that this would be a string integer (ex: "123") , however it is plausible this could be a integer claim too, and we should support both. The OIDC spec includes an integer max_age in the [example for request objects](https://openid.net/specs/openid-connect-core-1_0.html#:~:text=The%20following%20is%20a%20non%2Dnormative%20example%20of%20the%20Claims%20in%20a%20Request%20Object%20before%20base64url%2Dencoding%20and%20signing%3A), however is not specific on [max_age being a number.](https://openid.net/specs/openid-connect-core-1_0.html#:~:text=OPTIONAL.%20Maximum%20Authentication,prompt%3Dlogin.)

Previously the code would throw if the request object included a number for max_age, this corrects that and supports both. 

### What’s changed:

- Numerical max_age claims in request objects are now supported alongside string representations
- Some refactoring of the requestObject transform method to persist the max_age claim in the top level auth request. This makes dealing with the max_age claim easier in subsequent code.   
- Simplification of some the handler code due to above refactoring

### Manual testing

Deploy to dev
- Run through a max_age reauth journey with number max_age formatting on the stub (deploying this branch: https://github.com/govuk-one-login/relying-party-stub/tree/refs/heads/ATO-000-testing-max-age-as-number-not-string)
- Revert stub changes and test string formatted max_age claim 

### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
