### PR TITLE
BAU: Remove guava library

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -37,7 +37,6 @@ dependencies {
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
     testImplementation("uk.org.webcompere:system-stubs-jupiter:2.1.3")
-    testImplementation("com.google.guava:guava:33.3.1-jre")
     testImplementation("org.awaitility:awaitility:4.2.0")
     testImplementation('org.wiremock:wiremock-jetty12:3.10.0')
 }


### PR DESCRIPTION
## What

Remove guava library as it is not in use.

## How to review

1. Code Review
2. Check that code compiles and all github actions complete.


