### PR TITLE
ATO-1117: replace userprofile with authuserinfo

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -278,7 +278,10 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         .nonce(new Nonce())
                         .state(RP_STATE);
         redis.createClientSession(
-                CLIENT_SESSION_ID, CLIENT_NAME, authRequestBuilder.build().toParameters());
+                CLIENT_SESSION_ID,
+                CLIENT_NAME,
+                authRequestBuilder.build().toParameters(),
+                "rp-pairwise-id");
         redis.addClientSessionAndStateToRedis(ORCH_TO_AUTH_STATE, CLIENT_SESSION_ID);
 
         var response =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -122,12 +122,14 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     public static final String CLIENT_SESSION_ID = "some-client-session-id";
     public static final State RP_STATE = new State();
     public static final State ORCHESTRATION_STATE = new State();
-    private static final Subject TEST_SUBJECT = new Subject();
-    private static final String TEST_INTERNAL_SECTOR_ID = "test.com";
+    private static final Subject TEST_SUBJECT = new Subject("test-subject");
+    private static final String INTERNAL_SECTOR_HOST = "test.account.gov.uk";
+    private static final String RP_SECTOR_HOST = "test.com";
 
     private static byte[] salt;
     private static String base64EncodedSalt;
     private static String internalCommonSubjectId;
+    private static String rpPairwiseId;
 
     @BeforeEach
     void setup() {
@@ -142,7 +144,8 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         salt = userStore.addSalt(TEST_EMAIL_ADDRESS);
         base64EncodedSalt = Base64.getEncoder().encodeToString(salt);
         internalCommonSubjectId =
-                calculatePairwiseIdentifier(TEST_SUBJECT.getValue(), TEST_INTERNAL_SECTOR_ID, salt);
+                calculatePairwiseIdentifier(TEST_SUBJECT.getValue(), INTERNAL_SECTOR_HOST, salt);
+        rpPairwiseId = calculatePairwiseIdentifier(TEST_SUBJECT.getValue(), RP_SECTOR_HOST, salt);
 
         setupOrchSession(internalCommonSubjectId);
         setupAuthUserInfoTable(internalCommonSubjectId, salt);
@@ -166,14 +169,16 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 CLIENT_SESSION_ID,
                 CLIENT_NAME,
                 authRequestBuilder.build().toParameters(),
+                rpPairwiseId,
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
         redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
@@ -217,7 +222,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 TEST_SUBJECT.getValue(),
                                 salt,
                                 sectorId,
-                                internalCommonSubjectId,
+                                rpPairwiseId,
                                 new LogIds(
                                         SESSION_ID,
                                         PERSISTENT_SESSION_ID,
@@ -303,6 +308,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 CLIENT_SESSION_ID,
                 CLIENT_NAME,
                 authRequestBuilder.build().toParameters(),
+                rpPairwiseId,
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
@@ -343,7 +349,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                         + SerializationService.getInstance().writeValueAsString(base64EncodedSalt)
                         + ",\"in_rp_sector_id\":\"test.com\","
                         + "\"out_sub\":\""
-                        + internalCommonSubjectId
+                        + rpPairwiseId
                         + "\",\"log_ids\":{\"session_id\":\"some-session-id\""
                         + ",\"persistent_session_id\":\""
                         + PERSISTENT_SESSION_ID
@@ -368,14 +374,16 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 CLIENT_SESSION_ID,
                 CLIENT_NAME,
                 authRequestBuilder.build().toParameters(),
+                rpPairwiseId,
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
         redis.addClientSessionAndStateToRedis(ORCHESTRATION_STATE, CLIENT_SESSION_ID);
 
         var response =
@@ -422,14 +430,16 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 CLIENT_SESSION_ID,
                 CLIENT_NAME,
                 authRequestBuilder.build().toParameters(),
+                rpPairwiseId,
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
 
         var response =
                 makeRequest(
@@ -478,14 +488,16 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 CLIENT_SESSION_ID,
                 CLIENT_NAME,
                 authRequestBuilder.build().toParameters(),
+                rpPairwiseId,
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
         redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
@@ -575,14 +587,16 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 CLIENT_SESSION_ID,
                 CLIENT_NAME,
                 authRequestBuilder.build().toParameters(),
+                rpPairwiseId,
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
         redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
@@ -634,14 +648,16 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 CLIENT_SESSION_ID,
                 CLIENT_NAME,
                 authRequestBuilder.build().toParameters(),
+                rpPairwiseId,
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, sessionId);
         redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -220,7 +220,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                         VTM.getValue(),
                                         "/trustmark"),
                                 TEST_SUBJECT.getValue(),
-                                salt,
+                                base64EncodedSalt,
                                 sectorId,
                                 rpPairwiseId,
                                 new LogIds(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -138,7 +138,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         txmaAuditQueue.clear();
         spotQueue.clear();
 
-        setupUserProfileAndUserCredentials();
+        setupUserCredentials();
         setupClientStore();
 
         salt = userStore.addSalt(TEST_EMAIL_ADDRESS);
@@ -685,7 +685,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 startsWith(REDIRECT_URI + "?error=access_denied"));
     }
 
