### PR TITLE
ATO-1339: type authuserinfo to userinfo

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.services;
 
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.Test;
@@ -21,15 +22,31 @@ class AuthenticationUserInfoStorageServiceIntegrationTest {
             new AuthenticationCallbackUserInfoStoreExtension(180);
 
     @Test
-    void shouldAddAndRetrieveUserInfo() {
+    void shouldAddAndRetrieveUserInfo() throws ParseException {
         UserInfo userInfo = new UserInfo(new Subject(SUBJECT_ID));
 
         userInfoExtension.addAuthenticationUserInfoData(SUBJECT_ID, userInfo);
 
-        Optional<AuthenticationUserInfo> retrievedUserInfo =
+        Optional<AuthenticationUserInfo> retrievedUserInfoData =
                 userInfoExtension.getUserInfoBySubjectId(SUBJECT_ID);
 
-        assertThat(retrievedUserInfo.isPresent(), equalTo(true));
-        assertThat(retrievedUserInfo.get().getSubjectID(), equalTo(SUBJECT_ID));
+        UserInfo retrievedUserInfo =
+                userInfoExtension.getAuthenticationUserInfo(SUBJECT_ID).orElseThrow();
+
+        assertThat(retrievedUserInfoData.isPresent(), equalTo(true));
+        assertThat(retrievedUserInfoData.get().getSubjectID(), equalTo(SUBJECT_ID));
+
+        assertThat(retrievedUserInfo.getSubject().getValue(), equalTo(SUBJECT_ID));
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyWhenNoUserInfo() throws ParseException {
+        Optional<AuthenticationUserInfo> retrievedUserInfoData =
+                userInfoExtension.getUserInfoBySubjectId(SUBJECT_ID);
+        Optional<UserInfo> retrievedUserInfo =
+                userInfoExtension.getAuthenticationUserInfo(SUBJECT_ID);
+
+        assertThat(retrievedUserInfoData.isEmpty(), equalTo(true));
+        assertThat(retrievedUserInfo.isEmpty(), equalTo(true));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
@@ -5,7 +5,6 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.di.orchestration.shared.entity.AuthenticationUserInfo;
 import uk.gov.di.orchestration.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
 
 import java.util.Optional;
@@ -27,26 +26,18 @@ class AuthenticationUserInfoStorageServiceIntegrationTest {
 
         userInfoExtension.addAuthenticationUserInfoData(SUBJECT_ID, userInfo);
 
-        Optional<AuthenticationUserInfo> retrievedUserInfoData =
-                userInfoExtension.getUserInfoBySubjectId(SUBJECT_ID);
+        Optional<UserInfo> retrievedUserInfo =
+                userInfoExtension.getAuthenticationUserInfo(SUBJECT_ID);
 
-        UserInfo retrievedUserInfo =
-                userInfoExtension.getAuthenticationUserInfo(SUBJECT_ID).orElseThrow();
-
-        assertThat(retrievedUserInfoData.isPresent(), equalTo(true));
-        assertThat(retrievedUserInfoData.get().getSubjectID(), equalTo(SUBJECT_ID));
-
-        assertThat(retrievedUserInfo.getSubject().getValue(), equalTo(SUBJECT_ID));
+        assertThat(retrievedUserInfo.isPresent(), equalTo(true));
+        assertThat(retrievedUserInfo.get().getSubject().getValue(), equalTo(SUBJECT_ID));
     }
 
     @Test
     void shouldReturnOptionalEmptyWhenNoUserInfo() throws ParseException {
-        Optional<AuthenticationUserInfo> retrievedUserInfoData =
-                userInfoExtension.getUserInfoBySubjectId(SUBJECT_ID);
         Optional<UserInfo> retrievedUserInfo =
                 userInfoExtension.getAuthenticationUserInfo(SUBJECT_ID);
 
-        assertThat(retrievedUserInfoData.isEmpty(), equalTo(true));
         assertThat(retrievedUserInfo.isEmpty(), equalTo(true));
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -6,6 +6,7 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -23,7 +24,6 @@ import uk.gov.di.authentication.app.entity.DocAppCredential;
 import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.orchestration.shared.entity.AccessTokenStore;
-import uk.gov.di.orchestration.shared.entity.AuthenticationUserInfo;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
 import uk.gov.di.orchestration.shared.entity.IdentityCredentials;
@@ -133,7 +133,7 @@ class UserInfoServiceTest {
 
     @Test
     void shouldJustPopulateUserInfoWhenIdentityNotEnabled()
-            throws JOSEException, AccessTokenException, ClientNotFoundException {
+            throws JOSEException, AccessTokenException, ClientNotFoundException, ParseException {
         when(configurationService.isIdentityEnabled()).thenReturn(false);
         accessToken = createSignedAccessToken(null);
         var accessTokenStore =
@@ -162,7 +162,7 @@ class UserInfoServiceTest {
 
     @Test
     void shouldJustPopulateWalletSubjectIdClaimWhenWalletSubjectIdScopeIsPresent()
-            throws JOSEException, AccessTokenException, ClientNotFoundException {
+            throws JOSEException, AccessTokenException, ClientNotFoundException, ParseException {
         givenThereIsUserInfo();
         when(dynamoClientService.getClient(any()))
                 .thenReturn(
@@ -210,7 +210,10 @@ class UserInfoServiceTest {
 
         @Test
         void shouldJustPopulateUserInfoWhenIdentityEnabledButNoIdentityClaimsPresent()
-                throws JOSEException, AccessTokenException, ClientNotFoundException {
+                throws JOSEException,
+                        AccessTokenException,
+                        ClientNotFoundException,
+                        ParseException {
             when(configurationService.isIdentityEnabled()).thenReturn(true);
             accessToken = createSignedAccessToken(null);
             var accessTokenStore =
@@ -240,7 +243,10 @@ class UserInfoServiceTest {
 
         @Test
         void shouldPopulateIdentityClaimsWhenClaimsArePresentAndIdentityIsEnabled()
-                throws JOSEException, AccessTokenException, ClientNotFoundException {
+                throws JOSEException,
+                        AccessTokenException,
+                        ClientNotFoundException,
+                        ParseException {
             when(configurationService.isIdentityEnabled()).thenReturn(true);
             var identityCredentials =
                     new IdentityCredentials()
@@ -312,7 +318,10 @@ class UserInfoServiceTest {
 
         @Test
         void shouldJustPopulateEmailClaimWhenOnlyEmailScopeIsPresentAndIdentityNotEnabled()
-                throws JOSEException, AccessTokenException, ClientNotFoundException {
+                throws JOSEException,
+                        AccessTokenException,
+                        ClientNotFoundException,
+                        ParseException {
             givenThereIsUserInfo();
             when(configurationService.isIdentityEnabled()).thenReturn(false);
             accessToken = createSignedAccessToken(null);
@@ -346,7 +355,10 @@ class UserInfoServiceTest {
 
         @Test
         void shouldJustPopulateEmailClaimWhenOnlyEmailScopeIsPresentAndIdentity()
-                throws JOSEException, AccessTokenException, ClientNotFoundException {
+                throws JOSEException,
+                        AccessTokenException,
+                        ClientNotFoundException,
+                        ParseException {
             when(configurationService.isIdentityEnabled()).thenReturn(false);
             accessToken = createSignedAccessToken(null);
             var scopes = List.of(OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.EMAIL.getValue());
@@ -378,7 +390,10 @@ class UserInfoServiceTest {
 
         @Test
         void shouldPopulateIdentityClaimsWhenClaimsArePresentButNoAdditionalClaimsArePresent()
-                throws JOSEException, AccessTokenException, ClientNotFoundException {
+                throws JOSEException,
+                        AccessTokenException,
+                        ClientNotFoundException,
+                        ParseException {
             when(configurationService.isIdentityEnabled()).thenReturn(true);
             var identityCredentials =
                     new IdentityCredentials()
@@ -568,12 +583,10 @@ class UserInfoServiceTest {
                         Map.of("Environment", "test", "Client", CLIENT_ID, "Claim", v3));
     }
 
-    private void givenThereIsUserInfo() {
-        var testUserInfo =
-                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+    private void givenThereIsUserInfo() throws ParseException {
+        var testUserInfo = generateUserInfo();
 
-        when(userInfoStorageService.getAuthenticationUserInfoData(
-                        INTERNAL_PAIRWISE_SUBJECT.getValue()))
+        when(userInfoStorageService.getAuthenticationUserInfo(INTERNAL_PAIRWISE_SUBJECT.getValue()))
                 .thenReturn(Optional.of(testUserInfo));
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
@@ -10,7 +10,6 @@ import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
-import uk.gov.di.orchestration.shared.entity.AuthenticationUserInfo;
 import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.sharedtest.basetest.DynamoTestConfiguration;
@@ -74,10 +73,6 @@ public class AuthenticationCallbackUserInfoStoreExtension extends DynamoExtensio
                                         .build())
                         .build();
         dynamoDB.createTable(request);
-    }
-
-    public Optional<AuthenticationUserInfo> getUserInfoBySubjectId(String subjectId) {
-        return userInfoService.getAuthenticationUserInfoData(subjectId);
     }
 
     public Optional<UserInfo> getAuthenticationUserInfo(String subjectId) throws ParseException {

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
@@ -1,5 +1,6 @@
 package uk.gov.di.orchestration.sharedtest.extensions;
 
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -77,6 +78,10 @@ public class AuthenticationCallbackUserInfoStoreExtension extends DynamoExtensio
 
     public Optional<AuthenticationUserInfo> getUserInfoBySubjectId(String subjectId) {
         return userInfoService.getAuthenticationUserInfoData(subjectId);
+    }
+
+    public Optional<UserInfo> getAuthenticationUserInfo(String subjectId) throws ParseException {
+        return userInfoService.getAuthenticationUserInfo(subjectId);
     }
 
     public void addAuthenticationUserInfoData(String subjectId, UserInfo userInfo) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
@@ -44,7 +44,7 @@ public class AuthenticationUserInfoStorageService
         return Optional.of(userInfo);
     }
 
-    public Optional<AuthenticationUserInfo> getAuthenticationUserInfoData(String subjectID) {
+    private Optional<AuthenticationUserInfo> getAuthenticationUserInfoData(String subjectID) {
         return get(subjectID)
                 .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
@@ -34,6 +34,16 @@ public class AuthenticationUserInfoStorageService
         put(userInfoDbObject);
     }
 
+    public Optional<UserInfo> getAuthenticationUserInfo(String subjectID)
+            throws com.nimbusds.oauth2.sdk.ParseException {
+        var userInfoData = getAuthenticationUserInfoData(subjectID);
+        if (userInfoData.isEmpty()) {
+            return Optional.empty();
+        }
+        var userInfo = UserInfo.parse(userInfoData.get().getUserInfo());
+        return Optional.of(userInfo);
+    }
+
     public Optional<AuthenticationUserInfo> getAuthenticationUserInfoData(String subjectID) {
         return get(subjectID)
                 .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());


### PR DESCRIPTION
### Wider context of change
In the `authentication-callback-userinfo` table, the UserInfo data is stored as a stringified JSON block. In code, we need to parse it. Currently, we parse it inline within the the Handler. In this PR, I've added a method `getAuthenticationUserInfo` which gets the data as a UserInfo object, and makes the dynamodb getter a private method, so in the handlers, we're always using the parsed data, and never the raw string.

### What’s changed
- Adds method `getAuthenticationUserInfo`, and makes the dynamodb getter `getAuthenticationUserInfoData` private.
- Migrates the use of `getAuthenticationUserInfoData` to `getAuthenticationUserInfo`.
- Normalises the error messages, so this fails with the same error message.

### Manual testing
- [x] deploy to dev and run through a journey to see AuthUserInfo is still able to be retrieved

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
