### PR TITLE
AUT-3968: OpenTelemetry for AWS + HTTPClient

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -64,6 +64,8 @@ jobs:
             !*/build/reports
             !*/build/jacoco
           key: ${{ runner.os }}-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-build
       - name: Run Build
         if: needs.check-changed-files.outputs.java_changed == 'true'
         run: ./gradlew --parallel build -x test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,8 @@ subprojects {
         pact_consumer
         pact_provider
         vavr
+        otel
+        otel_http_client
         otel_aws_auto_instrumentation
     }
 
@@ -225,8 +227,12 @@ subprojects {
 
         vavr "io.vavr:vavr:${dependencyVersions.vavr}"
 
+        otel platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${dependencyVersions.opentelemetry_instrumentation}"),
+                "io.opentelemetry:opentelemetry-api"
         otel_aws_auto_instrumentation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${dependencyVersions.opentelemetry_instrumentation}"),
                 "io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2-autoconfigure"
+        otel_http_client platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${dependencyVersions.opentelemetry_instrumentation}"),
+                "io.opentelemetry.instrumentation:opentelemetry-java-http-client"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,8 @@ ext {
         junit: "5.11.4",
         xray: "2.18.2",
         pact: "4.6.17",
-        vavr: "0.10.6"
+        vavr: "0.10.6",
+        opentelemetry_instrumentation: "2.12.0-alpha"
     ]
 
     terraformEnvironment = project.properties["terraformEnvironment"] ?: "localstack"
@@ -111,6 +112,7 @@ subprojects {
         pact_consumer
         pact_provider
         vavr
+        otel_aws_auto_instrumentation
     }
 
     // Check dependencies using:
@@ -222,6 +224,19 @@ subprojects {
         pact_provider "au.com.dius.pact.provider:junit5:${dependencyVersions.pact}"
 
         vavr "io.vavr:vavr:${dependencyVersions.vavr}"
+
+        otel_aws_auto_instrumentation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${dependencyVersions.opentelemetry_instrumentation}"),
+                "io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2-autoconfigure"
+    }
+}
+
+subprojects {
+    afterEvaluate { subproject ->
+        if (subproject.plugins.hasPlugin('java')) {
+            dependencies {
+                runtimeOnly configurations.otel_aws_auto_instrumentation
+            }
+        }
     }
 }
 

