### PR TITLE
AUT-4048: Allow ingress access to session store redis

### DIFF
--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -64,3 +64,6 @@ logging_endpoint_enabled = false
 enforce_code_signing     = false
 
 orchestration_account_id = "816047645251"
+
+auth_new_account_id               = "058264536367"
+new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]

--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -65,5 +65,5 @@ enforce_code_signing     = false
 
 orchestration_account_id = "816047645251"
 
-auth_new_account_id               = "058264536367"
+auth_new_account_id               = "975050272416"
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]

--- a/ci/terraform/shared/authdev2.tfvars
+++ b/ci/terraform/shared/authdev2.tfvars
@@ -64,5 +64,5 @@ enforce_code_signing     = false
 
 orchestration_account_id = "816047645251"
 
-auth_new_account_id               = "058264536367"
+auth_new_account_id               = "975050272416"
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]

--- a/ci/terraform/shared/authdev2.tfvars
+++ b/ci/terraform/shared/authdev2.tfvars
@@ -63,3 +63,6 @@ logging_endpoint_enabled = false
 enforce_code_signing     = false
 
 orchestration_account_id = "816047645251"
+
+auth_new_account_id               = "058264536367"
+new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]

--- a/ci/terraform/shared/build.tfvars
+++ b/ci/terraform/shared/build.tfvars
@@ -3,8 +3,10 @@ common_state_bucket                  = "digital-identity-dev-tfstate"
 di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:114407264696:/signing-profiles/di_auth_lambda_signing_20220215170204371800000001/zLiNn2Hi1I"
 tools_account_id                     = 706615647326
 orchestration_account_id             = "767397776536"
-auth_new_frontend_account_id         = "058264536367"
+auth_new_account_id                  = "058264536367"
 orch_stub_deployed                   = false
 
 orch_privatesub_cidr_blocks   = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
 orch_protectedsub_cidr_blocks = ["10.1.4.0/23", "10.1.6.0/23", "10.1.8.0/23"]
+
+new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]

--- a/ci/terraform/shared/dev.tfvars
+++ b/ci/terraform/shared/dev.tfvars
@@ -6,3 +6,6 @@ orchestration_account_id             = "816047645251"
 
 orch_privatesub_cidr_blocks   = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
 orch_protectedsub_cidr_blocks = ["10.1.4.0/23", "10.1.6.0/23", "10.1.8.0/23"]
+
+auth_new_account_id               = "975050272416"
+new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]

--- a/ci/terraform/shared/iam.tf
+++ b/ci/terraform/shared/iam.tf
@@ -13,7 +13,7 @@ resource "aws_iam_role" "cross_account_role" {
         Action = "sts:AssumeRole"
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::${var.auth_new_frontend_account_id}:root"
+          AWS = "arn:aws:iam::${var.auth_new_account_id}:root"
         }
       }
     ]

--- a/ci/terraform/shared/security-groups.tf
+++ b/ci/terraform/shared/security-groups.tf
@@ -76,7 +76,7 @@ resource "aws_security_group_rule" "allow_incoming_redis_from_orch_protected_sub
   type        = "ingress"
 }
 
-resource "aws_security_group_rule" "allow_incoming_frontend_redis_from_new_auth" {
+resource "aws_security_group_rule" "allow_incoming_session_redis_from_new_auth" {
   count = length(var.new_auth_protectedsub_cidr_blocks) == 0 ? 0 : 1
 
   description       = "Allow ingress to Redis from new Auth equivalent environment protected subnets"

--- a/ci/terraform/shared/security-groups.tf
+++ b/ci/terraform/shared/security-groups.tf
@@ -75,3 +75,16 @@ resource "aws_security_group_rule" "allow_incoming_redis_from_orch_protected_sub
   to_port     = local.redis_port_number
   type        = "ingress"
 }
+
+resource "aws_security_group_rule" "allow_incoming_frontend_redis_from_new_auth" {
+  count = length(var.new_auth_protectedsub_cidr_blocks) == 0 ? 0 : 1
+
+  description       = "Allow ingress to Redis from new Auth equivalent environment protected subnets"
+  security_group_id = aws_security_group.redis_security_group.id
+
+  from_port   = local.redis_port_number
+  protocol    = "tcp"
+  cidr_blocks = var.new_auth_protectedsub_cidr_blocks
+  to_port     = local.redis_port_number
+  type        = "ingress"
+}

--- a/ci/terraform/shared/staging.tfvars
+++ b/ci/terraform/shared/staging.tfvars
@@ -2,9 +2,11 @@ logging_endpoint_enabled             = false
 common_state_bucket                  = "di-auth-staging-tfstate"
 di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:114407264696:/signing-profiles/di_auth_lambda_signing_20220215170204371800000001/zLiNn2Hi1I"
 tools_account_id                     = 706615647326
-auth_new_frontend_account_id         = "851725205974"
+auth_new_account_id                  = "851725205974"
 orch_stub_deployed                   = false
 
 orchestration_account_id      = "590183975515"
 orch_privatesub_cidr_blocks   = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
 orch_protectedsub_cidr_blocks = ["10.1.4.0/23", "10.1.6.0/23", "10.1.8.0/23"]
+
+new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -195,7 +195,7 @@ variable "orch_protectedsub_cidr_blocks" {
   default     = []
 }
 
-variable "auth_new_frontend_account_id" {
+variable "auth_new_account_id" {
   type        = string
   description = "Account id of the auth new frontend"
   default     = ""
@@ -205,4 +205,10 @@ variable "vpc_environment" {
   description = "The name of the environment this environment is sharing the VPC , this var is only for Authdevs env and must be overide using Authdevs.tfvars, default value should be null always."
   type        = string
   default     = null
+}
+
+variable "new_auth_protectedsub_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "New Auth equivalent environment protected subnets"
 }


### PR DESCRIPTION
## What

AUT-4048: Allow ingress access to session store redis from new Auth account to Deploy ORCH Stub in new Account 
Current ORC stub for Build & Staging are deployment in old Aws account , we will me migrating the signin Zone ID to new Auth AWS account , this is cause issue in Deployment of ORCh Stub.

So to Move the ORCH Stub to new Account we need to allow ingress Access in Redis session store.

Note : we only allowing this access in Devs, Build, Staging only  


## Templates

- [Auth Team](?expand=1&template=auth_template.md)
- [Orchestration Team](?expand=1&template=orch_template.md)
