### PR TITLE
ATO-1321: Remove shared session `getInternalCommonSubjectIdentifier` from authentication callback handler

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -353,8 +353,11 @@ public class AuthenticationCallbackHandler
                         clientId,
                         user);
                 LOG.info("Adding Authentication userinfo to dynamo");
+
+                String internalCommonSubjectId = userInfo.getSubject().getValue();
+
                 userInfoStorageService.addAuthenticationUserInfoData(
-                        userInfo.getSubject().getValue(), userInfo);
+                        internalCommonSubjectId, userInfo);
                 addClaimsToOrchSession(orchSession, userInfo);
 
                 ClientRegistry client = clientService.getClient(clientId).orElseThrow();
@@ -471,7 +474,7 @@ public class AuthenticationCallbackHandler
                                 clientSessionId,
                                 sessionId,
                                 clientId,
-                                userInfo.getSubject().getValue(),
+                                internalCommonSubjectId,
                                 Objects.isNull(userInfo.getEmailAddress())
                                         ? UNKNOWN
                                         : userInfo.getEmailAddress(),
@@ -484,7 +487,7 @@ public class AuthenticationCallbackHandler
                 Long passwordResetTime = getPasswordResetTimeClaim(userInfo);
                 AccountIntervention intervention =
                         accountInterventionService.getAccountIntervention(
-                                userInfo.getSubject().getValue(), passwordResetTime, auditContext);
+                                internalCommonSubjectId, passwordResetTime, auditContext);
 
                 Boolean reproveIdentity = null;
                 if (configurationService.isAccountInterventionServiceActionEnabled()) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
@@ -80,16 +80,16 @@ public class InitiateIPVAuthorisationService {
 
         attachLogFieldToLogs(CLIENT_ID, rpClientID);
         LOG.info("AuthenticationCallbackHandler initiated IPV authorisation request");
-        var pairwiseSubject = userInfo.getSubject();
+        var internalCommonSubjectId = userInfo.getSubject();
 
         var state = new State();
-        var claimsSetRequest = buildIpvClaimsRequest(authRequest, pairwiseSubject);
+        var claimsSetRequest = buildIpvClaimsRequest(authRequest, internalCommonSubjectId);
 
         var encryptedJWT =
                 authorisationService.constructRequestJWT(
                         state,
                         authRequest.getScope(),
-                        pairwiseSubject,
+                        internalCommonSubjectId,
                         claimsSetRequest,
                         Optional.ofNullable(clientSessionId).orElse("unknown"),
                         userInfo.getEmailAddress(),
@@ -115,7 +115,7 @@ public class InitiateIPVAuthorisationService {
                 TxmaAuditUser.user()
                         .withGovukSigninJourneyId(clientSessionId)
                         .withSessionId(session.getSessionId())
-                        .withUserId(session.getInternalCommonSubjectIdentifier())
+                        .withUserId(internalCommonSubjectId.getValue())
                         .withEmail(userInfo.getEmailAddress())
                         .withIpAddress(IpAddressHelper.extractIpAddress(input))
                         .withPersistentSessionId(persistentSessionCookieId),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -232,7 +232,7 @@ public class InitiateIPVAuthorisationServiceTest {
                         TxmaAuditUser.user()
                                 .withGovukSigninJourneyId(CLIENT_SESSION_ID)
                                 .withSessionId(SESSION_ID)
-                                .withUserId(expectedCommonSubject)
+                                .withUserId(userInfo.getSubject().getValue())
                                 .withEmail(EMAIL_ADDRESS)
                                 .withIpAddress(IP_ADDRESS)
                                 .withPersistentSessionId(PERSISTENT_SESSION_ID),


### PR DESCRIPTION
### Wider context of change:

As part of the session migration work, we'd like to remove usages of `getInternalCommonSubjectIdentifier` from the shared session and instead use the orch session where appropriate. In Authentication Callback handler, we have the Auth's userinfo response, we we'll replace the usage with the subject field from this. This is fine as this is the field we use to derive the value we set on the orch session anyway

### What’s changed:
- Pulled the subject getting from Auth's userinfo response into an appropriately named variable `internalCommonSubjectId` to reduce some repetition in the handler
- Removed a `session.getInternalCommonSubjectIdentifier()` call and replaced it with using the subject from Auth's userinfo response

### Manual testing: 
-  N/A minor changes

### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
