### PR TITLE
Ato 1179/ato 1180 max age log out success event changes

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -44,6 +44,7 @@ import uk.gov.di.orchestration.shared.entity.ServiceType;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.AccountInterventionException;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
@@ -856,6 +857,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                             OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
                             AccountInterventionsAuditableEvent.AIS_RESPONSE_RECEIVED,
                             OidcAuditableEvent.AUTHENTICATION_COMPLETE,
+                            LogoutAuditableEvent.LOG_OUT_SUCCESS,
                             OidcAuditableEvent.AUTH_CODE_ISSUED));
 
             var sharedSession = redis.getSession(SESSION_ID);
@@ -888,7 +890,11 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
             setUpClientSession();
             orchSessionExtension.addSession(
                     new OrchSessionItem(PREVIOUS_SESSION_ID)
-                            .withInternalCommonSubjectId(internalCommonSubjectId));
+                            .withInternalCommonSubjectId(internalCommonSubjectId)
+                            .withAuthTime(
+                                    NowHelper.nowMinus(1, ChronoUnit.HOURS)
+                                            .toInstant()
+                                            .getEpochSecond()));
         }
 
         private void setupPreviousClientsAndPreviousClientSessions() throws Json.JsonException {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -403,7 +403,7 @@ public class AuthenticationCallbackHandler
                 if (configurationService.supportMaxAgeEnabled()
                         && Objects.nonNull(orchSession.getPreviousSessionId())) {
                     LOG.info("Previous session id is present - handling max age");
-                    handleMaxAgeSession(orchSession, userSession);
+                    handleMaxAgeSession(orchSession, userSession, user);
                 }
 
                 userSession.setAuthenticated(true);
@@ -800,7 +800,7 @@ public class AuthenticationCallbackHandler
     }
 
     private void handleMaxAgeSession(
-            OrchSessionItem currentOrchSession, Session currentSharedSession) {
+            OrchSessionItem currentOrchSession, Session currentSharedSession, TxmaAuditUser user) {
         var previousSessionId = currentOrchSession.getPreviousSessionId();
         var previousSharedSession = sessionService.getSession(previousSessionId);
         var previousOrchSession = orchSessionService.getSession(previousSessionId);
@@ -827,7 +827,8 @@ public class AuthenticationCallbackHandler
         } else {
             LOG.info(
                     "Previous OrchSession InternalCommonSubjectId does not match Auth UserInfo response");
-            logoutService.handleMaxAgeLogout(previousSharedSession.get());
+            logoutService.handleMaxAgeLogout(
+                    previousSharedSession.get(), previousOrchSession.get(), user);
         }
         currentOrchSession.setPreviousSessionId(null);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/LogoutReason.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/LogoutReason.java
@@ -3,7 +3,8 @@ package uk.gov.di.orchestration.shared.entity;
 public enum LogoutReason {
     FRONT_CHANNEL("front-channel"),
     INTERVENTION("intervention"),
-    REAUTHENTICATION_FAILURE("reauthentication-failure");
+    REAUTHENTICATION_FAILURE("reauthentication-failure"),
+    MAX_AGE_EXPIRY("max-session-age");
 
     private String value;
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -9,9 +9,11 @@ import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.LogoutReason;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
 
 import java.net.URI;
 import java.util.LinkedList;
@@ -95,7 +97,7 @@ public class LogoutService {
         LOG.info(
                 "Generating logout response using URI: {}",
                 logoutUri.getHost() + logoutUri.getPath());
-        sendAuditEvent(auditUser, logoutReason, clientId, rpPairwiseId);
+        sendAuditEvent(auditUser, logoutReason, clientId, rpPairwiseId, Optional.empty());
         return generateApiGatewayProxyResponse(
                 302, "", Map.of(ResponseHeaders.LOCATION, logoutUri.toString()), null);
     }
@@ -214,20 +216,31 @@ public class LogoutService {
                 Optional.empty());
     }
 
