### PR TITLE
ATO-1321: Auth Code handler - use OrchSession InternalCommonSubjectId

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -250,7 +250,7 @@ public class AuthCodeHandler
                 internalCommonSubjectId = clientSession.getDocAppSubjectId().getValue();
             } else {
                 authCodeResponseService.processVectorOfTrust(clientSession, dimensions);
-                internalCommonSubjectId = session.getInternalCommonSubjectIdentifier();
+                internalCommonSubjectId = orchSession.getInternalCommonSubjectId();
                 subjectId = authCodeResponseService.getSubjectId(session);
                 rpPairwiseId =
                         authCodeResponseService.getRpPairwiseId(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -244,13 +244,13 @@ public class AuthCodeHandler
 
             var subjectId = AuditService.UNKNOWN;
             var rpPairwiseId = AuditService.UNKNOWN;
-            String internalCommonPairwiseSubjectId;
+            String internalCommonSubjectId;
             if (docAppJourney) {
                 LOG.info("Session not saved for DocCheckingAppUser");
-                internalCommonPairwiseSubjectId = clientSession.getDocAppSubjectId().getValue();
+                internalCommonSubjectId = clientSession.getDocAppSubjectId().getValue();
             } else {
                 authCodeResponseService.processVectorOfTrust(clientSession, dimensions);
-                internalCommonPairwiseSubjectId = session.getInternalCommonSubjectIdentifier();
+                internalCommonSubjectId = session.getInternalCommonSubjectIdentifier();
                 subjectId = authCodeResponseService.getSubjectId(session);
                 rpPairwiseId =
                         authCodeResponseService.getRpPairwiseId(
@@ -272,7 +272,7 @@ public class AuthCodeHandler
                     TxmaAuditUser.user()
                             .withGovukSigninJourneyId(clientSessionId)
                             .withSessionId(sessionId)
-                            .withUserId(internalCommonPairwiseSubjectId)
+                            .withUserId(internalCommonSubjectId)
                             .withEmail(
                                     Optional.ofNullable(session.getEmailAddress())
                                             .orElse(AuditService.UNKNOWN))

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -130,6 +130,7 @@ class AuthCodeHandlerTest {
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final Subject SUBJECT = new Subject();
     private static final String DOC_APP_SUBJECT_ID = "docAppSubjectId";
+    private static final String INTERNAL_COMMON_SUBJECT_ID = "internalCommonSubjectId";
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String CLIENT_NAME = "test-client-name";
     private static final String AUDIENCE = "oidc-audience";
@@ -143,6 +144,7 @@ class AuthCodeHandlerTest {
     private final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID)
                     .withAccountState(OrchSessionItem.AccountState.NEW)
+                    .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID)
                     .withAuthTime(12345L);
 
     @RegisterExtension
@@ -251,10 +253,6 @@ class AuthCodeHandlerTest {
         doCallRealMethod()
                 .when(authCodeResponseService)
                 .processVectorOfTrust(eq(clientSession), any());
-        var expectedCommonSubject =
-                ClientSubjectHelper.calculatePairwiseIdentifier(
-                        SUBJECT.getValue(), "test.account.gov.uk", SaltHelper.generateNewSalt());
-        session.setInternalCommonSubjectIdentifier(expectedCommonSubject);
         var authorizationCode = new AuthorizationCode();
         var authRequest = generateValidSessionAndAuthRequest(requestedLevel, false);
         session.setCurrentCredentialStrength(initialLevel)
@@ -314,7 +312,7 @@ class AuthCodeHandlerTest {
                         TxmaAuditUser.user()
                                 .withGovukSigninJourneyId(CLIENT_SESSION_ID)
                                 .withSessionId(SESSION_ID)
-                                .withUserId(expectedCommonSubject)
+                                .withUserId(INTERNAL_COMMON_SUBJECT_ID)
                                 .withEmail(EMAIL)
                                 .withIpAddress("123.123.123.123")
                                 .withPersistentSessionId(PERSISTENT_SESSION_ID),


### PR DESCRIPTION
### Wider context of change

As part of the session migration work, we'd like to remove usages of getInternalCommonSubjectIdentifier from the shared session and instead use the orch session where appropriate. This updates the code in the AuthCodeHandler to use the already retrieved OrchSession instead of the previous share session.

### What’s changed: 
- Renames internalCommonPairwiseSubjectId to the name we've decided to adopt -> internalCommonSubjectId
- Uses orch session instead of shared session to derive this value.

### Manual testing: 
- Minor change, N/A

### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
