### PR TITLE
AUT-3910: Validate state back from IPV

### DIFF
--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -11,7 +11,8 @@ module "reverification_result_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    aws_iam_policy.dynamo_auth_session_read_policy.arn
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
+    aws_iam_policy.dynamo_id_reverification_state_read_policy.arn
   ]
   extra_tags = {
     Service = "reverification-result"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ReverificationResultRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ReverificationResultRequest.java
@@ -3,4 +3,5 @@ package uk.gov.di.authentication.frontendapi.entity;
 import com.google.gson.annotations.Expose;
 import uk.gov.di.authentication.shared.validation.Required;
 
-public record ReverificationResultRequest(@Expose @Required String code, @Expose String email) {}
+public record ReverificationResultRequest(
+        @Expose @Required String code, @Expose @Required String state, @Expose String email) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
@@ -80,8 +80,7 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.ipvReverificationService =
-                new IPVReverificationService(
-                        configurationService, jwtService, tokenService, redisConnectionService);
+                new IPVReverificationService(configurationService, jwtService, tokenService);
         this.idReverificationStateService = new IDReverificationStateService(configurationService);
     }
 
@@ -122,10 +121,7 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
             State authenticationState = new State();
             var ipvReverificationRequestURI =
                     ipvReverificationService.buildIpvReverificationRedirectUri(
-                            internalCommonSubjectId,
-                            clientSessionId,
-                            userSession,
-                            authenticationState);
+                            internalCommonSubjectId, clientSessionId, authenticationState);
 
             idReverificationStateService.store(
                     authenticationState.getValue(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
@@ -97,11 +97,13 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
 
         var idReverificationStateMaybe = idReverificationStateService.get(request.state());
         if (idReverificationStateMaybe.isEmpty()) {
+            LOG.error("Cannot match received state to a recorded state");
             return generateApiGatewayProxyErrorResponse(400, ERROR_1061);
         }
 
         var idReverificationState = idReverificationStateMaybe.get();
         if (!idReverificationState.getClientSessionId().equals(userContext.getClientSessionId())) {
+            LOG.error("Received state belongs to a different session");
             return generateApiGatewayProxyErrorResponse(400, ERROR_1061);
         }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
@@ -121,10 +121,7 @@ class MfaResetAuthorizeHandlerTest {
         String expectedBody =
                 objectMapper.writeValueAsString(new MfaResetResponse(TEST_REDIRECT_URI));
         when(ipvReverificationService.buildIpvReverificationRedirectUri(
-                        eq(new Subject(COMMON_SUBJECT_ID)),
-                        eq(CLIENT_SESSION_ID),
-                        eq(session),
-                        any()))
+                        eq(new Subject(COMMON_SUBJECT_ID)), eq(CLIENT_SESSION_ID), any()))
                 .thenReturn(TEST_REDIRECT_URI);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(TEST_INVOKE_EVENT, context);
@@ -144,7 +141,7 @@ class MfaResetAuthorizeHandlerTest {
         ArgumentCaptor<State> authenticationStateCaptor = ArgumentCaptor.forClass(State.class);
         verify(ipvReverificationService)
                 .buildIpvReverificationRedirectUri(
-                        any(), any(), any(), authenticationStateCaptor.capture());
+                        any(), any(), authenticationStateCaptor.capture());
         verify(idReverificationStateService)
                 .store(
                         authenticationStateCaptor.getValue().getValue(),
@@ -155,10 +152,7 @@ class MfaResetAuthorizeHandlerTest {
     @Test
     void returnsA500WithErrorMessageWhenServiceThrowsJwtServiceException() {
         when(ipvReverificationService.buildIpvReverificationRedirectUri(
-                        eq(new Subject(COMMON_SUBJECT_ID)),
-                        eq(CLIENT_SESSION_ID),
-                        eq(session),
-                        any()))
+                        eq(new Subject(COMMON_SUBJECT_ID)), eq(CLIENT_SESSION_ID), any()))
                 .thenThrow(new JwtServiceException("SomeError"));
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(TEST_INVOKE_EVENT, context);
@@ -170,10 +164,7 @@ class MfaResetAuthorizeHandlerTest {
     @Test
     void returns500WithErrorMessageWhenIpvReverificationServiceExceptionIsThrown() {
         when(ipvReverificationService.buildIpvReverificationRedirectUri(
-                        eq(new Subject(COMMON_SUBJECT_ID)),
-                        eq(CLIENT_SESSION_ID),
-                        eq(session),
-                        any()))
+                        eq(new Subject(COMMON_SUBJECT_ID)), eq(CLIENT_SESSION_ID), any()))
                 .thenThrow(new IPVReverificationServiceException("SomeError"));
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(TEST_INVOKE_EVENT, context);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
@@ -45,9 +45,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
-import static uk.gov.di.authentication.frontendapi.services.IPVReverificationService.STATE_STORAGE_PREFIX;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 @ExtendWith(SystemStubsExtension.class)
@@ -174,7 +172,6 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
         assertThat(response, hasStatus(200));
 
         checkCorrectKeysUsedViaIntegrationWithKms();
-        checkStateIsStoredViaIntegrationWithRedis(sessionId);
         checkTxmaEventPublishedViaIntegrationWithSQS();
     }
 
@@ -186,11 +183,6 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
                                         "$.KeyId",
                                         new ContainsPattern(
                                                 ipvReverificationRequestsSigningKey.getKeyId()))));
-    }
-
-    private static void checkStateIsStoredViaIntegrationWithRedis(String sessionId) {
-        var state = redisExtension.getFromRedis(STATE_STORAGE_PREFIX + sessionId);
-        assertNotNull(state);
     }
 
     private static void checkTxmaEventPublishedViaIntegrationWithSQS() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -71,7 +71,8 @@ public enum ErrorResponse {
     ERROR_1057(1057, "User entered invalid reauth sign in details too many times"),
     ERROR_1058(1058, "IPV TokenResponse was not successful"),
     ERROR_1059(1059, "Error getting reverification result"),
-    ERROR_1060(1060, "Failed to generate MFA Reset Authorize JAR for IPV");
+    ERROR_1060(1060, "Failed to generate MFA Reset Authorize JAR for IPV"),
+    ERROR_1061(1061, "State returned from IPV does not match expected state");
 
     private int code;
 


### PR DESCRIPTION
## What

Validate the state we send IPV (via the user) for MFA reset journeys is the same state IPV send when they redirect the user back to us. This helps prevent cross-site request forgery attacks.

Also clean up some unnecessary state storage.

## How to review

1. Code Review
1. Deploy to an environment
1. See a successful MFA reset with IPV journey
1. Start the journey again, pause while on IPV stub page
1. Change the value of the `ClientSessionId` field value in the DynamoDB table `*-id-reverification-state` to something else (probably the latest record).
1. Continue the journey, see "Something went wrong" error
1. Start the journey again, pause while on IPV stub page
1. Change the value of the `AuthenticationState` field value in the table (will require recreating the record, AWS Console will help do this)
1. Continue the journey, see "Something went wrong" error
 