-    public void handleMaxAgeLogout(Session previousSession) {
+    public void handleMaxAgeLogout(
+            Session previousSession, OrchSessionItem previousOrchSession, TxmaAuditUser user) {
         destroySessions(previousSession);
         cloudwatchMetricsService.incrementLogout(Optional.empty());
+        Long sessionAge =
+                NowHelper.now().toInstant().getEpochSecond() - previousOrchSession.getAuthTime();
+        sendAuditEvent(
+                user,
+                LogoutReason.MAX_AGE_EXPIRY,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(sessionAge));
     }
 
     private void sendAuditEvent(
             TxmaAuditUser auditUser,
             LogoutReason logoutReason,
             Optional<String> clientId,
-            Optional<String> rpPairwiseId) {
+            Optional<String> rpPairwiseId,
+            Optional<Long> sessionAge) {
         String auditClientId = clientId.orElse(AuditService.UNKNOWN);
         var metadata = new LinkedList<AuditService.MetadataPair>();
         metadata.add(pair(LOGOUT_REASON, logoutReason.getValue()));
         rpPairwiseId.ifPresent(i -> metadata.add(pair("rpPairwiseId", i)));
+        sessionAge.ifPresent(age -> metadata.add(pair("sessionAge", age.intValue())));
         auditService.submitAuditEvent(
                 LOG_OUT_SUCCESS,
                 auditClientId,

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -24,18 +24,22 @@ import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.sharedtest.helper.TokenGeneratorHelper;
 
 import java.net.URI;
 import java.text.ParseException;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,6 +60,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.shared.domain.LogoutAuditableEvent.LOG_OUT_SUCCESS;
+import static uk.gov.di.orchestration.shared.entity.LogoutReason.MAX_AGE_EXPIRY;
+import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.orchestration.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -202,8 +208,8 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
-                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
-                        AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
+                        pair("logoutReason", "front-channel"),
+                        pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
                         argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
@@ -235,8 +241,8 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
-                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
-                        AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
+                        pair("logoutReason", "front-channel"),
+                        pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
                         argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
@@ -268,8 +274,8 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
-                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
-                        AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
+                        pair("logoutReason", "front-channel"),
+                        pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
                         argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
@@ -302,8 +308,8 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
-                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
-                        AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
+                        pair("logoutReason", "front-channel"),
+                        pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
                         argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
@@ -346,7 +352,7 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
-                        AuditService.MetadataPair.pair("logoutReason", "intervention"));
+                        pair("logoutReason", "intervention"));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
                         argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
@@ -376,7 +382,7 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
-                        AuditService.MetadataPair.pair("logoutReason", "intervention"));
+                        pair("logoutReason", "intervention"));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
                         argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
@@ -421,8 +427,8 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         AuditService.UNKNOWN,
                         auditUserWhenNoCookie,
-                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
-                        AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
+                        pair("logoutReason", "front-channel"),
+                        pair("rpPairwiseId", rpPairwiseId.get()));
     }
 
     @Test
@@ -458,8 +464,8 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
-                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
-                        AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
+                        pair("logoutReason", "front-channel"),
+                        pair("rpPairwiseId", rpPairwiseId.get()));
     }
 
     @Test
@@ -486,8 +492,8 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
-                        AuditService.MetadataPair.pair("logoutReason", "front-channel"),
-                        AuditService.MetadataPair.pair("rpPairwiseId", rpPairwiseId.get()));
+                        pair("logoutReason", "front-channel"),
+                        pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
                         argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
@@ -537,7 +543,7 @@ class LogoutServiceTest {
                         LOG_OUT_SUCCESS,
                         CLIENT_ID,
                         auditUser,
-                        AuditService.MetadataPair.pair("logoutReason", "reauthentication-failure"));
+                        pair("logoutReason", "reauthentication-failure"));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
                 is(equalTo(REAUTH_FAILURE_URI.toString())));
@@ -554,10 +560,17 @@ class LogoutServiceTest {
                         .setEmailAddress(EMAIL)
                         .addClientSession(clientSessionId1)
                         .addClientSession(clientSessionId2);
+
+        var previousOrchSession =
+                new OrchSessionItem(SESSION_ID)
+                        .withAuthTime(
+                                NowHelper.nowMinus(1, ChronoUnit.HOURS)
+                                        .toInstant()
+                                        .getEpochSecond());
         setUpClientSession(clientSessionId1, clientId1);
         setUpClientSession(clientSessionId2, clientId2);
 
-        logoutService.handleMaxAgeLogout(prevousSession);
+        logoutService.handleMaxAgeLogout(prevousSession, previousOrchSession, auditUser);
 
         verify(clientSessionService, times(1)).deleteStoredClientSession(clientSessionId1);
         verify(clientSessionService, times(1)).deleteStoredClientSession(clientSessionId2);
@@ -570,6 +583,15 @@ class LogoutServiceTest {
                 .sendLogoutMessage(
                         argThat(withClientId(clientId2)), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
         verify(cloudwatchMetricsService).incrementLogout(Optional.empty());
+        var expectedExtensions = new ArrayList<AuditService.MetadataPair>();
+        expectedExtensions.add(pair("logoutReason", MAX_AGE_EXPIRY.getValue()));
+        expectedExtensions.add(pair("sessionAge", 3600));
+        verify(auditService)
+                .submitAuditEvent(
+                        LOG_OUT_SUCCESS,
+                        AuditService.UNKNOWN,
+                        auditUser,
+                        expectedExtensions.toArray(AuditService.MetadataPair[]::new));
     }
 
     private void setupAdditionalClientSessions() {


### PR DESCRIPTION
### Wider context of change

As part of the max age initiative, we are now adding more fields to our the LOG_OUT_SUCESS audit event and emitting one when a max_age logout is triggered. 

### What’s changed:

- Emits LOG_OUT_SUCCESS event when max_age logout occurs
- Adds new extension for logoutReason -> "max-session-age"
- Adds new extension for sessionAge ->  derived from current time - auth time of previous session
- Changes are behind MAX_AGE_ENABLED feature flag

### Manual testing:

Not required

### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
