### PR TITLE
ATO-1367: Remove session id getter from SessionService

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -49,10 +49,9 @@ class AuthOrchSerializationServicesIntegrationTest {
     @Test
     void authCanReadFromSessionCreatedByOrch() {
         var orchSession = orchSessionService.generateSession(SESSION_ID);
-        var sessionId = orchSession.getSessionId();
         orchSession.addClientSession(CLIENT_SESSION_ID);
-        orchSessionService.storeOrUpdateSession(orchSession);
-        var authSession = authSessionService.getSession(sessionId).get();
+        orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
+        var authSession = authSessionService.getSession(SESSION_ID).get();
         assertThat(authSession.getClientSessions(), contains(CLIENT_SESSION_ID));
     }
 
@@ -69,12 +68,11 @@ class AuthOrchSerializationServicesIntegrationTest {
     @Test
     void authCanUpdateSharedFieldInSessionCreatedByOrch() {
         var orchSession = orchSessionService.generateSession(SESSION_ID);
-        var sessionId = orchSession.getSessionId();
-        orchSessionService.storeOrUpdateSession(orchSession);
-        var authSession = authSessionService.getSession(sessionId).get();
+        orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
+        var authSession = authSessionService.getSession(SESSION_ID).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
         authSessionService.storeOrUpdateSession(authSession);
-        orchSession = orchSessionService.getSession(sessionId).get();
+        orchSession = orchSessionService.getSession(SESSION_ID).get();
         assertThat(orchSession.getClientSessions(), contains(CLIENT_SESSION_ID));
     }
 
@@ -85,7 +83,7 @@ class AuthOrchSerializationServicesIntegrationTest {
         authSessionService.storeOrUpdateSession(authSession);
         var orchSession = orchSessionService.getSession(sessionId).get();
         orchSession.addClientSession(CLIENT_SESSION_ID);
-        orchSessionService.storeOrUpdateSession(orchSession);
+        orchSessionService.storeOrUpdateSession(orchSession, sessionId);
         authSession = authSessionService.getSession(sessionId).get();
         assertThat(authSession.getClientSessions(), contains(CLIENT_SESSION_ID));
     }
@@ -93,13 +91,12 @@ class AuthOrchSerializationServicesIntegrationTest {
     @Test
     void orchCanReadUnsharedFieldAfterAuthUpdatesSession() {
         var orchSession = orchSessionService.generateSession(SESSION_ID);
-        var sessionId = orchSession.getSessionId();
         orchSession.incrementProcessingIdentityAttempts();
-        orchSessionService.storeOrUpdateSession(orchSession);
-        var authSession = authSessionService.getSession(sessionId).get();
+        orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
+        var authSession = authSessionService.getSession(SESSION_ID).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
         authSessionService.storeOrUpdateSession(authSession);
-        orchSession = orchSessionService.getSession(sessionId).get();
+        orchSession = orchSessionService.getSession(SESSION_ID).get();
         assertThat(orchSession.getProcessingIdentityAttempts(), is(equalTo(1)));
     }
 
@@ -113,22 +110,22 @@ class AuthOrchSerializationServicesIntegrationTest {
         authSessionService.storeOrUpdateSession(authSession);
         var orchSession = orchSessionService.getSession(sessionId).get();
         orchSession.addClientSession(CLIENT_SESSION_ID);
-        orchSessionService.storeOrUpdateSession(orchSession);
+        orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         authSession = authSessionService.getSession(sessionId).get();
         assertThat(authSession.getPasswordResetCount(), is(equalTo(3)));
     }
 
     @Test
     void authCanReadSessionAfterSessionIdIsUpdated() {
-        var orchSession = orchSessionService.generateSession(SESSION_ID);
-        var originalSessionId = orchSession.getSessionId();
-        orchSessionService.storeOrUpdateSession(orchSession);
-        var authSession = authSessionService.getSession(originalSessionId).get();
+        var oldSessionId = SESSION_ID;
+        var newSessionId = "new-session-id";
+        var orchSession = orchSessionService.generateSession(oldSessionId);
+        orchSessionService.storeOrUpdateSession(orchSession, oldSessionId);
+        var authSession = authSessionService.getSession(oldSessionId).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
         authSessionService.storeOrUpdateSession(authSession);
-        orchSession = orchSessionService.getSession(originalSessionId).get();
-        orchSessionService.updateWithNewSessionId(orchSession);
-        var newSessionId = orchSession.getSessionId();
+        orchSession = orchSessionService.getSession(oldSessionId).get();
+        orchSessionService.updateWithNewSessionId(orchSession, oldSessionId, newSessionId);
         authSessionService.getSession(newSessionId).get();
         assertThat(authSession.getClientSessions(), contains(CLIENT_SESSION_ID));
     }
@@ -136,13 +133,12 @@ class AuthOrchSerializationServicesIntegrationTest {
     @Test
     void authCanResetSharedFieldsWithoutOverridingUnsharedFields() {
         var orchSession = orchSessionService.generateSession(SESSION_ID);
-        var sessionId = orchSession.getSessionId();
         orchSession.addClientSession(CLIENT_SESSION_ID);
         orchSession.incrementProcessingIdentityAttempts();
-        orchSessionService.storeOrUpdateSession(orchSession);
-        var authSession = new Session(sessionId);
+        orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
+        var authSession = new Session(SESSION_ID);
         authSessionService.storeOrUpdateSession(authSession);
-        orchSession = orchSessionService.getSession(sessionId).get();
+        orchSession = orchSessionService.getSession(SESSION_ID).get();
         assertThat(orchSession.getClientSessions(), is(empty()));
         assertThat(orchSession.getProcessingIdentityAttempts(), is(equalTo(1)));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -18,6 +18,7 @@ class AuthOrchSerializationServicesIntegrationTest {
             System.getenv().getOrDefault("REDIS_HOST", "localhost");
     private static final Optional<String> REDIS_PASSWORD =
             Optional.ofNullable(System.getenv("REDIS_PASSWORD"));
+    private static final String SESSION_ID = "session-id";
     private static final String BROWSER_SESSION_ID = "browser-session-id";
     private static final String CLIENT_SESSION_ID = "client-session-id";
 
@@ -47,7 +48,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void authCanReadFromSessionCreatedByOrch() {
-        var orchSession = orchSessionService.generateSession();
+        var orchSession = orchSessionService.generateSession(SESSION_ID);
         var sessionId = orchSession.getSessionId();
         orchSession.addClientSession(CLIENT_SESSION_ID);
         orchSessionService.storeOrUpdateSession(orchSession);
@@ -67,7 +68,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void authCanUpdateSharedFieldInSessionCreatedByOrch() {
-        var orchSession = orchSessionService.generateSession();
+        var orchSession = orchSessionService.generateSession(SESSION_ID);
         var sessionId = orchSession.getSessionId();
         orchSessionService.storeOrUpdateSession(orchSession);
         var authSession = authSessionService.getSession(sessionId).get();
@@ -91,7 +92,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void orchCanReadUnsharedFieldAfterAuthUpdatesSession() {
-        var orchSession = orchSessionService.generateSession();
+        var orchSession = orchSessionService.generateSession(SESSION_ID);
         var sessionId = orchSession.getSessionId();
         orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession);
@@ -119,7 +120,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void authCanReadSessionAfterSessionIdIsUpdated() {
-        var orchSession = orchSessionService.generateSession();
+        var orchSession = orchSessionService.generateSession(SESSION_ID);
         var originalSessionId = orchSession.getSessionId();
         orchSessionService.storeOrUpdateSession(orchSession);
         var authSession = authSessionService.getSession(originalSessionId).get();
@@ -134,7 +135,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void authCanResetSharedFieldsWithoutOverridingUnsharedFields() {
-        var orchSession = orchSessionService.generateSession();
+        var orchSession = orchSessionService.generateSession(SESSION_ID);
         var sessionId = orchSession.getSessionId();
         orchSession.addClientSession(CLIENT_SESSION_ID);
         orchSession.incrementProcessingIdentityAttempts();

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -265,7 +265,7 @@ public class IPVCallbackHelper {
                 isTestJourney);
 
         authCodeResponseService.saveSession(
-                false, sessionService, session, orchSessionService, orchSession);
+                false, sessionService, session, sessionId, orchSessionService, orchSession);
         return authenticationResponse;
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -159,7 +159,8 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
                             .orElse(AuditService.UNKNOWN),
                     user);
 
-            sessionService.storeOrUpdateSession(userSession.getSession());
+            sessionService.storeOrUpdateSession(
+                    userSession.getSession(), userSession.getSessionId());
 
             LOG.info(
                     "Generating IdentityProgressResponse with IdentityProgressStatus: {}",

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -174,7 +174,8 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
 
             auditService.submitAuditEvent(
                     IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST, auditContext);
-            sessionService.storeOrUpdateSession(userContext.getSession());
+            sessionService.storeOrUpdateSession(
+                    userContext.getSession(), userContext.getSessionId());
             LOG.info(
                     "Generating ProcessingIdentityResponse with ProcessingIdentityStatus: {}",
                     processingStatus);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -290,7 +290,12 @@ public class AuthCodeHandler
                     clientSession.getClientName(),
                     isTestJourney);
             authCodeResponseService.saveSession(
-                    docAppJourney, sessionService, session, orchSessionService, orchSession);
+                    docAppJourney,
+                    sessionService,
+                    session,
+                    sessionId,
+                    orchSessionService,
+                    orchSession);
 
             LOG.info("Generating successful auth code response");
             return generateApiGatewayProxyResponse(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -418,7 +418,7 @@ public class AuthenticationCallbackHandler
                 clientSession.setRpPairwiseId(
                         userInfo.getStringClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue()));
 
-                sessionService.storeOrUpdateSession(session);
+                sessionService.storeOrUpdateSession(session, sessionId);
                 orchSessionService.updateSession(orchSession);
                 clientSessionService.updateStoredClientSession(clientSessionId, clientSession);
 
@@ -563,7 +563,7 @@ public class AuthenticationCallbackHandler
                         new AuthenticationSuccessResponse(
                                 clientRedirectURI, authCode, null, null, state, null, responseMode);
 
-                sessionService.storeOrUpdateSession(session);
+                sessionService.storeOrUpdateSession(session, sessionId);
                 var currentCredentialStrength =
                         userInfo.getStringClaim(
                                 AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue());

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -557,7 +557,7 @@ public class AuthorisationHandler
         session.addClientSession(clientSessionId);
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         updateAttachedLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
-        sessionService.storeOrUpdateSession(session);
+        sessionService.storeOrUpdateSession(session, newSessionId);
         orchSessionOptional.ifPresentOrElse(
                 s -> orchSessionService.updateSession(orchSession),
                 () -> orchSessionService.addSession(orchSession));
@@ -711,7 +711,7 @@ public class AuthorisationHandler
         session.addClientSession(clientSessionId);
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         updateAttachedLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
-        sessionService.storeOrUpdateSession(session);
+        sessionService.storeOrUpdateSession(session, newSessionId);
         LOG.info("Session saved successfully");
         return generateAuthRedirect(
                 newSessionId,
@@ -779,7 +779,7 @@ public class AuthorisationHandler
             Session previousSession, String newSessionIdForPreviousSession, String newSessionId) {
         sessionService.updateWithNewSessionId(previousSession, newSessionIdForPreviousSession);
         var newSession = sessionService.copySessionForMaxAge(previousSession, newSessionId);
-        sessionService.storeOrUpdateSession(newSession);
+        sessionService.storeOrUpdateSession(newSession, newSessionId);
         return newSession;
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -658,6 +658,7 @@ public class AuthorisationHandler
                 session =
                         updateSharedSessionDueToMaxAgeExpiry(
                                 existingSession.get(),
+                                existingSessionId.get(),
                                 newSessionIdForPreviousSession,
                                 newSessionId);
 
@@ -776,8 +777,12 @@ public class AuthorisationHandler
     }
 
     private Session updateSharedSessionDueToMaxAgeExpiry(
-            Session previousSession, String newSessionIdForPreviousSession, String newSessionId) {
-        sessionService.updateWithNewSessionId(previousSession, newSessionIdForPreviousSession);
+            Session previousSession,
+            String previousSessionId,
+            String newSessionIdForPreviousSession,
+            String newSessionId) {
+        sessionService.updateWithNewSessionId(
+                previousSession, previousSessionId, newSessionIdForPreviousSession);
         var newSession = sessionService.copySessionForMaxAge(previousSession, newSessionId);
         sessionService.storeOrUpdateSession(newSession, newSessionId);
         return newSession;

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -465,8 +465,6 @@ class AuthCodeHandlerTest {
 
     @Test
     void shouldGenerateErrorResponseWhenOrchSessionIsNotFound() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(clientSession));
         when(clientSession.getClientName()).thenReturn(CLIENT_NAME);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -192,14 +192,21 @@ class AuthCodeHandlerTest {
                             return null;
                         })
                 .when(authCodeResponseService)
-                .saveSession(true, sessionService, session, orchSessionService, orchSession);
+                .saveSession(
+                        true, sessionService, session, SESSION_ID, orchSessionService, orchSession);
         doAnswer(
                         (i) -> {
                             session.setAuthenticated(true).setNewAccount(EXISTING);
                             return null;
                         })
                 .when(authCodeResponseService)
-                .saveSession(false, sessionService, session, orchSessionService, orchSession);
+                .saveSession(
+                        false,
+                        sessionService,
+                        session,
+                        SESSION_ID,
+                        orchSessionService,
+                        orchSession);
     }
 
     private static Stream<Arguments> upliftTestParameters() {
@@ -300,6 +307,7 @@ class AuthCodeHandlerTest {
                         anyBoolean(),
                         eq(sessionService),
                         eq(session),
+                        eq(SESSION_ID),
                         eq(orchSessionService),
                         eq(orchSession));
 
@@ -416,6 +424,7 @@ class AuthCodeHandlerTest {
                         anyBoolean(),
                         eq(sessionService),
                         eq(session),
+                        eq(SESSION_ID),
                         any(OrchSessionService.class),
                         any(OrchSessionItem.class));
         verify(auditService)
@@ -644,6 +653,7 @@ class AuthCodeHandlerTest {
                         anyBoolean(),
                         eq(sessionService),
                         eq(session),
+                        eq(SESSION_ID),
                         any(OrchSessionService.class),
                         any(OrchSessionItem.class));
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -559,7 +559,8 @@ class AuthenticationCallbackHandlerTest {
 
         var sessionSaveCaptor = ArgumentCaptor.forClass(Session.class);
         var orchSessionCaptor = ArgumentCaptor.forClass(OrchSessionItem.class);
-        verify(sessionService, times(2)).storeOrUpdateSession(sessionSaveCaptor.capture());
+        verify(sessionService, times(2))
+                .storeOrUpdateSession(sessionSaveCaptor.capture(), anyString());
         verify(orchSessionService, times(3)).updateSession(orchSessionCaptor.capture());
         assertThat(
                 Session.AccountState.UNKNOWN,
@@ -930,7 +931,8 @@ class AuthenticationCallbackHandlerTest {
                                 eq(reproveIdentity),
                                 any());
                 verifyNoInteractions(logoutService);
-                verify(sessionService).storeOrUpdateSession(argThat(Session::isAuthenticated));
+                verify(sessionService)
+                        .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
             }
@@ -953,7 +955,8 @@ class AuthenticationCallbackHandlerTest {
                                 CLIENT_ID.getValue(),
                                 intervention);
                 verifyNoInteractions(initiateIPVAuthorisationService);
-                verify(sessionService).storeOrUpdateSession(argThat(Session::isAuthenticated));
+                verify(sessionService)
+                        .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
             }
@@ -981,7 +984,8 @@ class AuthenticationCallbackHandlerTest {
                                 eq(reproveIdentity),
                                 any());
                 verifyNoInteractions(logoutService);
-                verify(sessionService).storeOrUpdateSession(argThat(Session::isAuthenticated));
+                verify(sessionService)
+                        .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
             }
@@ -1004,7 +1008,8 @@ class AuthenticationCallbackHandlerTest {
                                 CLIENT_ID.toString(),
                                 intervention);
                 verifyNoInteractions(initiateIPVAuthorisationService);
-                verify(sessionService).storeOrUpdateSession(argThat(Session::isAuthenticated));
+                verify(sessionService)
+                        .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
             }
 
             @Test
@@ -1030,7 +1035,8 @@ class AuthenticationCallbackHandlerTest {
                                 eq(reproveIdentity),
                                 any());
                 verifyNoInteractions(logoutService);
-                verify(sessionService).storeOrUpdateSession(argThat(Session::isAuthenticated));
+                verify(sessionService)
+                        .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
             }
@@ -1108,7 +1114,8 @@ class AuthenticationCallbackHandlerTest {
                     .updateSession(argThat(s -> s.getPreviousSessionId() == null));
             verify(sessionService, times(2))
                     .storeOrUpdateSession(
-                            argThat(s -> s.getClientSessions().equals(PREVIOUS_CLIENT_SESSIONS)));
+                            argThat(s -> s.getClientSessions().equals(PREVIOUS_CLIENT_SESSIONS)),
+                            anyString());
         }
 
         @Test
@@ -1141,7 +1148,8 @@ class AuthenticationCallbackHandlerTest {
             verify(orchSessionService, times(3))
                     .updateSession(argThat(s -> s.getPreviousSessionId() == null));
             verify(sessionService, times(2))
-                    .storeOrUpdateSession(argThat(s -> s.getClientSessions().equals(List.of())));
+                    .storeOrUpdateSession(
+                            argThat(s -> s.getClientSessions().equals(List.of())), anyString());
         }
 
         @Test
@@ -1174,7 +1182,8 @@ class AuthenticationCallbackHandlerTest {
             verify(orchSessionService, times(3))
                     .updateSession(argThat(s -> s.getPreviousSessionId() == null));
             verify(sessionService, times(2))
-                    .storeOrUpdateSession(argThat(s -> s.getClientSessions().equals(List.of())));
+                    .storeOrUpdateSession(
+                            argThat(s -> s.getClientSessions().equals(List.of())), anyString());
         }
 
         @Test
@@ -1209,7 +1218,8 @@ class AuthenticationCallbackHandlerTest {
             verify(orchSessionService, times(3))
                     .updateSession(argThat(s -> s.getPreviousSessionId() == null));
             verify(sessionService, times(2))
-                    .storeOrUpdateSession(argThat(s -> s.getClientSessions().equals(List.of())));
+                    .storeOrUpdateSession(
+                            argThat(s -> s.getClientSessions().equals(List.of())), anyString());
 
             verify(logoutService, times(1))
                     .handleMaxAgeLogout(
@@ -1382,7 +1392,8 @@ class AuthenticationCallbackHandlerTest {
 
     private void assertSessionUpdatedAuthJourney() {
         var sessionSaveCaptor = ArgumentCaptor.forClass(Session.class);
-        verify(sessionService, times(2)).storeOrUpdateSession(sessionSaveCaptor.capture());
+        verify(sessionService, times(2))
+                .storeOrUpdateSession(sessionSaveCaptor.capture(), anyString());
         assertThat(
                 sessionSaveCaptor.getAllValues().get(0).getCurrentCredentialStrength(),
                 equalTo(lowestCredentialTrustLevel));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -762,7 +762,7 @@ class AuthorisationHandlerTest {
                     .submitAuditEvent(
                             OidcAuditableEvent.AUTHORISATION_INITIATED,
                             CLIENT_ID.getValue(),
-                            BASE_AUDIT_USER.withSessionId(session.getSessionId()),
+                            BASE_AUDIT_USER.withSessionId(NEW_SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME),
                             pair("new_authentication_required", false));
         }
@@ -2026,11 +2026,9 @@ class AuthorisationHandlerTest {
                 withExistingOrchSession(null);
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
-                verify(sessionService).generateSession(anyString());
+                verify(sessionService).generateSession(NEW_SESSION_ID);
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
-                var actualSession = sessionCaptor.getValue();
-                assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 
                 verify(orchSessionService).addSession(orchSessionCaptor.capture());
                 var actualOrchSession = orchSessionCaptor.getValue();
@@ -2058,11 +2056,9 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
-                verify(sessionService).generateSession(anyString());
+                verify(sessionService).generateSession(NEW_SESSION_ID);
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
-                var actualSession = sessionCaptor.getValue();
-                assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 
                 verify(orchSessionService).addSession(orchSessionCaptor.capture());
                 var actualOrchSession = orchSessionCaptor.getValue();
@@ -2089,11 +2085,9 @@ class AuthorisationHandlerTest {
                 withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
-                verify(sessionService).generateSession(anyString());
+                verify(sessionService).generateSession(NEW_SESSION_ID);
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
-                var actualSession = sessionCaptor.getValue();
-                assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 
                 verify(orchSessionService).addSession(orchSessionCaptor.capture());
                 var actualOrchSession = orchSessionCaptor.getValue();
@@ -2123,8 +2117,6 @@ class AuthorisationHandlerTest {
                 verify(sessionService, never()).generateSession(anyString());
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
-                var actualSession = sessionCaptor.getValue();
-                assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 
                 verify(orchSessionService).addSession(orchSessionCaptor.capture());
                 var actualOrchSession = orchSessionCaptor.getValue();
@@ -2160,8 +2152,6 @@ class AuthorisationHandlerTest {
                 verify(sessionService, never()).generateSession(anyString());
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
-                var actualSession = sessionCaptor.getValue();
-                assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 
                 verify(orchSessionService).addSession(orchSessionCaptor.capture());
                 var actualOrchSession = orchSessionCaptor.getValue();
@@ -2189,11 +2179,9 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(DIFFERENT_BROWSER_SESSION_ID);
 
-                verify(sessionService).generateSession(anyString());
+                verify(sessionService).generateSession(NEW_SESSION_ID);
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
-                var actualSession = sessionCaptor.getValue();
-                assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 
                 verify(orchSessionService).addSession(orchSessionCaptor.capture());
                 var actualOrchSession = orchSessionCaptor.getValue();

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -356,7 +356,7 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).storeOrUpdateSession(newSession);
+            verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
@@ -641,7 +641,7 @@ class AuthorisationHandlerTest {
                                 .contains("lng="));
             }
 
-            verify(sessionService).storeOrUpdateSession(newSession);
+            verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
 
             inOrder.verify(auditService)
@@ -681,7 +681,7 @@ class AuthorisationHandlerTest {
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
-            verify(sessionService).storeOrUpdateSession(eq(session));
+            verify(sessionService).storeOrUpdateSession(session, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
             verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -753,7 +753,7 @@ class AuthorisationHandlerTest {
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
-            verify(sessionService).storeOrUpdateSession(eq(session));
+            verify(sessionService).storeOrUpdateSession(session, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
             verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -795,7 +795,7 @@ class AuthorisationHandlerTest {
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
-            verify(sessionService).storeOrUpdateSession(session);
+            verify(sessionService).storeOrUpdateSession(session, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
             verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -842,7 +842,7 @@ class AuthorisationHandlerTest {
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
-            verify(sessionService).storeOrUpdateSession(eq(session));
+            verify(sessionService).storeOrUpdateSession(session, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
             verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
@@ -1289,7 +1289,7 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).storeOrUpdateSession(newSession);
+            verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
 
             verify(requestObjectAuthorizeValidator).validate(any());
@@ -1338,7 +1338,7 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).storeOrUpdateSession(newSession);
+            verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
 
             inOrder.verify(auditService)
@@ -1491,7 +1491,7 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).storeOrUpdateSession(newSession);
+            verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
 
             verify(requestObjectAuthorizeValidator).validate(any());
@@ -2027,7 +2027,8 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
                 verify(sessionService).generateSession(anyString());
-                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
+                verify(sessionService)
+                        .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 
@@ -2058,7 +2059,8 @@ class AuthorisationHandlerTest {
                         makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
                 verify(sessionService).generateSession(anyString());
-                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
+                verify(sessionService)
+                        .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 
@@ -2088,7 +2090,8 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
                 verify(sessionService).generateSession(anyString());
-                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
+                verify(sessionService)
+                        .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 
@@ -2118,7 +2121,8 @@ class AuthorisationHandlerTest {
                 var response = makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
                 verify(sessionService, never()).generateSession(anyString());
-                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
+                verify(sessionService)
+                        .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 
@@ -2154,7 +2158,8 @@ class AuthorisationHandlerTest {
                         makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
                 verify(sessionService, never()).generateSession(anyString());
-                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
+                verify(sessionService)
+                        .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 
@@ -2185,7 +2190,8 @@ class AuthorisationHandlerTest {
                         makeRequestWithBSIDInCookie(DIFFERENT_BROWSER_SESSION_ID);
 
                 verify(sessionService).generateSession(anyString());
-                verify(sessionService).storeOrUpdateSession(sessionCaptor.capture());
+                verify(sessionService)
+                        .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
                 var actualSession = sessionCaptor.getValue();
                 assertEquals(NEW_SESSION_ID, actualSession.getSessionId());
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -314,7 +314,6 @@ class AuthorisationHandlerTest {
         session = new Session(SESSION_ID);
         newSession = new Session(NEW_SESSION_ID);
         orchSession = new OrchSessionItem(SESSION_ID);
-        when(sessionService.generateSession()).thenReturn(new Session(newSession));
         when(sessionService.generateSession(anyString())).thenReturn(newSession);
         when(clientSessionService.generateClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(clientSessionService.generateClientSession(any(), any(), any(), any()))

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -120,17 +120,19 @@ public class AuthCodeResponseGenerationService {
             boolean docAppJourney,
             SessionService sessionService,
             Session session,
+            String sessionId,
             OrchSessionService orchSessionService,
             OrchSessionItem orchSession) {
 
         if (docAppJourney) {
-            sessionService.storeOrUpdateSession(session.setNewAccount(EXISTING_DOC_APP_JOURNEY));
+            sessionService.storeOrUpdateSession(
+                    session.setNewAccount(EXISTING_DOC_APP_JOURNEY), sessionId);
             orchSessionService.updateSession(
                     orchSession.withAccountState(
                             OrchSessionItem.AccountState.EXISTING_DOC_APP_JOURNEY));
         } else {
             sessionService.storeOrUpdateSession(
-                    session.setAuthenticated(true).setNewAccount(EXISTING));
+                    session.setAuthenticated(true).setNewAccount(EXISTING), sessionId);
             orchSessionService.updateSession(
                     orchSession
                             .withAuthenticated(true)

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -1,7 +1,6 @@
 package uk.gov.di.orchestration.shared.services;
 
 import uk.gov.di.orchestration.shared.entity.Session;
-import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.JsonUpdateHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 
@@ -60,14 +59,6 @@ public class SessionService {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public void updateWithNewSessionId(Session session) {
-        updateWithNewSessionId(session, IdGenerator.generate());
-    }
-
-    public void updateWithNewSessionId(Session session, String newSessionId) {
-        updateWithNewSessionId(session, session.getSessionId(), newSessionId);
     }
 
     public Session updateWithNewSessionId(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -43,11 +43,11 @@ public class SessionService {
         return copiedSession;
     }
 
-    public void storeOrUpdateSession(Session session) {
-        storeOrUpdateSession(session, session.getSessionId());
+    public void storeOrUpdateSession(Session session, String sessionId) {
+        storeOrUpdateSession(session, sessionId, sessionId);
     }
 
-    private void storeOrUpdateSession(Session session, String oldSessionId) {
+    private void storeOrUpdateSession(Session session, String oldSessionId, String newSessionId) {
         try {
             var newSession = OBJECT_MAPPER.writeValueAsString(session);
             if (redisConnectionService.keyExists(oldSessionId)) {
@@ -56,7 +56,7 @@ public class SessionService {
             }
 
             redisConnectionService.saveWithExpiry(
-                    session.getSessionId(), newSession, configurationService.getSessionExpiry());
+                    newSessionId, newSession, configurationService.getSessionExpiry());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -75,7 +75,7 @@ public class SessionService {
         try {
             session.setSessionId(newSessionId);
             session.resetProcessingIdentityAttempts();
-            storeOrUpdateSession(session, oldSessionId);
+            storeOrUpdateSession(session, oldSessionId, newSessionId);
             redisConnectionService.deleteValue(oldSessionId);
             return session;
         } catch (Exception e) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -89,7 +90,7 @@ class AuthCodeResponseGenerationServiceTest {
     @Test
     void saveSessionUpdatesNonDocAppSessionWithAuthenticatedAndAccountState() {
         authCodeResponseGenerationService.saveSession(
-                false, sessionService, session, orchSessionService, orchSession);
+                false, sessionService, session, SESSION_ID, orchSessionService, orchSession);
 
         verify(sessionService)
                 .storeOrUpdateSession(
@@ -97,7 +98,8 @@ class AuthCodeResponseGenerationServiceTest {
                                 s ->
                                         s.isAuthenticated()
                                                 && s.isNewAccount()
-                                                        == Session.AccountState.EXISTING));
+                                                        == Session.AccountState.EXISTING),
+                        eq(SESSION_ID));
         verify(orchSessionService)
                 .updateSession(
                         argThat(
@@ -110,14 +112,15 @@ class AuthCodeResponseGenerationServiceTest {
     @Test
     void saveSessionUpdatesDocAppSessionWithDocAppState() {
         authCodeResponseGenerationService.saveSession(
-                true, sessionService, session, orchSessionService, orchSession);
+                true, sessionService, session, SESSION_ID, orchSessionService, orchSession);
 
         verify(sessionService)
                 .storeOrUpdateSession(
                         argThat(
                                 s ->
                                         s.isNewAccount()
-                                                == Session.AccountState.EXISTING_DOC_APP_JOURNEY));
+                                                == Session.AccountState.EXISTING_DOC_APP_JOURNEY),
+                        eq(SESSION_ID));
         verify(orchSessionService)
                 .updateSession(
                         argThat(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
@@ -6,6 +6,7 @@ import uk.gov.di.orchestration.shared.serialization.Json;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -36,9 +37,10 @@ class SessionServiceTest {
         var session = new Session("session-id").addClientSession("client-session-id");
 
         sessionService.storeOrUpdateSession(session, "session-id");
-        sessionService.updateWithNewSessionId(session);
+        sessionService.updateWithNewSessionId(session, "session-id", "new-session-id");
 
-        verify(redis, times(2)).saveWithExpiry(anyString(), anyString(), anyLong());
+        verify(redis).saveWithExpiry(eq("session-id"), anyString(), anyLong());
+        verify(redis).saveWithExpiry(eq("new-session-id"), anyString(), anyLong());
         verify(redis).deleteValue("session-id");
     }
 
@@ -47,7 +49,7 @@ class SessionServiceTest {
         var session = new Session("session-id").addClientSession("client-session-id");
 
         sessionService.storeOrUpdateSession(session, "session-id");
-        sessionService.deleteStoredSession(session.getSessionId());
+        sessionService.deleteStoredSession("session-id");
 
         verify(redis).deleteValue("session-id");
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
@@ -25,7 +25,7 @@ class SessionServiceTest {
 
         var session = new Session("session-id").addClientSession("client-session-id");
 
-        sessionService.storeOrUpdateSession(session);
+        sessionService.storeOrUpdateSession(session, "session-id");
 
         verify(redis, times(1))
                 .saveWithExpiry("session-id", objectMapper.writeValueAsString(session), 1234L);
@@ -35,7 +35,7 @@ class SessionServiceTest {
     void shouldUpdateSessionIdInRedisAndDeleteOldKey() {
         var session = new Session("session-id").addClientSession("client-session-id");
 
-        sessionService.storeOrUpdateSession(session);
+        sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.updateWithNewSessionId(session);
 
         verify(redis, times(2)).saveWithExpiry(anyString(), anyString(), anyLong());
@@ -46,15 +46,9 @@ class SessionServiceTest {
     void shouldDeleteSessionIdFromRedis() {
         var session = new Session("session-id").addClientSession("client-session-id");
 
-        sessionService.storeOrUpdateSession(session);
+        sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.deleteStoredSession(session.getSessionId());
 
         verify(redis).deleteValue("session-id");
-    }
-
-    private String generateSearlizedSession() throws Json.JsonException {
-        var session = new Session("session-id").addClientSession("client-session-id");
-
-        return objectMapper.writeValueAsString(session);
     }
 }


### PR DESCRIPTION
### Wider context of change

We would like to migrate away from the shared session and use the orch session instead. The parent issue for this is for migrating use of the sessionId. We've already used setters to set the sessionId on OrchSessionItem and AuthSessionItem. This issue is for removing the getters.

### What’s changed

This PR removes usage of `Session.getSessionId()` from `SessionService`. 

There were also a few methods in `SessionService` that were only used in tests, so I've removed them and their associated tests. These were `SessionService.generateSession` and `SessionService.getSessionFromRequestHeaders`

I've also removed some getters from a test that I forgot to remove in another PR for removing session id getters (https://github.com/govuk-one-login/authentication-api/pull/5816)

### Manual Testing

Tested in dev:
- Performed a full login journey and logged in successfully. 
- Went back to the login page and logged in again, which used my previous session as expected.
- Logged out, then logged back in, which was also successful in creating a new session.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
