### PR TITLE
BAU: Refactor CloudwatchMetricsService to prepare for default dimensions

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -125,6 +125,7 @@ public class CloudwatchMetricsService {
         DimensionSet dimensionSet = new DimensionSet();
 
         dimensionSet.addDimension("Environment", configurationService.getEnvironment());
+        dimensions.forEach(dimensionSet::addDimension);
 
         return dimensionSet;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -120,4 +120,12 @@ public class CloudwatchMetricsService {
                 MFA_RESET_HANDOFF.getValue(),
                 Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
     }
+
+    public DimensionSet getDimensions(Map<String, String> dimensions) {
+        DimensionSet dimensionSet = new DimensionSet();
+
+        dimensionSet.addDimension("Environment", configurationService.getEnvironment());
+
+        return dimensionSet;
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -38,22 +38,25 @@ public class CloudwatchMetricsService {
         segmentedFunctionCall(
                 "Metrics::EMF",
                 () -> {
-                    var metrics = new MetricsLogger();
-                    var dimensionsSet = new DimensionSet();
-
-                    String namespace = "Authentication";
-                    dimensions.forEach(dimensionsSet::addDimension);
-                    Unit unit = Unit.NONE;
-
-                    MetricValidationWarningLogger.validateNamespace(namespace);
-                    MetricValidationWarningLogger.validateMetric(name, value, unit);
-                    dimensions.forEach(MetricValidationWarningLogger::validateDimensionSet);
-
-                    metrics.setNamespace(namespace);
-                    metrics.putDimensions(dimensionsSet);
-                    metrics.putMetric(name, value, unit);
-                    metrics.flush();
+                    emitMetric(name, value, dimensions, new MetricsLogger());
                 });
+    }
+
+    protected void emitMetric(String name, double value, Map<String, String> dimensions, MetricsLogger metrics) {
+        var dimensionsSet = new DimensionSet();
+
+        String namespace = "Authentication";
+        dimensions.forEach(dimensionsSet::addDimension);
+        Unit unit = Unit.NONE;
+
+        MetricValidationWarningLogger.validateNamespace(namespace);
+        MetricValidationWarningLogger.validateMetric(name, value, unit);
+        dimensions.forEach(MetricValidationWarningLogger::validateDimensionSet);
+
+        metrics.setNamespace(namespace);
+        metrics.putDimensions(dimensionsSet);
+        metrics.putMetric(name, value, unit);
+        metrics.flush();
     }
 
     public void incrementCounter(String name, Map<String, String> dimensions) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -36,13 +36,11 @@ public class CloudwatchMetricsService {
 
     public void putEmbeddedValue(String name, double value, Map<String, String> dimensions) {
         segmentedFunctionCall(
-                "Metrics::EMF",
-                () -> {
-                    emitMetric(name, value, dimensions, new MetricsLogger());
-                });
+                "Metrics::EMF", () -> emitMetric(name, value, dimensions, new MetricsLogger()));
     }
 
-    protected void emitMetric(String name, double value, Map<String, String> dimensions, MetricsLogger metrics) {
+    protected void emitMetric(
+            String name, double value, Map<String, String> dimensions, MetricsLogger metrics) {
         var dimensionsSet = new DimensionSet();
 
         String namespace = "Authentication";

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
@@ -3,6 +3,8 @@ package uk.gov.di.authentication.shared.services;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 
 import java.util.Collections;
@@ -46,6 +48,22 @@ class CloudwatchMetricsServiceTest {
         assertThat(dimensions.getDimensionKeys().size(), is(2));
         assertThat(dimensions.getDimensionValue("Environment"), is(randomEnvironment));
         assertThat(dimensions.getDimensionValue("Key1"), is("Value1"));
+    }
+
+    @Test
+    void shouldEmitMetricWithNamespace() {
+        var metricsLogger = Mockito.mock(MetricsLogger.class);
+
+        var service = new CloudwatchMetricsService(new ConfigurationService() {
+            @Override
+            public String getEnvironment() {
+                return "test";
+            }
+        });
+
+        service.emitMetric("Metric", 1, Collections.emptyMap(), metricsLogger);
+
+        Mockito.verify(metricsLogger).setNamespace("Authentication");
     }
 
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 
 import java.util.Collections;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,6 +28,24 @@ class CloudwatchMetricsServiceTest {
 
         assertThat(dimensions.getDimensionKeys().size(), is(1));
         assertThat(dimensions.getDimensionValue("Environment"), is(randomEnvironment));
+    }
+
+    @Test
+    void shouldIncludeEnvironmentDimensionAndAllExtraDimensions() {
+        var randomEnvironment = RandomStringUtils.secure().nextAlphanumeric(10);
+
+        var service = new CloudwatchMetricsService(new ConfigurationService() {
+            @Override
+            public String getEnvironment() {
+                return randomEnvironment;
+            }
+        });
+
+        var dimensions = service.getDimensions(Map.of("Key1","Value1"));
+
+        assertThat(dimensions.getDimensionKeys().size(), is(2));
+        assertThat(dimensions.getDimensionValue("Environment"), is(randomEnvironment));
+        assertThat(dimensions.getDimensionValue("Key1"), is("Value1"));
     }
 
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
@@ -1,0 +1,32 @@
+package uk.gov.di.authentication.shared.services;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Test;
+import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class CloudwatchMetricsServiceTest {
+
+    @Test
+    void shouldAlwaysIncludeEnvironmentDimensionFromConfiguration() {
+        var randomEnvironment = RandomStringUtils.secure().nextAlphanumeric(10);
+
+        var service = new CloudwatchMetricsService(new ConfigurationService() {
+            @Override
+            public String getEnvironment() {
+                return randomEnvironment;
+            }
+        });
+
+        var dimensions = service.getDimensions(Collections.emptyMap());
+
+        assertThat(dimensions.getDimensionKeys().size(), is(1));
+        assertThat(dimensions.getDimensionValue("Environment"), is(randomEnvironment));
+    }
+
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
@@ -1,11 +1,9 @@
 package uk.gov.di.authentication.shared.services;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
-import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 
 import java.util.Collections;
 import java.util.Map;
@@ -19,12 +17,7 @@ class CloudwatchMetricsServiceTest {
     void shouldAlwaysIncludeEnvironmentDimensionFromConfiguration() {
         var randomEnvironment = RandomStringUtils.secure().nextAlphanumeric(10);
 
-        var service = new CloudwatchMetricsService(new ConfigurationService() {
-            @Override
-            public String getEnvironment() {
-                return randomEnvironment;
-            }
-        });
+        var service = new CloudwatchMetricsService(configurationWithEnvironment(randomEnvironment));
 
         var dimensions = service.getDimensions(Collections.emptyMap());
 
@@ -36,12 +29,7 @@ class CloudwatchMetricsServiceTest {
     void shouldIncludeEnvironmentDimensionAndAllExtraDimensions() {
         var randomEnvironment = RandomStringUtils.secure().nextAlphanumeric(10);
 
-        var service = new CloudwatchMetricsService(new ConfigurationService() {
-            @Override
-            public String getEnvironment() {
-                return randomEnvironment;
-            }
-        });
+        var service = new CloudwatchMetricsService(configurationWithEnvironment(randomEnvironment));
 
         var dimensions = service.getDimensions(Map.of("Key1","Value1"));
 
@@ -54,16 +42,20 @@ class CloudwatchMetricsServiceTest {
     void shouldEmitMetricWithNamespace() {
         var metricsLogger = Mockito.mock(MetricsLogger.class);
 
-        var service = new CloudwatchMetricsService(new ConfigurationService() {
-            @Override
-            public String getEnvironment() {
-                return "test";
-            }
-        });
+        var service = new CloudwatchMetricsService(configurationWithEnvironment("test"));
 
         service.emitMetric("Metric", 1, Collections.emptyMap(), metricsLogger);
 
         Mockito.verify(metricsLogger).setNamespace("Authentication");
+    }
+
+    private static ConfigurationService configurationWithEnvironment(String test) {
+        return new ConfigurationService() {
+            @Override
+            public String getEnvironment() {
+                return test;
+            }
+        };
     }
 
 }


### PR DESCRIPTION
## What is this?

The `CloudwatchMetricsService` is used to publish metrics, unsurprisingly, to Cloudwatch from our applications.

Almost every consumer invocation of this functionality passes in an `Environment` dimension, despite the service itself already knowing what environment it is running in.

This PR does two things:
1. Retrofits tests (which did not exist) onto the service
2. Adds a default `Environment` dimension 

These changes are not in the hot path yet, so this PR is something of a noop, but there's no reason not to [land this in main now](https://gds-way.digital.cabinet-office.gov.uk/standards/breaking-down-work.html#breaking-down-work)