### PR TITLE
ATO-1390: read from new auth user info table

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -205,7 +205,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                 txmaAuditQueue, List.of(AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED));
 
         Optional<UserInfo> userInfo =
-                userInfoStoreExtension.getAuthenticationUserInfo(SUBJECT_ID.getValue());
+                userInfoStoreExtension.getAuthenticationUserInfo(
+                        SUBJECT_ID.getValue(), CLIENT_SESSION_ID);
         assertTrue(userInfo.isEmpty());
     }
 
@@ -1066,7 +1067,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                         OidcAuditableEvent.AUTH_CODE_ISSUED));
 
         Optional<UserInfo> userInfo =
-                userInfoStoreExtension.getAuthenticationUserInfo(SUBJECT_ID.getValue());
+                userInfoStoreExtension.getAuthenticationUserInfo(
+                        SUBJECT_ID.getValue(), CLIENT_SESSION_ID);
         assertTrue(userInfo.isPresent());
         assertEquals(SUBJECT_ID, userInfo.get().getSubject());
         assertEquals(true, userInfo.get().getBooleanClaim("new_account"));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
@@ -28,7 +28,7 @@ class AuthenticationUserInfoStorageServiceIntegrationTest {
         userInfoExtension.addAuthenticationUserInfoData(SUBJECT_ID, CLIENT_SESSION_ID, userInfo);
 
         Optional<UserInfo> retrievedUserInfo =
-                userInfoExtension.getAuthenticationUserInfo(SUBJECT_ID);
+                userInfoExtension.getAuthenticationUserInfo(SUBJECT_ID, CLIENT_SESSION_ID);
 
         assertThat(retrievedUserInfo.isPresent(), equalTo(true));
         assertThat(retrievedUserInfo.get().getSubject().getValue(), equalTo(SUBJECT_ID));
@@ -37,7 +37,7 @@ class AuthenticationUserInfoStorageServiceIntegrationTest {
     @Test
     void shouldReturnOptionalEmptyWhenNoUserInfo() throws ParseException {
         Optional<UserInfo> retrievedUserInfo =
-                userInfoExtension.getAuthenticationUserInfo(SUBJECT_ID);
+                userInfoExtension.getAuthenticationUserInfo(SUBJECT_ID, CLIENT_SESSION_ID);
 
         assertThat(retrievedUserInfo.isEmpty(), equalTo(true));
     }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -350,7 +350,8 @@ public class IPVCallbackHandler
                 Optional<UserInfo> authUserInfo =
                         getAuthUserInfo(
                                 authUserInfoStorageService,
-                                orchSession.getInternalCommonSubjectId());
+                                orchSession.getInternalCommonSubjectId(),
+                                clientSessionId);
 
                 if (authUserInfo.isEmpty()) {
                     LOG.info("authUserInfo not found");
@@ -546,9 +547,11 @@ public class IPVCallbackHandler
 
     private static Optional<UserInfo> getAuthUserInfo(
             AuthenticationUserInfoStorageService authUserInfoStorageService,
-            String internalCommonSubjectId) {
+            String internalCommonSubjectId,
+            String clientSessionId) {
         try {
-            return authUserInfoStorageService.getAuthenticationUserInfo(internalCommonSubjectId);
+            return authUserInfoStorageService.getAuthenticationUserInfo(
+                    internalCommonSubjectId, clientSessionId);
         } catch (ParseException e) {
             // TODO: ATO-1117: temporary logs. authUserInfo is not essential, so we don't want this
             // to exit the lambda yet.

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -111,7 +111,7 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
             try {
                 Optional<UserInfo> userInfoFromStorage =
                         userInfoStorageService.getAuthenticationUserInfo(
-                                internalCommonSubjectIdentifier);
+                                internalCommonSubjectIdentifier, userSession.getClientSessionId());
 
                 if (userInfoFromStorage.isEmpty()) {
                     LOG.warn("Unable to find user info for subject");

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -104,7 +104,8 @@ public class IdentityProgressFrontendHandlerTest {
     @BeforeEach
     void setup() throws ParseException {
         when(configurationService.getEnvironment()).thenReturn(ENVIRONMENT);
-        when(userInfoStorageService.getAuthenticationUserInfo(INTERNAL_COMMON_SUBJECT_ID))
+        when(userInfoStorageService.getAuthenticationUserInfo(
+                        INTERNAL_COMMON_SUBJECT_ID, CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(AUTH_USER_INFO));
         Map<String, String> headers = new HashMap<>();
         headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -101,7 +101,8 @@ public class UserInfoService {
         try {
             Optional<UserInfo> userInfoFromStorage =
                     userInfoStorageService.getAuthenticationUserInfo(
-                            accessTokenInfo.getAccessTokenStore().getInternalPairwiseSubjectId());
+                            accessTokenInfo.getAccessTokenStore().getInternalPairwiseSubjectId(),
+                            accessTokenInfo.getAccessTokenStore().getJourneyId());
 
             if (userInfoFromStorage.isEmpty()) {
                 throw new AccessTokenException(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -586,7 +586,8 @@ class UserInfoServiceTest {
     private void givenThereIsUserInfo() throws ParseException {
         var testUserInfo = generateUserInfo();
 
-        when(userInfoStorageService.getAuthenticationUserInfo(INTERNAL_PAIRWISE_SUBJECT.getValue()))
+        when(userInfoStorageService.getAuthenticationUserInfo(
+                        INTERNAL_PAIRWISE_SUBJECT.getValue(), JOURNEY_ID))
                 .thenReturn(Optional.of(testUserInfo));
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
@@ -113,8 +113,9 @@ public class AuthenticationCallbackUserInfoStoreExtension extends DynamoExtensio
         dynamoDB.createTable(request);
     }
 
-    public Optional<UserInfo> getAuthenticationUserInfo(String subjectId) throws ParseException {
-        return userInfoService.getAuthenticationUserInfo(subjectId);
+    public Optional<UserInfo> getAuthenticationUserInfo(String subjectId, String clientSessionId)
+            throws ParseException {
+        return userInfoService.getAuthenticationUserInfo(subjectId, clientSessionId);
     }
 
     public void addAuthenticationUserInfoData(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
@@ -53,7 +53,7 @@ public class AuthenticationUserInfoStorageService {
         authUserInfoDynamoService.put(userInfoDbObject);
     }
 
-    public Optional<UserInfo> getAuthenticationUserInfo(String subjectID)
+    public Optional<UserInfo> getAuthenticationUserInfo(String subjectID, String clientSessionId)
             throws com.nimbusds.oauth2.sdk.ParseException {
         var userInfoData = getAuthenticationUserInfoData(subjectID);
         if (userInfoData.isEmpty()) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthenticationUserInfoStorageService.java
@@ -55,7 +55,7 @@ public class AuthenticationUserInfoStorageService {
 
     public Optional<UserInfo> getAuthenticationUserInfo(String subjectID, String clientSessionId)
             throws com.nimbusds.oauth2.sdk.ParseException {
-        var userInfoData = getAuthenticationUserInfoData(subjectID);
+        var userInfoData = getAuthUserInfoData(subjectID, clientSessionId);
         if (userInfoData.isEmpty()) {
             return Optional.empty();
         }
@@ -63,9 +63,9 @@ public class AuthenticationUserInfoStorageService {
         return Optional.of(userInfo);
     }
 
-    private Optional<OldAuthenticationUserInfo> getAuthenticationUserInfoData(String subjectID) {
-        return oldAuthenticationUserInfoDynamoService
-                .get(subjectID)
+    private Optional<AuthUserInfo> getAuthUserInfoData(String subjectID, String clientSessionId) {
+        return authUserInfoDynamoService
+                .get(subjectID, clientSessionId)
                 .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
     }
 }


### PR DESCRIPTION
### Wider context of change
We are migrating the authUserInfo table from auth accounts to orch accounts. We want to minimise code change, so we're keeping the change within the service.

### What’s changed
The first commit adds clientSessionId to the method interface, as that is the sort key on the new table. The second commit swaps to read from the new table instead of the old table

### Manual testing
Deployed to dev. Tested several journeys and all worked ok.

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked. 
- [x] Changes have been made to contract tests or not required. **Not required**
- [x] Changes have been made to the simulator or not required. **Not required**
- [x] Changes have been made to stubs or not required. **Not required**
- [x] Successfully deployed to authdev or not required. **Not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required**