### PR TITLE
Aut 3993/feature flag writing to account modifiers

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordCompletionRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordCompletionRequest.java
@@ -6,4 +6,6 @@ import uk.gov.di.authentication.shared.validation.Required;
 
 public record ResetPasswordCompletionRequest(
         @SerializedName("password") @Expose @Required String password,
-        @SerializedName("isForcedPasswordReset") @Expose @Required boolean isForcedPasswordReset) {}
+        @SerializedName("isForcedPasswordReset") @Expose @Required boolean isForcedPasswordReset,
+        @SerializedName("allowMfaResetAfterPasswordReset") @Expose
+                boolean allowMfaResetAfterPasswordReset) {}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import uk.gov.di.authentication.frontendapi.entity.ResetPasswordCompletionRequest;
 import uk.gov.di.authentication.frontendapi.lambda.ResetPasswordHandler;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -21,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -38,6 +38,24 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     private static final String INTERNAl_SECTOR_URI = "https://test.account.gov.uk";
     private static final String INTERNAl_SECTOR_HOST = "test.account.gov.uk";
     private static final Subject SUBJECT = new Subject();
+    private static final String RESET_PASSWORD_REQUEST =
+            format(
+                    """
+                            {
+                            "password": %s,
+                            "isForcedPasswordReset": false
+                            }
+                            """,
+                    PASSWORD);
+    private static final String FORCED_RESET_PASSWORD_REQUEST =
+            format(
+                    """
+                            {
+                            "password": %s,
+                            "isForcedPasswordReset": true
+                            }
+                            """,
+                    PASSWORD);
 
     @BeforeEach
     public void setUp() {
@@ -55,7 +73,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         var response =
                 makeRequest(
-                        Optional.of(new ResetPasswordCompletionRequest(PASSWORD, false)),
+                        Optional.of(RESET_PASSWORD_REQUEST),
                         constructFrontendHeaders(sessionId),
                         Map.of());
 
@@ -82,7 +100,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         var response =
                 makeRequest(
-                        Optional.of(new ResetPasswordCompletionRequest(PASSWORD, false)),
+                        Optional.of(RESET_PASSWORD_REQUEST),
                         constructFrontendHeaders(sessionId),
                         Map.of());
 
@@ -112,13 +130,18 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
+        var body =
+                format(
+                        """
+                            {
+                            "password": "%s",
+                            "isForcedPasswordReset": false
+                            }
+                            """,
+                        CommonPasswordsExtension.TEST_COMMON_PASSWORD);
+
         var response =
-                makeRequest(
-                        Optional.of(
-                                new ResetPasswordCompletionRequest(
-                                        CommonPasswordsExtension.TEST_COMMON_PASSWORD, false)),
-                        constructFrontendHeaders(sessionId),
-                        Map.of());
+                makeRequest(Optional.of(body), constructFrontendHeaders(sessionId), Map.of());
 
         assertThat(response, hasStatus(400));
         assertTrue(response.getBody().contains(ErrorResponse.ERROR_1040.getMessage()));
@@ -133,7 +156,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         var response =
                 makeRequest(
-                        Optional.of(new ResetPasswordCompletionRequest(PASSWORD, true)),
+                        Optional.of(FORCED_RESET_PASSWORD_REQUEST),
                         constructFrontendHeaders(sessionId),
                         Map.of());
 
@@ -168,7 +191,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         var response =
                 makeRequest(
-                        Optional.of(new ResetPasswordCompletionRequest(PASSWORD, false)),
+                        Optional.of(RESET_PASSWORD_REQUEST),
                         constructFrontendHeaders(sessionId),
                         Map.of());
 
@@ -217,7 +240,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         var response =
                 makeRequest(
-                        Optional.of(new ResetPasswordCompletionRequest(PASSWORD, false)),
+                        Optional.of(RESET_PASSWORD_REQUEST),
                         constructFrontendHeaders(sessionId),
                         Map.of());
 


### PR DESCRIPTION
## What

Adds a new optional field to the json request to the reset password handler, that allows the frontend to control whether or ot we allow mfa reset after password reset. If this field is omitted, the behaviour will default to current (not allowing this).

Currently, when a user resets their password, we don't want them to immediately also be able to reset their MFA for security reasons. However, when we switch on the new mfa reset journey which goes via IPV, there is sufficient security to not need this block. Therefore, when this feature is switched on, we no longer need to add an account modifiers block for the user.

We've made a decision here not to introduce a separate feature flag on the backend that reflects whether the new support mfa journey is on or not. Instead the behaviour is controlled via the frontend feature flag which will be used to populate this field, meaning this new behaviour will all be switched on at once.

## How to review

Code review (testing covered off separately)
