### PR TITLE
BAU: add null check to logs, as salt is sometimes null

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -366,11 +366,17 @@ public class IPVCallbackHandler
                                         .equals(authUserInfo.get().getPhoneNumber()));
                     }
                     var saltFromAuthUserInfo = authUserInfo.get().getStringClaim("salt");
-                    var saltDecoded = Base64.getDecoder().decode(saltFromAuthUserInfo);
-                    var saltBuffer = ByteBuffer.wrap(saltDecoded).asReadOnlyBuffer();
-                    LOG.info(
-                            "is salt the same on authUserInfo as on UserProfile: {}",
-                            userProfile.getSalt().equals(saltBuffer));
+                    if (saltFromAuthUserInfo != null && !saltFromAuthUserInfo.isBlank()) {
+                        var saltDecoded = Base64.getDecoder().decode(saltFromAuthUserInfo);
+                        var saltBuffer = ByteBuffer.wrap(saltDecoded).asReadOnlyBuffer();
+                        LOG.info(
+                                "is salt the same on authUserInfo as on UserProfile: {}",
+                                userProfile.getSalt().equals(saltBuffer));
+                    } else {
+                        LOG.info(
+                                "salt on authUserInfo is null or blank. Is salt on UserProfile defined: {}",
+                                userProfile.getSalt() != null);
+                    }
                     LOG.info(
                             "is subjectId the same on authUserInfo as on UserProfile: {}",
                             userProfile


### PR DESCRIPTION
### Wider context of change
This is part of the migration work. Salt on authUserInfo is null a few times a day, so we only want to log here if it's not null. This is a temporary fix. An additional PR will be needed to figure out why it is null, but we don't want journeys to be interrupted due to non essential logging.

### What’s changed
Adds null check around a log