### PR TITLE
ATO-1362: Remove use of session id getter from AuthorisationHandler

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -75,7 +75,6 @@ public class DocAppCallbackHandler
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final NoSessionOrchestrationService noSessionOrchestrationService;
     private final AuthorisationCodeService authorisationCodeService;
-    private final CookieHelper cookieHelper;
     private final AuthFrontend authFrontend;
     private final DocAppCriAPI docAppCriApi;
     private final OrchSessionService orchSessionService;
@@ -94,7 +93,6 @@ public class DocAppCallbackHandler
             AuditService auditService,
             DynamoDocAppService dynamoDocAppService,
             AuthorisationCodeService authorisationCodeService,
-            CookieHelper cookieHelper,
             CloudwatchMetricsService cloudwatchMetricsService,
             NoSessionOrchestrationService noSessionOrchestrationService,
             AuthFrontend authFrontend,
@@ -108,7 +106,6 @@ public class DocAppCallbackHandler
         this.auditService = auditService;
         this.dynamoDocAppService = dynamoDocAppService;
         this.authorisationCodeService = authorisationCodeService;
-        this.cookieHelper = cookieHelper;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.noSessionOrchestrationService = noSessionOrchestrationService;
         this.authFrontend = authFrontend;
@@ -133,7 +130,6 @@ public class DocAppCallbackHandler
         this.auditService = new AuditService(configurationService);
         this.dynamoDocAppService = new DynamoDocAppService(configurationService);
         this.authorisationCodeService = new AuthorisationCodeService(configurationService);
-        this.cookieHelper = new CookieHelper();
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService);
@@ -161,7 +157,6 @@ public class DocAppCallbackHandler
         this.authorisationCodeService =
                 new AuthorisationCodeService(
                         configurationService, redis, SerializationService.getInstance());
