### PR TITLE
ATO-1248: add read access to all auth lambdas

### DIFF
--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -15,7 +15,9 @@ module "frontend_api_account_interventions_role" {
     module.oidc_txma_audit.access_policy_arn,
     ], local.deploy_ticf_cri_count == 1 ? [
     aws_iam_policy.ticf_cri_lambda_invocation_policy[0].arn,
-  ] : [])
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
+    ] : [
+  aws_iam_policy.dynamo_auth_session_read_policy.arn])
   extra_tags = {
     Service = "account-interventions"
   }

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -15,7 +15,8 @@ module "frontend_api_account_recovery_role" {
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
   extra_tags = {
     Service = "account-recovery"

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -19,6 +19,7 @@ module "frontend_api_orch_auth_code_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     local.email_check_results_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
   extra_tags = {
     Service = "orch-auth-code"

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -14,6 +14,7 @@ module "frontend_api_check_email_fraud_block_role" {
     aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
     local.client_registry_encryption_policy_arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
   extra_tags = {
     Service = "check-email-fraud-block"

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -14,7 +14,8 @@ module "frontend_api_check_reauth_user_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_authentication_attempt_write_policy.arn,
     aws_iam_policy.dynamo_authentication_attempt_read_policy.arn,
-    aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn
+    aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
   extra_tags = {
     Service = "check-reauth-user"

--- a/ci/terraform/oidc/mfa-reset-authorize.tf
+++ b/ci/terraform/oidc/mfa-reset-authorize.tf
@@ -13,6 +13,7 @@ module "mfa_reset_authorize_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     aws_iam_policy.dynamo_id_reverification_state_write_policy.arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
   extra_tags = {
     Service = "mfa-reset-authorize"

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -13,7 +13,8 @@ module "frontend_api_mfa_role" {
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
   extra_tags = {
     Service = "mfa"

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -12,7 +12,8 @@ module "frontend_api_reset_password_request_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
   extra_tags = {
     Service = "reset-password-request"

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -18,7 +18,8 @@ module "frontend_api_reset_password_role" {
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.common_passwords_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
   extra_tags = {
     Service = "reset-password"

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -11,6 +11,7 @@ module "reverification_result_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
   extra_tags = {
     Service = "reverification-result"

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -18,6 +18,7 @@ module "frontend_api_send_notification_role" {
     local.pending_email_check_queue_access_policy_arn,
     local.email_check_results_encryption_policy_arn,
     aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
   extra_tags = {
     Service = "send-notification"

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -14,7 +14,8 @@ module "frontend_api_update_profile_role" {
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_auth_session_read_policy.arn
   ]
   extra_tags = {
     Service = "update-profile"


### PR DESCRIPTION
## What:

- This PR adds read access to the auth session table for all lambdas which inherit from the `BaseFrontendHandler` class. 
- Some already had read access so this is only the ones which did not already have the read permissions
- This is preparatory work to ensure we can add the `AuthSession` to the user context

## How to review
- Code review commit-by-commit
- Double check all the handlers which inherit from the `BaseFrontendHandler` have read access to the auth_session table
- Deploy to sandpit to validate we're not hitting any policy limits - done!

Checking which handlers inherit from `BaseFrontEndHandler`: 
` grep --include=\*.java -r '.' -e 'extends BaseFrontendHandler'  -l | sort`

Checking which terraform files include the read permission:
`grep --include=\*.tf -r '.' -e 'aws_iam_policy.dynamo_auth_session_read*'  -l | sort`


