### PR TITLE
BAU: Fix account interventions alarm

### DIFF
--- a/ci/terraform/oidc/account-interventions-alerts.tf
+++ b/ci/terraform/oidc/account-interventions-alerts.tf
@@ -45,7 +45,3 @@ resource "aws_cloudwatch_metric_alarm" "account_interventions_p1_cloudwatch_alar
     Service = "account-interventions"
   }
 }
-moved {
-  from = aws_cloudwatch_metric_alarm.account_interventions_p1_cloudwatch_alarm[0]
-  to   = aws_cloudwatch_metric_alarm.account_interventions_p1_cloudwatch_alarm
-}


### PR DESCRIPTION
## What

I forgot to remove a `moved` block, left over from the localstack removal. That causes terraform to get in a tizzy.

## How to review

Code review
