### PR TITLE
ATO-1424: Support filtering keys by use in JwkCache

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/EncryptionJwkCache.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/EncryptionJwkCache.java
@@ -27,7 +27,7 @@ public class EncryptionJwkCache {
                     "Cache entry does not exist for JWKS URL {}, creating new one with expiration of {} seconds",
                     url,
                     cacheExpiration);
-            jwkCacheEntry = JwkCacheEntry.withUrlAndExpiration(url, cacheExpiration);
+            jwkCacheEntry = JwkCacheEntry.forEncryptionKeys(url, cacheExpiration);
             cacheEntryByUrl.put(url.toString(), jwkCacheEntry);
         } else {
             LOG.info("Cache entry exists for JWKS URL {}", url);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/EncryptionJwkCache.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/EncryptionJwkCache.java
@@ -7,16 +7,16 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-public class JwkCache {
-    private static final Logger LOG = LogManager.getLogger(JwkCache.class);
-    private static final JwkCache instance = new JwkCache();
+public class EncryptionJwkCache {
+    private static final Logger LOG = LogManager.getLogger(EncryptionJwkCache.class);
+    private static final EncryptionJwkCache instance = new EncryptionJwkCache();
     private final Map<String, JwkCacheEntry> cacheEntryByUrl;
 
-    private JwkCache() {
+    private EncryptionJwkCache() {
         cacheEntryByUrl = new HashMap<>();
     }
 
-    public static JwkCache getInstance() {
+    public static EncryptionJwkCache getInstance() {
         return instance;
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
@@ -13,7 +13,7 @@ import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 import uk.gov.di.orchestration.shared.helpers.CryptoProviderHelper;
-import uk.gov.di.orchestration.shared.helpers.JwkCache;
+import uk.gov.di.orchestration.shared.helpers.EncryptionJwkCache;
 import uk.gov.di.orchestration.shared.utils.JwksUtils;
 
 import java.net.URL;
@@ -68,9 +68,9 @@ public class JwksService {
     }
 
     public JWK getIpvJwk() {
-        JwkCache jwkCache = JwkCache.getInstance();
+        EncryptionJwkCache encryptionJwkCache = EncryptionJwkCache.getInstance();
         var ipvJwkCacheEntry =
-                jwkCache.getOrCreateEntry(
+                encryptionJwkCache.getOrCreateEntry(
                         configurationService.getIPVJwksUrl(),
                         configurationService.getIPVJwkCacheExpirationInSeconds());
         return ipvJwkCacheEntry.getKey();

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/EncryptionJwkCacheTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/EncryptionJwkCacheTest.java
@@ -8,12 +8,12 @@ import java.net.URL;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 
-class JwkCacheTest {
-    private static final JwkCache jwkCache = JwkCache.getInstance();
+class EncryptionJwkCacheTest {
+    private static final EncryptionJwkCache ENCRYPTION_JWK_CACHE = EncryptionJwkCache.getInstance();
 
     @BeforeEach
     void setup() {
-        jwkCache.clear();
+        ENCRYPTION_JWK_CACHE.clear();
     }
 
     @Test
@@ -22,7 +22,7 @@ class JwkCacheTest {
             URL testJwksUrl = new URL("http://localhost/.well-known/jwks.json");
             int testExpiry = 123;
 
-            jwkCache.getOrCreateEntry(testJwksUrl, testExpiry);
+            ENCRYPTION_JWK_CACHE.getOrCreateEntry(testJwksUrl, testExpiry);
             mockJwkCacheEntry.verify(
                     () -> JwkCacheEntry.withUrlAndExpiration(testJwksUrl, testExpiry));
         }
@@ -34,8 +34,8 @@ class JwkCacheTest {
             URL testJwksUrl = new URL("http://localhost/.well-known/jwks.json");
             int testExpiry = 123;
 
-            jwkCache.getOrCreateEntry(testJwksUrl, testExpiry);
-            jwkCache.getOrCreateEntry(testJwksUrl, testExpiry);
+            ENCRYPTION_JWK_CACHE.getOrCreateEntry(testJwksUrl, testExpiry);
+            ENCRYPTION_JWK_CACHE.getOrCreateEntry(testJwksUrl, testExpiry);
             mockJwkCacheEntry.verify(
                     () -> JwkCacheEntry.withUrlAndExpiration(testJwksUrl, testExpiry), times(1));
         }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/EncryptionJwkCacheTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/EncryptionJwkCacheTest.java
@@ -24,7 +24,7 @@ class EncryptionJwkCacheTest {
 
             ENCRYPTION_JWK_CACHE.getOrCreateEntry(testJwksUrl, testExpiry);
             mockJwkCacheEntry.verify(
-                    () -> JwkCacheEntry.withUrlAndExpiration(testJwksUrl, testExpiry));
+                    () -> JwkCacheEntry.forEncryptionKeys(testJwksUrl, testExpiry));
         }
     }
 
@@ -37,7 +37,7 @@ class EncryptionJwkCacheTest {
             ENCRYPTION_JWK_CACHE.getOrCreateEntry(testJwksUrl, testExpiry);
             ENCRYPTION_JWK_CACHE.getOrCreateEntry(testJwksUrl, testExpiry);
             mockJwkCacheEntry.verify(
-                    () -> JwkCacheEntry.withUrlAndExpiration(testJwksUrl, testExpiry), times(1));
+                    () -> JwkCacheEntry.forEncryptionKeys(testJwksUrl, testExpiry), times(1));
         }
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
@@ -9,7 +9,7 @@ import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 import software.amazon.awssdk.services.kms.model.KeyUsageType;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
-import uk.gov.di.orchestration.shared.helpers.JwkCache;
+import uk.gov.di.orchestration.shared.helpers.EncryptionJwkCache;
 import uk.gov.di.orchestration.shared.utils.JwksUtils;
 
 import java.net.URL;
@@ -91,7 +91,7 @@ class JwksServiceTest {
 
     @Test
     void shouldUseJwkCacheToGetKeyWhenFeatureFlagEnabled() throws Exception {
-        JwkCache.getInstance().clear();
+        EncryptionJwkCache.getInstance().clear();
         when(configurationService.isUseIPVJwksEndpointEnabled()).thenReturn(true);
         URL testJwksUrl = new URL("http://localhost/.well-known/jwks.json");
         int testTimeout = 123;

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
@@ -100,6 +100,7 @@ class JwksServiceTest {
 
         try (var mockJwksUtils = mockStatic(JwksUtils.class)) {
             JWK testKey1 = mock(JWK.class);
+            when(testKey1.getKeyUse()).thenReturn(KeyUse.ENCRYPTION);
             mockJwksUtils
                     .when(() -> JwksUtils.retrieveJwksFromUrl(testJwksUrl))
                     .thenReturn(List.of(testKey1));


### PR DESCRIPTION
### Wider context of change

Previously, we added a JwkCache that would cache JWKs from a URL. This class did not differentiate between key uses though, so could retrieve a signing key to be used in encryption for example.

### What’s changed

A `keyUse` field has been added to `JwkCacheEntry`. When keys are retrieved from the JWKS URL, they are filtered to only include keys that match the use field. Additionally, `JwkCache` has been renamed to `EncryptionJwkCache` to be more specific.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
