### PR TITLE
ATO-1402: Store client ID in auth code exchange data

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -311,7 +311,10 @@ public class DocAppCallbackHandler
 
                 var authCode =
                         authorisationCodeService.generateAndSaveAuthorisationCode(
-                                clientSessionId, session.getEmailAddress(), clientSession);
+                                clientId,
+                                clientSessionId,
+                                session.getEmailAddress(),
+                                clientSession);
 
                 var authenticationResponse =
                         new AuthenticationSuccessResponse(

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -135,7 +135,7 @@ class DocAppCallbackHandlerTest {
     @BeforeEach
     void setUp() {
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        CLIENT_SESSION_ID, TEST_EMAIL_ADDRESS, clientSession))
+                        CLIENT_ID.getValue(), CLIENT_SESSION_ID, TEST_EMAIL_ADDRESS, clientSession))
                 .thenReturn(AUTH_CODE);
         handler =
                 new DocAppCallbackHandler(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -209,6 +209,7 @@ public class IPVCallbackHelper {
                 () -> saveIdentityClaimsToDynamo(rpPairwiseSubject, userIdentityUserInfo));
         var authCode =
                 authorisationCodeService.generateAndSaveAuthorisationCode(
+                        clientId,
                         clientSessionId,
                         userProfile.getEmail(),
                         clientSession,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -171,7 +171,11 @@ class IPVCallbackHelperTest {
                         new AccountIntervention(
                                 new AccountInterventionState(false, true, false, false)));
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        anyString(), anyString(), any(ClientSession.class), any(Long.class)))
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        any(ClientSession.class),
+                        any(Long.class)))
                 .thenReturn(AUTH_CODE);
 
         when(oidcAPI.trustmarkURI()).thenReturn(OIDC_TRUSTMARK_URI);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -398,6 +398,7 @@ public class AuthCodeHandler
             orchSession.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
         }
         return authorisationCodeService.generateAndSaveAuthorisationCode(
+                clientID.getValue(),
                 clientSessionId,
                 session.getEmailAddress(),
                 clientSession,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -557,6 +557,7 @@ public class AuthenticationCallbackHandler
 
                 var authCode =
                         authorisationCodeService.generateAndSaveAuthorisationCode(
+                                clientId,
                                 clientSessionId,
                                 userInfo.getEmailAddress(),
                                 clientSession,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -275,7 +275,11 @@ class AuthCodeHandlerTest {
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        eq(CLIENT_SESSION_ID), eq(EMAIL), eq(clientSession), any(Long.class)))
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(EMAIL),
+                        eq(clientSession),
+                        any(Long.class)))
                 .thenReturn(authorizationCode);
         when(orchestrationAuthorizationService.generateSuccessfulAuthResponse(
                         any(AuthenticationRequest.class),
@@ -374,7 +378,11 @@ class AuthCodeHandlerTest {
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        eq(CLIENT_SESSION_ID), eq(null), eq(clientSession), any(Long.class)))
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(null),
+                        eq(clientSession),
+                        any(Long.class)))
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(
                         eq(orchSession),
@@ -609,7 +617,11 @@ class AuthCodeHandlerTest {
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        eq(CLIENT_SESSION_ID), eq(null), eq(clientSession), any(Long.class)))
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(null),
+                        eq(clientSession),
+                        any(Long.class)))
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(
                         eq(orchSession),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -193,6 +193,7 @@ class AuthenticationCallbackHandlerTest {
                         new AccountIntervention(
                                 new AccountInterventionState(false, false, false, false)));
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
+                        eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(TEST_EMAIL_ADDRESS),
                         eq(clientSession),
@@ -586,6 +587,7 @@ class AuthenticationCallbackHandlerTest {
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(mediumRequestSession));
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
+                        eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(TEST_EMAIL_ADDRESS),
                         eq(mediumRequestSession),
@@ -1412,6 +1414,7 @@ class AuthenticationCallbackHandlerTest {
         ClientSession clientSessionWithCredentialTrustLevel =
                 createClientSession(credentialTrustLevel);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
+                        eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(TEST_EMAIL_ADDRESS),
                         eq(clientSessionWithCredentialTrustLevel),

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthCodeExchangeData.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthCodeExchangeData.java
@@ -4,6 +4,9 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
 public class AuthCodeExchangeData {
+    @Expose
+    @SerializedName("clientId")
+    private String clientId;
 
     @Expose
     @SerializedName("clientSessionId")
@@ -52,6 +55,15 @@ public class AuthCodeExchangeData {
 
     public AuthCodeExchangeData setAuthTime(Long authTime) {
         this.authTime = authTime;
+        return this;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public AuthCodeExchangeData setClientId(String clientId) {
+        this.clientId = clientId;
         return this;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
@@ -40,8 +40,9 @@ public class AuthorisationCodeService {
     }
 
     public AuthorizationCode generateAndSaveAuthorisationCode(
-            String clientSessionId, String email, ClientSession clientSession) {
-        return generateAndSaveAuthorisationCode(clientSessionId, email, clientSession, null);
+            String clientId, String clientSessionId, String email, ClientSession clientSession) {
+        return generateAndSaveAuthorisationCode(
+                clientId, clientSessionId, email, clientSession, null);
     }
 
     public AuthorizationCode generateAndSaveAuthorisationCode(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
@@ -46,6 +46,16 @@ public class AuthorisationCodeService {
 
     public AuthorizationCode generateAndSaveAuthorisationCode(
             String clientSessionId, String email, ClientSession clientSession, Long authTime) {
+        return generateAndSaveAuthorisationCode(
+                null, clientSessionId, email, clientSession, authTime);
+    }
+
+    public AuthorizationCode generateAndSaveAuthorisationCode(
+            String clientId,
+            String clientSessionId,
+            String email,
+            ClientSession clientSession,
+            Long authTime) {
         LOG.info("Generating and saving AuthorisationCode");
         AuthorizationCode authorizationCode = new AuthorizationCode();
         try {
@@ -54,6 +64,7 @@ public class AuthorisationCodeService {
                     objectMapper.writeValueAsString(
                             new AuthCodeExchangeData()
                                     .setEmail(email)
+                                    .setClientId(clientId)
                                     .setClientSessionId(clientSessionId)
                                     .setClientSession(clientSession)
                                     .setAuthTime(authTime)),

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
@@ -46,12 +46,6 @@ public class AuthorisationCodeService {
     }
 
     public AuthorizationCode generateAndSaveAuthorisationCode(
-            String clientSessionId, String email, ClientSession clientSession, Long authTime) {
-        return generateAndSaveAuthorisationCode(
-                null, clientSessionId, email, clientSession, authTime);
-    }
-
-    public AuthorizationCode generateAndSaveAuthorisationCode(
             String clientId,
             String clientSessionId,
             String email,

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
@@ -37,10 +37,11 @@ class AuthorisationCodeServiceTest {
                 new ClientSession(Map.of(), LocalDateTime.now(), List.of(), "test-client");
 
         authCodeService.generateAndSaveAuthorisationCode(
-                "test-client-session", "test@email.com", clientSession, 12345L);
+                "test-client-id", "test-client-session", "test@email.com", clientSession, 12345L);
 
         AuthCodeExchangeData expectedExchangeData =
                 new AuthCodeExchangeData()
+                        .setClientId("test-client-id")
                         .setClientSessionId("test-client-session")
                         .setEmail("test@email.com")
                         .setClientSession(clientSession)


### PR DESCRIPTION
### Wider context of change

We would like to validate the client ID provided to the /token endpoint is valid for the current journey. To do this we need a way of associating an auth code with a client.

### What’s changed

This PR adds the `clientId` field to the auth code exchange data, and updates the method signature so the `clientId` is always set.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
