### PR TITLE
ATO-1332: Remove shared session browserSessionId getter

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -533,7 +533,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
         redis.addBrowserSesssionIdToSession(previousSessionId, BROWSER_SESSION_ID);
         registerUser();
-        withExistingOrchSession(previousSessionId);
+        withExistingOrchSessionAndBsid(previousSessionId);
 
         var response =
                 makeRequest(
@@ -578,7 +578,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
         redis.addBrowserSesssionIdToSession(previousSessionId, BROWSER_SESSION_ID);
         registerUser();
-        withExistingOrchSession(previousSessionId);
+        withExistingOrchSessionAndBsid(previousSessionId);
 
         var response =
                 makeRequest(
@@ -675,7 +675,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
         redis.addBrowserSesssionIdToSession(previousSessionId, BROWSER_SESSION_ID);
         registerUser();
-        withExistingOrchSession(previousSessionId);
+        withExistingOrchSessionAndBsid(previousSessionId);
 
         var response =
                 makeRequest(
@@ -722,7 +722,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
         redis.addBrowserSesssionIdToSession(previousSessionId, BROWSER_SESSION_ID);
         registerUser();
-        withExistingOrchSession(previousSessionId);
+        withExistingOrchSessionAndBsid(previousSessionId);
 
         var response =
                 makeRequest(
@@ -771,7 +771,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
         redis.addBrowserSesssionIdToSession(previousSessionId, BROWSER_SESSION_ID);
         registerUser();
-        withExistingOrchSession(previousSessionId);
+        withExistingOrchSessionAndBsid(previousSessionId);
 
         var response =
                 makeRequest(
@@ -1409,8 +1409,11 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         return kpg.generateKeyPair();
     }
 
-    private void withExistingOrchSession(String sessionId) {
-        orchSessionExtension.addSession(new OrchSessionItem(sessionId).withAuthenticated(true));
+    private void withExistingOrchSessionAndBsid(String sessionId) {
+        orchSessionExtension.addSession(
+                new OrchSessionItem(sessionId)
+                        .withBrowserSessionId(BROWSER_SESSION_ID)
+                        .withAuthenticated(true));
         assertTrue(orchSessionExtension.getSession(sessionId).isPresent());
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -93,13 +93,13 @@ class AuthOrchSerializationServicesIntegrationTest {
     void orchCanReadUnsharedFieldAfterAuthUpdatesSession() {
         var orchSession = orchSessionService.generateSession();
         var sessionId = orchSession.getSessionId();
-        orchSession.setBrowserSessionId(BROWSER_SESSION_ID);
+        orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession);
         var authSession = authSessionService.getSession(sessionId).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
         authSessionService.storeOrUpdateSession(authSession);
         orchSession = orchSessionService.getSession(sessionId).get();
-        assertThat(orchSession.getBrowserSessionId(), is(equalTo(BROWSER_SESSION_ID)));
+        assertThat(orchSession.getProcessingIdentityAttempts(), is(equalTo(1)));
     }
 
     @Test
@@ -137,12 +137,12 @@ class AuthOrchSerializationServicesIntegrationTest {
         var orchSession = orchSessionService.generateSession();
         var sessionId = orchSession.getSessionId();
         orchSession.addClientSession(CLIENT_SESSION_ID);
-        orchSession.setBrowserSessionId(BROWSER_SESSION_ID);
+        orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession);
         var authSession = new Session(sessionId);
         authSessionService.storeOrUpdateSession(authSession);
         orchSession = orchSessionService.getSession(sessionId).get();
         assertThat(orchSession.getClientSessions(), is(empty()));
-        assertThat(orchSession.getBrowserSessionId(), is(equalTo(BROWSER_SESSION_ID)));
+        assertThat(orchSession.getProcessingIdentityAttempts(), is(equalTo(1)));
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -441,13 +441,8 @@ public class AuthorisationHandler
                     user);
         }
 
-        Optional<String> browserSessionIdFromSession;
-        if (configurationService.isUseBrowserSessionIdStoredInOrchSessionEnabled()) {
-            browserSessionIdFromSession =
-                    orchSessionOptional.map(OrchSessionItem::getBrowserSessionId);
-        } else {
-            browserSessionIdFromSession = session.map(Session::getBrowserSessionId);
-        }
+        Optional<String> browserSessionIdFromSession =
+                orchSessionOptional.map(OrchSessionItem::getBrowserSessionId);
         Optional<String> browserSessionIdFromCookie =
                 CookieHelper.parseBrowserSessionCookie(input.getHeaders());
 
@@ -699,11 +694,6 @@ public class AuthorisationHandler
                         session.getSessionId());
             }
         }
-        var browserSessionIdsMatch =
-                Objects.equals(session.getBrowserSessionId(), orchSession.getBrowserSessionId());
-        LOG.info(
-                "Orch session and shared session {}have the same browserSessionId",
-                !browserSessionIdsMatch ? "do not " : "");
 
         attachSessionIdToLogs(session);
         attachOrchSessionIdToLogs(orchSession.getSessionId());
@@ -1111,12 +1101,7 @@ public class AuthorisationHandler
                         configurationService.getSessionCookieAttributes(),
                         configurationService.getDomainName()));
 
