### PR TITLE
PSREGOV-1968: Add write policy for client registry updated

### DIFF
--- a/ci/terraform/shared/iam-ct.tf
+++ b/ci/terraform/shared/iam-ct.tf
@@ -65,3 +65,70 @@ resource "aws_iam_policy" "client_registry_read_only" {
   description = "Policy for use in Control Tower to be attached to the role assumed by support users to view the Client Registry"
   policy      = data.aws_iam_policy_document.client_registry_read_only.json
 }
+
+data "aws_iam_policy_document" "client_registry_write" {
+  statement {
+    sid    = "ClientRegistryWrite"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DeleteItem",
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:DescribeImport",
+      "dynamodb:ListTables",
+      "dynamodb:DescribeContributorInsights",
+      "dynamodb:ListTagsOfResource",
+      "dynamodb:DescribeReservedCapacityOfferings",
+      "dynamodb:PartiQLSelect",
+      "dynamodb:DescribeTable",
+      "dynamodb:GetItem",
+      "dynamodb:DescribeContinuousBackups",
+      "dynamodb:DescribeExport",
+      "dynamodb:ListImports",
+      "dynamodb:DescribeKinesisStreamingDestination",
+      "dynamodb:ListExports",
+      "dynamodb:DescribeLimits",
+      "dynamodb:BatchGetItem",
+      "dynamodb:ConditionCheckItem",
+      "dynamodb:ListBackups",
+      "dynamodb:Scan",
+      "dynamodb:Query",
+      "dynamodb:DescribeStream",
+      "dynamodb:DescribeTimeToLive",
+      "dynamodb:ListStreams",
+      "dynamodb:ListContributorInsights",
+      "dynamodb:DescribeGlobalTableSettings",
+      "dynamodb:ListGlobalTables",
+      "dynamodb:GetShardIterator",
+      "dynamodb:DescribeGlobalTable",
+      "dynamodb:DescribeReservedCapacity",
+      "dynamodb:DescribeBackup",
+      "dynamodb:DescribeEndpoints",
+      "dynamodb:GetRecords",
+      "dynamodb:DescribeTableReplicaAutoScaling"
+    ]
+    resources = [aws_dynamodb_table.client_registry_table.arn]
+  }
+
+  statement {
+    sid       = "AllowListAllTables"
+    effect    = "Allow"
+    actions   = ["dynamodb:ListTables"]
+    resources = ["arn:aws:dynamodb:eu-west-2:${data.aws_caller_identity.current.account_id}:table/*"]
+  }
+
+  statement {
+    sid       = "ClientRegistryKeyDecrypt"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt", "kms:GenerateDataKey*"]
+    resources = [aws_kms_key.client_registry_table_encryption_key.arn]
+  }
+}
+
+resource "aws_iam_policy" "client_registry_write" {
+  count       = local.should_create_client_registry_policy ? 1 : 0
+  name        = "client-registry-write-user-policy"
+  path        = "/control-tower/shared/"
+  description = "Policy for use in Control Tower to be attached to the role assumed by support users to update the Client Registry"
+  policy      = data.aws_iam_policy_document.client_registry_write.json
+}


### PR DESCRIPTION
This is to replace the existing gds-users process

### Wider context of change

@andyloughran  has request this [here](https://gds.slack.com/archives/C04UJ0F91QA/p1738161061710099)

### What’s changed
Create a policy for write access to the client registry for use in a control tower role. It needs to be defined here because the KMS key ID is different for each table. The name needs to be exactly the same in every environment it's used in.

### Manual testing

I've deployed this to Sandpit, but will be able to test it better once it's in Staging.

### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
