### PR TITLE
ATO-1333: Remove browserSessionId from shared session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -481,7 +481,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldRedirectToLoginUriWhenUserHasPreviousSessionButNoBsidCookie() throws Exception {
         setupForAuthJourney();
         String previousSessionId = givenAnExistingSession(LOW_LEVEL);
-        redis.addBrowserSesssionIdToSession(previousSessionId, BROWSER_SESSION_ID);
         registerUser();
 
         var response =
@@ -531,7 +530,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setupForAuthJourney();
         String previousSessionId = givenAnExistingSession(MEDIUM_LEVEL);
         redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
-        redis.addBrowserSesssionIdToSession(previousSessionId, BROWSER_SESSION_ID);
         registerUser();
         withExistingOrchSessionAndBsid(previousSessionId);
 
@@ -576,7 +574,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setupForAuthJourney();
         String previousSessionId = givenAnExistingSession(MEDIUM_LEVEL);
         redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
-        redis.addBrowserSesssionIdToSession(previousSessionId, BROWSER_SESSION_ID);
         registerUser();
         withExistingOrchSessionAndBsid(previousSessionId);
 
@@ -620,7 +617,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setupForAuthJourney();
         String sessionId = givenAnExistingSession(MEDIUM_LEVEL);
         redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
-        redis.addBrowserSesssionIdToSession(sessionId, BROWSER_SESSION_ID);
         registerUser();
 
         var response =
@@ -673,7 +669,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setupForAuthJourney();
         String previousSessionId = givenAnExistingSession(MEDIUM_LEVEL);
         redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
-        redis.addBrowserSesssionIdToSession(previousSessionId, BROWSER_SESSION_ID);
         registerUser();
         withExistingOrchSessionAndBsid(previousSessionId);
 
@@ -720,7 +715,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setupForAuthJourney();
         String previousSessionId = givenAnExistingSession(MEDIUM_LEVEL);
         redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
-        redis.addBrowserSesssionIdToSession(previousSessionId, BROWSER_SESSION_ID);
         registerUser();
         withExistingOrchSessionAndBsid(previousSessionId);
 
@@ -769,7 +763,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setupForAuthJourney();
         String previousSessionId = givenAnExistingSession(LOW_LEVEL);
         redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
-        redis.addBrowserSesssionIdToSession(previousSessionId, BROWSER_SESSION_ID);
         registerUser();
         withExistingOrchSessionAndBsid(previousSessionId);
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -517,7 +517,7 @@ public class AuthorisationHandler
         var newBrowserSessionId = IdGenerator.generate();
 
         if (existingSession.isEmpty()) {
-            session = sessionService.generateSession(newSessionId, newBrowserSessionId);
+            session = sessionService.generateSession(newSessionId);
             updateAttachedSessionIdToLogs(newSessionId);
             LOG.info("Created new session with ID {}", newSessionId);
         } else {
@@ -637,7 +637,7 @@ public class AuthorisationHandler
         if (existingSession.isEmpty() || existingOrchSessionOptional.isEmpty()) {
             var newSessionId = IdGenerator.generate();
             var newBrowserSessionId = IdGenerator.generate();
-            session = sessionService.generateSession(newSessionId, newBrowserSessionId);
+            session = sessionService.generateSession(newSessionId);
             orchSession = createNewOrchSession(newSessionId, newBrowserSessionId);
             LOG.info("Created session with id: {}", newSessionId);
         } else {
@@ -659,8 +659,7 @@ public class AuthorisationHandler
                         updateSharedSessionDueToMaxAgeExpiry(
                                 existingSession.get(),
                                 newSessionIdForPreviousSession,
-                                newSessionId,
-                                newBrowserSessionId);
+                                newSessionId);
 
                 orchSession =
                         updateOrchSessionDueToMaxAgeExpiry(
@@ -776,14 +775,9 @@ public class AuthorisationHandler
     }
 
     private Session updateSharedSessionDueToMaxAgeExpiry(
-            Session previousSession,
-            String newSessionIdForPreviousSession,
-            String newSessionId,
-            String newBrowserSessionId) {
+            Session previousSession, String newSessionIdForPreviousSession, String newSessionId) {
         sessionService.updateWithNewSessionId(previousSession, newSessionIdForPreviousSession);
-        var newSession =
-                sessionService.copySessionForMaxAge(
-                        previousSession, newSessionId, newBrowserSessionId);
+        var newSession = sessionService.copySessionForMaxAge(previousSession, newSessionId);
         sessionService.storeOrUpdateSession(newSession);
         return newSession;
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -2008,9 +2008,7 @@ class AuthorisationHandlerTest {
             @BeforeEach
             void setup() {
                 when(sessionService.generateSession(anyString()))
-                        .thenReturn(
-                                new Session(NEW_SESSION_ID)
-                                        .withBrowserSessionId(NEW_BROWSER_SESSION_ID));
+                        .thenReturn(new Session(NEW_SESSION_ID));
             }
 
             @Test
@@ -2076,7 +2074,7 @@ class AuthorisationHandlerTest {
 
             @Test
             void shouldCreateNewSessionWhenSessionHasBSIDButCookieDoesNot() {
-                withExistingSession(session.withBrowserSessionId(BROWSER_SESSION_ID));
+                withExistingSession(session);
                 withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
@@ -2106,7 +2104,7 @@ class AuthorisationHandlerTest {
 
             @Test
             void shouldUseExistingSessionWithNoBSIDEvenWhenBSIDCookiePresent() {
-                withExistingSession(session.withBrowserSessionId(null));
+                withExistingSession(session);
                 withExistingOrchSession(orchSession.withBrowserSessionId(null));
                 var response = makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
@@ -2141,7 +2139,7 @@ class AuthorisationHandlerTest {
 
             @Test
             void shouldUseExistingSessionWhenSessionBSIDMatchesBSIDInCookie() {
-                withExistingSession(session.withBrowserSessionId(BROWSER_SESSION_ID));
+                withExistingSession(session);
                 withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
@@ -2172,7 +2170,7 @@ class AuthorisationHandlerTest {
 
             @Test
             void shouldCreateNewSessionWhenSessionAndCookieBSIDDoNotMatch() {
-                withExistingSession(session.withBrowserSessionId(BROWSER_SESSION_ID));
+                withExistingSession(session);
                 withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(DIFFERENT_BROWSER_SESSION_ID);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -308,7 +308,7 @@ class AuthorisationHandlerTest {
         session = new Session(SESSION_ID);
         orchSession = new OrchSessionItem(SESSION_ID);
         when(sessionService.generateSession()).thenReturn(session);
-        when(sessionService.generateSession(anyString(), anyString())).thenReturn(session);
+        when(sessionService.generateSession(anyString())).thenReturn(session);
         when(clientSessionService.generateClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(clientSessionService.generateClientSession(any(), any(), any(), any()))
                 .thenReturn(clientSession);
@@ -2007,7 +2007,7 @@ class AuthorisationHandlerTest {
 
             @BeforeEach
             void setup() {
-                when(sessionService.generateSession(anyString(), anyString()))
+                when(sessionService.generateSession(anyString()))
                         .thenReturn(
                                 new Session(NEW_SESSION_ID)
                                         .withBrowserSessionId(NEW_BROWSER_SESSION_ID));
@@ -2019,7 +2019,7 @@ class AuthorisationHandlerTest {
                 withExistingOrchSession(null);
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
-                verify(sessionService).generateSession(anyString(), anyString());
+                verify(sessionService).generateSession(anyString());
                 verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
@@ -2050,7 +2050,7 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
-                verify(sessionService).generateSession(anyString(), anyString());
+                verify(sessionService).generateSession(anyString());
                 verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
@@ -2080,7 +2080,7 @@ class AuthorisationHandlerTest {
                 withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
-                verify(sessionService).generateSession(anyString(), anyString());
+                verify(sessionService).generateSession(anyString());
                 verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
@@ -2110,7 +2110,7 @@ class AuthorisationHandlerTest {
                 withExistingOrchSession(orchSession.withBrowserSessionId(null));
                 var response = makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
-                verify(sessionService, never()).generateSession(anyString(), anyString());
+                verify(sessionService, never()).generateSession(anyString());
                 verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(SESSION_ID, actualSession.getSessionId());
@@ -2146,7 +2146,7 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
-                verify(sessionService, never()).generateSession(anyString(), anyString());
+                verify(sessionService, never()).generateSession(anyString());
                 verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(SESSION_ID, actualSession.getSessionId());
@@ -2177,7 +2177,7 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(DIFFERENT_BROWSER_SESSION_ID);
 
-                verify(sessionService).generateSession(anyString(), anyString());
+                verify(sessionService).generateSession(anyString());
                 verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
@@ -2601,7 +2601,7 @@ class AuthorisationHandlerTest {
             when(configService.supportMaxAgeEnabled()).thenReturn(true);
             when(configService.getSessionExpiry()).thenReturn(3600L);
             withExistingSession(session);
-            when(sessionService.copySessionForMaxAge(any(Session.class), anyString(), anyString()))
+            when(sessionService.copySessionForMaxAge(any(Session.class), anyString()))
                     .thenCallRealMethod();
         }
 

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -5,8 +5,17 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
-import org.junit.jupiter.api.extension.*;
-import uk.gov.di.orchestration.shared.entity.*;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
+import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
+import uk.gov.di.orchestration.shared.entity.MFAMethodType;
+import uk.gov.di.orchestration.shared.entity.Session;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -148,14 +157,6 @@ public class RedisExtension
     public void addEmailToSession(String sessionId, String emailAddress) throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.setEmailAddress(emailAddress);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
-    }
-
-    public void addBrowserSesssionIdToSession(String sessionId, String browserSessionId)
-            throws Json.JsonException {
-        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.setBrowserSessionId(browserSessionId);
         redis.saveWithExpiry(
                 session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -77,10 +77,6 @@ public class Session {
         this.sessionId = sessionId;
     }
 
-    public void setBrowserSessionId(String browserSessionId) {
-        this.browserSessionId = browserSessionId;
-    }
-
     public Session withBrowserSessionId(String browserSessionId) {
         this.browserSessionId = browserSessionId;
         return this;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -22,8 +22,6 @@ public class Session {
 
     @Expose private String sessionId;
 
-    @Expose private String browserSessionId;
-
     @Expose private List<String> clientSessions;
 
     @Expose private String emailAddress;
@@ -59,7 +57,6 @@ public class Session {
         this.isNewAccount = session.isNewAccount;
         this.processingIdentityAttempts = session.processingIdentityAttempts;
         this.codeRequestCountMap = session.codeRequestCountMap;
-        this.browserSessionId = session.browserSessionId;
         this.authenticated = session.authenticated;
         this.currentCredentialStrength = session.currentCredentialStrength;
         this.emailAddress = session.emailAddress;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -77,11 +77,6 @@ public class Session {
         this.sessionId = sessionId;
     }
 
-    public Session withBrowserSessionId(String browserSessionId) {
-        this.browserSessionId = browserSessionId;
-        return this;
-    }
-
     public List<String> getClientSessions() {
         return clientSessions;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -45,21 +45,16 @@ public class SessionService {
     }
 
     public Session generateSession() {
-        return generateSession(IdGenerator.generate(), IdGenerator.generate());
+        return generateSession(IdGenerator.generate());
     }
 
-    public Session generateSession(String sessionId, String browserSessionId) {
-        Session session = new Session(sessionId);
-        session.setBrowserSessionId(browserSessionId);
-
-        return session;
+    public Session generateSession(String sessionId) {
+        return new Session(sessionId);
     }
 
-    public Session copySessionForMaxAge(
-            Session previousSession, String newSessionId, String newBrowserSessionId) {
+    public Session copySessionForMaxAge(Session previousSession, String newSessionId) {
         var copiedSession = new Session(previousSession);
         copiedSession.setSessionId(newSessionId);
-        copiedSession.setBrowserSessionId(newBrowserSessionId);
         copiedSession.setAuthenticated(false).setCurrentCredentialStrength(null);
         copiedSession.resetClientSessions();
         return copiedSession;


### PR DESCRIPTION
### Wider context of change

We have been working on migrating `browserSessionId` to be stored in the orch session. The latest PR for this change got rid of the getter for `browserSessionId` on the shared session, and got rid of the feature flag we used in the migration process. 

### What’s changed

Now we are certain that the `browserSessiondId` field is not used at all in the shared session, we can safely remove the setter and builder method for the field, as well as the field itself. Tests added in https://github.com/govuk-one-login/authentication-api/pull/5765 ensure that if we remove a field from an object we save to redis, the extra field will be ignored, so this wont be a breaking change.

### Manual testing

Tested in dev
- Sending a request after opening new browser prompts you to login.
- Sending a request with a previous session does not prompt you to login.
- Closing the browser window and sending a request again prompts you to login.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
