### PR TITLE
ATO-1412: Use correct JWKS endpoint URL in staging

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1884,7 +1884,7 @@ Resources:
           IPV_JWKS_URL: !If
             - IpvExists
             - !Sub
-              - https://identity.${ServiceDomain}/.well-known/jwks.json
+              - https://api.identity.${ServiceDomain}/.well-known/jwks.json
               - ServiceDomain:
                   !FindInMap [
                     EnvironmentConfiguration,


### PR DESCRIPTION
### What’s changed

The JWKS URL was incorrect for staging, this fixes it.
