### PR TITLE
ATO-1366: Remove use of session id getter from LogoutService

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -29,6 +29,7 @@ import uk.gov.di.orchestration.shared.api.OrchFrontend;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
@@ -325,7 +326,11 @@ public class IPVCallbackHandler
                 if (configurationService.isAccountInterventionServiceActionEnabled()
                         && (intervention.getBlocked() || intervention.getSuspended())) {
                     return logoutService.handleAccountInterventionLogout(
-                            session, input, clientId, intervention);
+                            new DestroySessionsRequest(sessionId, session),
+                            session.getInternalCommonSubjectIdentifier(),
+                            input,
+                            clientId,
+                            intervention);
                 }
 
                 return ipvCallbackHelper.generateAuthenticationErrorResponse(
@@ -431,7 +436,11 @@ public class IPVCallbackHandler
                 if (configurationService.isAccountInterventionServiceActionEnabled()
                         && (intervention.getBlocked() || intervention.getSuspended())) {
                     return logoutService.handleAccountInterventionLogout(
-                            session, input, clientId, intervention);
+                            new DestroySessionsRequest(sessionId, session),
+                            session.getInternalCommonSubjectIdentifier(),
+                            input,
+                            clientId,
+                            intervention);
                 }
                 var returnCode = userIdentityUserInfo.getClaim(RETURN_CODE.getValue());
                 if (returnCodePresentInIPVResponse(returnCode)) {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.ipv.entity.ProcessingIdentityStatus;
 import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
@@ -213,7 +214,12 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             throws Json.JsonException {
         var logoutResult =
                 logoutService.handleAccountInterventionLogout(
-                        userContext.getSession(), input, client.getClientID(), intervention);
+                        new DestroySessionsRequest(
+                                userContext.getSessionId(), userContext.getSession()),
+                        userContext.getSession().getInternalCommonSubjectIdentifier(),
+                        input,
+                        client.getClientID(),
+                        intervention);
         var redirectUrl = logoutResult.getHeaders().get(ResponseHeaders.LOCATION);
         return generateApiGatewayProxyResponse(
                 200,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
 import uk.gov.di.orchestration.shared.entity.IdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -229,7 +230,7 @@ class ProcessingIdentityHandlerTest {
         when(accountInterventionService.getAccountIntervention(anyString(), any()))
                 .thenReturn(intervention);
         String redirectUrl = "https://example.com/intervention";
-        when(logoutService.handleAccountInterventionLogout(any(), any(), any(), any()))
+        when(logoutService.handleAccountInterventionLogout(any(), any(), any(), any(), any()))
                 .thenReturn(
                         generateApiGatewayProxyResponse(
                                 302, "", Map.of(ResponseHeaders.LOCATION, redirectUrl), null));
@@ -237,7 +238,12 @@ class ProcessingIdentityHandlerTest {
         var result = handler.handleRequest(event, context);
 
         verify(logoutService)
-                .handleAccountInterventionLogout(session, event, CLIENT_ID, intervention);
+                .handleAccountInterventionLogout(
+                        new DestroySessionsRequest(SESSION_ID, List.of(), null),
+                        null,
+                        event,
+                        CLIENT_ID,
+                        intervention);
         assertThat(result, hasStatus(200));
         assertThat(
                 result,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -410,7 +410,7 @@ public class AuthenticationCallbackHandler
                 if (configurationService.supportMaxAgeEnabled()
                         && Objects.nonNull(orchSession.getPreviousSessionId())) {
                     LOG.info("Previous session id is present - handling max age");
-                    handleMaxAgeSession(orchSession, session, user);
+                    handleMaxAgeSession(session, orchSession, user);
                 }
 
                 session.setAuthenticated(true);
@@ -841,7 +841,7 @@ public class AuthenticationCallbackHandler
     }
 
     private void handleMaxAgeSession(
-            OrchSessionItem currentOrchSession, Session currentSharedSession, TxmaAuditUser user) {
+            Session currentSharedSession, OrchSessionItem currentOrchSession, TxmaAuditUser user) {
         var previousSessionId = currentOrchSession.getPreviousSessionId();
         var previousSharedSession = sessionService.getSession(previousSessionId);
         var previousOrchSession = orchSessionService.getSession(previousSessionId);
@@ -869,7 +869,9 @@ public class AuthenticationCallbackHandler
             LOG.info(
                     "Previous OrchSession InternalCommonSubjectId does not match Auth UserInfo response");
             logoutService.handleMaxAgeLogout(
-                    previousSharedSession.get(), previousOrchSession.get(), user);
+                    new DestroySessionsRequest(previousSessionId, previousSharedSession.get()),
+                    previousOrchSession.get(),
+                    user);
         }
         currentOrchSession.setPreviousSessionId(null);
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -495,12 +495,20 @@ public class AuthenticationCallbackHandler
                                 SUSPENDED_RESET_PASSWORD,
                                 SUSPENDED_RESET_PASSWORD_REPROVE_ID -> {
                             return logoutService.handleAccountInterventionLogout(
-                                    session, input, clientId, intervention);
+                                    new DestroySessionsRequest(sessionId, session),
+                                    session.getInternalCommonSubjectIdentifier(),
+                                    input,
+                                    clientId,
+                                    intervention);
                         }
                         case SUSPENDED_NO_ACTION -> {
                             if (!identityRequired) {
                                 return logoutService.handleAccountInterventionLogout(
-                                        session, input, clientId, intervention);
+                                        new DestroySessionsRequest(sessionId, session),
+                                        session.getInternalCommonSubjectIdentifier(),
+                                        input,
+                                        clientId,
+                                        intervention);
                             }
                             // continue
                         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -38,6 +38,7 @@ import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
+import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -753,7 +754,7 @@ public class AuthenticationCallbackHandler
         } catch (AuthenticationCallbackValidationException e) {
             return Optional.of(
                     generateAuthenticationErrorResponse(
-                            authenticationRequest, input, e, user, session));
+                            authenticationRequest, input, e, user, session, sessionId));
         }
         return Optional.empty();
     }
