### PR TITLE
ATO-1389: add infrastructure for AuthUserInfo DynamoDb table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -481,6 +481,66 @@ Resources:
 
   #endregion
 
+  #region AuthUserInfo DynamoDB Table
+
+  AuthUserInfoEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS encryption key for AuthUserInfo DynamoDB table
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Sid: AllowDynamodbAccessToEncryptionKey
+            Effect: Allow
+            Principal:
+              Service: dynamodb.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+
+  AuthUserInfoTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${Environment}-Auth-User-Info
+      AttributeDefinitions:
+        - AttributeName: InternalCommonSubjectId
+          AttributeType: S
+        - AttributeName: ClientSessionId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: InternalCommonSubjectId
+          KeyType: HASH
+        - AttributeName: ClientSessionId
+          KeyType: RANGE
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEEnabled: true
+        KMSMasterKeyId: !GetAtt AuthUserInfoEncryptionKey.Arn
+        SSEType: KMS
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - Key: Name
+          Value: AuthUserInfoTable
+  #endregion
+
   #region RP Public Key DynamoDB Table
 
   RpPublicKeyTableEncryptionKey:


### PR DESCRIPTION
### Wider context of change
This table will replace the table of the same name that exists on Auth accounts. This table will store the UserInfo that Auth sents to Orch. Auth don't need to know about the table. In this migration, we also fix an issue with the current table, which is only indexed by internalCommonSubjectId. If a user has multiple client sessions, the authUserInfo entry gets overwritten. Hence, we have clientSessionId as a sort key as well. We keep ICSID as the partition key so we can still easily delete user data on request.

### What’s changed
Add infrastructure for AuthUserInfo DynamoDb table 

### Manual testing
Deployed to Dev. Built successfully, and saw that ICSID was the partitian key and ClientSessionId the sort key

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
