### PR TITLE
ATO-1413/set up build notifications

### DIFF
--- a/ci/stack-orchestration/configuration/integration/build-notifications/parameters.json
+++ b/ci/stack-orchestration/configuration/integration/build-notifications/parameters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "InitialNotificationStack",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "SlackWorkspaceId",
+    "ParameterValue": "T8GT9416G"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C072WHLJRRP"
+  },
+  {
+    "ParameterKey": "EnrichedNotifications",
+    "ParameterValue": "True"
+  }
+]

--- a/ci/stack-orchestration/configuration/integration/integration-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/integration/integration-orch-be-pipeline/parameters.json
@@ -40,6 +40,10 @@
     "ParameterValue": "arn:aws:iam::590183975515:role/PL-staging-orch-be-pipeline-PromoTrigRole-02b3dd38ed99"
   },
   {
+    "ParameterKey": "BuildNotificationStackName",
+    "ParameterValue": "build-notifications"
+  },
+  {
     "ParameterKey": "CustomKmsKeyArns",
     "ParameterValue": "arn:aws:kms:eu-west-2:216552277552:key/4bc58ab5-c9bb-4702-a2c3-5d339604a8fe"
   },

--- a/ci/stack-orchestration/configuration/production/build-notifications/parameters.json
+++ b/ci/stack-orchestration/configuration/production/build-notifications/parameters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "InitialNotificationStack",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "SlackWorkspaceId",
+    "ParameterValue": "T8GT9416G"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C072F1QUKQV"
+  },
+  {
+    "ParameterKey": "EnrichedNotifications",
+    "ParameterValue": "True"
+  }
+]

--- a/ci/stack-orchestration/configuration/production/production-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/production/production-orch-be-pipeline/parameters.json
@@ -40,6 +40,10 @@
     "ParameterValue": "arn:aws:iam::590183975515:role/PL-staging-orch-be-pipeline-PromoTrigRole-02b3dd38ed99"
   },
   {
+    "ParameterKey": "BuildNotificationStackName",
+    "ParameterValue": "build-notifications"
+  },
+  {
     "ParameterKey": "CustomKmsKeyArns",
     "ParameterValue": "arn:aws:kms:eu-west-2:216552277552:key/4bc58ab5-c9bb-4702-a2c3-5d339604a8fe"
   },

--- a/ci/stack-orchestration/configuration/staging/build-notifications/parameters.json
+++ b/ci/stack-orchestration/configuration/staging/build-notifications/parameters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "InitialNotificationStack",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "SlackWorkspaceId",
+    "ParameterValue": "T8GT9416G"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C072WHLJRRP"
+  },
+  {
+    "ParameterKey": "EnrichedNotifications",
+    "ParameterValue": "True"
+  }
+]

--- a/ci/stack-orchestration/configuration/staging/staging-orch-be-pipeline/parameters.json
+++ b/ci/stack-orchestration/configuration/staging/staging-orch-be-pipeline/parameters.json
@@ -44,6 +44,10 @@
     "ParameterValue": "arn:aws:iam::767397776536:role/PL-build-orch-be-pipeline-PromoTrigRole-069c01797277"
   },
   {
+    "ParameterKey": "BuildNotificationStackName",
+    "ParameterValue": "build-notifications"
+  },
+  {
     "ParameterKey": "CustomKmsKeyArns",
     "ParameterValue": "arn:aws:kms:eu-west-2:216552277552:key/4bc58ab5-c9bb-4702-a2c3-5d339604a8fe"
   },

--- a/ci/stack-orchestration/provision_all.sh
+++ b/ci/stack-orchestration/provision_all.sh
@@ -2,19 +2,23 @@
 ENVIRONMENT=${1}
 
 PROVISION_COMMAND="../../../devplatform-deploy/stack-orchestration-tool/provisioner.sh"
+TAGS_FILE="$(pwd)/configuration/${ENVIRONMENT}/tags.json"
 
 export AUTO_APPLY_CHANGESET=true
 export SKIP_AWS_AUTHENTICATION=true
 export AWS_PAGER=""
+export TAGS_FILE
 
 # Provision dependencies
-for dir in configuration/"$ENVIRONMENT"/*/; do
+for dir in configuration/"${ENVIRONMENT}"/*/; do
   # shellcheck disable=SC2086
-  STACK=$(basename "$dir")
-  if [[ $STACK != "$ENVIRONMENT-orch-be-pipeline" && -f configuration/$ENVIRONMENT/$STACK/parameters.json ]]; then
-    $PROVISION_COMMAND "$ENVIRONMENT" "$STACK" "$STACK" LATEST &
+  STACK=$(basename "${dir}")
+  if [[ ${STACK} != "${ENVIRONMENT}-orch-be-pipeline" && -f configuration/${ENVIRONMENT}/${STACK}/parameters.json ]]; then
+    PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/${STACK}/parameters.json"
+    export PARAMETERS_FILE
+    ${PROVISION_COMMAND} "${ENVIRONMENT}" "${STACK}" "${STACK}" LATEST &
   fi
 done
 
 ### Provision secure pipelines
-$PROVISION_COMMAND "$ENVIRONMENT" "$ENVIRONMENT-orch-be-pipeline" sam-deploy-pipeline LATEST
+${PROVISION_COMMAND} "${ENVIRONMENT}" "${ENVIRONMENT}-orch-be-pipeline" sam-deploy-pipeline LATEST

--- a/ci/stack-orchestration/provision_all.sh
+++ b/ci/stack-orchestration/provision_all.sh
@@ -21,4 +21,6 @@ for dir in configuration/"${ENVIRONMENT}"/*/; do
 done
 
 ### Provision secure pipelines
+PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/${ENVIRONMENT}-orch-be-pipeline/parameters.json"
+export PARAMETERS_FILE
 ${PROVISION_COMMAND} "${ENVIRONMENT}" "${ENVIRONMENT}-orch-be-pipeline" sam-deploy-pipeline LATEST


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