@@ -763,7 +764,8 @@ public class AuthenticationCallbackHandler
             APIGatewayProxyRequestEvent input,
             AuthenticationCallbackValidationException exception,
             TxmaAuditUser user,
-            Session session) {
+            Session session,
+            String sessionId) {
         var error = exception.getError();
         LOG.warn(
                 "Error in Authentication Authorisation Response. ErrorCode: {}. ErrorDescription: {}.{}",
@@ -784,7 +786,8 @@ public class AuthenticationCallbackHandler
 
         if (exception.getLogoutRequired()) {
             return logoutService.handleReauthenticationFailureLogout(
-                    session,
+                    new DestroySessionsRequest(sessionId, session),
+                    session.getInternalCommonSubjectIdentifier(),
                     input,
                     authenticationRequest.getClientID().getValue(),
                     errorResponseUri);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -8,7 +8,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.oidc.entity.LogoutRequest;
-import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
@@ -94,10 +93,9 @@ public class LogoutHandler
                 new LogoutRequest(
                         sessionService, tokenValidationService, dynamoClientService, input);
 
-        if (logoutRequest.session().isPresent()) {
-            Session session = logoutRequest.session().get();
-            attachSessionToLogs(session, input.getHeaders());
-        }
+        logoutRequest
+                .sessionId()
+                .ifPresent(sessionId -> attachSessionToLogs(sessionId, input.getHeaders()));
         return logoutService.handleLogout(
                 logoutRequest.destroySessionsRequest(),
                 logoutRequest.errorObject(),
@@ -108,10 +106,10 @@ public class LogoutHandler
                 logoutRequest.rpPairwiseId());
     }
 
-    private void attachSessionToLogs(Session session, Map<String, String> headers) {
+    private void attachSessionToLogs(String sessionId, Map<String, String> headers) {
         CookieHelper.SessionCookieIds sessionCookieIds =
                 CookieHelper.parseSessionCookie(headers).orElseThrow();
-        attachSessionIdToLogs(session);
+        attachSessionIdToLogs(sessionId);
         attachLogFieldToLogs(CLIENT_SESSION_ID, sessionCookieIds.getClientSessionId());
         attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, sessionCookieIds.getClientSessionId());
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -98,9 +98,8 @@ public class LogoutHandler
             Session session = logoutRequest.session().get();
             attachSessionToLogs(session, input.getHeaders());
         }
-
         return logoutService.handleLogout(
-                logoutRequest.session(),
+                logoutRequest.destroySessionsRequest(),
                 logoutRequest.errorObject(),
                 logoutRequest.postLogoutRedirectUri(),
                 logoutRequest.state(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -39,7 +40,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
@@ -416,13 +417,12 @@ class LogoutRequestTest {
         assertEquals(Optional.of(clientRegistry), logoutRequest.clientRegistry());
     }
 
-    private uk.gov.di.orchestration.shared.entity.Session generateSession() {
-        return new uk.gov.di.orchestration.shared.entity.Session(SESSION_ID)
-                .addClientSession(CLIENT_SESSION_ID);
+    private Session generateSession() {
+        return new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID);
     }
 
-    private void generateSessionFromCookie(uk.gov.di.orchestration.shared.entity.Session session) {
-        when(sessionService.getSessionFromSessionCookie(anyMap())).thenReturn(Optional.of(session));
+    private void generateSessionFromCookie(Session session) {
+        when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
     }
 
     private ClientRegistry createClientRegistry() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -143,6 +143,7 @@ class AuthenticationCallbackHandlerTest {
     private static final String PERSISTENT_SESSION_ID =
             "uDjIfGhoKwP8bFpRewlpd-AVrI4--1700750982787";
     private static final String SESSION_ID = "a-session-id";
+
     private static final Session session =
             new Session(SESSION_ID)
                     .setVerifiedMfaMethodType(MFAMethodType.EMAIL)
@@ -810,7 +811,12 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                session, event, CLIENT_ID.toString(), intervention);
+                                new DestroySessionsRequest(
+                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                null,
+                                event,
+                                CLIENT_ID.toString(),
+                                intervention);
             }
 
             @Test
@@ -824,7 +830,12 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                session, event, CLIENT_ID.toString(), intervention);
+                                new DestroySessionsRequest(
+                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                null,
+                                event,
+                                CLIENT_ID.toString(),
+                                intervention);
             }
 
             @Test
@@ -838,7 +849,12 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                session, event, CLIENT_ID.toString(), intervention);
+                                new DestroySessionsRequest(
+                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                null,
+                                event,
+                                CLIENT_ID.toString(),
+                                intervention);
             }
 
             @Test
