### PR TITLE
ATO-1358: orch cross browser

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AuthenticationCallbackException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AuthenticationCallbackException.java
@@ -4,4 +4,8 @@ public class AuthenticationCallbackException extends RuntimeException {
     public AuthenticationCallbackException(String message) {
         super(message);
     }
+
+    public AuthenticationCallbackException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -44,6 +44,7 @@ import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.Session.AccountState;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
+import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
@@ -115,6 +116,7 @@ public class AuthenticationCallbackHandler
     private final AccountInterventionService accountInterventionService;
     private final LogoutService logoutService;
     private final AuthFrontend authFrontend;
+    private final NoSessionOrchestrationService noSessionOrchestrationService;
 
     public AuthenticationCallbackHandler() {
         this(ConfigurationService.getInstance());
@@ -156,13 +158,15 @@ public class AuthenticationCallbackHandler
                         configurationService, cloudwatchMetricsService, auditService);
         this.logoutService = new LogoutService(configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
+        this.noSessionOrchestrationService =
+                new NoSessionOrchestrationService(configurationService);
     }
 
     public AuthenticationCallbackHandler(
-            ConfigurationService configurationService, RedisConnectionService redis) {
+            ConfigurationService configurationService,
+            RedisConnectionService redisConnectionService) {
 
         var kmsConnectionService = new KmsConnectionService(configurationService);
-        var redisConnectionService = redis;
         this.configurationService = configurationService;
         this.authorisationService = new AuthenticationAuthorizationService(redisConnectionService);
         this.tokenService =
@@ -200,6 +204,8 @@ public class AuthenticationCallbackHandler
                         configurationService, cloudwatchMetricsService, auditService);
         this.logoutService = new LogoutService(configurationService, redisConnectionService);
         this.authFrontend = new AuthFrontend(configurationService);
+        this.noSessionOrchestrationService =
+                new NoSessionOrchestrationService(configurationService, redisConnectionService);
     }
 
     public AuthenticationCallbackHandler(
@@ -217,7 +223,8 @@ public class AuthenticationCallbackHandler
             InitiateIPVAuthorisationService initiateIPVAuthorisationService,
             AccountInterventionService accountInterventionService,
             LogoutService logoutService,
-            AuthFrontend authFrontend) {
+            AuthFrontend authFrontend,
+            NoSessionOrchestrationService noSessionOrchestrationService) {
         this.configurationService = configurationService;
         this.authorisationService = responseService;
         this.tokenService = tokenService;
@@ -233,6 +240,7 @@ public class AuthenticationCallbackHandler
         this.accountInterventionService = accountInterventionService;
         this.logoutService = logoutService;
         this.authFrontend = authFrontend;
+        this.noSessionOrchestrationService = noSessionOrchestrationService;
     }
 
     public APIGatewayProxyResponseEvent handleRequest(
@@ -246,7 +254,7 @@ public class AuthenticationCallbackHandler
                     CookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
 
             if (sessionCookiesIds == null) {
-                throw new AuthenticationCallbackException("No session cookie found");
+                return handleMissingSession(input);
             }
 
             var sessionId = sessionCookiesIds.getSessionId();
@@ -621,6 +629,38 @@ public class AuthenticationCallbackHandler
             LOG.info("Cannot retrieve auth request params from client session id");
             return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
         }
+    }
+
+    private APIGatewayProxyResponseEvent handleMissingSession(APIGatewayProxyRequestEvent input)
+            throws ParseException {
+        try {
+            return handleCrossBrowserError(input);
+        } catch (NoSessionException e) {
+            throw new AuthenticationCallbackException("No session cookie found", e);
+        }
+    }
+
+    private APIGatewayProxyResponseEvent handleCrossBrowserError(APIGatewayProxyRequestEvent input)
+            throws NoSessionException, ParseException {
+        var noSessionEntity =
+                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                        input.getQueryStringParameters());
+        var authenticationRequest =
+                AuthenticationRequest.parse(
+                        noSessionEntity.getClientSession().getAuthRequestParams());
+        auditService.submitAuditEvent(
+                OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED,
+                authenticationRequest.getClientID().getValue(),
+                TxmaAuditUser.user()
+                        .withGovukSigninJourneyId(noSessionEntity.getClientSessionId()));
+        var errorResponse =
+                new AuthenticationErrorResponse(
+                        authenticationRequest.getRedirectionURI(),
+                        noSessionEntity.getErrorObject(),
+                        authenticationRequest.getState(),
+                        authenticationRequest.getResponseMode());
+        return generateApiGatewayProxyResponse(
+                302, "", Map.of(ResponseHeaders.LOCATION, errorResponse.toURI().toString()), null);
     }
 
     private boolean deduceUpliftRequired(UserInfo userInfo) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -857,7 +857,7 @@ public class AuthorisationHandler
                 ClientSubjectHelper.getSectorIdentifierForClient(
                         client, configurationService.getInternalSectorURI());
         var state = new State();
