### PR TITLE
ATO-1365: Remove use of session id getter from DocAppCallbackHandler

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -206,34 +206,27 @@ public class DocAppCallbackHandler
                                                 .getDocAppSubjectId()
                                                 .getValue()));
             }
+            var sessionId = sessionCookiesIds.getSessionId();
+            var clientSessionId = sessionCookiesIds.getClientSessionId();
             var session =
                     sessionService
-                            .getSession(sessionCookiesIds.getSessionId())
-                            .orElseThrow(
-                                    () -> {
-                                        throw new DocAppCallbackException("Session not found");
-                                    });
+                            .getSession(sessionId)
+                            .orElseThrow(() -> new DocAppCallbackException("Session not found"));
 
             var orchSession =
                     orchSessionService
-                            .getSession(sessionCookiesIds.getSessionId())
+                            .getSession(sessionId)
                             .orElseThrow(
-                                    () -> {
-                                        throw new DocAppCallbackException("Orch Session not found");
-                                    });
+                                    () -> new DocAppCallbackException("Orch Session not found"));
 
-            attachSessionIdToLogs(session);
-            var clientSessionId = sessionCookiesIds.getClientSessionId();
+            attachSessionIdToLogs(sessionId);
             attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
             attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
             var clientSession =
                     clientSessionService
                             .getClientSession(clientSessionId)
                             .orElseThrow(
-                                    () -> {
-                                        throw new DocAppCallbackException(
-                                                "ClientSession not found");
-                                    });
+                                    () -> new DocAppCallbackException("ClientSession not found"));
             if (Objects.isNull(clientSession.getDocAppSubjectId()))
                 throw new DocAppCallbackException("No DocAppSubjectId present in ClientSession");
 
@@ -249,12 +242,12 @@ public class DocAppCallbackHandler
 
             var errorObject =
                     authorisationService.validateResponse(
-                            input.getQueryStringParameters(), session.getSessionId());
+                            input.getQueryStringParameters(), sessionId);
 
             var user =
                     TxmaAuditUser.user()
                             .withGovukSigninJourneyId(clientSessionId)
-                            .withSessionId(session.getSessionId())
+                            .withSessionId(sessionId)
                             .withUserId(clientSession.getDocAppSubjectId().getValue());
 
             if (errorObject.isPresent()) {


### PR DESCRIPTION
### Wider context of change

We would like to migrate away from the shared session and use the orch session instead. The parent issue for this is for migrating use of the sessionId. We've already used setters to set the sessionId on OrchSessionItem and AuthSessionItem. This issue is for removing the getters.

### What’s changed

This PR removes usage of `Session.getSessionId()` from `DocAppCallbackHandler`. The session id was already available , so we did not need to call the getter.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