-    private void setupUserProfileAndUserCredentials() {
+    private void setupUserCredentials() {
         userStore.signUp(TEST_EMAIL_ADDRESS, "password", TEST_SUBJECT);
         userStore.addVerifiedPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/SpotQueueAssertionHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/SpotQueueAssertionHelper.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.testsupport.helpers;
 import uk.gov.di.authentication.ipv.entity.SPOTRequest;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -13,7 +12,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.testsupport.matchers.SpotRequestMatcher.hasAccountId;
 import static uk.gov.di.authentication.testsupport.matchers.SpotRequestMatcher.hasSub;
 
@@ -39,10 +38,9 @@ public class SpotQueueAssertionHelper {
 
         var expectedSpotRequest = expectedRequests.stream().findFirst().orElseThrow();
 
-        assertTrue(
-                Arrays.equals(
-                        actualRequests.stream().findFirst().orElseThrow().getSalt(),
-                        expectedSpotRequest.getSalt()));
+        assertEquals(
+                actualRequests.stream().findFirst().orElseThrow().getSalt(),
+                expectedSpotRequest.getSalt());
 
         assertThat(
                 expectedSpotRequest.getLogIds().getSessionId(),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
@@ -1,9 +1,7 @@
 package uk.gov.di.authentication.ipv.entity;
 
 import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
-import uk.gov.di.orchestration.shared.serialization.Base64ByteArrayAdapter;
 
 import java.util.Map;
 
@@ -19,8 +17,7 @@ public class SPOTRequest {
 
     @SerializedName(value = "in_salt")
     @Expose
-    @JsonAdapter(Base64ByteArrayAdapter.class)
-    private byte[] salt;
+    private String salt;
 
     @SerializedName(value = "in_rp_sector_id")
     @Expose
@@ -41,7 +38,7 @@ public class SPOTRequest {
     public SPOTRequest(
             Map<String, Object> spotClaims,
             String localAccountId,
-            byte[] salt,
+            String salt,
             String rpSectorId,
             String sub,
             LogIds logIds,
@@ -65,7 +62,7 @@ public class SPOTRequest {
         return localAccountId;
     }
 
-    public byte[] getSalt() {
+    public String getSalt() {
         return salt;
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -35,7 +35,6 @@ import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
-import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
@@ -63,7 +62,6 @@ public class IPVCallbackHelper {
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final DynamoClientService dynamoClientService;
     private final DynamoIdentityService dynamoIdentityService;
-    private final DynamoService dynamoService;
     private final SessionService sessionService;
     private final AwsSqsClient sqsClient;
     private final OidcAPI oidcAPI;
@@ -75,7 +73,6 @@ public class IPVCallbackHelper {
         this.authorisationCodeService = new AuthorisationCodeService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);
         this.dynamoIdentityService = new DynamoIdentityService(configurationService);
-        this.dynamoService = new DynamoService(configurationService);
         this.objectMapper = SerializationService.getInstance();
         this.sessionService = new SessionService(configurationService);
         this.sqsClient =
@@ -83,8 +80,7 @@ public class IPVCallbackHelper {
                         configurationService.getAwsRegion(),
                         configurationService.getSpotQueueURI(),
                         configurationService.getSqsEndpointURI());
-        this.authCodeResponseService =
-                new AuthCodeResponseGenerationService(configurationService, dynamoService);
+        this.authCodeResponseService = new AuthCodeResponseGenerationService(configurationService);
         this.oidcAPI = new OidcAPI(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
     }
@@ -98,7 +94,6 @@ public class IPVCallbackHelper {
                         configurationService, redis, SerializationService.getInstance());
         this.dynamoClientService = new DynamoClientService(configurationService);
         this.dynamoIdentityService = new DynamoIdentityService(configurationService);
-        this.dynamoService = new DynamoService(configurationService);
         this.objectMapper = SerializationService.getInstance();
         this.sessionService = new SessionService(configurationService, redis);
         this.sqsClient =
@@ -106,8 +101,7 @@ public class IPVCallbackHelper {
                         configurationService.getAwsRegion(),
                         configurationService.getSpotQueueURI(),
                         configurationService.getSqsEndpointURI());
-        this.authCodeResponseService =
-                new AuthCodeResponseGenerationService(configurationService, dynamoService);
+        this.authCodeResponseService = new AuthCodeResponseGenerationService(configurationService);
         this.oidcAPI = new OidcAPI(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
     }
@@ -119,7 +113,6 @@ public class IPVCallbackHelper {
             CloudwatchMetricsService cloudwatchMetricsService,
             DynamoClientService dynamoClientService,
             DynamoIdentityService dynamoIdentityService,
-            DynamoService dynamoService,
             SerializationService objectMapper,
             SessionService sessionService,
             AwsSqsClient sqsClient,
@@ -131,7 +124,6 @@ public class IPVCallbackHelper {
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.dynamoClientService = dynamoClientService;
         this.dynamoIdentityService = dynamoIdentityService;
-        this.dynamoService = dynamoService;
         this.objectMapper = objectMapper;
         this.sessionService = sessionService;
         this.sqsClient = sqsClient;

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -275,7 +275,7 @@ public class IPVCallbackHelper {
             LogIds logIds,
             String sectorIdentifier,
             UserProfile userProfile,
-            Subject pairwiseSubject,
+            Subject rpPairwiseSubject,
             UserInfo userIdentityUserInfo,
             String clientId)
             throws JsonException {
@@ -301,7 +301,7 @@ public class IPVCallbackHelper {
                         userProfile.getSubjectID(),
                         dynamoService.getOrGenerateSalt(userProfile),
                         sectorIdentifier,
-                        pairwiseSubject.getValue(),
+                        rpPairwiseSubject.getValue(),
                         logIds,
                         clientId);
         var spotRequestString = objectMapper.writeValueAsString(spotRequest);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -274,7 +274,6 @@ public class IPVCallbackHelper {
     public void queueSPOTRequest(
             LogIds logIds,
             String sectorIdentifier,
-            UserProfile userProfile,
             UserInfo authUserInfo,
             Subject rpPairwiseSubject,
             UserInfo userIdentityUserInfo,
@@ -299,7 +298,7 @@ public class IPVCallbackHelper {
         var spotRequest =
                 new SPOTRequest(
                         spotClaimsBuilder.build(),
-                        userProfile.getSubjectID(),
+                        authUserInfo.getStringClaim(AuthUserInfoClaims.LOCAL_ACCOUNT_ID.getValue()),
                         authUserInfo.getStringClaim(AuthUserInfoClaims.SALT.getValue()),
                         sectorIdentifier,
                         rpPairwiseSubject.getValue(),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -275,6 +275,7 @@ public class IPVCallbackHelper {
             LogIds logIds,
             String sectorIdentifier,
             UserProfile userProfile,
+            UserInfo authUserInfo,
             Subject rpPairwiseSubject,
             UserInfo userIdentityUserInfo,
             String clientId)
@@ -299,7 +300,7 @@ public class IPVCallbackHelper {
                 new SPOTRequest(
                         spotClaimsBuilder.build(),
                         userProfile.getSubjectID(),
-                        dynamoService.getOrGenerateSalt(userProfile),
+                        authUserInfo.getStringClaim(AuthUserInfoClaims.SALT.getValue()),
                         sectorIdentifier,
                         rpPairwiseSubject.getValue(),
                         logIds,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -25,7 +25,6 @@ import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
-import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 import uk.gov.di.orchestration.shared.services.AuditService;
@@ -201,8 +200,8 @@ public class IPVCallbackHelper {
             String ipAddress,
             String persistentSessionId,
             String clientId,
-            String email)
-            throws UserNotFoundException {
+            String email,
+            String subjectId) {
         LOG.warn("SPOT will not be invoked due to returnCode. Returning authCode to RP");
         segmentedFunctionCall(
                 "saveIdentityClaims",
@@ -225,8 +224,6 @@ public class IPVCallbackHelper {
         var dimensions =
                 authCodeResponseService.getDimensions(
                         orchSession, clientSession, clientSessionId, false, false);
-
-        var subjectId = authCodeResponseService.getSubjectId(session);
 
         var metadataPairs = new ArrayList<AuditService.MetadataPair>();
         metadataPairs.add(pair("internalSubjectId", subjectId));

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -478,6 +478,7 @@ public class IPVCallbackHandler
                     getSectorIdentifierForClient(
                             clientRegistry, configurationService.getInternalSectorURI()),
                     userProfile,
+                    authUserInfo,
                     rpPairwiseSubject,
                     userIdentityUserInfo,
                     clientId);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.UserInfoRequest;
@@ -344,12 +345,7 @@ public class IPVCallbackHandler
                         sessionId);
             }
 
-            var rpPairwiseSubject =
-                    ClientSubjectHelper.getSubject(
-                            userProfile,
-                            clientRegistry,
-                            dynamoService,
-                            configurationService.getInternalSectorURI());
+            var rpPairwiseSubject = new Subject(clientSession.getRpPairwiseId());
 
             var user =
                     TxmaAuditUser.user()

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -28,13 +28,13 @@ import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.api.CommonFrontend;
 import uk.gov.di.orchestration.shared.api.OrchFrontend;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
+import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
-import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.ConstructUriHelper;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
@@ -411,7 +411,9 @@ public class IPVCallbackHandler
                                         ipAddress,
                                         persistentId,
                                         clientId,
-                                        authUserInfo.getEmailAddress());
+                                        authUserInfo.getEmailAddress(),
+                                        authUserInfo.getStringClaim(
+                                                AuthUserInfoClaims.LOCAL_ACCOUNT_ID.getValue()));
                         return generateApiGatewayProxyResponse(
                                 302,
                                 "",
@@ -488,9 +490,6 @@ public class IPVCallbackHandler
         } catch (JsonException e) {
             LOG.error("Unable to serialize SPOTRequest when placing on queue");
             return RedirectService.redirectToFrontendErrorPage(frontend.errorURI());
-        } catch (UserNotFoundException e) {
-            LOG.error(e.getMessage());
-            throw new RuntimeException(e);
         }
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -290,12 +290,6 @@ public class IPVCallbackHandler
                                     () ->
                                             new IpvCallbackException(
                                                     "Email from session does not have a user profile"));
-            var rpPairwiseSubject =
-                    ClientSubjectHelper.getSubject(
-                            userProfile,
-                            clientRegistry,
-                            dynamoService,
-                            configurationService.getInternalSectorURI());
 
             var internalPairwiseSubjectId =
                     ClientSubjectHelper.calculatePairwiseIdentifier(
@@ -304,14 +298,6 @@ public class IPVCallbackHandler
                             dynamoService.getOrGenerateSalt(userProfile));
 
             var ipAddress = IpAddressHelper.extractIpAddress(input);
-            var user =
-                    TxmaAuditUser.user()
-                            .withGovukSigninJourneyId(clientSessionId)
-                            .withSessionId(sessionId)
-                            .withUserId(internalPairwiseSubjectId)
-                            .withEmail(session.getEmailAddress())
-                            .withPhone(userProfile.getPhoneNumber())
-                            .withPersistentSessionId(persistentId);
 
             var auditContext =
                     new AuditContext(
@@ -350,6 +336,22 @@ public class IPVCallbackHandler
                         clientSessionId,
                         sessionId);
             }
+
+            var rpPairwiseSubject =
+                    ClientSubjectHelper.getSubject(
+                            userProfile,
+                            clientRegistry,
+                            dynamoService,
+                            configurationService.getInternalSectorURI());
+
+            var user =
+                    TxmaAuditUser.user()
+                            .withGovukSigninJourneyId(clientSessionId)
+                            .withSessionId(sessionId)
+                            .withUserId(internalPairwiseSubjectId)
+                            .withEmail(session.getEmailAddress())
+                            .withPhone(userProfile.getPhoneNumber())
+                            .withPersistentSessionId(persistentId);
 
             auditService.submitAuditEvent(
                     IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED, clientId, user);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -477,7 +477,6 @@ public class IPVCallbackHandler
                     logIds,
                     getSectorIdentifierForClient(
                             clientRegistry, configurationService.getInternalSectorURI()),
-                    userProfile,
                     authUserInfo,
                     rpPairwiseSubject,
                     userIdentityUserInfo,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -282,13 +282,6 @@ public class IPVCallbackHandler
                             () ->
                                     ipvAuthorisationService.validateResponse(
                                             input.getQueryStringParameters(), sessionId));
-            var userProfile =
-                    dynamoService
-                            .getUserProfileByEmailMaybe(session.getEmailAddress())
-                            .orElseThrow(
-                                    () ->
-                                            new IpvCallbackException(
-                                                    "Email from session does not have a user profile"));
 
             UserInfo authUserInfo =
                     getAuthUserInfo(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -305,11 +305,11 @@ public class IPVCallbackHandler
                             sessionId,
                             clientId,
                             orchSession.getInternalCommonSubjectId(),
-                            session.getEmailAddress(),
+                            authUserInfo.getEmailAddress(),
                             ipAddress,
-                            Objects.isNull(userProfile.getPhoneNumber())
+                            Objects.isNull(authUserInfo.getPhoneNumber())
                                     ? AuditService.UNKNOWN
-                                    : userProfile.getPhoneNumber(),
+                                    : authUserInfo.getPhoneNumber(),
                             persistentId);
 
             if (errorObject.isPresent()) {
@@ -345,8 +345,11 @@ public class IPVCallbackHandler
                             .withGovukSigninJourneyId(clientSessionId)
                             .withSessionId(sessionId)
                             .withUserId(orchSession.getInternalCommonSubjectId())
-                            .withEmail(session.getEmailAddress())
-                            .withPhone(userProfile.getPhoneNumber())
+                            .withEmail(authUserInfo.getEmailAddress())
+                            .withPhone(
+                                    Objects.isNull(authUserInfo.getPhoneNumber())
+                                            ? AuditService.UNKNOWN
+                                            : authUserInfo.getPhoneNumber())
                             .withPersistentSessionId(persistentId);
 
             auditService.submitAuditEvent(
@@ -411,7 +414,6 @@ public class IPVCallbackHandler
                                 ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
                                         authRequest,
                                         clientSessionId,
-                                        userProfile,
                                         session,
                                         sessionId,
                                         orchSession,
@@ -421,7 +423,8 @@ public class IPVCallbackHandler
                                         userIdentityUserInfo,
                                         ipAddress,
                                         persistentId,
-                                        clientId);
+                                        clientId,
+                                        authUserInfo.getEmailAddress());
                         return generateApiGatewayProxyResponse(
                                 302,
                                 "",

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -48,7 +48,6 @@ import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
-import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
@@ -89,7 +88,6 @@ public class IPVCallbackHandler
     private final SessionService sessionService;
     private final OrchSessionService orchSessionService;
     private final AuthenticationUserInfoStorageService authUserInfoStorageService;
-    private final DynamoService dynamoService;
     private final ClientSessionService clientSessionService;
     private final OrchClientSessionService orchClientSessionService;
     private final DynamoClientService dynamoClientService;
@@ -112,7 +110,6 @@ public class IPVCallbackHandler
             SessionService sessionService,
             OrchSessionService orchSessionService,
             AuthenticationUserInfoStorageService authUserInfoStorageService,
-            DynamoService dynamoService,
             ClientSessionService clientSessionService,
             OrchClientSessionService orchClientSessionService,
             DynamoClientService dynamoClientService,
@@ -128,7 +125,6 @@ public class IPVCallbackHandler
         this.sessionService = sessionService;
         this.orchSessionService = orchSessionService;
         this.authUserInfoStorageService = authUserInfoStorageService;
-        this.dynamoService = dynamoService;
         this.clientSessionService = clientSessionService;
         this.orchClientSessionService = orchClientSessionService;
         this.dynamoClientService = dynamoClientService;
@@ -153,7 +149,6 @@ public class IPVCallbackHandler
         this.orchSessionService = new OrchSessionService(configurationService);
         this.authUserInfoStorageService =
                 new AuthenticationUserInfoStorageService(configurationService);
-        this.dynamoService = new DynamoService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);
@@ -181,7 +176,6 @@ public class IPVCallbackHandler
         this.orchSessionService = new OrchSessionService(configurationService);
         this.authUserInfoStorageService =
                 new AuthenticationUserInfoStorageService(configurationService);
-        this.dynamoService = new DynamoService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService, redis);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/entity/SPOTRequestTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/entity/SPOTRequestTest.java
@@ -35,7 +35,7 @@ class SPOTRequestTest {
                 spotRequest.getSpotClaims().get(IdentityClaims.CREDENTIAL_JWT.getValue()));
         assertEquals("P2", spotRequest.getSpotClaims().get("vot"));
         assertEquals("/trustmark", spotRequest.getSpotClaims().get("vtm"));
-        assertEquals(saltString, Base64.getEncoder().encodeToString(spotRequest.getSalt()));
+        assertEquals(saltString, spotRequest.getSalt());
         assertEquals("<id>", spotRequest.getLocalAccountId());
         assertEquals("<subject identifier>", spotRequest.getSub());
         assertEquals("<id>", spotRequest.getLogIds().getSessionId());

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -50,6 +50,8 @@ import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +94,7 @@ class IPVCallbackHelperTest {
     private static final String SESSION_ID = "a-session-id";
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
+    private static final String TEST_PHONE_NUMBER = "012345678902";
     private static final Subject PUBLIC_SUBJECT =
             new Subject("TsEVC7vg0NPAmzB33vRUFztL2c0-fecKWKcc73fuDhc");
     private static final Subject SUBJECT = new Subject("subject-id");
@@ -99,6 +102,9 @@ class IPVCallbackHelperTest {
     private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
     private static final String TEST_INTERNAL_COMMON_SUBJECT_ID_WITH_INTERVENTION =
             "internal-common-subject-id-with-intervention";
+    private static final byte[] salt =
+            "Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw=".getBytes(StandardCharsets.UTF_8);
+    private static final String BASE_64_ENCODED_SALT = Base64.getEncoder().encodeToString(salt);
     private static final List<VectorOfTrust> VTR_LIST_P1_AND_P2 =
             List.of(
                     VectorOfTrust.of(CredentialTrustLevel.MEDIUM_LEVEL, LevelOfConfidence.NONE),
@@ -114,6 +120,7 @@ class IPVCallbackHelperTest {
     private static final State RP_STATE = new State();
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final UserProfile userProfile = generateUserProfile();
+    private static final UserInfo authUserInfo = generateAuthUserInfo();
     private static final UserInfo p0VotUserIdentityUserInfo =
             new UserInfo(
                     new JSONObject(
@@ -407,10 +414,28 @@ class IPVCallbackHelperTest {
         return new UserProfile()
                 .withEmail(TEST_EMAIL_ADDRESS)
                 .withEmailVerified(true)
-                .withPhoneNumber("012345678902")
+                .withPhoneNumber(TEST_PHONE_NUMBER)
                 .withPhoneNumberVerified(true)
                 .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
                 .withSubjectID(SUBJECT.getValue());
+    }
+
+    private static UserInfo generateAuthUserInfo() {
+        return new UserInfo(
+                new JSONObject(
+                        Map.of(
+                                "sub",
+                                TEST_INTERNAL_COMMON_SUBJECT_ID,
+                                "client_session_id",
+                                CLIENT_SESSION_ID,
+                                "email",
+                                TEST_EMAIL_ADDRESS,
+                                "phone_number",
+                                TEST_PHONE_NUMBER,
+                                "salt",
+                                BASE_64_ENCODED_SALT,
+                                "local_account_id",
+                                SUBJECT.getValue())));
     }
 
     public static AuthenticationRequest generateAuthRequest(OIDCClaimsRequest oidcClaimsRequest) {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -32,7 +32,6 @@ import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
-import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
@@ -97,8 +96,6 @@ class IPVCallbackHelperTest {
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String TEST_PHONE_NUMBER = "012345678902";
-    private static final Subject PUBLIC_SUBJECT =
-            new Subject("TsEVC7vg0NPAmzB33vRUFztL2c0-fecKWKcc73fuDhc");
     private static final Subject SUBJECT = new Subject("subject-id");
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
@@ -121,7 +118,6 @@ class IPVCallbackHelperTest {
     private static final Subject RP_PAIRWISE_SUBJECT = new Subject("rp-pairwise-id");
     private static final State RP_STATE = new State();
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
-    private static final UserProfile userProfile = generateUserProfile();
     private static final UserInfo authUserInfo = generateAuthUserInfo();
     private static final UserInfo p0VotUserIdentityUserInfo =
             new UserInfo(
@@ -414,16 +410,6 @@ class IPVCallbackHelperTest {
                         Map.of("https://vocab.account.gov.uk/v1/passport", "passport"),
                         "P2",
                         "");
-    }
-
-    private static UserProfile generateUserProfile() {
-        return new UserProfile()
-                .withEmail(TEST_EMAIL_ADDRESS)
-                .withEmailVerified(true)
-                .withPhoneNumber(TEST_PHONE_NUMBER)
-                .withPhoneNumberVerified(true)
-                .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
-                .withSubjectID(SUBJECT.getValue());
     }
 
     private static UserInfo generateAuthUserInfo() {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -43,7 +43,6 @@ import uk.gov.di.orchestration.shared.services.AwsSqsClient;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
-import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
@@ -84,7 +83,6 @@ class IPVCallbackHelperTest {
             mock(CloudwatchMetricsService.class);
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final DynamoIdentityService dynamoIdentityService = mock(DynamoIdentityService.class);
-    private final DynamoService dynamoService = mock(DynamoService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final OidcAPI oidcAPI = mock(OidcAPI.class);
@@ -158,7 +156,6 @@ class IPVCallbackHelperTest {
                         cloudwatchMetricsService,
                         dynamoClientService,
                         dynamoIdentityService,
-                        dynamoService,
                         SerializationService.getInstance(),
                         sessionService,
                         sqsClient,
@@ -299,7 +296,6 @@ class IPVCallbackHelperTest {
                         cloudwatchMetricsService,
                         dynamoClientService,
                         dynamoIdentityService,
-                        dynamoService,
                         objectMapperMock,
                         sessionService,
                         sqsClient,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -34,6 +34,7 @@ import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
+import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
@@ -71,6 +72,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class IPVCallbackHelperTest {
+    protected final Json objectMapper = SerializationService.getInstance();
     private final AccountInterventionService accountInterventionService =
             mock(AccountInterventionService.class);
     private final AuditContext auditContext = mock(AuditContext.class);
@@ -271,6 +273,7 @@ class IPVCallbackHelperTest {
                 new LogIds(),
                 "sector-identifier",
                 userProfile,
+                authUserInfo,
                 SUBJECT,
                 p2VotUserIdentityUserInfo,
                 CLIENT_ID.getValue());
@@ -279,7 +282,10 @@ class IPVCallbackHelperTest {
                 logging.events(),
                 hasItem(withMessageContaining("Constructing SPOT request ready to queue")));
         var spotRequestString =
-                "{\"in_claims\":{\"https://vocab.account.gov.uk/v1/coreIdentity\":\"core-identity\",\"https://vocab.account.gov.uk/v1/credentialJWT\":null,\"vot\":\"P2\",\"vtm\":\"https://base-url.com/trustmark\"},\"in_local_account_id\":\"subject-id\",\"in_salt\":null,\"in_rp_sector_id\":\"sector-identifier\",\"out_sub\":\"subject-id\",\"log_ids\":{\"session_id\":null,\"persistent_session_id\":null,\"request_id\":null,\"client_id\":null,\"client_session_id\":null},\"out_audience\":\""
+                "{\"in_claims\":{\"https://vocab.account.gov.uk/v1/coreIdentity\":\"core-identity\",\"https://vocab.account.gov.uk/v1/credentialJWT\":null,\"vot\":\"P2\",\"vtm\":\"https://base-url.com/trustmark\"},\"in_local_account_id\":\"subject-id\","
+                        + "\"in_salt\":"
+                        + objectMapper.writeValueAsString(BASE_64_ENCODED_SALT)
+                        + ",\"in_rp_sector_id\":\"sector-identifier\",\"out_sub\":\"subject-id\",\"log_ids\":{\"session_id\":null,\"persistent_session_id\":null,\"request_id\":null,\"client_id\":null,\"client_session_id\":null},\"out_audience\":\""
                         + CLIENT_ID.getValue()
                         + "\"}";
         verify(sqsClient).send(spotRequestString);
@@ -289,7 +295,7 @@ class IPVCallbackHelperTest {
 
     @Test
     void shouldThrowJsonExceptionAndDoesNotInteractWithSqsIfCannotMapRequestToJson() {
-        var objectMapper = mock(SerializationService.class);
+        var objectMapperMock = mock(SerializationService.class);
         helper =
                 new IPVCallbackHelper(
                         auditService,
@@ -299,12 +305,13 @@ class IPVCallbackHelperTest {
                         dynamoClientService,
                         dynamoIdentityService,
                         dynamoService,
-                        objectMapper,
+                        objectMapperMock,
                         sessionService,
                         sqsClient,
                         oidcAPI,
                         orchSessionService);
-        when(objectMapper.writeValueAsString(any())).thenThrow(new JsonException("json-exception"));
+        when(objectMapperMock.writeValueAsString(any()))
+                .thenThrow(new JsonException("json-exception"));
 
         var exception =
                 assertThrows(
@@ -314,6 +321,7 @@ class IPVCallbackHelperTest {
                                         new LogIds(),
                                         "sector-identifier",
                                         userProfile,
+                                        authUserInfo,
                                         SUBJECT,
                                         p2VotUserIdentityUserInfo,
                                         CLIENT_ID.getValue()),

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -272,7 +272,6 @@ class IPVCallbackHelperTest {
         helper.queueSPOTRequest(
                 new LogIds(),
                 "sector-identifier",
-                userProfile,
                 authUserInfo,
                 SUBJECT,
                 p2VotUserIdentityUserInfo,
@@ -320,7 +319,6 @@ class IPVCallbackHelperTest {
                                 helper.queueSPOTRequest(
                                         new LogIds(),
                                         "sector-identifier",
-                                        userProfile,
                                         authUserInfo,
                                         SUBJECT,
                                         p2VotUserIdentityUserInfo,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -700,7 +700,6 @@ class IPVCallbackHandlerTest {
                 .queueSPOTRequest(
                         any(),
                         anyString(),
-                        eq(userProfile),
                         eq(authUserInfo),
                         eq(new Subject(TEST_RP_PAIRWISE_ID)),
                         any(UserInfo.class),

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -73,7 +73,6 @@ import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
-import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
@@ -128,7 +127,6 @@ class IPVCallbackHandlerTest {
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
     private final AuthenticationUserInfoStorageService authUserInfoStorageService =
             mock(AuthenticationUserInfoStorageService.class);
-    private final DynamoService dynamoService = mock(DynamoService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final OrchClientSessionService orchClientSessionService =
             mock(OrchClientSessionService.class);
@@ -295,7 +293,6 @@ class IPVCallbackHandlerTest {
                         sessionService,
                         orchSessionService,
                         authUserInfoStorageService,
-                        dynamoService,
                         clientSessionService,
                         orchClientSessionService,
                         dynamoClientService,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -61,7 +61,6 @@ import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
-import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.serialization.Json;
@@ -381,10 +380,7 @@ class IPVCallbackHandlerTest {
     @MethodSource("returnCodeClaims")
     void shouldReturnAccessDeniedToRPIfReturnCodePresentButNotPermittedAndRequested(
             ClientRegistry clientRegistry, OIDCClaimsRequest claimsRequest, URI expectedURI)
-            throws UnsuccessfulCredentialResponseException,
-                    IpvCallbackException,
-                    UserNotFoundException,
-                    ParseException {
+            throws UnsuccessfulCredentialResponseException, IpvCallbackException, ParseException {
         usingValidSession();
         usingValidAuthUserInfo();
 
@@ -404,7 +400,7 @@ class IPVCallbackHandlerTest {
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
                         any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-                        any(), any()))
+                        any(), any(), any()))
                 .thenReturn(
                         new AuthenticationSuccessResponse(
                                 REDIRECT_URI, null, null, null, null, null, null));
@@ -452,7 +448,6 @@ class IPVCallbackHandlerTest {
         void shouldCallHelperWithFeatureFlag(boolean isFlagEnabled)
                 throws UnsuccessfulCredentialResponseException,
                         IpvCallbackException,
-                        UserNotFoundException,
                         ParseException {
             usingValidSession();
             usingValidAuthUserInfo();
@@ -490,7 +485,7 @@ class IPVCallbackHandlerTest {
                     .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
             when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
                             any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-                            any(), any(), any()))
+                            any(), any(), any(), any()))
                     .thenReturn(
                             new AuthenticationSuccessResponse(
                                     REDIRECT_URI, null, null, null, null, null, null));
@@ -538,10 +533,7 @@ class IPVCallbackHandlerTest {
 
     @Test
     void shouldReturnAuthCodeToRPWhenP0AndReturnCodePresentPermittedAndRequested()
-            throws UnsuccessfulCredentialResponseException,
-                    IpvCallbackException,
-                    UserNotFoundException,
-                    ParseException {
+            throws UnsuccessfulCredentialResponseException, IpvCallbackException, ParseException {
         usingValidSession();
         usingValidAuthUserInfo();
 
@@ -597,7 +589,7 @@ class IPVCallbackHandlerTest {
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
                         any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-                        any(), any()))
+                        any(), any(), any()))
                 .thenReturn(
                         new AuthenticationSuccessResponse(
                                 FRONT_END_IPV_CALLBACK_URI, null, null, null, null, null, null));

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -701,6 +701,7 @@ class IPVCallbackHandlerTest {
                         any(),
                         anyString(),
                         eq(userProfile),
+                        eq(authUserInfo),
                         eq(new Subject(TEST_RP_PAIRWISE_ID)),
                         any(UserInfo.class),
                         eq(CLIENT_ID.getValue()));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -39,7 +39,6 @@ import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
-import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
@@ -86,7 +85,6 @@ public class AuthCodeHandler
     private final AuditService auditService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final ConfigurationService configurationService;
-    private final DynamoService dynamoService;
 
     public AuthCodeHandler(
             SessionService sessionService,
@@ -99,8 +97,7 @@ public class AuthCodeHandler
             OrchClientSessionService orchClientSessionService,
             AuditService auditService,
             CloudwatchMetricsService cloudwatchMetricsService,
-            ConfigurationService configurationService,
-            DynamoService dynamoService) {
+            ConfigurationService configurationService) {
         this.sessionService = sessionService;
         this.orchSessionService = orchSessionService;
         this.authUserInfoStorageService = authUserInfoStorageService;
@@ -112,7 +109,6 @@ public class AuthCodeHandler
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.configurationService = configurationService;
-        this.dynamoService = dynamoService;
     }
 
     public AuthCodeHandler(ConfigurationService configurationService) {
@@ -127,9 +123,7 @@ public class AuthCodeHandler
         auditService = new AuditService(configurationService);
         cloudwatchMetricsService = new CloudwatchMetricsService();
         this.configurationService = configurationService;
-        dynamoService = new DynamoService(configurationService);
-        authCodeResponseService =
-                new AuthCodeResponseGenerationService(configurationService, dynamoService);
+        authCodeResponseService = new AuthCodeResponseGenerationService(configurationService);
     }
 
     public AuthCodeHandler(
@@ -145,9 +139,7 @@ public class AuthCodeHandler
         auditService = new AuditService(configurationService);
         cloudwatchMetricsService = new CloudwatchMetricsService();
         this.configurationService = configurationService;
-        dynamoService = new DynamoService(configurationService);
-        authCodeResponseService =
-                new AuthCodeResponseGenerationService(configurationService, dynamoService);
+        authCodeResponseService = new AuthCodeResponseGenerationService(configurationService);
     }
 
     public AuthCodeHandler() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -54,7 +54,6 @@ import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
-import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
@@ -120,7 +119,6 @@ class AuthCodeHandlerTest {
             mock(CloudwatchMetricsService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final Context context = mock(Context.class);
-    private final DynamoService dynamoService = mock(DynamoService.class);
     private final OrchestrationAuthorizationService orchestrationAuthorizationService =
             mock(OrchestrationAuthorizationService.class);
     private final SessionService sessionService = mock(SessionService.class);
@@ -188,8 +186,7 @@ class AuthCodeHandlerTest {
                         orchClientSessionService,
                         auditService,
                         cloudwatchMetricsService,
-                        configurationService,
-                        dynamoService);
+                        configurationService);
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(configurationService.getEnvironment()).thenReturn("unit-test");
         when(configurationService.getInternalSectorURI()).thenReturn(INTERNAL_SECTOR_URI);

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -205,25 +205,31 @@ public class RedisExtension
     }
 
     public void createClientSession(
-            String clientSessionId, String clientName, Map<String, List<String>> authRequest)
+            String clientSessionId,
+            String clientName,
+            Map<String, List<String>> authRequest,
+            String rpPairwiseId)
             throws Json.JsonException {
-        createClientSession(clientSessionId, clientName, authRequest, LocalDateTime.now());
+        createClientSession(
+                clientSessionId, clientName, authRequest, rpPairwiseId, LocalDateTime.now());
     }
 
     public void createClientSession(
             String clientSessionId,
             String clientName,
             Map<String, List<String>> authRequest,
+            String rpPairwiseId,
             LocalDateTime localDateTime)
             throws Json.JsonException {
         redis.saveWithExpiry(
                 CLIENT_SESSION_PREFIX.concat(clientSessionId),
                 objectMapper.writeValueAsString(
                         new ClientSession(
-                                authRequest,
-                                localDateTime,
-                                List.of(VectorOfTrust.getDefaults()),
-                                clientName)),
+                                        authRequest,
+                                        localDateTime,
+                                        List.of(VectorOfTrust.getDefaults()),
+                                        clientName)
+                                .setRpPairwiseId(rpPairwiseId)),
                 300);
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -7,7 +7,6 @@ import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
-import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,17 +19,9 @@ public class AuthCodeResponseGenerationService {
     private static final Logger LOG = LogManager.getLogger(AuthCodeResponseGenerationService.class);
 
     private final ConfigurationService configurationService;
-    private final DynamoService dynamoService;
-
-    public AuthCodeResponseGenerationService(
-            ConfigurationService configurationService, DynamoService dynamoService) {
-        this.configurationService = configurationService;
-        this.dynamoService = dynamoService;
-    }
 
     public AuthCodeResponseGenerationService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
-        dynamoService = new DynamoService(configurationService);
     }
 
     public AuthCodeResponseGenerationService() {
@@ -76,19 +67,6 @@ public class AuthCodeResponseGenerationService {
         dimensions.put("MfaRequired", mfaNotRequired ? "No" : "Yes");
         dimensions.put(
                 "RequestedLevelOfConfidence", clientSession.getVtrLocsAsCommaSeparatedString());
-    }
-
-    public String getSubjectId(Session session) throws UserNotFoundException {
-        var userProfile =
-                dynamoService
-                        .getUserProfileByEmailMaybe(session.getEmailAddress())
-                        .orElseThrow(
-                                () ->
-                                        new UserNotFoundException(
-                                                "Unable to find user with given email address"));
-        return Objects.isNull(session.getEmailAddress())
-                ? AuditService.UNKNOWN
-                : userProfile.getSubjectID();
     }
 
     public void saveSession(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
@@ -30,7 +30,6 @@ import static uk.gov.di.orchestration.sharedtest.helper.Constants.SESSION_ID;
 class AuthCodeResponseGenerationServiceTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private final DynamoService dynamoService = mock(DynamoService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private OrchSessionItem orchSession;
@@ -50,7 +49,7 @@ class AuthCodeResponseGenerationServiceTest {
                         .withVerifiedMfaMethodType(AUTH_APP.toString());
         session = new Session();
         authCodeResponseGenerationService =
-                new AuthCodeResponseGenerationService(configurationService, dynamoService);
+                new AuthCodeResponseGenerationService(configurationService);
         clientSession =
                 new ClientSession(
                         new HashMap<>(),


### PR DESCRIPTION
### Note:
There appears to be one instance in the past few weeks of someone getting to IPVCallback with a null salt and subject still:
https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22is%20subjectId%20the%20same%20on%20authUserInfo*%22%20message%3D%22is%20subjectId%20the%20same%20on%20authUserInfo%20as%20on%20UserProfile%3A%20false%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=-30d%40d&latest=now&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&display.events.timelineEarliestTime=1739750400&display.events.timelineLatestTime=1739836800&sid=1740406436.59117

Most peculiar. We should find out why.

Edit: This happened only once since the AuthUserInfo table got migrated to key of clientSessionId, and nothing seems odd about the journey.

### Wider context of change
This is part of the session migration work. Here, we migrate IPVCallbackHandler away from using UserProfile and to using AuthUserInfo instead. A lot has needed to happen before this PR can be raised, from destroying orch session on logout, to migrating the AuthUserInfo table itself to orch. We can now safely migrate this handler over 🥳 

### What’s changed
In a nutshell, move from using UserProfile to using AuthUserInfo. That required a lot of detangling, as a lot of properties on UserProfile are used.

Also as part of this migration, I've swapped to get rpPairwiseId from the client session instead of via UserProfile

### Manual testing
Deployed to dev and tested an identity reuse journey worked

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required**
- [x] Changes have been made to the simulator or not required. **Not required**
- [x] Changes have been made to stubs or not required. **Not required**
- [x] Successfully deployed to authdev or not required. **Not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required**
