### PR TITLE
ATO-1169: check if docAppSubjectId is defined in logs

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -268,6 +268,10 @@ public class StartHandler
                                 userContext.getClientSession().getAuthRequestParams(),
                                 configurationService.isCustomDocAppClaimEnabled(),
                                 configurationService.getDocAppDomain());
+                LOG.info(
+                        "is docAppSubjectId updated: {}",
+                        !docAppSubjectId.equals(clientSession.get().getDocAppSubjectId()));
+
                 clientSessionService.updateStoredClientSession(
                         clientSessionId, clientSession.get().setDocAppSubjectId(docAppSubjectId));
                 LOG.info("Subject saved to ClientSession for DocCheckingAppUser");


### PR DESCRIPTION
### Wider context of change
This is part of the work to scope out the ClientSession table migration. See epic here: https://govukverify.atlassian.net/browse/ATO-1106

### What’s changed
Adds logging to check if docAppSubjectId is defined. This is the only place any setter on Auths ClientSession Class is called. Orch already sets it in AuthorisationHandler, so we should be able to safely remove this. If this assumoption is correct, then we can safely just pass the client session from orch to auth, and orch can forget about it. Ie, we don't need any info from Auth to set on the ClientSession.