### PR TITLE
ATO-646: Log warning if client id in auth code does not match request params

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.oidc.lambda.TokenHandler;
+import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.RefreshTokenStore;
 import uk.gov.di.orchestration.shared.entity.ServiceType;
@@ -61,6 +62,7 @@ import java.net.URI;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Collections;
@@ -497,6 +499,99 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
+    @Test
+    void
+            shouldCallTokenResourceUsingClientSecretPostAndWarnWhenClientIdInAuthCodeDoesNotMatchRequest()
+                    throws Exception {
+        var clientSecret = new Secret();
+        Scope scope =
+                new Scope(
+                        OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
+        userStore.signUp(TEST_EMAIL, "password-1", new Subject());
+        registerClientSecretClient(
+                "test-client-1",
+                clientSecret.getValue(),
+                ClientAuthenticationMethod.CLIENT_SECRET_POST,
+                scope);
+        registerClientSecretClient(
+                "test-client-2",
+                clientSecret.getValue(),
+                ClientAuthenticationMethod.CLIENT_SECRET_POST,
+                scope);
+
+        createAuthCodeForClient(Optional.of("test-client-1"), "test-auth-code-1");
+        createAuthCodeForClient(Optional.of("test-client-2"), "test-auth-code-2");
+
+        var baseTokenRequest =
+                constructBaseTokenRequest(
+                        scope,
+                        Optional.of("Cl.Cm"),
+                        Optional.empty(),
+                        Optional.of("test-client-1"),
+                        "test-auth-code-2");
+        var response =
+                makeTokenRequestWithClientSecretPost(
+                        "test-client-1", baseTokenRequest, clientSecret);
+
+        assertThat(response, hasStatus(200));
+        JSONObject jsonResponse = JSONObjectUtils.parse(response.getBody());
+
+        assertNotNull(
+                TokenResponse.parse(jsonResponse)
+                        .toSuccessResponse()
+                        .getTokens()
+                        .getRefreshToken());
+        assertNotNull(
+                TokenResponse.parse(jsonResponse)
+                        .toSuccessResponse()
+                        .getTokens()
+                        .getBearerAccessToken());
+
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+    }
+
+    @Test
+    void shouldCallTokenResourceUsingPrivateKeyJwtAndWarnWhenClientIdInAuthCodeDoesNotMatchRequest()
+            throws Exception {
+        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        Scope scope =
+                new Scope(
+                        OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
+        userStore.signUp(TEST_EMAIL, "password-1", new Subject());
+        registerClientWithPrivateKeyJwtAuthentication(
+                "test-client-1", keyPair.getPublic(), scope, SubjectType.PAIRWISE);
+
+        createAuthCodeForClient(Optional.of("test-client-1"), "test-auth-code-1");
+        createAuthCodeForClient(Optional.of("test-client-2"), "test-auth-code-2");
+
+        var baseTokenRequest =
+                constructBaseTokenRequest(
+                        scope,
+                        Optional.of("Cl.Cm"),
+                        Optional.empty(),
+                        Optional.of("test-client-1"),
+                        "test-auth-code-2");
+        var response =
+                makeTokenRequestWithPrivateKeyJWT(
+                        "test-client-1", baseTokenRequest, keyPair.getPrivate());
+
+        assertThat(response, hasStatus(200));
+        JSONObject jsonResponse = JSONObjectUtils.parse(response.getBody());
+
+        assertNotNull(
+                TokenResponse.parse(jsonResponse)
+                        .toSuccessResponse()
+                        .getTokens()
+                        .getRefreshToken());
+        assertNotNull(
+                TokenResponse.parse(jsonResponse)
+                        .toSuccessResponse()
+                        .getTokens()
+                        .getBearerAccessToken());
+
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+    }
+
     private SignedJWT generateSignedRefreshToken(Scope scope, Subject publicSubject) {
         Date expiryDate = NowHelper.nowPlus(60, ChronoUnit.MINUTES);
         JWTClaimsSet claimsSet =
@@ -514,8 +609,13 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private void registerClientWithPrivateKeyJwtAuthentication(
             PublicKey publicKey, Scope scope, SubjectType subjectType) {
+        registerClientWithPrivateKeyJwtAuthentication(CLIENT_ID, publicKey, scope, subjectType);
+    }
+
+    private void registerClientWithPrivateKeyJwtAuthentication(
+            String clientId, PublicKey publicKey, Scope scope, SubjectType subjectType) {
         clientStore.registerClient(
-                CLIENT_ID,
+                clientId,
                 "test-client",
                 singletonList(REDIRECT_URI),
                 singletonList(TEST_EMAIL),
@@ -537,8 +637,16 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             String clientSecret,
             ClientAuthenticationMethod clientAuthenticationMethod,
             Scope scope) {
+        registerClientSecretClient(CLIENT_ID, clientSecret, clientAuthenticationMethod, scope);
+    }
+
+    private void registerClientSecretClient(
+            String clientId,
+            String clientSecret,
+            ClientAuthenticationMethod clientAuthenticationMethod,
+            Scope scope) {
         clientStore.registerClient(
-                CLIENT_ID,
+                clientId,
                 "test-client",
                 singletonList(REDIRECT_URI),
                 singletonList(TEST_EMAIL),
@@ -577,10 +685,16 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private APIGatewayProxyResponseEvent makeTokenRequestWithPrivateKeyJWT(
             Map<String, List<String>> requestParams, PrivateKey privateKey) throws JOSEException {
+        return makeTokenRequestWithPrivateKeyJWT(CLIENT_ID, requestParams, privateKey);
+    }
+
+    private APIGatewayProxyResponseEvent makeTokenRequestWithPrivateKeyJWT(
+            String clientId, Map<String, List<String>> requestParams, PrivateKey privateKey)
+            throws JOSEException {
         var expiryDate = NowHelper.nowPlus(5, ChronoUnit.MINUTES);
         var claimsSet =
                 new JWTAuthenticationClaimsSet(
-                        new ClientID(CLIENT_ID), new Audience(ROOT_RESOURCE_URL + TOKEN_ENDPOINT));
+                        new ClientID(clientId), new Audience(ROOT_RESOURCE_URL + TOKEN_ENDPOINT));
         claimsSet.getExpirationTime().setTime(expiryDate.getTime());
         var privateKeyJWT =
                 new PrivateKeyJWT(claimsSet, JWSAlgorithm.RS256, privateKey, null, null);
@@ -592,7 +706,12 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private APIGatewayProxyResponseEvent makeTokenRequestWithClientSecretPost(
             Map<String, List<String>> requestParams, Secret clientSecret) {
-        var clientSecretPost = new ClientSecretPost(new ClientID(CLIENT_ID), clientSecret);
+        return makeTokenRequestWithClientSecretPost(CLIENT_ID, requestParams, clientSecret);
+    }
+
+    private APIGatewayProxyResponseEvent makeTokenRequestWithClientSecretPost(
+            String clientId, Map<String, List<String>> requestParams, Secret clientSecret) {
+        var clientSecretPost = new ClientSecretPost(new ClientID(clientId), clientSecret);
         clientSecretPost.toParameters();
         requestParams.putAll(clientSecretPost.toParameters());
         var requestBody = URLUtils.serializeParameters(requestParams);
@@ -605,21 +724,43 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             Optional<OIDCClaimsRequest> oidcClaimsRequest,
             Optional<String> clientId)
             throws Json.JsonException {
-        String code = new AuthorizationCode().toString();
+        return constructBaseTokenRequest(
+                scope, vtr, oidcClaimsRequest, clientId, new AuthorizationCode().toString());
+    }
+
+    private Map<String, List<String>> constructBaseTokenRequest(
+            Scope scope,
+            Optional<String> vtr,
+            Optional<OIDCClaimsRequest> oidcClaimsRequest,
+            Optional<String> clientId,
+            String code)
+            throws Json.JsonException {
         List<VectorOfTrust> vtrList = List.of(VectorOfTrust.getDefaults());
         if (vtr.isPresent()) {
             vtrList =
                     VectorOfTrust.parseFromAuthRequestAttribute(
                             singletonList(JsonArrayHelper.jsonArrayOf(vtr.get())));
         }
-        redis.addAuthCodeAndCreateClientSession(
-                code,
-                "a-client-session-id",
-                TEST_EMAIL,
-                generateAuthRequest(scope, vtr, oidcClaimsRequest).toParameters(),
-                vtrList,
-                "client-name",
-                AUTH_TIME);
+        var clientSession =
+                new ClientSession(
+                        generateAuthRequest(scope, vtr, oidcClaimsRequest).toParameters(),
+                        LocalDateTime.now(),
+                        vtrList,
+                        "client-name");
+        redis.createClientSession("a-client-session-id", clientSession);
+        redis.addAuthCode(
+                code, CLIENT_ID, "a-client-session-id", clientSession, TEST_EMAIL, AUTH_TIME);
+        Map<String, List<String>> customParams = new HashMap<>();
+        customParams.put(
+                "grant_type", Collections.singletonList(GrantType.AUTHORIZATION_CODE.getValue()));
+        clientId.map(cid -> customParams.put("client_id", Collections.singletonList(cid)));
+        customParams.put("code", Collections.singletonList(code));
+        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
+        return customParams;
+    }
+
+    private Map<String, List<String>> createAuthCodeForClient(
+            Optional<String> clientId, String code) {
         Map<String, List<String>> customParams = new HashMap<>();
         customParams.put(
                 "grant_type", Collections.singletonList(GrantType.AUTHORIZATION_CODE.getValue()));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -219,6 +219,11 @@ public class TokenHandler
                     400, OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString());
         }
         AuthCodeExchangeData authCodeExchangeData = authCodeExchangeDataMaybe.get();
+        if (!Objects.equals(authCodeExchangeData.getClientId(), clientRegistry.getClientID())) {
+            LOG.warn("Client ID from auth code does not match client ID from request body");
+            // ATO-646: Make this return 400 error when we are confident that
+            // it won't cause issues with existing clients
+        }
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, authCodeExchangeData.getClientSessionId());
         updateAttachedLogFieldToLogs(
                 GOVUK_SIGNIN_JOURNEY_ID, authCodeExchangeData.getClientSessionId());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -184,17 +184,19 @@ public class TokenHandlerTest {
 
     private static Stream<Arguments> validVectorValues() {
         return Stream.of(
-                Arguments.of("Cl.Cm", true),
-                Arguments.of("Cl", true),
-                Arguments.of("P2.Cl.Cm", true),
-                Arguments.of("Cl.Cm", false),
-                Arguments.of("Cl", false),
-                Arguments.of("P2.Cl.Cm", false));
+                Arguments.of("Cl.Cm", true, CLIENT_ID),
+                Arguments.of("Cl", true, CLIENT_ID),
+                Arguments.of("P2.Cl.Cm", true, CLIENT_ID),
+                Arguments.of("Cl.Cm", false, CLIENT_ID),
+                Arguments.of("Cl", false, CLIENT_ID),
+                Arguments.of("P2.Cl.Cm", false, CLIENT_ID),
+                Arguments.of("Cl.Cm", true, "some-other-client"));
     }
 
     @ParameterizedTest
     @MethodSource("validVectorValues")
-    void shouldReturn200ForSuccessfulTokenRequest(String vectorValue, boolean clientIdInHeader)
+    void shouldReturn200ForSuccessfulTokenRequest(
+            String vectorValue, boolean clientIdInHeader, String clientIdInAuthCode)
             throws JOSEException, TokenAuthInvalidException {
         KeyPair keyPair = generateRsaKeyPair();
         UserProfile userProfile = generateUserProfile();
@@ -234,7 +236,8 @@ public class TokenHandlerTest {
                                                         LocalDateTime.now(),
                                                         vtr,
                                                         CLIENT_NAME))
-                                        .setAuthTime(AUTH_TIME)));
+                                        .setAuthTime(AUTH_TIME)
+                                        .setClientId(clientIdInAuthCode)));
         when(dynamoService.getUserProfileByEmail(eq(TEST_EMAIL))).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -179,17 +179,14 @@ public class RedisExtension
         }
     }
 
