### PR TITLE
BAU: Remove feature flag for cross browser response

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -11,7 +11,6 @@ doc_app_encryption_key_id                   = "dcmaw-cri-stubs-build-INqHBvMYWmN
 spot_enabled                                = false
 internal_sector_uri                         = "https://identity.build.account.gov.uk"
 custom_doc_app_claim_enabled                = true
-ipv_no_session_response_enabled             = true
 doc_app_cri_data_v2_endpoint                = "credentials/issue"
 orch_client_id                              = "orchestrationAuth"
 account_intervention_service_call_enabled   = true

--- a/ci/terraform/oidc/dev-overrides.tfvars
+++ b/ci/terraform/oidc/dev-overrides.tfvars
@@ -11,7 +11,6 @@ doc_app_encryption_key_id                   = ""
 spot_enabled                                = false
 internal_sector_uri                         = "https://identity.dev.account.gov.uk"
 custom_doc_app_claim_enabled                = true
-ipv_no_session_response_enabled             = true
 ipv_audience                                = "https://ipvstub.signin.dev.account.gov.uk"
 doc_app_cri_data_v2_endpoint                = "credentials/issue"
 orch_client_id                              = "orchestrationAuth"

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -20,7 +20,6 @@ ipv_audience                                = "https://identity.integration.acco
 internal_sector_uri                         = "https://identity.integration.account.gov.uk"
 spot_enabled                                = true
 custom_doc_app_claim_enabled                = true
-ipv_no_session_response_enabled             = true
 orch_client_id                              = "orchestrationAuth"
 account_intervention_service_call_enabled   = true
 account_intervention_service_action_enabled = true

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -49,7 +49,6 @@ module "ipv-callback" {
     IPV_AUTHORISATION_CLIENT_ID                 = var.ipv_authorisation_client_id
     IPV_AUTHORISATION_URI                       = var.ipv_authorisation_uri
     IPV_BACKEND_URI                             = var.ipv_backend_uri
-    IPV_NO_SESSION_RESPONSE_ENABLED             = var.ipv_no_session_response_enabled
     IPV_TOKEN_SIGNING_KEY_ALIAS                 = local.ipv_token_auth_key_alias_name
     OIDC_API_BASE_URL                           = local.api_base_url
     REDIS_KEY                                   = local.redis_key

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -29,7 +29,6 @@ client_registry_api_enabled                 = false
 spot_enabled                                = true
 ipv_api_enabled                             = true
 ipv_capacity_allowed                        = true
-ipv_no_session_response_enabled             = true
 ipv_authorisation_uri                       = "https://identity.account.gov.uk/oauth2/authorize"
 ipv_authorisation_callback_uri              = "https://oidc.account.gov.uk/ipv-callback"
 ipv_backend_uri                             = "https://api.identity.account.gov.uk"

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -21,7 +21,6 @@ ipv_backend_uri                             = "https://api.identity.staging.acco
 internal_sector_uri                         = "https://identity.staging.account.gov.uk"
 spot_enabled                                = true
 test_clients_enabled                        = "true"
-ipv_no_session_response_enabled             = true
 doc_app_cri_data_v2_endpoint                = "userinfo/v2"
 orch_client_id                              = "orchestrationAuth"
 account_intervention_service_call_enabled   = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -362,11 +362,6 @@ variable "ipv_auth_authorize_client_id" {
   default = "undefined"
 }
 
-variable "ipv_no_session_response_enabled" {
-  type    = bool
-  default = false
-}
-
 variable "phone_checker_with_retry" {
   type    = bool
   default = true

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -190,8 +190,7 @@ public class DocAppCallbackHandler
                 LOG.warn("No session cookie present. Attempt to find session using state");
                 var noSessionEntity =
                         noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                input.getQueryStringParameters(),
-                                configurationService.isCustomDocAppClaimEnabled());
+                                input.getQueryStringParameters());
                 var authRequest =
                         AuthenticationRequest.parse(
                                 noSessionEntity.getClientSession().getAuthRequestParams());

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -443,8 +443,7 @@ class DocAppCallbackHandlerTest {
         queryParameters.put("state", STATE.getValue());
         queryParameters.put("error", OAuth2Error.ACCESS_DENIED_CODE);
         queryParameters.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
-        when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                        queryParameters, true))
+        when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
                 .thenReturn(
                         new NoSessionEntity(
                                 CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, clientSession));
