### PR TITLE
ATO-1319: Include signing key id  in JWS header of IPV requests

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -165,7 +165,9 @@ public class IPVAuthorisationService {
             List<String> vtr,
             Boolean reproveIdentity) {
         LOG.info("Generating request JWT");
-        var jwsHeader = new JWSHeader(SIGNING_ALGORITHM);
+        var signingKeyJwt = jwksService.getPublicIpvTokenJwkWithOpaqueId();
+        var jwsHeader =
+                new JWSHeader.Builder(SIGNING_ALGORITHM).keyID(signingKeyJwt.getKeyID()).build();
         var jwtID = IdGenerator.generate();
         var expiryDate = nowClock.nowPlus(3, ChronoUnit.MINUTES);
         var claimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claims);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -92,14 +92,20 @@ class IPVTokenServiceTest {
     private IPVTokenService ipvTokenService;
 
     @BeforeEach
-    void setUp() {
-        ipvTokenService = new IPVTokenService(configService, kmsService);
+    void setUp() throws JOSEException {
+        ipvTokenService = new IPVTokenService(configService, kmsService, jwksService);
         when(configService.getIPVBackendURI()).thenReturn(IPV_URI);
         when(configService.getIPVAuthorisationClientId()).thenReturn(CLIENT_ID.getValue());
         when(configService.getAccessTokenExpiry()).thenReturn(300L);
         when(configService.getIPVAuthorisationCallbackURI()).thenReturn(REDIRECT_URI);
         when(configService.getIPVAudience()).thenReturn(IPV_URI.toString());
         when(configService.getIPVTokenSigningKeyAlias()).thenReturn(KEY_ID);
+        when(jwksService.getPublicIpvTokenJwkWithOpaqueId())
+                .thenReturn(
+                        new ECKeyGenerator(Curve.P_256)
+                                .keyID(KEY_ID)
+                                .algorithm(JWSAlgorithm.ES256)
+                                .generate());
     }
 
     @Test


### PR DESCRIPTION
### Wider context of change

In order to support key rotation easier in the future, we have introduced a jwks endpoint that serves the signing key for IPV requests. We need to let IPV know what key we have used to sign the request though. 

### What’s changed

This PR adds the signing key ID to the IPV auth request and the IPV token request. 

### Checklist


- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