-        orchestrationAuthorizationService.storeState(sessionId, state);
+        orchestrationAuthorizationService.storeState(sessionId, clientSessionId, state);
 
         String reauthSub = null;
         String reauthSid = null;

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -388,7 +388,7 @@ class AuthorisationHandlerTest {
             assertThat(response, hasStatus(302));
             var locationHeader = response.getHeaders().get(ResponseHeaders.LOCATION);
             verify(orchestrationAuthorizationService)
-                    .storeState(eq(NEW_SESSION_ID), any(State.class));
+                    .storeState(eq(NEW_SESSION_ID), eq(CLIENT_SESSION_ID), any(State.class));
             assertThat(locationHeader, containsString(TEST_ENCRYPTED_JWT.serialize()));
             assertThat(
                     splitQuery(locationHeader).get("request"),
@@ -427,7 +427,7 @@ class AuthorisationHandlerTest {
             assertThat(response, hasStatus(302));
             var locationHeader = response.getHeaders().get(ResponseHeaders.LOCATION);
             verify(orchestrationAuthorizationService)
-                    .storeState(eq(NEW_SESSION_ID), any(State.class));
+                    .storeState(eq(NEW_SESSION_ID), eq(CLIENT_SESSION_ID), any(State.class));
             assertThat(locationHeader, containsString(TEST_ENCRYPTED_JWT.serialize()));
             assertThat(
                     splitQuery(locationHeader).get("request"),
@@ -466,7 +466,7 @@ class AuthorisationHandlerTest {
             assertThat(response, hasStatus(302));
             var locationHeader = response.getHeaders().get(ResponseHeaders.LOCATION);
             verify(orchestrationAuthorizationService)
-                    .storeState(eq(NEW_SESSION_ID), any(State.class));
+                    .storeState(eq(NEW_SESSION_ID), eq(CLIENT_SESSION_ID), any(State.class));
             assertThat(locationHeader, containsString(TEST_ENCRYPTED_JWT.serialize()));
             assertThat(
                     splitQuery(locationHeader).get("request"),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
@@ -288,9 +288,10 @@ class OrchestrationAuthorizationServiceTest {
     void shouldSaveStateInRedis() {
         when(configurationService.getSessionExpiry()).thenReturn(3600L);
         var sessionId = "new-session-id";
+        var clientSessionId = "new-client-session-id";
         var state = new State();
 
-        orchestrationAuthorizationService.storeState(sessionId, state);
+        orchestrationAuthorizationService.storeState(sessionId, clientSessionId, state);
 
         verify(redisConnectionService)
                 .saveWithExpiry("auth-state:" + sessionId, state.getValue(), 3600);


### PR DESCRIPTION
This should make most sense commit-wise. I've tried to keep all the refactor to a separate commit, but I'm afraid a little has leaked. Happy to split it out if it's confusing, but the refactor is contained to tests.

### Wider context of change

As part of their work around resetting MFA with ID re-verification (https://govukverify.atlassian.net/browse/DCP-3200 ), Auth are sending users to IPV on a re-verification journey. This means that users may experience the same cross browser issue as in a standard proofing journey. Orchestration needs to handle the return from Auth in the same way as from IPV: namely returning the user to the RP with an error and the correct state value.


### What’s changed
Reuse code from the IPV and docapp solution to store and retrieve client session ID when cross browser issue occurs.
Return user to RP with correct error.

### Manual testing
Deployed to Orch dev, successful Auth, xbrowser Auth, hit /orchestration-redirect with no cookies or query params, successful ipv stub just for luck


### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->