-        this.cookieHelper = new CookieHelper();
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService, redis);
@@ -184,7 +179,7 @@ public class DocAppCallbackHandler
         attachTxmaAuditFieldFromHeaders(input.getHeaders());
         try {
             var sessionCookiesIds =
-                    cookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
+                    CookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
 
             if (Objects.isNull(sessionCookiesIds)) {
                 LOG.warn("No session cookie present. Attempt to find session using state");

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -39,7 +39,6 @@ import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
-import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
@@ -65,7 +64,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -94,7 +92,6 @@ class DocAppCallbackHandlerTest {
             mock(NoSessionOrchestrationService.class);
     private static final AuthorisationCodeService authorisationCodeService =
             mock(AuthorisationCodeService.class);
-    private final CookieHelper cookieHelper = mock(CookieHelper.class);
     private final DocAppCriAPI docAppCriApi = mock(DocAppCriAPI.class);
     private final AuthFrontend authFrontend = mock(AuthFrontend.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
@@ -150,7 +147,6 @@ class DocAppCallbackHandlerTest {
                         auditService,
                         dynamoDocAppService,
                         authorisationCodeService,
-                        cookieHelper,
                         cloudwatchMetricsService,
                         noSessionOrchestrationService,
                         authFrontend,
@@ -160,7 +156,6 @@ class DocAppCallbackHandlerTest {
         when(docAppCriApi.criDataURI()).thenReturn(DOC_APP_CRI_V2_URI);
         when(configService.getDocAppBackendURI()).thenReturn(CRI_URI);
         when(context.getAwsRequestId()).thenReturn(REQUEST_ID);
-        when(cookieHelper.parseSessionCookie(anyMap())).thenCallRealMethod();
         when(configService.getEnvironment()).thenReturn(ENVIRONMENT);
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -99,7 +99,6 @@ public class IPVCallbackHandler
     private final NoSessionOrchestrationService noSessionOrchestrationService;
     private final CommonFrontend frontend;
     protected final Json objectMapper = SerializationService.getInstance();
-    private final CookieHelper cookieHelper;
 
     public IPVCallbackHandler() {
         this(ConfigurationService.getInstance());
@@ -118,7 +117,6 @@ public class IPVCallbackHandler
             AuditService auditService,
             LogoutService logoutService,
             AccountInterventionService accountInterventionService,
-            CookieHelper cookieHelper,
             NoSessionOrchestrationService noSessionOrchestrationService,
             IPVCallbackHelper ipvCallbackHelper,
             CommonFrontend frontend) {
@@ -134,7 +132,6 @@ public class IPVCallbackHandler
         this.auditService = auditService;
         this.logoutService = logoutService;
         this.accountInterventionService = accountInterventionService;
-        this.cookieHelper = cookieHelper;
         this.noSessionOrchestrationService = noSessionOrchestrationService;
         this.ipvCallbackHelper = ipvCallbackHelper;
         this.frontend = frontend;
@@ -163,7 +160,6 @@ public class IPVCallbackHandler
                         configurationService,
                         new CloudwatchMetricsService(configurationService),
                         auditService);
-        this.cookieHelper = new CookieHelper();
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService);
         this.ipvCallbackHelper = new IPVCallbackHelper(configurationService);
@@ -191,7 +187,6 @@ public class IPVCallbackHandler
                         configurationService,
                         new CloudwatchMetricsService(configurationService),
                         auditService);
-        this.cookieHelper = new CookieHelper();
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService, redis);
         this.ipvCallbackHelper = new IPVCallbackHelper(configurationService, redis);
@@ -215,7 +210,7 @@ public class IPVCallbackHandler
                 throw new IpvCallbackException("Identity is not enabled");
             }
             var sessionCookiesIds =
-                    cookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
+                    CookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
             if (Objects.isNull(sessionCookiesIds)) {
                 var noSessionEntity =
                         noSessionOrchestrationService.generateNoSessionOrchestrationEntity(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -61,7 +61,6 @@ import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
@@ -127,7 +126,6 @@ class IPVCallbackHandlerTest {
     private final AuthenticationUserInfoStorageService authUserInfoStorageService =
             mock(AuthenticationUserInfoStorageService.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
-    private final CookieHelper cookieHelper = mock(CookieHelper.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final DynamoIdentityService dynamoIdentityService = mock(DynamoIdentityService.class);
@@ -279,7 +277,6 @@ class IPVCallbackHandlerTest {
                         auditService,
                         logoutService,
                         accountInterventionService,
-                        cookieHelper,
                         noSessionOrchestrationService,
                         ipvCallbackHelper,
                         frontend);
@@ -291,7 +288,6 @@ class IPVCallbackHandlerTest {
         when(configService.isIdentityEnabled()).thenReturn(true);
         when(configService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
         when(context.getAwsRequestId()).thenReturn(REQUEST_ID);
-        when(cookieHelper.parseSessionCookie(anyMap())).thenCallRealMethod();
         when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(salt);
         when(accountInterventionService.getAccountIntervention(anyString(), any()))
                 .thenReturn(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/LogoutRequest.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/LogoutRequest.java
@@ -41,7 +41,6 @@ public class LogoutRequest {
     private Optional<String> rpPairwiseId = Optional.empty();
     Optional<URI> postLogoutRedirectUri = Optional.empty();
     private Optional<ClientRegistry> clientRegistry = Optional.empty();
-    private final CookieHelper cookieHelper = new CookieHelper();
 
     public LogoutRequest(
             SessionService sessionService,
@@ -173,7 +172,7 @@ public class LogoutRequest {
     }
 
     private Optional<String> extractClientSessionIdFromCookieHeaders(Map<String, String> headers) {
-        var sessionCookieIds = cookieHelper.parseSessionCookie(headers);
+        var sessionCookieIds = CookieHelper.parseSessionCookie(headers);
         return sessionCookieIds.map(CookieHelper.SessionCookieIds::getClientSessionId);
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -113,7 +113,6 @@ public class AuthenticationCallbackHandler
     private final ClientService clientService;
     private final InitiateIPVAuthorisationService initiateIPVAuthorisationService;
     private final AccountInterventionService accountInterventionService;
-    private final CookieHelper cookieHelper;
     private final LogoutService logoutService;
     private final AuthFrontend authFrontend;
 
@@ -135,7 +134,6 @@ public class AuthenticationCallbackHandler
         this.auditService = new AuditService(configurationService);
         this.userInfoStorageService =
                 new AuthenticationUserInfoStorageService(configurationService);
-        this.cookieHelper = new CookieHelper();
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.authorisationCodeService = new AuthorisationCodeService(configurationService);
         this.clientService = new DynamoClientService(configurationService);
@@ -176,7 +174,6 @@ public class AuthenticationCallbackHandler
         this.auditService = new AuditService(configurationService);
         this.userInfoStorageService =
                 new AuthenticationUserInfoStorageService(configurationService);
-        this.cookieHelper = new CookieHelper();
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.authorisationCodeService =
                 new AuthorisationCodeService(
@@ -214,7 +211,6 @@ public class AuthenticationCallbackHandler
             ClientSessionService clientSessionService,
             AuditService auditService,
             AuthenticationUserInfoStorageService dynamoAuthUserInfoService,
-            CookieHelper cookieHelper,
             CloudwatchMetricsService cloudwatchMetricsService,
             AuthorisationCodeService authorisationCodeService,
             ClientService clientService,
@@ -230,7 +226,6 @@ public class AuthenticationCallbackHandler
         this.clientSessionService = clientSessionService;
         this.auditService = auditService;
         this.userInfoStorageService = dynamoAuthUserInfoService;
-        this.cookieHelper = cookieHelper;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.authorisationCodeService = authorisationCodeService;
         this.clientService = clientService;
@@ -248,7 +243,7 @@ public class AuthenticationCallbackHandler
 
         try {
             CookieHelper.SessionCookieIds sessionCookiesIds =
-                    cookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
+                    CookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
 
             if (sessionCookiesIds == null) {
                 throw new AuthenticationCallbackException("No session cookie found");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -36,7 +36,6 @@ public class LogoutHandler
     private final SessionService sessionService;
     private final DynamoClientService dynamoClientService;
     private final TokenValidationService tokenValidationService;
-    private final CookieHelper cookieHelper;
 
     private final LogoutService logoutService;
 
@@ -53,7 +52,6 @@ public class LogoutHandler
                                 configurationService,
                                 new KmsConnectionService(configurationService)),
                         configurationService);
-        this.cookieHelper = new CookieHelper();
         this.logoutService = new LogoutService(configurationService);
     }
 
@@ -66,7 +64,6 @@ public class LogoutHandler
                                 configurationService,
                                 new KmsConnectionService(configurationService)),
                         configurationService);
-        this.cookieHelper = new CookieHelper();
         this.logoutService = new LogoutService(configurationService);
     }
 
@@ -78,7 +75,6 @@ public class LogoutHandler
         this.sessionService = sessionService;
         this.dynamoClientService = dynamoClientService;
         this.tokenValidationService = tokenValidationService;
-        this.cookieHelper = new CookieHelper();
         this.logoutService = logoutService;
     }
 
@@ -115,7 +111,7 @@ public class LogoutHandler
 
     private void attachSessionToLogs(Session session, Map<String, String> headers) {
         CookieHelper.SessionCookieIds sessionCookieIds =
-                cookieHelper.parseSessionCookie(headers).orElseThrow();
+                CookieHelper.parseSessionCookie(headers).orElseThrow();
         attachSessionIdToLogs(session);
         attachLogFieldToLogs(CLIENT_SESSION_ID, sessionCookieIds.getClientSessionId());
         attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, sessionCookieIds.getClientSessionId());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helper/TestIdGeneratorHelper.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helper/TestIdGeneratorHelper.java
@@ -1,0 +1,43 @@
+package uk.gov.di.authentication.oidc.helper;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import uk.gov.di.orchestration.shared.helpers.IdGenerator;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+import static org.mockito.AdditionalAnswers.returnsElementsOf;
+import static org.mockito.Mockito.mockStatic;
+
+public class TestIdGeneratorHelper {
+    public static <T> T runWithIds(Supplier<T> method, List<String> ids) {
+        try (var mockIdGenerator = mockStatic(IdGenerator.class)) {
+            mockIdGenerator.when(IdGenerator::generate).then(returnsElementsOf(ids));
+            return method.get();
+        }
+    }
+
+    public static <T> T runWithIncrementalIds(Supplier<T> method, String idPrefix) {
+        var incrementalIdGenerator = new IncrementalIdGenerator(idPrefix);
+        try (var mockIdGenerator = mockStatic(IdGenerator.class)) {
+            mockIdGenerator.when(IdGenerator::generate).then(incrementalIdGenerator);
+            return method.get();
+        }
+    }
+
+    private static class IncrementalIdGenerator implements Answer<String> {
+        private final String prefix;
+        private int idNum = 1;
+
+        IncrementalIdGenerator(String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public String answer(InvocationOnMock invocation) {
+            return format("%s%d", prefix, idNum++);
+        }
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helper/TestIdGeneratorHelperTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helper/TestIdGeneratorHelperTest.java
@@ -1,0 +1,31 @@
+package uk.gov.di.authentication.oidc.helper;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.shared.helpers.IdGenerator;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.oidc.helper.TestIdGeneratorHelper.runWithIds;
+import static uk.gov.di.authentication.oidc.helper.TestIdGeneratorHelper.runWithIncrementalIds;
+
+class TestIdGeneratorHelperTest {
+    @Test
+    void shouldUseIdsProvidedForMock() {
+        assertEquals(
+                "test-id-1,test-id-2,test-id-3",
+                runWithIds(this::generateId, List.of("test-id-1", "test-id-2", "test-id-3")));
+    }
+
+    @Test
+    void shouldUseIncrementalIdsForMock() {
+        var prefix = "test-id-";
+        assertEquals(
+                "test-id-1,test-id-2,test-id-3", runWithIncrementalIds(this::generateId, prefix));
+    }
+
+    private String generateId() {
+        return String.format(
+                "%s,%s,%s", IdGenerator.generate(), IdGenerator.generate(), IdGenerator.generate());
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
@@ -21,6 +21,8 @@ public class CookieHelper {
 
     public static final String LANGUAGE_COOKIE_NAME = "lng";
 
+    private CookieHelper() {}
+
     public static Optional<HttpCookie> getHttpCookieFromRequestHeaders(
             Map<String, String> headers, String cookieName) {
         return getHttpCookieFromHeaders(headers, cookieName, REQUEST_COOKIE_HEADER);
@@ -78,14 +80,10 @@ public class CookieHelper {
     }
 
     public static Optional<String> getSessionIdFromRequestHeaders(Map<String, String> headers) {
-        return parseSessionCookieStatic(headers).map(SessionCookieIds::getSessionId);
+        return parseSessionCookie(headers).map(SessionCookieIds::getSessionId);
     }
 
-    public static Optional<SessionCookieIds> parseSessionCookieStatic(Map<String, String> headers) {
-        return new CookieHelper().parseSessionCookie(headers);
-    }
-
-    public Optional<SessionCookieIds> parseSessionCookie(Map<String, String> headers) {
+    public static Optional<SessionCookieIds> parseSessionCookie(Map<String, String> headers) {
         Optional<HttpCookie> httpCookie =
                 getHttpCookieFromRequestHeaders(headers, SESSION_COOKIE_NAME);
         if (httpCookie.isEmpty()) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
@@ -77,6 +77,14 @@ public class CookieHelper {
         return parseStringToHttpCookie(cookie);
     }
 
+    public static Optional<String> getSessionIdFromRequestHeaders(Map<String, String> headers) {
+        return parseSessionCookieStatic(headers).map(SessionCookieIds::getSessionId);
+    }
+
+    public static Optional<SessionCookieIds> parseSessionCookieStatic(Map<String, String> headers) {
+        return new CookieHelper().parseSessionCookie(headers);
+    }
+
     public Optional<SessionCookieIds> parseSessionCookie(Map<String, String> headers) {
         Optional<HttpCookie> httpCookie =
                 getHttpCookieFromRequestHeaders(headers, SESSION_COOKIE_NAME);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/CookieHelper.java
@@ -83,6 +83,11 @@ public class CookieHelper {
         return parseSessionCookie(headers).map(SessionCookieIds::getSessionId);
     }
 
+    public static Optional<String> getClientSessionIdFromRequestHeaders(
+            Map<String, String> headers) {
+        return parseSessionCookie(headers).map(SessionCookieIds::getClientSessionId);
+    }
+
     public static Optional<SessionCookieIds> parseSessionCookie(Map<String, String> headers) {
         Optional<HttpCookie> httpCookie =
                 getHttpCookieFromRequestHeaders(headers, SESSION_COOKIE_NAME);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -254,7 +254,7 @@ public class LogoutService {
     }
 
     private Optional<String> extractClientSessionIdFromCookieHeaders(Map<String, String> headers) {
-        var sessionCookieIds = new CookieHelper().parseSessionCookie(headers);
+        var sessionCookieIds = CookieHelper.parseSessionCookie(headers);
         return sessionCookieIds.map(CookieHelper.SessionCookieIds::getClientSessionId);
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -253,18 +253,14 @@ public class LogoutService {
                 metadata.toArray(AuditService.MetadataPair[]::new));
     }
 
-    private Optional<String> extractClientSessionIdFromCookieHeaders(Map<String, String> headers) {
-        var sessionCookieIds = CookieHelper.parseSessionCookie(headers);
-        return sessionCookieIds.map(CookieHelper.SessionCookieIds::getClientSessionId);
-    }
-
     private TxmaAuditUser createAuditUser(APIGatewayProxyRequestEvent input, Session session) {
         return TxmaAuditUser.user()
                 .withIpAddress(extractIpAddress(input))
                 .withPersistentSessionId(extractPersistentIdFromCookieHeader(input.getHeaders()))
                 .withSessionId(session.getSessionId())
                 .withGovukSigninJourneyId(
-                        extractClientSessionIdFromCookieHeaders(input.getHeaders()).orElse(null))
+                        CookieHelper.getClientSessionIdFromRequestHeaders(input.getHeaders())
+                                .orElse(null))
                 .withUserId(session.getInternalCommonSubjectIdentifier());
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
@@ -23,14 +23,12 @@ public class OrchSessionService extends BaseDynamoService<OrchSessionItem> {
     private static final Logger LOG = LogManager.getLogger(OrchSessionService.class);
 
     private final ConfigurationService configurationService;
-    private final CookieHelper cookieHelper;
 
     private final long timeToLive;
 
     public OrchSessionService(ConfigurationService configurationService) {
         super(OrchSessionItem.class, "Orch-Session", configurationService, true);
         this.timeToLive = configurationService.getSessionExpiry();
-        this.cookieHelper = new CookieHelper();
         this.configurationService = configurationService;
     }
 
@@ -40,7 +38,6 @@ public class OrchSessionService extends BaseDynamoService<OrchSessionItem> {
             ConfigurationService configurationService) {
         super(dynamoDbTable, dynamoDbClient);
         this.timeToLive = configurationService.getSessionExpiry();
-        this.cookieHelper = new CookieHelper();
         this.configurationService = configurationService;
     }
 
@@ -121,7 +118,7 @@ public class OrchSessionService extends BaseDynamoService<OrchSessionItem> {
 
     public Optional<OrchSessionItem> getSessionFromSessionCookie(Map<String, String> headers) {
         try {
-            Optional<CookieHelper.SessionCookieIds> ids = cookieHelper.parseSessionCookie(headers);
+            Optional<CookieHelper.SessionCookieIds> ids = CookieHelper.parseSessionCookie(headers);
             return ids.flatMap(s -> getSession(s.getSessionId()));
         } catch (Exception e) {
             logAndThrowOrchSessionException(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -84,12 +84,17 @@ public class SessionService {
     }
 
     public void updateWithNewSessionId(Session session, String newSessionId) {
+        updateWithNewSessionId(session, session.getSessionId(), newSessionId);
+    }
+
+    public Session updateWithNewSessionId(
+            Session session, String oldSessionId, String newSessionId) {
         try {
-            String oldSessionId = session.getSessionId();
             session.setSessionId(newSessionId);
             session.resetProcessingIdentityAttempts();
             storeOrUpdateSession(session, oldSessionId);
             redisConnectionService.deleteValue(oldSessionId);
+            return session;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -24,14 +24,12 @@ public class SessionService {
 
     private final ConfigurationService configurationService;
     private final RedisConnectionService redisConnectionService;
-    private final CookieHelper cookieHelper;
 
     public SessionService(
             ConfigurationService configurationService,
             RedisConnectionService redisConnectionService) {
         this.configurationService = configurationService;
         this.redisConnectionService = redisConnectionService;
-        this.cookieHelper = new CookieHelper();
     }
 
     public SessionService(ConfigurationService configurationService) {
@@ -129,7 +127,7 @@ public class SessionService {
 
     public Optional<Session> getSessionFromSessionCookie(Map<String, String> headers) {
         try {
-            Optional<CookieHelper.SessionCookieIds> ids = cookieHelper.parseSessionCookie(headers);
+            Optional<CookieHelper.SessionCookieIds> ids = CookieHelper.parseSessionCookie(headers);
             return ids.flatMap(s -> getSession(s.getSessionId()));
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/CookieHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/CookieHelperTest.java
@@ -25,7 +25,6 @@ import static uk.gov.di.orchestration.shared.helpers.CookieHelper.parseBrowserSe
 import static uk.gov.di.orchestration.shared.helpers.CookieHelper.parsePersistentCookie;
 
 class CookieHelperTest {
-    private static final CookieHelper cookieHelper = new CookieHelper();
 
     static Stream<String> inputs() {
         return Stream.of(REQUEST_COOKIE_HEADER, REQUEST_COOKIE_HEADER.toLowerCase());
@@ -47,7 +46,7 @@ class CookieHelperTest {
                 "Version=1; gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts";
         Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString));
 
-        CookieHelper.SessionCookieIds ids = cookieHelper.parseSessionCookie(headers).orElseThrow();
+        CookieHelper.SessionCookieIds ids = CookieHelper.parseSessionCookie(headers).orElseThrow();
 
         assertEquals("session-id", ids.getSessionId());
         assertEquals("456", ids.getClientSessionId());
@@ -73,7 +72,7 @@ class CookieHelperTest {
         HttpCookie cookie = new HttpCookie("gs", "session-id.456");
         Map<String, String> headers = Map.ofEntries(Map.entry(header, cookie.toString()));
 
-        CookieHelper.SessionCookieIds ids = cookieHelper.parseSessionCookie(headers).orElseThrow();
+        CookieHelper.SessionCookieIds ids = CookieHelper.parseSessionCookie(headers).orElseThrow();
 
         assertEquals("session-id", ids.getSessionId());
         assertEquals("456", ids.getClientSessionId());
@@ -133,22 +132,22 @@ class CookieHelperTest {
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
     void shouldReturnEmptyIfSessionCookieNotPresent(String header) {
-        assertEmpty(cookieHelper.parseSessionCookie(null));
-        assertEmpty(cookieHelper.parseSessionCookie(Map.of()));
-        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "value")));
+        assertEmpty(CookieHelper.parseSessionCookie(null));
+        assertEmpty(CookieHelper.parseSessionCookie(Map.of()));
+        assertEmpty(CookieHelper.parseSessionCookie(Map.of(header, "value")));
     }
 
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
     void shouldReturnEmptyIfCookieMalformatted(String header) {
-        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "")));
-        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "someinvalidvalue")));
-        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "gs=this is bad")));
-        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "gs=no-dot")));
+        assertEmpty(CookieHelper.parseSessionCookie(Map.of(header, "")));
+        assertEmpty(CookieHelper.parseSessionCookie(Map.of(header, "someinvalidvalue")));
+        assertEmpty(CookieHelper.parseSessionCookie(Map.of(header, "gs=this is bad")));
+        assertEmpty(CookieHelper.parseSessionCookie(Map.of(header, "gs=no-dot")));
         assertEmpty(
-                cookieHelper.parseSessionCookie(
+                CookieHelper.parseSessionCookie(
                         Map.of(header, "gs=one-value.two-value.three-value;")));
-        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "gsdsds=one-value.two-value")));
+        assertEmpty(CookieHelper.parseSessionCookie(Map.of(header, "gsdsds=one-value.two-value")));
     }
 
     @ParameterizedTest(name = "with header {0}")


### PR DESCRIPTION
### Wider context of change

We would like to migrate away from the shared session and use the orch session instead. The parent issue for this is for migrating use of the sessionId. We've already used setters to set the sessionId on OrchSessionItem and AuthSessionItem. This issue is for removing the getters.

### What’s changed

This PR removes usage of `Session.getSessionId()` from `AuthorisationHandler`. To achieve this, we get the session ID from the cookie first, instead of getting the session directly from the cookie. We can then pass this sessionId variable around and use it where `Session.getSessionId()` was used.

The tests for this handler were also slightly inaccurate. In most cases, they were mocking `generateSession()` with the same session that you already had at the start of the workflow. Instead, I've created a new variable for the new session (the same as the old session except with the new ID), and updated all the assertions to use this.

Finally, I've extracted a test helper class TestIdGeneratorHelper, which adds a shortcut to static mocking the IdGenerator class. You can use it like so: `var result = runWithIds(() -> methodWhichGeneratesIds(), List.of("id1", "id2"));`.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
