### PR TITLE
ATO-646: Add client id authcode validation to token endpoint

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -533,21 +533,8 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 makeTokenRequestWithClientSecretPost(
                         "test-client-1", baseTokenRequest, clientSecret);
 
-        assertThat(response, hasStatus(200));
-        JSONObject jsonResponse = JSONObjectUtils.parse(response.getBody());
-
-        assertNotNull(
-                TokenResponse.parse(jsonResponse)
-                        .toSuccessResponse()
-                        .getTokens()
-                        .getRefreshToken());
-        assertNotNull(
-                TokenResponse.parse(jsonResponse)
-                        .toSuccessResponse()
-                        .getTokens()
-                        .getBearerAccessToken());
-
-        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasBody(OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString()));
     }
 
     @Test
@@ -575,21 +562,8 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 makeTokenRequestWithPrivateKeyJWT(
                         "test-client-1", baseTokenRequest, keyPair.getPrivate());
 
-        assertThat(response, hasStatus(200));
-        JSONObject jsonResponse = JSONObjectUtils.parse(response.getBody());
-
-        assertNotNull(
-                TokenResponse.parse(jsonResponse)
-                        .toSuccessResponse()
-                        .getTokens()
-                        .getRefreshToken());
-        assertNotNull(
-                TokenResponse.parse(jsonResponse)
-                        .toSuccessResponse()
-                        .getTokens()
-                        .getBearerAccessToken());
-
-        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasBody(OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString()));
     }
 
     private SignedJWT generateSignedRefreshToken(Scope scope, Subject publicSubject) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -221,8 +221,8 @@ public class TokenHandler
         AuthCodeExchangeData authCodeExchangeData = authCodeExchangeDataMaybe.get();
         if (!Objects.equals(authCodeExchangeData.getClientId(), clientRegistry.getClientID())) {
             LOG.warn("Client ID from auth code does not match client ID from request body");
-            // ATO-646: Make this return 400 error when we are confident that
-            // it won't cause issues with existing clients
+            return generateApiGatewayProxyResponse(
+                    400, OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString());
         }
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, authCodeExchangeData.getClientSessionId());
         updateAttachedLogFieldToLogs(


### PR DESCRIPTION
### Wider context of change

Previously, it was possible for a client to use another client's valid auth code. We want to add validation for this to prevent this from happening.

### What’s changed

If the client id in the auth code does not match the client id in the request parameters, then a 400 `invalid_client` response will be generated. 

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.