### PR TITLE
BAU: Increase evaluation period on canary alarms

### DIFF
--- a/orchestration-canary-alarms.template.yaml
+++ b/orchestration-canary-alarms.template.yaml
@@ -19,8 +19,7 @@ FetchJwksErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} FetchJwks lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -64,8 +63,7 @@ OpenIdConfigurationErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} OpenIdConfiguration lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -109,8 +107,7 @@ TrustmarkFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} trustmark lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -153,8 +150,7 @@ BackChannelLogoutRequestErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} BackChannelLogoutRequest lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -197,8 +193,7 @@ DocAppCallbackErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} DocAppCallback lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -240,8 +235,7 @@ TokenFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} TokenFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -283,8 +277,7 @@ LogoutFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} LogoutFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -326,8 +319,7 @@ AuthenticationCallbackFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} AuthenticationCallbackFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -370,8 +362,7 @@ JwksFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} JwksFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -414,8 +405,7 @@ AuthorisationFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} AuthorisationFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -458,8 +448,7 @@ UserInfoFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} UserInfoFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -502,8 +491,7 @@ AuthCodeFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} AuthCodeFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -548,8 +536,7 @@ UpdateClientConfigFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} UpdateClientConfigFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -594,8 +581,7 @@ ClientRegistrationFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} ClientRegistrationFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -638,8 +624,7 @@ IpvCallbackFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} IpvCallbackFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -684,8 +669,7 @@ SpotResponseFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} SpotResponseFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:
@@ -728,8 +712,7 @@ StorageTokenJwkFunctionErrorAnomalyAlarm:
       Fn::Sub: "Anomalous Error rate in ${Environment} StorageTokenJwkFunction lambda.ACCOUNT: di-orchestration-${Environment}"
     ActionsEnabled: false
     ComparisonOperator: GreaterThanUpperThreshold
-    EvaluationPeriods: 1
-    DatapointsToAlarm: 1
+    EvaluationPeriods: 3
     ThresholdMetricId: ad1
     TreatMissingData: notBreaching
     Metrics:


### PR DESCRIPTION
This means there must be errors in 3 consecutive minutes to alarm. It should be a better mechanism to look for anomalies.

### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