@@ -502,7 +501,7 @@ class DocAppCallbackHandlerTest {
                         new NoSessionException(
                                 "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: false"))
                 .when(noSessionOrchestrationService)
-                .generateNoSessionOrchestrationEntity(queryParameters, false);
+                .generateNoSessionOrchestrationEntity(queryParameters);
 
         var response =
                 handler.handleRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -623,10 +623,5 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         public String getTxmaAuditQueueUrl() {
             return txmaAuditQueue.getQueueUrl();
         }
-
-        @Override
-        public boolean isIPVNoSessionResponseEnabled() {
-            return true;
-        }
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -206,8 +206,7 @@ public class IPVCallbackHandler
             if (Objects.isNull(sessionCookiesIds)) {
                 var noSessionEntity =
                         noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                input.getQueryStringParameters(),
-                                configurationService.isIPVNoSessionResponseEnabled());
+                                input.getQueryStringParameters());
                 var authRequest =
                         AuthenticationRequest.parse(
                                 noSessionEntity.getClientSession().getAuthRequestParams());

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -898,14 +898,12 @@ class IPVCallbackHandlerTest {
                     throws NoSessionException {
         usingValidSession();
         usingValidClientSession();
-        when(configService.isIPVNoSessionResponseEnabled()).thenReturn(true);
 
         Map<String, String> queryParameters = new HashMap<>();
         queryParameters.put("state", STATE.getValue());
         queryParameters.put("error", OAuth2Error.ACCESS_DENIED_CODE);
         queryParameters.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
-        when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                        queryParameters, true))
+        when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
                 .thenReturn(
                         new NoSessionEntity(
                                 CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, clientSession));
@@ -948,7 +946,7 @@ class IPVCallbackHandlerTest {
                         new NoSessionException(
                                 "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: false"))
                 .when(noSessionOrchestrationService)
-                .generateNoSessionOrchestrationEntity(queryParameters, false);
+                .generateNoSessionOrchestrationEntity(queryParameters);
 
         var response =
                 handler.handleRequest(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -257,10 +257,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("IDENTITY_ENABLED");
     }
 
-    public boolean isIPVNoSessionResponseEnabled() {
-        return getFlagOrFalse("IPV_NO_SESSION_RESPONSE_ENABLED");
-    }
-
     public long getIDTokenExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationService.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import static java.lang.String.format;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_NAME;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
@@ -51,12 +50,9 @@ public class NoSessionOrchestrationService {
     }
 
     public NoSessionEntity generateNoSessionOrchestrationEntity(
-            Map<String, String> queryStringParameters, boolean noSessionResponseEnabled)
-            throws NoSessionException {
-        LOG.info(
-                "Attempting to generate error response using state. NoSessionResponseEnabled: {}",
-                noSessionResponseEnabled);
-        if (isAccessDeniedErrorAndStatePresent(queryStringParameters, noSessionResponseEnabled)) {
+            Map<String, String> queryStringParameters) throws NoSessionException {
+        LOG.info("Attempting to generate error response using state");
+        if (isAccessDeniedErrorAndStatePresent(queryStringParameters)) {
             LOG.info("access_denied error and state param are both present");
             var clientSessionId =
                     getClientSessionIdFromState(State.parse(queryStringParameters.get("state")))
@@ -93,12 +89,9 @@ public class NoSessionOrchestrationService {
             return new NoSessionEntity(clientSessionId, errorObject, clientSession);
         } else {
             LOG.warn(
-                    "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: {}",
-                    noSessionResponseEnabled);
+                    "Session Cookie not present and access_denied or state param missing from error response");
             throw new NoSessionException(
-                    format(
-                            "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: %s",
-                            noSessionResponseEnabled));
+                    "Session Cookie not present and access_denied or state param missing from error response");
         }
     }
 
@@ -123,10 +116,8 @@ public class NoSessionOrchestrationService {
                 redisConnectionService.getValue(STATE_STORAGE_PREFIX + state.getValue()));
     }
 
