### PR TITLE
ATO-1389: add access policies for auth user info table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1946,6 +1946,8 @@ Resources:
         - !Ref UserProfileTableWriteAccessPolicy
         - !Ref AuthenticationCallbackUserInfoTableReadAccessPolicy
         - !Ref AuthenticationCallbackUserInfoTableWriteAccessPolicy
+        - !Ref AuthUserInfoTableReadAccessPolicy
+        - !Ref AuthUserInfoTableWriteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref RedisParametersAccessPolicy
         - !Ref StorageTokenSigningKmsAccessPolicy
@@ -2808,6 +2810,7 @@ Resources:
         - !Ref DocAppCredentialTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy
         - !Ref AuthenticationCallbackUserInfoTableReadAccessPolicy
+        - !Ref AuthUserInfoTableReadAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref RedisParametersAccessPolicy
         - !Ref IdTokenKmsAccessPolicy
@@ -3651,6 +3654,7 @@ Resources:
         - !Ref OrchSessionTableWriteAccessPolicy
         - !Ref OrchSessionTableDeleteAccessPolicy
         - !Ref AuthenticationCallbackUserInfoTableReadAccessPolicy
+        - !Ref AuthUserInfoTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 

--- a/template.yaml
+++ b/template.yaml
@@ -483,7 +483,7 @@ Resources:
 
   #region AuthUserInfo DynamoDB Table
 
-  AuthUserInfoEncryptionKey:
+  AuthUserInfoTableEncryptionKey:
     Type: AWS::KMS::Key
     Properties:
       Description: KMS encryption key for AuthUserInfo DynamoDB table
@@ -529,7 +529,7 @@ Resources:
       BillingMode: PAY_PER_REQUEST
       SSESpecification:
         SSEEnabled: true
-        KMSMasterKeyId: !GetAtt AuthUserInfoEncryptionKey.Arn
+        KMSMasterKeyId: !GetAtt AuthUserInfoTableEncryptionKey.Arn
         SSEType: KMS
       TimeToLiveSpecification:
         AttributeName: ttl

--- a/template.yaml
+++ b/template.yaml
@@ -4289,6 +4289,42 @@ Resources:
               - dynamodb:DeleteItem
             Resource: !GetAtt OrchSessionTable.Arn
 
+  AuthUserInfoTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowAuthUserInfoTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt AuthUserInfoTable.Arn
+          - Sid: AllowAuthUserInfoTableDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: !GetAtt AuthUserInfoTableEncryptionKey.Arn
+
+  AuthUserInfoTableWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowAuthUserInfoTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+            Resource: !GetAtt AuthUserInfoTable.Arn
+          - Sid: AllowAuthUserInfoTableEncryption
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+            Resource: !GetAtt AuthUserInfoTableEncryptionKey.Arn
+
   IdentityCredentialsTableReadAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:


### PR DESCRIPTION
### Wider context of change
We are migrating the authUserInfo table from auth accounts to orch accounts. We want to minimise code change, so we're keeping the change within the service.

### What’s changed
Adds policies to read and write to the new AuthUserInfo table on orch accounts, and adds those policies to the same lambdas the old AuthUserInfo table needs them for.

### Manual testing
Successfully built and deployed to dev.

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked. **Not Needed**
- [x] Changes have been made to contract tests or not required. **Not Needed**
- [x] Changes have been made to the simulator or not required. **Not Needed**
- [x] Changes have been made to stubs or not required. **Not Needed**
- [x] Successfully deployed to authdev or not required. **Not Needed**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not Needed**

### Related PRs
