### PR TITLE
AUT-4069: Improve tflint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,27 +32,19 @@ repos:
   - repo: local
     hooks:
       - id: tflint
-        name: Init tflint (hack)
-        files: ^ci/terraform/
-        pass_filenames: false
-        types_or:
-          - hcl
-          - terraform
-        language: golang
-        additional_dependencies:
-          - github.com/terraform-linters/tflint@v0.55.0
-        entry: tflint --chdir ci/terraform --init
-      - id: tflint
         name: Run tflint (terraform linter)
         files: ^ci/terraform/
-        pass_filenames: false
+        require_serial: true
         types_or:
           - hcl
           - terraform
         language: golang
         additional_dependencies:
           - github.com/terraform-linters/tflint@v0.55.0
-        entry: tflint --chdir ci/terraform --recursive --fix
+        entry: scripts/tflint.py
+        args:
+          - --minimum-failure-severity=warning
+          - --fix
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.6

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,3 +1,12 @@
+tflint {
+    required_version = ">= 0.55"
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
 plugin "aws" {
     enabled = true
     version = "0.37.0"

--- a/scripts/tflint.py
+++ b/scripts/tflint.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import multiprocessing
+import os
+import pathlib
+import subprocess
+import sys
+from collections import defaultdict
+from functools import cache
+from multiprocessing.pool import AsyncResult
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONFIG_FILE = os.path.join(REPO_ROOT, ".tflint.hcl")
+
+
+def run_tflint(
+    directory: pathlib.Path, files: list[str], args: list[str]
+) -> subprocess.Popen:
+    # strip out the format argument, as we are always going to use 'json'
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-f", "--format")
+    parsed, unknown = parser.parse_known_args(args)
+
+    filter_args = [f"--filter={file}" for file in files]
+
+    cmd = (
+        [
+            "tflint",
+            "--config",
+            CONFIG_FILE,
+            "--chdir",
+            str(directory),
+            "--format",
+            "json",
+        ]
+        + filter_args
+        + unknown
+    )
+    return subprocess.run(cmd, capture_output=True)
+
+
+class TflintResult:
+    def __init__(self, result: subprocess.CompletedProcess):
+        self.result = result
+
+    @cache
+    def _data(self):
+        return json.loads(self.result.stdout)
+
+    def issues(self):
+        for issue in self._data()["issues"]:
+            yield issue
+
+    def errors(self):
+        for error in self._data()["errors"]:
+            yield error
+
+    @property
+    def return_code(self):
+        return self.result.returncode
+
+    @property
+    def error(self):
+        return any([error for error in self.errors()])
+
+
+class TflintResults:
+    results: list[TflintResult] = []
+
+    def __init__(self, results: list[subprocess.CompletedProcess]):
+        self.results = [TflintResult(result) for result in results]
+
+    @property
+    def was_error(self):
+        return any([result.error for result in self.results])
+
+    def issues(self):
+        for result in self.results:
+            yield from result.issues()
+
+    def errors(self):
+        for result in self.results:
+            yield from result.errors()
+
+    @property
+    def return_code(self):
+        return max([result.return_code for result in self.results])
+
+
+def parse_tflint_runs(runs: list[subprocess.CompletedProcess]) -> list[TflintResult]:
+    pass
+
+
+def main(args: argparse.Namespace, tflint_args: list[str]):
+    directories = defaultdict(list[str])
+    file: pathlib.Path
+    for file in args.files:
+        parent = file.parent
+        directories.setdefault(parent, []).append(file.name)
+
+    try:
+        subprocess.run(
+            ["tflint", "--config", CONFIG_FILE, "--init"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(e.stdout)
+        sys.exit(e.returncode)
+
+    results: list[subprocess.CompletedProcess] = []
+    with multiprocessing.Pool(len(directories.keys())) as pool:
+        processes: list[AsyncResult] = []
+        for directory, files in directories.items():
+            processes.append(
+                pool.apply_async(run_tflint, (directory, files, tflint_args))
+            )
+        while not all([result.ready() for result in processes]):
+            pass
+        for result in processes:
+            results.append(result.get())
+
+    parsed_results = TflintResults(results)
+    if parsed_results.was_error:
+        for error in parsed_results.errors():
+            print(f"Error: {error['message']}")
+        sys.exit(parsed_results.return_code)
+    issues = list(parsed_results.issues())
+    if issues:
+        print(f"{len(issues)} issue(s) found:\n")
+        for issue in issues:
+            rule = issue["rule"]
+            range = issue["range"]
+            print(
+                f"{range['filename']}:{range['start']['line']}:{range['start']['column']}: {rule['severity'].title()} - {issue['message']} ({rule['name']})"
+            )
+    sys.exit(parsed_results.return_code)
+
+
+class ValidatePathAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        pvalues = []
+        for value in values:
+            path = pathlib.Path(value)
+            if not path.exists():
+                parser.error(f"Path {value} does not exist.")
+            if not path.is_file():
+                parser.error(f"Path {value} is not a file.")
+            pvalues.append(path)
+        setattr(namespace, self.dest, pvalues)
+
+
+if __name__ == "__main__":
+    app_parser = argparse.ArgumentParser(
+        usage="%(prog)s [tflint-options] FILE [FILE ...]",
+    )
+    app_parser.add_argument(
+        "files",
+        nargs="+",
+        help="file(s) to lint",
+        metavar="FILE",
+        action=ValidatePathAction,
+    )
+    app_args, tflint_args = app_parser.parse_known_args()
+    main(app_args, tflint_args)


### PR DESCRIPTION
## What

- Actually use the .tflint.hcl configuration file
- Run tflint explicitly on each directory with changed files, which
  reduces the runtime significantly when oidc hasn't changed
- Filter the files to validate, to emulate the 'normal' pre-commit
  behaviour - if a file hasn't been changed in a commit, it won't cause
  a linting failure
- only fail on warning and above - no need to fail on notices
- Remove the tflint init hook, as it's not needed anymore

## How to review

1. Introduce a linting error into a terraform file (eg. remove a type from a variable), and try to commit it - if pre-commit complains, this confirms that it's running properly
2. commit the change (`git commit -m 'test' --no-verify`)
3. Change another terraform file (eg. add an extra `\n` between two `resource` definitions), and try to commit it - if pre-commit doesn't complain, this confirms that the filter works properly.
