### PR TITLE
ATO-1332: Enable feature flag for getting browserSessionId from orch session up to production

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -89,7 +89,13 @@ Conditions:
       !Equals [staging, !Ref Environment],
     ]
   UseBrowserSessionIdStoredInOrchSession:
-    !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]]
+    !Or [
+      !Equals [dev, !Ref Environment],
+      !Equals [build, !Ref Environment],
+      !Equals [staging, !Ref Environment],
+      !Equals [integration, !Ref Environment],
+      !Equals [production, !Ref Environment],
+    ]
 
 Mappings:
   EnvironmentConfiguration:


### PR DESCRIPTION
### Wider context of change

As part of the migration from auth to orch, we would like to remove the getter for browserSessionId from the shared session. We've already added a feature flag to enable using the orch session to store the browserSessionId, and have tested it works in dev and build.

### What’s changed

This PR enables the feature flag mentioned above in staging, integration, and production.