-        String browserSessionId;
-        if (configurationService.isUseBrowserSessionIdStoredInOrchSessionEnabled()) {
-            browserSessionId = orchSessionItem.getBrowserSessionId();
-        } else {
-            browserSessionId = session.getBrowserSessionId();
-        }
+        String browserSessionId = orchSessionItem.getBrowserSessionId();
 
         if (browserSessionId != null) {
             cookies.add(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -2330,8 +2330,7 @@ class AuthorisationHandlerTest {
             makeDocAppHandlerRequest();
 
             verify(orchSessionService)
-                    .addOrUpdateSessionId(
-                            Optional.of(orchSession.getSessionId()), session.getSessionId());
+                    .addOrUpdateSessionId(Optional.of(orchSession.getSessionId()), NEW_SESSION_ID);
             verify(orchSessionService).updateSession(orchSession);
         }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -77,10 +77,6 @@ public class Session {
         this.sessionId = sessionId;
     }
 
-    public String getBrowserSessionId() {
-        return browserSessionId;
-    }
-
     public void setBrowserSessionId(String browserSessionId) {
         this.browserSessionId = browserSessionId;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -409,10 +409,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("RETURN_AUTH_TIME_IN_ID_TOKEN_ENABLED");
     }
 
-    public boolean isUseBrowserSessionIdStoredInOrchSessionEnabled() {
-        return getFlagOrFalse("USE_BROWSERSESSIONID_STORED_IN_ORCH_SESSION");
-    }
-
     public Optional<String> getIPVCapacity() {
         try {
             var request =

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
@@ -35,13 +35,12 @@ class SessionServiceTest {
     private final SessionService sessionService = new SessionService(configuration, redis);
 
     @Test
-    void shouldCreateSessionWithNewSessionIdAndBrowserSessionId() {
+    void shouldCreateSessionWithNewSessionId() {
         try (MockedStatic<IdGenerator> idGenerator = mockStatic(IdGenerator.class)) {
-            idGenerator.when(IdGenerator::generate).thenReturn("id-1", "id-2");
+            idGenerator.when(IdGenerator::generate).thenReturn("id-1");
             Session session = sessionService.generateSession();
 
             assertEquals("id-1", session.getSessionId());
-            assertEquals("id-2", session.getBrowserSessionId());
         }
     }
 

--- a/template.yaml
+++ b/template.yaml
@@ -80,14 +80,6 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
     ]
-  UseBrowserSessionIdStoredInOrchSession:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -2366,10 +2358,6 @@ Resources:
             - false
           SUPPORT_MAX_AGE_ENABLED: !If
             - SupportMaxAgeEnabled
-            - true
-            - false
-          USE_BROWSERSESSIONID_STORED_IN_ORCH_SESSION: !If
-            - UseBrowserSessionIdStoredInOrchSession
             - true
             - false
 


### PR DESCRIPTION
### Wider context of change

As part of the linked ticket, we are aiming to move the browserSessionId to be stored in the OrchSessionItem. We have introduced a feature flag called `UseBrowserSessionIdStoredInOrchSession`, and it has been enabled in production for a couple of days now. We have monitored logging and have ensured that the bsid stored in the orch session is identical to the bsid stored in the shared session.

### What’s changed

This PR removes the getter for the browserSessionId in the shared session, as well as the feature flag mentioned above. 

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