@@ -873,7 +889,12 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                session, event, CLIENT_ID.getValue(), intervention);
+                                new DestroySessionsRequest(
+                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                null,
+                                event,
+                                CLIENT_ID.getValue(),
+                                intervention);
             }
         }
 
@@ -924,7 +945,13 @@ class AuthenticationCallbackHandlerTest {
                 handler.handleRequest(event, null);
 
                 verify(logoutService)
-                        .handleAccountInterventionLogout(any(), any(), any(), eq(intervention));
+                        .handleAccountInterventionLogout(
+                                new DestroySessionsRequest(
+                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                null,
+                                event,
+                                CLIENT_ID.getValue(),
+                                intervention);
                 verifyNoInteractions(initiateIPVAuthorisationService);
                 verify(sessionService).storeOrUpdateSession(argThat(Session::isAuthenticated));
                 verify(orchSessionService, times(2))
@@ -969,7 +996,13 @@ class AuthenticationCallbackHandlerTest {
                 handler.handleRequest(event, null);
 
                 verify(logoutService)
-                        .handleAccountInterventionLogout(any(), any(), any(), eq(intervention));
+                        .handleAccountInterventionLogout(
+                                new DestroySessionsRequest(
+                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                null,
+                                event,
+                                CLIENT_ID.toString(),
+                                intervention);
                 verifyNoInteractions(initiateIPVAuthorisationService);
                 verify(sessionService).storeOrUpdateSession(argThat(Session::isAuthenticated));
             }
@@ -1012,7 +1045,13 @@ class AuthenticationCallbackHandlerTest {
                 handler.handleRequest(event, null);
 
                 verify(logoutService)
-                        .handleAccountInterventionLogout(any(), any(), any(), eq(intervention));
+                        .handleAccountInterventionLogout(
+                                new DestroySessionsRequest(
+                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                null,
+                                event,
+                                CLIENT_ID.toString(),
+                                intervention);
                 verifyNoInteractions(initiateIPVAuthorisationService);
             }
         }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -1145,7 +1145,7 @@ class AuthenticationCallbackHandlerTest {
             var orchSession = withMaxAgeOrchSession(INTERNAL_COMMON_SUBJECT_ID);
             var sharedSession = withMaxAgeSharedSession();
             var previousOrchSession = withPreviousOrchSessionDueToMaxAge();
-            var previousSharedSession = withPreviousSharedSessionDueToMaxAge();
+            withPreviousSharedSessionDueToMaxAge();
 
             when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
             when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
@@ -1174,7 +1174,11 @@ class AuthenticationCallbackHandlerTest {
 
             verify(logoutService, times(1))
                     .handleMaxAgeLogout(
-                            eq(previousSharedSession),
+                            eq(
+                                    new DestroySessionsRequest(
+                                            PREVIOUS_SESSION_ID,
+                                            PREVIOUS_CLIENT_SESSIONS,
+                                            TEST_EMAIL_ADDRESS)),
                             eq(previousOrchSession),
                             any(TxmaAuditUser.class));
         }
@@ -1188,12 +1192,12 @@ class AuthenticationCallbackHandlerTest {
             return previousOrchSession;
         }
 
-        private Session withPreviousSharedSessionDueToMaxAge() {
+        private void withPreviousSharedSessionDueToMaxAge() {
             var previousSharedSession = new Session(PREVIOUS_SESSION_ID);
             PREVIOUS_CLIENT_SESSIONS.forEach(previousSharedSession::addClientSession);
+            previousSharedSession.setEmailAddress(TEST_EMAIL_ADDRESS);
             when(sessionService.getSession(PREVIOUS_SESSION_ID))
                     .thenReturn(Optional.of(previousSharedSession));
-            return previousSharedSession;
         }
 
         private void withNoPreviousSharedSession() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/DestroySessionsRequest.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/DestroySessionsRequest.java
@@ -8,6 +8,10 @@ public class DestroySessionsRequest {
     private final List<String> clientSessions;
     private final String emailAddress;
 
+    public DestroySessionsRequest(Session session) {
+        this(session.getSessionId(), session.getClientSessions(), session.getEmailAddress());
+    }
+
     public DestroySessionsRequest(String sessionId, Session session) {
         this(sessionId, session.getClientSessions(), session.getEmailAddress());
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/DestroySessionsRequest.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/DestroySessionsRequest.java
@@ -1,0 +1,62 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import java.util.List;
+import java.util.Objects;
+
+public class DestroySessionsRequest {
+    private final String sessionId;
+    private final List<String> clientSessions;
+    private final String emailAddress;
+
+    public DestroySessionsRequest(String sessionId, Session session) {
+        this(sessionId, session.getClientSessions(), session.getEmailAddress());
+    }
+
+    public DestroySessionsRequest(
+            String sessionId, List<String> clientSessions, String emailAddress) {
+        this.sessionId = sessionId;
+        this.clientSessions = clientSessions;
+        this.emailAddress = emailAddress;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public List<String> getClientSessions() {
+        return clientSessions;
+    }
+
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DestroySessionsRequest that = (DestroySessionsRequest) o;
+        return Objects.equals(sessionId, that.sessionId)
+                && Objects.equals(clientSessions, that.clientSessions)
+                && Objects.equals(emailAddress, that.emailAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sessionId, clientSessions, emailAddress);
+    }
+
+    @Override
+    public String toString() {
+        return "DestroySessionsRequest{"
+                + "sessionId='"
+                + sessionId
+                + '\''
+                + ", clientSessions="
+                + clientSessions
+                + ", emailAddress='"
+                + emailAddress
+                + '\''
+                + '}';
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/DestroySessionsRequest.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/DestroySessionsRequest.java
@@ -8,10 +8,6 @@ public class DestroySessionsRequest {
     private final List<String> clientSessions;
     private final String emailAddress;
 
-    public DestroySessionsRequest(Session session) {
-        this(session.getSessionId(), session.getClientSessions(), session.getEmailAddress());
-    }
-
     public DestroySessionsRequest(String sessionId, Session session) {
         this(sessionId, session.getClientSessions(), session.getEmailAddress());
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/LogLineHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/LogLineHelper.java
@@ -1,7 +1,6 @@
 package uk.gov.di.orchestration.shared.helpers;
 
 import org.apache.logging.log4j.ThreadContext;
-import uk.gov.di.orchestration.shared.entity.Session;
 
 import static uk.gov.di.orchestration.shared.helpers.InputSanitiser.sanitiseBase64;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.ORCH_SESSION_ID;
@@ -47,10 +46,6 @@ public class LogLineHelper {
             ThreadContext.remove(logFieldName.getLogFieldName());
         }
         attachLogFieldToLogs(logFieldName, value);
-    }
-
-    public static void attachSessionIdToLogs(Session session) {
-        attachLogFieldToLogs(SESSION_ID, session.getSessionId());
     }
 
     public static void attachSessionIdToLogs(String sessionId) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -233,8 +233,10 @@ public class LogoutService {
     }
 
     public void handleMaxAgeLogout(
-            Session previousSession, OrchSessionItem previousOrchSession, TxmaAuditUser user) {
-        destroySessions(previousSession);
+            DestroySessionsRequest request,
+            OrchSessionItem previousOrchSession,
+            TxmaAuditUser user) {
+        destroySessions(request);
         Long sessionAge =
                 nowClock.now().toInstant().getEpochSecond() - previousOrchSession.getAuthTime();
         sendAuditEvent(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/LogLineHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/LogLineHelperTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.orchestration.shared.helpers;
 import org.apache.logging.log4j.ThreadContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.orchestration.shared.entity.Session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,14 +33,6 @@ class LogLineHelperTest {
     @Test
     void shouldAttachSessionIdToThreadContextUsingString() {
         attachSessionIdToLogs(identifier);
-
-        assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
-        assertEquals(identifier, ThreadContext.get(SESSION_ID.getLogFieldName()));
-    }
-
-    @Test
-    void shouldAttachSessionIdToThreadContextUsingSession() {
-        attachSessionIdToLogs(new Session(identifier));
 
         assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
         assertEquals(identifier, ThreadContext.get(SESSION_ID.getLogFieldName()));

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -567,11 +567,9 @@ class LogoutServiceTest {
         var clientSessionId2 = IdGenerator.generate();
         var clientId1 = CLIENT_ID + "1";
         var clientId2 = CLIENT_ID + "2";
-        var prevousSession =
-                new Session(SESSION_ID)
-                        .setEmailAddress(EMAIL)
-                        .addClientSession(clientSessionId1)
-                        .addClientSession(clientSessionId2);
+        var destroySessionsRequestForClients =
+                new DestroySessionsRequest(
+                        SESSION_ID, List.of(clientSessionId1, clientSessionId2), EMAIL);
 
         var authTime = Instant.parse("2025-01-23T15:00:00Z");
         var previousOrchSession =
@@ -582,7 +580,8 @@ class LogoutServiceTest {
         var logoutTime = authTime.plus(3600, ChronoUnit.SECONDS);
         var clock = fixed(logoutTime, systemDefault());
         logoutServiceWithClock(clock)
-                .handleMaxAgeLogout(prevousSession, previousOrchSession, auditUser);
+                .handleMaxAgeLogout(
+                        destroySessionsRequestForClients, previousOrchSession, auditUser);
 
         verify(clientSessionService, times(1)).deleteStoredClientSession(clientSessionId1);
         verify(clientSessionService, times(1)).deleteStoredClientSession(clientSessionId2);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -209,7 +209,7 @@ class LogoutServiceTest {
                         rpPairwiseId);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(session.getSessionId());
+        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -242,7 +242,7 @@ class LogoutServiceTest {
                         rpPairwiseId);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(session.getSessionId());
+        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -275,7 +275,7 @@ class LogoutServiceTest {
                         rpPairwiseId);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(session.getSessionId());
+        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -309,7 +309,7 @@ class LogoutServiceTest {
                         rpPairwiseId);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(session.getSessionId());
+        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -357,7 +357,7 @@ class LogoutServiceTest {
                         intervention);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(session.getSessionId());
+        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -391,7 +391,7 @@ class LogoutServiceTest {
                         intervention);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(session.getSessionId());
+        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -432,7 +432,7 @@ class LogoutServiceTest {
                 rpPairwiseId);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(session.getSessionId());
+        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
@@ -508,7 +508,7 @@ class LogoutServiceTest {
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
         verify(clientSessionService).deleteStoredClientSession("client-session-id-2");
         verify(clientSessionService).deleteStoredClientSession("client-session-id-3");
-        verify(sessionService).deleteStoredSession(session.getSessionId());
+        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -559,7 +559,7 @@ class LogoutServiceTest {
                         REAUTH_FAILURE_URI);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(session.getSessionId());
+        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
@@ -600,7 +600,7 @@ class LogoutServiceTest {
 
         verify(clientSessionService, times(1)).deleteStoredClientSession(clientSessionId1);
         verify(clientSessionService, times(1)).deleteStoredClientSession(clientSessionId2);
-        verify(sessionService).deleteStoredSession(session.getSessionId());
+        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(backChannelLogoutService)
                 .sendLogoutMessage(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -350,7 +350,11 @@ class LogoutServiceTest {
                 new AccountIntervention(new AccountInterventionState(true, false, false, false));
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
-                        session, event, CLIENT_ID, intervention);
+                        new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID), EMAIL),
+                        SUBJECT.getValue(),
+                        event,
+                        CLIENT_ID,
+                        intervention);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
         verify(sessionService).deleteStoredSession(session.getSessionId());
@@ -380,7 +384,11 @@ class LogoutServiceTest {
 
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
-                        session, event, CLIENT_ID, intervention);
+                        new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID), EMAIL),
+                        SUBJECT.getValue(),
+                        event,
+                        CLIENT_ID,
+                        intervention);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
         verify(sessionService).deleteStoredSession(session.getSessionId());
@@ -444,12 +452,19 @@ class LogoutServiceTest {
         AccountIntervention intervention =
                 new AccountIntervention(new AccountInterventionState(false, false, false, false));
 
+        var expectedDestroySessionsRequest =
+                new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID), EMAIL);
+        var expectedInternalCommonSubjectId = SUBJECT.getValue();
         RuntimeException exception =
                 assertThrows(
                         RuntimeException.class,
                         () ->
                                 logoutService.handleAccountInterventionLogout(
-                                        session, event, CLIENT_ID, intervention),
+                                        expectedDestroySessionsRequest,
+                                        expectedInternalCommonSubjectId,
+                                        event,
+                                        CLIENT_ID,
+                                        intervention),
                         "Expected to throw exception");
 
         assertEquals("Account status must be blocked or suspended", exception.getMessage());

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -537,7 +537,11 @@ class LogoutServiceTest {
     void successfullyLogsOutAndGeneratesRedirectResponseForeReauthenticationFailure() {
         var response =
                 logoutService.handleReauthenticationFailureLogout(
-                        session, event, CLIENT_ID, REAUTH_FAILURE_URI);
+                        new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID), EMAIL),
+                        SUBJECT.getValue(),
+                        event,
+                        CLIENT_ID,
+                        REAUTH_FAILURE_URI);
 
         verify(clientSessionService).deleteStoredClientSession(session.getClientSessions().get(0));
         verify(sessionService).deleteStoredSession(session.getSessionId());


### PR DESCRIPTION
### Wider context of change

We would like to migrate away from the shared session and use the orch session instead. The parent issue for this is for migrating use of the sessionId. We've already used setters to set the sessionId on OrchSessionItem and AuthSessionItem. This issue is for removing the getters.

### What’s changed

This PR removes usage of Session.getSessionId() from LogoutService. I've introduced a new data class `DestroySessionsRequest`, which is used in the `LogoutService.destroySessions()` method, and requires setting the session ID directly on creation. This is used by all LogoutService methods that call `destroySessions` .

LogoutRequest was also the last place that `LogLineHelper.attachSessionIdToLogs(Session session)` was used, so I've updated it to use the version of the method where you provide the sessionId directly, and removed the old method signature and associated test.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
