### PR TITLE
ATO-1376: Remove use of session id getter in IPVCallbackHandler

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -193,6 +193,7 @@ public class IPVCallbackHelper {
             String clientSessionId,
             UserProfile userProfile,
             Session session,
+            String sessionId,
             OrchSessionItem orchSession,
             ClientSession clientSession,
             Subject rpPairwiseSubject,
@@ -242,7 +243,7 @@ public class IPVCallbackHelper {
                 authRequest.getClientID().getValue(),
                 TxmaAuditUser.user()
                         .withGovukSigninJourneyId(clientSessionId)
-                        .withSessionId(session.getSessionId())
+                        .withSessionId(sessionId)
                         .withUserId(internalPairwiseSubjectId)
                         .withEmail(
                                 Optional.ofNullable(session.getEmailAddress())

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -381,7 +381,7 @@ class IPVCallbackHandlerTest {
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
                         any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-                        any()))
+                        any(), any()))
                 .thenReturn(
                         new AuthenticationSuccessResponse(
                                 REDIRECT_URI, null, null, null, null, null, null));
@@ -446,7 +446,7 @@ class IPVCallbackHandlerTest {
                     .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
             when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
                             any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-                            any(), any()))
+                            any(), any(), any()))
                     .thenReturn(
                             new AuthenticationSuccessResponse(
                                     REDIRECT_URI, null, null, null, null, null, null));
@@ -523,7 +523,7 @@ class IPVCallbackHandlerTest {
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
                         any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-                        any()))
+                        any(), any()))
                 .thenReturn(
                         new AuthenticationSuccessResponse(
                                 FRONT_END_IPV_CALLBACK_URI, null, null, null, null, null, null));


### PR DESCRIPTION
### Wider context of change

We would like to migrate away from the shared session and use the orch session instead. The parent issue for this is for migrating use of the sessionId. We've already used setters to set the sessionId on OrchSessionItem and AuthSessionItem. This issue is for removing the getters.

### What’s changed

This PR removes usage of `Session.getSessionId()` from IPVCallbackHandler`. The session id was already available , so we did not need to call the getter.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
