### PR TITLE
ATO-1318: Add code for IpvJwksHandler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IpvJwksHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IpvJwksHandlerIntegrationTest.java
@@ -1,0 +1,36 @@
+package uk.gov.di.authentication.api;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.ipv.lambda.IpvJwksHandler;
+import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+
+import java.text.ParseException;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.assertNoTxmaAuditEventsReceived;
+import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class IpvJwksHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+    @Test
+    void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
+        var configurationService =
+                new IntegrationTestConfigurationService(
+                        externalTokenSigner,
+                        storageTokenSigner,
+                        ipvPrivateKeyJwtSigner,
+                        spotQueue,
+                        docAppPrivateKeyJwtSigner,
+                        configurationParameters);
+        handler = new IpvJwksHandler(configurationService);
+        var response = makeRequest(Optional.empty(), Map.of(), Map.of());
+
+        assertThat(response, hasStatus(200));
+        assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(1));
+
+        assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IpvJwksHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IpvJwksHandler.java
@@ -4,14 +4,67 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.JwksService;
+import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
 public class IpvJwksHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final JwksService jwksService;
+    private static final Logger LOG = LogManager.getLogger(IpvJwksHandler.class);
+
+    public IpvJwksHandler(JwksService jwksService) {
+        this.jwksService = jwksService;
+    }
+
+    public IpvJwksHandler(ConfigurationService configurationService) {
+        this.jwksService =
+                new JwksService(
+                        configurationService, new KmsConnectionService(configurationService));
+    }
+
+    public IpvJwksHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        return generateApiGatewayProxyResponse(200, "TODO - add code");
+        return segmentedFunctionCall(
+                "oidc-api::" + getClass().getSimpleName(), this::ipvJwksRequestHandler);
+    }
+
+    public APIGatewayProxyResponseEvent ipvJwksRequestHandler() {
+        try {
+            LOG.info("IpvJwks request received");
+
+            List<JWK> signingKeys = new ArrayList<>();
+            signingKeys.add(jwksService.getPublicIpvTokenJwkWithOpaqueId());
+
+            JWKSet jwkSet = new JWKSet(signingKeys);
+
+            LOG.info("Generating IpvJwks successful response");
+
+            return generateApiGatewayProxyResponse(
+                    200,
+                    segmentedFunctionCall("serialiseJWKSet", () -> jwkSet.toString(true)),
+                    Map.of("Cache-Control", "max-age=86400"),
+                    null);
+        } catch (Exception e) {
+            LOG.error("Error in IpvJwks lambda", e);
+            return generateApiGatewayProxyResponse(500, "Error providing IpvJwks data");
+        }
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/IpvJwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/IpvJwksHandlerTest.java
@@ -1,0 +1,67 @@
+package uk.gov.di.authentication.oidc.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.ipv.lambda.IpvJwksHandler;
+import uk.gov.di.orchestration.shared.services.JwksService;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasHeader;
+import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class IpvJwksHandlerTest {
+    private final Context context = mock(Context.class);
+    private final JwksService jwksService = mock(JwksService.class);
+    private IpvJwksHandler handler;
+    private final ECKey ipvTokenSigningKey =
+            new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
+
+    IpvJwksHandlerTest() throws JOSEException {}
+
+    @BeforeEach
+    public void setUp() {
+        handler = new IpvJwksHandler(jwksService);
+        when(jwksService.getPublicIpvTokenJwkWithOpaqueId()).thenReturn(ipvTokenSigningKey);
+    }
+
+    @Test
+    void shouldReturnIpvJwks() {
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
+
+        var expectedJWKSet = new JWKSet(List.of(ipvTokenSigningKey));
+
+        assertThat(result, hasStatus(200));
+        assertThat(result, hasBody(expectedJWKSet.toString(true)));
+    }
+
+    @Test
+    void shouldReturn500WhenSigningKeyIsNotPresent() {
+        when(jwksService.getPublicIpvTokenJwkWithOpaqueId()).thenReturn(null);
+
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasBody("Error providing IpvJwks data"));
+    }
+
+    @Test
+    void shouldSetACacheHeaderOfOneDayOnSuccess() {
+        var response = handler.handleRequest(new APIGatewayProxyRequestEvent(), context);
+        assertThat(response, hasHeader("Cache-Control", "max-age=86400"));
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
@@ -66,6 +66,11 @@ public class JwksService {
         return getPublicJWKWithKeyId(configurationService.getStorageTokenSigningKeyAlias());
     }
 
+    public JWK getPublicIpvTokenJwkWithOpaqueId() {
+        LOG.info("Retrieving IPV token public key");
+        return getPublicJWKWithKeyId(configurationService.getIPVTokenSigningKeyAlias());
+    }
+
     public JWK retrieveJwkFromURLWithKeyId(URL url, String keyId) throws KeySourceException {
         JWKSelector selector = new JWKSelector(new JWKMatcher.Builder().keyID(keyId).build());
         JWKSource<SecurityContext> jwkSource =


### PR DESCRIPTION
### Wider context of change

In a previous PR we added the infrastructure for a new lambda that will serve public JWKs for IPV that will support key rotation. The endpoint did nothing but the infrastructure was added and worked.

### What’s changed

This PR adds code to the IpvJwksHandler. It currently serves the `IPV_TOKEN_SIGNING_KEY_ALIAS` public key, but is configured to allow more keys to be served by the endpoint.

### Manual testing

Tested in sandpit/dev. Can see a list of keys containing the `IPV_TOKEN_SIGNING_KEY_ALIAS` at that endpoint

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.