### PR TITLE
ATO-1364: Remove use of session id getter from AuthCodeHandler

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -79,6 +79,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
@@ -575,10 +576,8 @@ class AuthCodeHandlerTest {
                         SESSION_ID,
                         PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
                         PERSISTENT_SESSION_ID));
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
-        when(orchSessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(orchSession));
+        when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
+        when(orchSessionService.getSession(anyString())).thenReturn(Optional.of(orchSession));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -673,10 +672,8 @@ class AuthCodeHandlerTest {
 
     private void generateValidSession(
             Map<String, List<String>> authRequestParams, CredentialTrustLevel requestedLevel) {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
-        when(orchSessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(orchSession));
+        when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
+        when(orchSessionService.getSession(anyString())).thenReturn(Optional.of(orchSession));
         when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(clientSession));
         when(vectorOfTrust.getCredentialTrustLevel()).thenReturn(requestedLevel);


### PR DESCRIPTION
### Wider context of change

We would like to migrate away from the shared session and use the orch session instead. The parent issue for this is for migrating use of the sessionId. We've already used setters to set the sessionId on OrchSessionItem and AuthSessionItem. This issue is for removing the getters.

### What’s changed

This PR removes usage of `Session.getSessionId()` from `AuthCodeHandler`. The session id was already available in the request headers, so we did not need to call the getter.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