-    public void addAuthCodeAndCreateClientSession(
+    public void addAuthCode(
             String authCode,
+            String clientId,
             String clientSessionId,
+            ClientSession clientSession,
             String email,
-            Map<String, List<String>> authRequest,
-            List<VectorOfTrust> vtrList,
-            String clientName,
             Long authTime)
             throws Json.JsonException {
-        var clientSession =
-                new ClientSession(authRequest, LocalDateTime.now(), vtrList, clientName);
         redis.saveWithExpiry(
                 AUTH_CODE_PREFIX.concat(authCode),
                 objectMapper.writeValueAsString(
@@ -197,12 +194,8 @@ public class RedisExtension
                                 .setClientSessionId(clientSessionId)
                                 .setEmail(email)
                                 .setClientSession(clientSession)
-                                .setAuthTime(authTime)),
-                300);
-
-        redis.saveWithExpiry(
-                CLIENT_SESSION_PREFIX.concat(clientSessionId),
-                objectMapper.writeValueAsString(clientSession),
+                                .setAuthTime(authTime)
+                                .setClientId(clientId)),
                 300);
     }
 


### PR DESCRIPTION
### Wider context of change

We'd like to validate whether the client id in the auth code exchange data matches the client id in the request params in the TokenHandler. 

### What’s changed

This PR adds a log line to warn if the client ids mismatch. This is to make sure we dont have any requests currently using the wrong auth code. Once we are certain that nobody is currently breaking this validation, we can make this generate an error.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
