### PR TITLE
ATO-1395: Remove session id getter for shared session

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -526,7 +526,7 @@ public class AuthenticationCallbackHandler
                             input,
                             authenticationRequest,
                             userInfo,
-                            session,
+                            sessionId,
                             client,
                             clientId,
                             clientSessionId,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
@@ -19,7 +19,6 @@ import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
-import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
@@ -66,7 +65,7 @@ public class InitiateIPVAuthorisationService {
             APIGatewayProxyRequestEvent input,
             AuthenticationRequest authRequest,
             UserInfo userInfo,
-            Session session,
+            String sessionId,
             ClientRegistry client,
             String rpClientID,
             String clientSessionId,
@@ -104,7 +103,7 @@ public class InitiateIPVAuthorisationService {
                         .requestObject(encryptedJWT);
 
         var ipvAuthorisationRequest = authRequestBuilder.build();
-        authorisationService.storeState(session.getSessionId(), state);
+        authorisationService.storeState(sessionId, state);
         noSessionOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
 
         var rpPairwiseId = userInfo.getClaim("rp_pairwise_id");
@@ -114,7 +113,7 @@ public class InitiateIPVAuthorisationService {
                 rpClientID,
                 TxmaAuditUser.user()
                         .withGovukSigninJourneyId(clientSessionId)
-                        .withSessionId(session.getSessionId())
+                        .withSessionId(sessionId)
                         .withUserId(internalCommonSubjectId.getValue())
                         .withEmail(userInfo.getEmailAddress())
                         .withIpAddress(IpAddressHelper.extractIpAddress(input))

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -61,7 +61,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -166,7 +169,7 @@ public class InitiateIPVAuthorisationServiceTest {
                                         event,
                                         authenticationRequest,
                                         userInfo,
-                                        session,
+                                        SESSION_ID,
                                         client,
                                         CLIENT_ID,
                                         CLIENT_SESSION_ID,
@@ -199,7 +202,7 @@ public class InitiateIPVAuthorisationServiceTest {
                         event,
                         authRequest,
                         userInfo,
-                        session,
+                        SESSION_ID,
                         client,
                         CLIENT_ID,
                         CLIENT_SESSION_ID,
@@ -212,7 +215,7 @@ public class InitiateIPVAuthorisationServiceTest {
         assertThat(redirectLocation, startsWith(IPV_AUTHORISATION_URI.toString()));
 
         assertThat(splitQuery(redirectLocation).get("request"), equalTo(encryptedJWT.serialize()));
-        verify(authorisationService).storeState(eq(session.getSessionId()), any(State.class));
+        verify(authorisationService).storeState(eq(SESSION_ID), any(State.class));
         verify(noSessionOrchestrationService)
                 .storeClientSessionIdAgainstState(eq(CLIENT_SESSION_ID), any(State.class));
         verify(authorisationService)
@@ -253,7 +256,7 @@ public class InitiateIPVAuthorisationServiceTest {
                         event,
                         authRequestWithStorageClaim,
                         userInfo,
-                        session,
+                        SESSION_ID,
                         client,
                         CLIENT_ID,
                         CLIENT_SESSION_ID,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -66,10 +66,6 @@ public class Session {
         initializeCodeRequestMap();
     }
 
-    public String getSessionId() {
-        return sessionId;
-    }
-
     public void setSessionId(String sessionId) {
         this.sessionId = sessionId;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/ClientNotFoundException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/ClientNotFoundException.java
@@ -1,16 +1,9 @@
 package uk.gov.di.orchestration.shared.exceptions;
 
-import uk.gov.di.orchestration.shared.entity.Session;
-
 import static java.lang.String.format;
 
 public class ClientNotFoundException extends Exception {
-
     public ClientNotFoundException(String clientID) {
         super(format("No Client found for ClientID: %s", clientID));
-    }
-
-    public ClientNotFoundException(Session session) {
-        super(format("No Client found for SessionId: %s", session.getSessionId()));
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/TestClientHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/TestClientHelper.java
@@ -28,7 +28,7 @@ public class TestClientHelper {
         var clientRegistry =
                 userContext
                         .getClient()
-                        .orElseThrow(() -> new ClientNotFoundException(userContext.getSession()));
+                        .orElseThrow(() -> new ClientNotFoundException(userContext.getClientId()));
 
         var isTestClientWithAllowedEmail =
                 (clientRegistry.isTestClient()


### PR DESCRIPTION
Reopening PR (had to revert because of pipeline issues)

### Wider context of change

We would like to migrate to using the orch session for storing the session ID. Previous PRs have been slowly removing usages of the shared session sessionId getter.

### What’s changed

This PR removes the final usages of the sessionId getter (ClientNotFoundException and InitiateIPVAuthorisationService) and removes the sessionId getter once there were no usages of it in the code.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
