### PR TITLE
ATO-1321: Remove shared session getInternalCommonSubjectIdentifier from IdentityProgressFrontendHandler

### DIFF
--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -11,6 +11,7 @@ module "identity_progress_role" {
     aws_iam_policy.authentication_callback_userinfo_encryption_key_kms_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn
   ]
   extra_tags = {
     Service = "identity-progress"
@@ -30,7 +31,8 @@ module "identity_progress" {
     ENVIRONMENT              = var.environment
     HEADERS_CASE_INSENSITIVE = "false"
     REDIS_KEY                = local.redis_key
-    OIDC_API_BASE_URL        = local.api_base_url
+    OIDC_API_BASE_URL        = local.api_base_url,
+    ORCH_DYNAMO_ARN_PREFIX   = "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-"
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IdentityProgressFrontendHandler::handleRequest"
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -102,6 +102,12 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
             }
 
             UserInfo userInfo;
+
+            if (Objects.isNull(internalCommonSubjectIdentifier)
+                    || internalCommonSubjectIdentifier.isBlank()) {
+                LOG.warn("InternalCommonSubjectId is null on orch session");
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
+            }
             try {
                 Optional<UserInfo> userInfoFromStorage =
                         userInfoStorageService.getAuthenticationUserInfo(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
+import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.shared.state.OrchestrationUserSession;
 
@@ -61,8 +62,9 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
             CloudwatchMetricsService cloudwatchMetricsService,
             SessionService sessionService,
             AuthenticationUserInfoStorageService userInfoStorageService,
-            ClientSessionService clientSessionService) {
-        super(configurationService, sessionService, clientSessionService);
+            ClientSessionService clientSessionService,
+            OrchSessionService orchSessionService) {
+        super(configurationService, sessionService, clientSessionService, orchSessionService);
         this.dynamoIdentityService = dynamoIdentityService;
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
@@ -83,7 +85,7 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
         LOG.info("IdentityProgress request received");
         try {
             var internalCommonSubjectIdentifier =
-                    userSession.getSession().getInternalCommonSubjectIdentifier();
+                    userSession.getOrchSession().getInternalCommonSubjectId();
 
             AuthenticationRequest authenticationRequest;
             try {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -144,6 +144,23 @@ public class IdentityProgressFrontendHandlerTest {
     }
 
     @Test
+    void shouldReturnErrorWhenInternalCommonSubjectIdIsNullOnOrchSession()
+            throws Json.JsonException {
+        when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
+        when(orchSessionService.getSession(anyString()))
+                .thenReturn(
+                        Optional.of(
+                                new OrchSessionItem(SESSION_ID).withInternalCommonSubjectId(null)));
+        when(clientSessionService.getClientSession(any()))
+                .thenReturn(Optional.of(getClientSession()));
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1000)));
+        verifyNoInteractions(cloudwatchMetricsService, auditService);
+    }
+
+    @Test
     void shouldReturnCOMPLETEDStatusWhenIdentityCredentialIsPresent() throws Json.JsonException {
         usingValidSession();
         var identityCredentials =

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
 import uk.gov.di.orchestration.shared.entity.IdentityCredentials;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.serialization.Json;
@@ -31,6 +32,7 @@ import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
+import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 
@@ -90,8 +92,11 @@ public class IdentityProgressFrontendHandlerTest {
             mock(CloudwatchMetricsService.class);
     private final AuthenticationUserInfoStorageService userInfoStorageService =
             mock(AuthenticationUserInfoStorageService.class);
+    private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
     private final Session session =
             new Session(SESSION_ID).setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
+    private final OrchSessionItem orchSession =
+            new OrchSessionItem(SESSION_ID).withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID);
     private final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
     protected final Json objectMapper = SerializationService.getInstance();
     private IdentityProgressFrontendHandler handler;
@@ -114,11 +119,23 @@ public class IdentityProgressFrontendHandlerTest {
                         cloudwatchMetricsService,
                         sessionService,
                         userInfoStorageService,
-                        clientSessionService);
+                        clientSessionService,
+                        orchSessionService);
     }
 
     @Test
     void shouldReturnErrorIfSessionIsNotFound() throws Json.JsonException {
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1000)));
+        verifyNoInteractions(cloudwatchMetricsService, auditService);
+    }
+
+    @Test
+    void shouldReturnErrorIfOrchSessionIsNotFound() throws Json.JsonException {
+        when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
+        when(orchSessionService.getSession(anyString())).thenReturn(Optional.empty());
         var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -305,5 +322,6 @@ public class IdentityProgressFrontendHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
+        when(orchSessionService.getSession(anyString())).thenReturn(Optional.of(orchSession));
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/OrchestrationUserSession.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/OrchestrationUserSession.java
@@ -2,6 +2,7 @@ package uk.gov.di.orchestration.shared.state;
 
 import org.jetbrains.annotations.Nullable;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 
 public class OrchestrationUserSession {
@@ -10,18 +11,21 @@ public class OrchestrationUserSession {
     @Nullable private final String clientId;
     @Nullable private final ClientSession clientSession;
     private final String clientSessionId;
+    private final OrchSessionItem orchSessionItem;
 
     protected OrchestrationUserSession(
             Session session,
             String sessionId,
             @Nullable String clientId,
             @Nullable ClientSession clientSession,
-            String clientSessionId) {
+            String clientSessionId,
+            OrchSessionItem orchSession) {
         this.session = session;
         this.sessionId = sessionId;
         this.clientId = clientId;
         this.clientSession = clientSession;
         this.clientSessionId = clientSessionId;
+        this.orchSessionItem = orchSession;
     }
 
     public Session getSession() {
@@ -44,6 +48,10 @@ public class OrchestrationUserSession {
         return clientSessionId;
     }
 
+    public OrchSessionItem getOrchSession() {
+        return orchSessionItem;
+    }
+
     public static Builder builder(Session session) {
         return new Builder(session);
     }
@@ -54,6 +62,7 @@ public class OrchestrationUserSession {
         private String clientId;
         private ClientSession clientSession;
         private String clientSessionId;
+        private OrchSessionItem orchSession;
 
         protected Builder(Session session) {
             this.session = session;
@@ -79,9 +88,14 @@ public class OrchestrationUserSession {
             return this;
         }
 
+        public Builder withOrchSession(OrchSessionItem orchSession) {
+            this.orchSession = orchSession;
+            return this;
+        }
+
         public OrchestrationUserSession build() {
             return new OrchestrationUserSession(
-                    session, sessionId, clientId, clientSession, clientSessionId);
+                    session, sessionId, clientId, clientSession, clientSessionId, orchSession);
         }
     }
 }


### PR DESCRIPTION
### Wider context of change

As part of the session migration work, we'd like to remove usages of getInternalCommonSubjectIdentifier from the shared session and instead use the orch session where appropriate. This updates the code in the IdentityProgressFrontendHandler to remove the use of the shared session getInternalCommonSubjectIdentifier. Currently this lambda is **unused** and as far as I can tell **not deployed** to the orchestration account. I have added the appropriate policy and environment variable to allow cross account access, just to ensure this lambda is not in a broken state

### What’s changed

- Updates BaseOrchestrationFrontendHandler to ensure it has the OrchSession attached
- Updates the unused  IdentityProgressFrontendHandler to replace a reference to the shared session `getInternalCommonSubjectIdentifier`

### Manual testing:
- Not applicable as this lambda is currently unsued

### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