--- a/ci/terraform/modules/endpoint-lambda/README.md
+++ b/ci/terraform/modules/endpoint-lambda/README.md
@@ -66,6 +66,7 @@ Eventually, this module will be consumed by [endpoint-module](../endpoint-module
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The id of the subnets for the lambda | `list(string)` | n/a | yes |
 | <a name="input_architectures"></a> [architectures](#input\_architectures) | n/a | `list(string)` | <pre>[<br/>  "x86_64"<br/>]</pre> | no |
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | n/a | `string` | `null` | no |
+| <a name="input_dt_logging"></a> [dt\_logging](#input\_dt\_logging) | enable extended dynatrace logging | `bool` | `false` | no |
 | <a name="input_endpoint_name_sanitized"></a> [endpoint\_name\_sanitized](#input\_endpoint\_name\_sanitized) | A sanitized version of endpoint\_name, required if endpoint\_name contains a dot. | `string` | `null` | no |
 | <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra tags to apply to resources | `map(string)` | `{}` | no |
 | <a name="input_handler_runtime"></a> [handler\_runtime](#input\_handler\_runtime) | n/a | `string` | `"java17"` | no |

--- a/ci/terraform/modules/endpoint-lambda/dynatrace.tf
+++ b/ci/terraform/modules/endpoint-lambda/dynatrace.tf
@@ -1,4 +1,9 @@
 locals {
+  dt_log_dest  = var.dt_logging ? "stdout" : null
+  dt_log_flags = var.dt_logging ? "log-AwsLambdaIntrospection=true,log-Transformer=true,log-OpenTelemetryUtils=true,log-AsyncClassRetransformer=true,log-ClassValue=true,log-dt-http-requests=true,log-span-content=true,log-debug-communication=true,log-debug-app-spans=true,log-debug-tags=true,log-debug-communication=true,log-debug-periodic-tasks=true" : null
+}
+
+locals {
   dynatrace_layer_arn = var.dynatrace_secret.JAVA_LAYER
   dynatrace_environment_variables = {
     AWS_LAMBDA_EXEC_WRAPPER = "/opt/dynatrace"
@@ -9,6 +14,11 @@ locals {
     DT_TENANT                    = var.dynatrace_secret.DT_TENANT
     DT_LOG_COLLECTION_AUTH_TOKEN = var.dynatrace_secret.DT_LOG_COLLECTION_AUTH_TOKEN
 
-    DT_OPEN_TELEMETRY_ENABLE_INTEGRATION = "true"
+    DT_OPEN_TELEMETRY_ENABLE_INTEGRATION                                   = "true"
+    OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING = "true"
+    OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED                                 = "true"
+
+    DT_LOGGING_DESTINATION = local.dt_log_dest
+    DT_LOGGING_JAVA_FLAGS  = local.dt_log_flags
   }
 }

--- a/ci/terraform/modules/endpoint-lambda/variables.tf
+++ b/ci/terraform/modules/endpoint-lambda/variables.tf
@@ -195,3 +195,9 @@ variable "runbook_link" {
   type        = string
   default     = null
 }
+
+variable "dt_logging" {
+  description = "enable extended dynatrace logging"
+  type        = bool
+  default     = false
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.shared.tracing.TracingHttpClient.newHttpClient;
 
 public class TicfCriHandler implements RequestHandler<InternalTICFCRIRequest, Void> {
 
@@ -41,7 +42,7 @@ public class TicfCriHandler implements RequestHandler<InternalTICFCRIRequest, Vo
 
     public TicfCriHandler() {
         this.configurationService = ConfigurationService.getInstance();
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = newHttpClient();
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccountInterventionsService.java
@@ -22,6 +22,7 @@ import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInte
 import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException.parseException;
 import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException.timeoutException;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.shared.tracing.TracingHttpClient.newHttpClient;
 
 public class AccountInterventionsService {
 
@@ -33,13 +34,13 @@ public class AccountInterventionsService {
     private ConfigurationService configurationService;
 
     public AccountInterventionsService() {
-        httpClient = HttpClient.newHttpClient();
+        httpClient = newHttpClient();
         configurationService = new ConfigurationService();
     }
 
     public AccountInterventionsService(ConfigurationService configService) {
         configurationService = configService;
-        httpClient = HttpClient.newHttpClient();
+        httpClient = newHttpClient();
     }
 
     public AccountInterventionsService(HttpClient client, ConfigurationService configService) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/HttpRequestService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/HttpRequestService.java
@@ -11,8 +11,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Map;
 
-import static java.net.http.HttpClient.newHttpClient;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
+import static uk.gov.di.orchestration.shared.tracing.TracingHttpClient.newHttpClient;
 
 public class HttpRequestService {
 

--- a/orchestration-shared/build.gradle
+++ b/orchestration-shared/build.gradle
@@ -28,6 +28,9 @@ dependencies {
             configurations.apache,
             "org.apache.httpcomponents.core5:httpcore5:5.3.4"
 
+    implementation configurations.otel,
+            configurations.otel_http_client
+
     testImplementation configurations.tests,
             configurations.lambda_tests,
             project(":orchestration-shared-test")

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/annotations/ExcludeFromGeneratedCoverageReport.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/annotations/ExcludeFromGeneratedCoverageReport.java
@@ -1,0 +1,12 @@
+package uk.gov.di.orchestration.shared.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.METHOD})
+public @interface ExcludeFromGeneratedCoverageReport {}
+
+// No-op annotation to exclude classes from JaCoCo coverage reports

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/LogLineHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/LogLineHelper.java
@@ -1,8 +1,14 @@
 package uk.gov.di.orchestration.shared.helpers;
 
 import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.message.StringMapMessage;
+
+import java.util.Objects;
 
 import static uk.gov.di.orchestration.shared.helpers.InputSanitiser.sanitiseBase64;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.LOG_ERROR_CODE;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.LOG_ERROR_DESCRIPTION;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.ORCH_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.SESSION_ID;
 
@@ -18,7 +24,10 @@ public class LogLineHelper {
         PERSISTENT_SESSION_ID("persistentSessionId", true),
         AWS_REQUEST_ID("awsRequestId", false),
         CLIENT_ID("clientId", true),
-        CLIENT_NAME("clientName", false);
+        CLIENT_NAME("clientName", false),
+        LOG_ERROR_DESCRIPTION("errorDescription", false),
+        LOG_ERROR_CODE("errorCode", false),
+        LOG_MESSAGE_DESCRIPTION("description", false);
 
         private final String logFieldName;
         private boolean isBase64;
@@ -61,5 +70,33 @@ public class LogLineHelper {
 
     public static void attachOrchSessionIdToLogs(String orchSessionId) {
         attachLogFieldToLogs(ORCH_SESSION_ID, orchSessionId);
+    }
+
+    public static StringMapMessage buildLogMessage(String message) {
+        return new StringMapMessage().with(LOG_MESSAGE_DESCRIPTION.getLogFieldName(), message);
+    }
+
+    public static StringMapMessage buildErrorMessage(String message, String errorDescription) {
+        return buildLogMessage(message)
+                .with(
+                        LOG_ERROR_DESCRIPTION.getLogFieldName(),
+                        Objects.requireNonNullElse(errorDescription, "Unknown"));
+    }
+
+    public static StringMapMessage buildErrorMessage(String message, Exception e) {
+        return buildLogMessage(message).with(LOG_ERROR_DESCRIPTION.getLogFieldName(), e);
+    }
+
+    public static StringMapMessage buildErrorMessage(
+            String message, String errorDescription, int errorCode) {
+        return buildErrorMessage(message, errorDescription, Integer.toString(errorCode));
+    }
+
+    public static StringMapMessage buildErrorMessage(
+            String message, String errorDescription, String errorCode) {
+        return buildErrorMessage(message, errorDescription)
+                .with(
+                        LOG_ERROR_CODE.getLogFieldName(),
+                        Objects.requireNonNullElse(errorCode, "Unknown"));
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 
 import static uk.gov.di.orchestration.shared.domain.AccountInterventionsAuditableEvent.AIS_RESPONSE_RECEIVED;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
+import static uk.gov.di.orchestration.shared.tracing.TracingHttpClient.newHttpClient;
 
 public class AccountInterventionService {
 
@@ -39,7 +40,7 @@ public class AccountInterventionService {
     public AccountInterventionService(ConfigurationService configService) {
         this(
                 configService,
-                HttpClient.newHttpClient(),
+                newHttpClient(),
                 new CloudwatchMetricsService(),
                 new AuditService(configService));
     }
@@ -48,7 +49,7 @@ public class AccountInterventionService {
             ConfigurationService configService,
             CloudwatchMetricsService cloudwatchMetricsService,
             AuditService auditService) {
-        this(configService, HttpClient.newHttpClient(), cloudwatchMetricsService, auditService);
+        this(configService, newHttpClient(), cloudwatchMetricsService, auditService);
     }
 
     public AccountInterventionService(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/tracing/TracingHttpClient.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/tracing/TracingHttpClient.java
@@ -1,0 +1,141 @@
+package uk.gov.di.orchestration.shared.tracing;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.httpclient.JavaHttpClientTelemetry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.orchestration.shared.helpers.LogLineHelper;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+@ExcludeFromGeneratedCoverageReport
+public class TracingHttpClient extends HttpClient {
+    private static final Logger LOG = LogManager.getLogger();
+    private static final List<String> HTTP_ERROR_MESSAGES_TO_RETRY =
+            List.of("GOAWAY received", "Connection reset");
+    private static final Duration MAX_CLIENT_AGE = Duration.ofHours(1);
+    private HttpClient baseClient;
+    private Instant creationTime;
+
+    private TracingHttpClient(HttpClient baseClient) {
+        this.baseClient = baseClient;
+        this.creationTime = Instant.now();
+    }
+
+    public static HttpClient newHttpClient() {
+        return new TracingHttpClient(
+                JavaHttpClientTelemetry.builder(GlobalOpenTelemetry.get())
+                        .build()
+                        .newHttpClient(HttpClient.newHttpClient()));
+    }
+
+    // Synchronize to prevent race conditions when multiple threads attempt to recreate client
+    private synchronized void recreateBaseClientIfNecessary() {
+        if (creationTime.plus(MAX_CLIENT_AGE).isBefore(Instant.now())) {
+            LOG.info("Recreating base HTTP client due to age");
+            this.baseClient = HttpClient.newHttpClient();
+            this.creationTime = Instant.now(); // Reset creation time
+        }
+    }
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+        return baseClient.cookieHandler();
+    }
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+        return baseClient.connectTimeout();
+    }
+
+    @Override
+    public Redirect followRedirects() {
+        return baseClient.followRedirects();
+    }
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+        return baseClient.proxy();
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return baseClient.sslContext();
+    }
+
+    @Override
+    public SSLParameters sslParameters() {
+        return baseClient.sslParameters();
+    }
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+        return baseClient.authenticator();
+    }
+
+    @Override
+    public Version version() {
+        return baseClient.version();
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+        return baseClient.executor();
+    }
+
+    @Override
+    public <T> HttpResponse<T> send(
+            HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+            throws IOException, InterruptedException {
+        // PYIC-7590: Recreate the HTTP client, to avoid HTTP/2 connection issues.
+        // Check for client is 1hour old, and recreate if older.
+        recreateBaseClientIfNecessary();
+        try {
+            return baseClient.send(request, responseBodyHandler);
+        } catch (IOException e) {
+            // We see occasional HTTP/2 GOAWAY messages from AWS when connections last
+            // for a long time (>1 hour). Retry them once, to recreate the connection.
+            // In the build environment we see connection resets for idle connections in
+            // the pool. Retrying uses a different connection.
+            if (HTTP_ERROR_MESSAGES_TO_RETRY.contains(e.getMessage())) {
+                LOG.warn(
+                        LogLineHelper.buildErrorMessage("Retrying after HTTP IOException", e)
+                                .with("host", request.uri().getHost()));
+                return baseClient.send(request, responseBodyHandler);
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+            HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+        throw new UnsupportedOperationException(
+                "TracingHttpClient does not support async requests yet");
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+            HttpRequest request,
+            HttpResponse.BodyHandler<T> responseBodyHandler,
+            HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+        throw new UnsupportedOperationException(
+                "TracingHttpClient does not support async requests yet");
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/LogLineHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/LogLineHelperTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.LOG_ERROR_CODE;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.LOG_ERROR_DESCRIPTION;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.ORCH_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
@@ -66,5 +69,36 @@ class LogLineHelperTest {
 
         assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
         assertEquals("invalid-identifier", ThreadContext.get(SESSION_ID.getLogFieldName()));
+    }
+
+    @Test
+    void buildLogMessageShouldCorrectlyAddDescription() {
+        var logMessage = LogLineHelper.buildLogMessage("Test message");
+
+        assertEquals("Test message", logMessage.get(LOG_MESSAGE_DESCRIPTION.getLogFieldName()));
+    }
+
+    @Test
+    void buildErrorMessageShouldAttachErrorDescription() {
+        var logMessage = LogLineHelper.buildErrorMessage("Test message", "Error description");
+
+        assertEquals("Test message", logMessage.get(LOG_MESSAGE_DESCRIPTION.getLogFieldName()));
+        assertEquals("Error description", logMessage.get(LOG_ERROR_DESCRIPTION.getLogFieldName()));
+    }
+
+    @Test
+    void buildErrorMessageShouldAttachErrorCode() {
+        var logMessage = LogLineHelper.buildErrorMessage("Test message", "Error description", 10);
+
+        assertEquals("Test message", logMessage.get(LOG_MESSAGE_DESCRIPTION.getLogFieldName()));
+        assertEquals("Error description", logMessage.get(LOG_ERROR_DESCRIPTION.getLogFieldName()));
+        assertEquals("10", logMessage.get(LOG_ERROR_CODE.getLogFieldName()));
+
+        var logMessage2 =
+                LogLineHelper.buildErrorMessage("Test message", "Error description", "10");
+
+        assertEquals("Test message", logMessage2.get(LOG_MESSAGE_DESCRIPTION.getLogFieldName()));
+        assertEquals("Error description", logMessage2.get(LOG_ERROR_DESCRIPTION.getLogFieldName()));
+        assertEquals("10", logMessage2.get(LOG_ERROR_CODE.getLogFieldName()));
     }
 }

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -29,6 +29,9 @@ dependencies {
             configurations.vavr
     implementation("software.amazon.awssdk:cloudwatchlogs:${dependencyVersions.aws_sdk_v2_version}")
 
+    implementation configurations.otel,
+            configurations.otel_http_client
+
     testImplementation configurations.tests,
             configurations.lambda_tests,
             project(":shared-test")

--- a/shared/src/main/java/uk/gov/di/authentication/shared/annotations/ExcludeFromGeneratedCoverageReport.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/annotations/ExcludeFromGeneratedCoverageReport.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.shared.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.METHOD})
+public @interface ExcludeFromGeneratedCoverageReport {}
+
+// No-op annotation to exclude classes from JaCoCo coverage reports

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -1,8 +1,14 @@
 package uk.gov.di.authentication.shared.helpers;
 
 import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.message.StringMapMessage;
+
+import java.util.Objects;
 
 import static uk.gov.di.authentication.shared.helpers.InputSanitiser.sanitiseBase64;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.LOG_ERROR_CODE;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.LOG_ERROR_DESCRIPTION;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.SESSION_ID;
 
 public class LogLineHelper {
@@ -17,7 +23,10 @@ public class LogLineHelper {
         AWS_REQUEST_ID("awsRequestId", false),
         CLIENT_ID("clientId", true),
         CLIENT_NAME("clientName", false),
-        JOURNEY_TYPE("journeyType", false);
+        JOURNEY_TYPE("journeyType", false),
+        LOG_ERROR_DESCRIPTION("errorDescription", false),
+        LOG_ERROR_CODE("errorCode", false),
+        LOG_MESSAGE_DESCRIPTION("description", false);
 
         private final String logFieldName;
         private boolean isBase64;
@@ -49,5 +58,33 @@ public class LogLineHelper {
             ThreadContext.remove(SESSION_ID.getLogFieldName());
         }
         attachSessionIdToLogs(sessionId);
+    }
+
+    public static StringMapMessage buildLogMessage(String message) {
+        return new StringMapMessage().with(LOG_MESSAGE_DESCRIPTION.getLogFieldName(), message);
+    }
+
+    public static StringMapMessage buildErrorMessage(String message, String errorDescription) {
+        return buildLogMessage(message)
+                .with(
+                        LOG_ERROR_DESCRIPTION.getLogFieldName(),
+                        Objects.requireNonNullElse(errorDescription, "Unknown"));
+    }
+
+    public static StringMapMessage buildErrorMessage(String message, Exception e) {
+        return buildLogMessage(message).with(LOG_ERROR_DESCRIPTION.getLogFieldName(), e);
+    }
+
+    public static StringMapMessage buildErrorMessage(
+            String message, String errorDescription, int errorCode) {
+        return buildErrorMessage(message, errorDescription, Integer.toString(errorCode));
+    }
+
+    public static StringMapMessage buildErrorMessage(
+            String message, String errorDescription, String errorCode) {
+        return buildErrorMessage(message, errorDescription)
+                .with(
+                        LOG_ERROR_CODE.getLogFieldName(),
+                        Objects.requireNonNullElse(errorCode, "Unknown"));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/tracing/TracingHttpClient.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/tracing/TracingHttpClient.java
@@ -1,0 +1,141 @@
+package uk.gov.di.authentication.shared.tracing;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.httpclient.JavaHttpClientTelemetry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.authentication.shared.helpers.LogLineHelper;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+@ExcludeFromGeneratedCoverageReport
+public class TracingHttpClient extends HttpClient {
+    private static final Logger LOG = LogManager.getLogger();
+    private static final List<String> HTTP_ERROR_MESSAGES_TO_RETRY =
+            List.of("GOAWAY received", "Connection reset");
+    private static final Duration MAX_CLIENT_AGE = Duration.ofHours(1);
+    private HttpClient baseClient;
+    private Instant creationTime;
+
+    private TracingHttpClient(HttpClient baseClient) {
+        this.baseClient = baseClient;
+        this.creationTime = Instant.now();
+    }
+
+    public static HttpClient newHttpClient() {
+        return new TracingHttpClient(
+                JavaHttpClientTelemetry.builder(GlobalOpenTelemetry.get())
+                        .build()
+                        .newHttpClient(HttpClient.newHttpClient()));
+    }
+
+    // Synchronize to prevent race conditions when multiple threads attempt to recreate client
+    private synchronized void recreateBaseClientIfNecessary() {
+        if (creationTime.plus(MAX_CLIENT_AGE).isBefore(Instant.now())) {
+            LOG.info("Recreating base HTTP client due to age");
+            this.baseClient = HttpClient.newHttpClient();
+            this.creationTime = Instant.now(); // Reset creation time
+        }
+    }
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+        return baseClient.cookieHandler();
+    }
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+        return baseClient.connectTimeout();
+    }
+
+    @Override
+    public Redirect followRedirects() {
+        return baseClient.followRedirects();
+    }
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+        return baseClient.proxy();
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return baseClient.sslContext();
+    }
+
+    @Override
+    public SSLParameters sslParameters() {
+        return baseClient.sslParameters();
+    }
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+        return baseClient.authenticator();
+    }
+
+    @Override
+    public Version version() {
+        return baseClient.version();
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+        return baseClient.executor();
+    }
+
+    @Override
+    public <T> HttpResponse<T> send(
+            HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+            throws IOException, InterruptedException {
+        // PYIC-7590: Recreate the HTTP client, to avoid HTTP/2 connection issues.
+        // Check for client is 1hour old, and recreate if older.
+        recreateBaseClientIfNecessary();
+        try {
+            return baseClient.send(request, responseBodyHandler);
+        } catch (IOException e) {
+            // We see occasional HTTP/2 GOAWAY messages from AWS when connections last
+            // for a long time (>1 hour). Retry them once, to recreate the connection.
+            // In the build environment we see connection resets for idle connections in
+            // the pool. Retrying uses a different connection.
+            if (HTTP_ERROR_MESSAGES_TO_RETRY.contains(e.getMessage())) {
+                LOG.warn(
+                        LogLineHelper.buildErrorMessage("Retrying after HTTP IOException", e)
+                                .with("host", request.uri().getHost()));
+                return baseClient.send(request, responseBodyHandler);
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+            HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+        throw new UnsupportedOperationException(
+                "TracingHttpClient does not support async requests yet");
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+            HttpRequest request,
+            HttpResponse.BodyHandler<T> responseBodyHandler,
+            HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+        throw new UnsupportedOperationException(
+                "TracingHttpClient does not support async requests yet");
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LogLineHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LogLineHelperTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.LOG_ERROR_CODE;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.LOG_ERROR_DESCRIPTION;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
@@ -56,5 +59,36 @@ class LogLineHelperTest {
 
         assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
         assertEquals("invalid-identifier", ThreadContext.get(SESSION_ID.getLogFieldName()));
+    }
+
+    @Test
+    void buildLogMessageShouldCorrectlyAddDescription() {
+        var logMessage = LogLineHelper.buildLogMessage("Test message");
+
+        assertEquals("Test message", logMessage.get(LOG_MESSAGE_DESCRIPTION.getLogFieldName()));
+    }
+
+    @Test
+    void buildErrorMessageShouldAttachErrorDescription() {
+        var logMessage = LogLineHelper.buildErrorMessage("Test message", "Error description");
+
+        assertEquals("Test message", logMessage.get(LOG_MESSAGE_DESCRIPTION.getLogFieldName()));
+        assertEquals("Error description", logMessage.get(LOG_ERROR_DESCRIPTION.getLogFieldName()));
+    }
+
+    @Test
+    void buildErrorMessageShouldAttachErrorCode() {
+        var logMessage = LogLineHelper.buildErrorMessage("Test message", "Error description", 10);
+
+        assertEquals("Test message", logMessage.get(LOG_MESSAGE_DESCRIPTION.getLogFieldName()));
+        assertEquals("Error description", logMessage.get(LOG_ERROR_DESCRIPTION.getLogFieldName()));
+        assertEquals("10", logMessage.get(LOG_ERROR_CODE.getLogFieldName()));
+
+        var logMessage2 =
+                LogLineHelper.buildErrorMessage("Test message", "Error description", "10");
+
+        assertEquals("Test message", logMessage2.get(LOG_MESSAGE_DESCRIPTION.getLogFieldName()));
+        assertEquals("Error description", logMessage2.get(LOG_ERROR_DESCRIPTION.getLogFieldName()));
+        assertEquals("10", logMessage2.get(LOG_ERROR_CODE.getLogFieldName()));
     }
 }


### PR DESCRIPTION
## What

- Add AWS SDK autoinstrumentation
- Add Environment variables to enable OTEL
- Add TracingHTTPClient, a drop-in replacement for the standard HTTP Client, that adds otel spans.

> [!NOTE]
> `bypass-sonarcloud` is required, as I've had to create the same class in both `shared` and `orchestration-shared`, so obviously it's 100% duplicated.

## How to review

- Ensure tests pass
- Ensure that my choices were sensible
- Ensure it works ok in a dev environment, and that spans are created on execution in dynatrace

## 🚨 BEFORE MERGING 🚨

Ensure that we have confirmation from dynatrace that their otel agent has been updated so that spans created before handler initial execution doesn't break everything.