### PR TITLE
BAU: Attach session ids to notify payloads

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -363,7 +363,12 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
 
             var notifyRequest =
                     new NotifyRequest(
-                            destination, notificationType, code, userContext.getUserLanguage());
+                            destination,
+                            notificationType,
+                            code,
+                            userContext.getUserLanguage(),
+                            session.getSessionId(),
+                            userContext.getClientSessionId());
             emailSqsClient.send(objectMapper.writeValueAsString((notifyRequest)));
             LOG.info("{} placed on queue", request.getNotificationType());
             LOG.info("Successfully processed request");

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -249,7 +249,9 @@ class SendNotificationHandlerTest {
                                                 EMAIL,
                                                 notificationType,
                                                 TEST_SIX_DIGIT_CODE,
-                                                SupportedLanguage.EN)));
+                                                SupportedLanguage.EN,
+                                                SESSION_ID,
+                                                CLIENT_SESSION_ID)));
                 if (notificationType == NotificationType.VERIFY_EMAIL
                         && journeyType == JourneyType.REGISTRATION) {
                     verify(pendingEmailCheckSqsClient)
@@ -392,7 +394,9 @@ class SendNotificationHandlerTest {
                                         EMAIL,
                                         notificationType,
                                         TEST_SIX_DIGIT_CODE,
-                                        SupportedLanguage.EN)));
+                                        SupportedLanguage.EN,
+                                        SESSION_ID,
+                                        CLIENT_SESSION_ID)));
         var expectedEvent =
                 notificationType.equals(VERIFY_EMAIL)
                         ? AUTH_EMAIL_CODE_SENT
@@ -434,7 +438,9 @@ class SendNotificationHandlerTest {
                                         CommonTestVariables.UK_MOBILE_NUMBER,
                                         VERIFY_PHONE_NUMBER,
                                         TEST_SIX_DIGIT_CODE,
-                                        SupportedLanguage.EN)));
+                                        SupportedLanguage.EN,
+                                        SESSION_ID,
+                                        CLIENT_SESSION_ID)));
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_PHONE_CODE_SENT, auditContext.withPhoneNumber(UK_MOBILE_NUMBER));
@@ -565,7 +571,9 @@ class SendNotificationHandlerTest {
                                         EMAIL,
                                         notificationType,
                                         TEST_SIX_DIGIT_CODE,
-                                        SupportedLanguage.EN)));
+                                        SupportedLanguage.EN,
+                                        SESSION_ID,
+                                        CLIENT_SESSION_ID)));
 
         var body =
                 format(
@@ -641,7 +649,9 @@ class SendNotificationHandlerTest {
                                         phoneNumber,
                                         VERIFY_PHONE_NUMBER,
                                         TEST_SIX_DIGIT_CODE,
-                                        SupportedLanguage.EN)));
+                                        SupportedLanguage.EN,
+                                        SESSION_ID,
+                                        CLIENT_SESSION_ID)));
         verify(auditService)
                 .submitAuditEvent(AUTH_PHONE_CODE_SENT, auditContext.withPhoneNumber(phoneNumber));
     }


### PR DESCRIPTION
We're logging these on the other side of the queue but not actually putting the values in the payload.
