### PR TITLE
ATO-1404: Improve logging around IPV/Doc app request failures

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
@@ -104,6 +104,13 @@ public class DocAppCriService {
                 if (count > 0) LOG.warn("Retrying DocApp token request");
                 count++;
                 tokenResponse = TokenResponse.parse(tokenRequest.toHTTPRequest().send());
+                if (!tokenResponse.indicatesSuccess()) {
+                    HTTPResponse response = tokenResponse.toHTTPResponse();
+                    LOG.warn(
+                            format(
+                                    "Unsuccessful %s response from DocApp token endpoint on attempt %d: %s ",
+                                    response.getStatusCode(), count, response.getContent()));
+                }
             } while (!tokenResponse.indicatesSuccess() && count < maxTries);
             return tokenResponse;
         } catch (IOException e) {
@@ -126,6 +133,12 @@ public class DocAppCriService {
                 if (count > 0) LOG.warn("Retrying DocApp cri data request");
                 count++;
                 response = request.send();
+                if (!response.indicatesSuccess()) {
+                    LOG.warn(
+                            format(
+                                    "Unsuccessful %s response from DocApp userinfo endpoint on attempt %d: %s ",
+                                    response.getStatusCode(), count, response.getContent()));
+                }
             } while (!response.indicatesSuccess() && count < maxTries);
 
             if (!response.indicatesSuccess()) {


### PR DESCRIPTION
Implements logging we already have in OAuth requests to authentication, so we can see the content of the http response

### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
