### PR TITLE
ATO-1378: Remove use of session id getter from RedisExtension

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -885,7 +885,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                 throws Json.JsonException {
             var session = new Session(PREVIOUS_SESSION_ID).setEmailAddress(TEST_EMAIL_ADDRESS);
             PREVIOUS_CLIENT_SESSIONS.forEach(session::addClientSession);
-            redis.addSession(session);
+            redis.addSessionWithId(session, PREVIOUS_SESSION_ID);
             redis.addStateToRedis(
                     AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX,
                     ORCH_TO_AUTH_STATE,

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -51,14 +51,12 @@ public class RedisExtension
             throws Json.JsonException {
         Session session = new Session(sessionId).setAuthenticated(isAuthenticated);
         email.ifPresent(session::setEmailAddress);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
-        return session.getSessionId();
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
+        return sessionId;
     }
 
-    public Session addSession(Session session) throws Json.JsonException {
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+    public Session addSessionWithId(Session session, String sessionId) throws Json.JsonException {
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
         return session;
     }
 
@@ -66,8 +64,7 @@ public class RedisExtension
             throws Json.JsonException {
         var session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.setVerifiedMfaMethodType(mfaMethodType);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public String createSession() throws Json.JsonException {
@@ -108,16 +105,14 @@ public class RedisExtension
             throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.addClientSession(clientSessionId);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public void incrementInitialProcessingIdentityAttemptsInSession(String sessionId)
             throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.incrementProcessingIdentityAttempts();
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public void addAuthRequestToSession(
@@ -128,8 +123,7 @@ public class RedisExtension
             throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.addClientSession(clientSessionId);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
         redis.saveWithExpiry(
                 CLIENT_SESSION_PREFIX.concat(clientSessionId),
                 objectMapper.writeValueAsString(
@@ -157,16 +151,14 @@ public class RedisExtension
     public void addEmailToSession(String sessionId, String emailAddress) throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.setEmailAddress(emailAddress);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public void setSessionCredentialTrustLevel(
             String sessionId, CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.setCurrentCredentialStrength(credentialTrustLevel);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public Session getSession(String sessionId) throws Json.JsonException {


### PR DESCRIPTION
### Wider context of change

We would like to migrate away from the shared session and use the orch session instead. The parent issue for this is for migrating use of the sessionId. We've already used setters to set the sessionId on OrchSessionItem and AuthSessionItem. This issue is for removing the getters.

### What’s changed

This PR removes usage of `Session.getSessionId()` from `RedisExtension`. In most cases, the sessionID was already available, so we did not need to call the getter. The method signature for adding a new session had to be updated to pass in the session ID in addition to the session.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