-    private boolean isAccessDeniedErrorAndStatePresent(
-            Map<String, String> queryStringParameters, boolean noSessionResponseEnabled) {
-        return noSessionResponseEnabled
-                && Objects.nonNull(queryStringParameters)
+    private boolean isAccessDeniedErrorAndStatePresent(Map<String, String> queryStringParameters) {
+        return Objects.nonNull(queryStringParameters)
                 && queryStringParameters.containsKey("error")
                 && queryStringParameters.get("error").equals(OAuth2Error.ACCESS_DENIED.getCode())
                 && queryStringParameters.containsKey("state")

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationServiceTest.java
@@ -61,8 +61,7 @@ class NoSessionOrchestrationServiceTest {
         queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
         queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
         var noSessionEntity =
-                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                        queryParams, true);
+                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParams);
 
         assertThat(
                 noSessionEntity.getErrorObject().getCode(),
@@ -81,30 +80,6 @@ class NoSessionOrchestrationServiceTest {
     }
 
     @Test
-    void shouldThrowIfNoSessionResponseIsDisabled() {
-        when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + STATE.getValue()))
-                .thenReturn(CLIENT_SESSION_ID);
-        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(Optional.of(generateClientSession()));
-
-        Map<String, String> queryParams = new HashMap<>();
-        queryParams.put("state", STATE.getValue());
-        queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
-        queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
-        var noSessionException =
-                assertThrows(
-                        NoSessionException.class,
-                        () ->
-                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams, false));
-
-        assertThat(
-                noSessionException.getMessage(),
-                equalTo(
-                        "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: false"));
-    }
-
-    @Test
     void shouldThrowIfErrorIsPresentButIsNotAccessDenied() {
         when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + STATE.getValue()))
                 .thenReturn(CLIENT_SESSION_ID);
@@ -120,12 +95,12 @@ class NoSessionOrchestrationServiceTest {
                         NoSessionException.class,
                         () ->
                                 noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams, true));
+                                        queryParams));
 
         assertThat(
                 noSessionException.getMessage(),
                 equalTo(
-                        "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: true"));
+                        "Session Cookie not present and access_denied or state param missing from error response"));
     }
 
     @Test
@@ -141,12 +116,12 @@ class NoSessionOrchestrationServiceTest {
                         NoSessionException.class,
                         () ->
                                 noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams, true));
+                                        queryParams));
 
         assertThat(
                 noSessionException.getMessage(),
                 equalTo(
-                        "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: true"));
+                        "Session Cookie not present and access_denied or state param missing from error response"));
     }
 
     @Test
@@ -160,12 +135,12 @@ class NoSessionOrchestrationServiceTest {
                         NoSessionException.class,
                         () ->
                                 noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams, true));
+                                        queryParams));
 
         assertThat(
                 noSessionException.getMessage(),
                 equalTo(
-                        "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: true"));
+                        "Session Cookie not present and access_denied or state param missing from error response"));
     }
 
     @Test
@@ -180,12 +155,12 @@ class NoSessionOrchestrationServiceTest {
                         NoSessionException.class,
                         () ->
                                 noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams, true));
+                                        queryParams));
 
         assertThat(
                 noSessionException.getMessage(),
                 equalTo(
-                        "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: true"));
+                        "Session Cookie not present and access_denied or state param missing from error response"));
     }
 
     @Test
@@ -203,7 +178,7 @@ class NoSessionOrchestrationServiceTest {
                         NoSessionException.class,
                         () ->
                                 noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams, true));
+                                        queryParams));
 
         assertThat(
                 noSessionException.getMessage(),
@@ -226,7 +201,7 @@ class NoSessionOrchestrationServiceTest {
                         NoSessionException.class,
                         () ->
                                 noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams, true));
+                                        queryParams));
 
         assertThat(
                 noSessionException.getMessage(),

--- a/template.yaml
+++ b/template.yaml
@@ -3380,7 +3380,6 @@ Resources:
                     !Ref Environment,
                     serviceDomain,
                   ]
-          IPV_NO_SESSION_RESPONSE_ENABLED: true
           IPV_TOKEN_SIGNING_KEY_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,


### PR DESCRIPTION
### Wider context of change
Auth are doing some work to allow users to reset their MFA using their identity. As a result, there's a potential to see the same cross browser issue we see with IPV in our interactions with Auth. We need to be able to return a user to the RP they came from with the correct state value, even when they have lost their cookies. This will mean reusing some of the code we have for IPV. This is a bit of prep work to make that reuse easier.

### What’s changed
Remove a feature flag that's been on for a long time. 

### Manual testing
None

### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
