### PR TITLE
ATO-1412: Turn on IPV encryption JWKS endpoint flag up to staging

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -84,7 +84,11 @@ Conditions:
       !Equals [production, !Ref Environment],
     ]
   UseIpvJwksEndpointToGetEncryptionKey:
-    !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]]
+    !Or [
+      !Equals [dev, !Ref Environment],
+      !Equals [build, !Ref Environment],
+      !Equals [staging, !Ref Environment],
+    ]
 
 Mappings:
   EnvironmentConfiguration:


### PR DESCRIPTION
Testing in dev at the moment

### What’s changed

IPV want to test some stuff in staging, just turning on the flag up to that environment

### Checklist
- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] Changes have been made to contract tests or not required.
- [ ] Changes have been made to the simulator or not required.
- [ ] Changes have been made to stubs or not required.
- [ ] Successfully deployed to authdev or not required.
- [ ] Successfully run Authentication acceptance tests against sandpit or not required.
