### PR TITLE
ATO-1406: Remove session id field from shared session

### DIFF
--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -120,7 +120,7 @@ class DocAppCallbackHandlerTest {
     private static final State RP_STATE = new State();
     private static final Nonce NONCE = new Nonce();
 
-    private final Session session = new Session(SESSION_ID).setEmailAddress(TEST_EMAIL_ADDRESS);
+    private final Session session = new Session().setEmailAddress(TEST_EMAIL_ADDRESS);
     private final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID)
                     .withAccountState(OrchSessionItem.AccountState.EXISTING_DOC_APP_JOURNEY);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -928,7 +928,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         private void setupPreviousSessions(String internalCommonSubjectId)
                 throws Json.JsonException {
-            var session = new Session(PREVIOUS_SESSION_ID).setEmailAddress(TEST_EMAIL_ADDRESS);
+            var session = new Session().setEmailAddress(TEST_EMAIL_ADDRESS);
             PREVIOUS_CLIENT_SESSIONS.forEach(session::addClientSession);
             redis.addSessionWithId(session, PREVIOUS_SESSION_ID);
             redis.addStateToRedis(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -48,7 +48,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void authCanReadFromSessionCreatedByOrch() {
-        var orchSession = orchSessionService.generateSession(SESSION_ID);
+        var orchSession = orchSessionService.generateSession();
         orchSession.addClientSession(CLIENT_SESSION_ID);
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
@@ -67,7 +67,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void authCanUpdateSharedFieldInSessionCreatedByOrch() {
-        var orchSession = orchSessionService.generateSession(SESSION_ID);
+        var orchSession = orchSessionService.generateSession();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
@@ -90,7 +90,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void orchCanReadUnsharedFieldAfterAuthUpdatesSession() {
-        var orchSession = orchSessionService.generateSession(SESSION_ID);
+        var orchSession = orchSessionService.generateSession();
         orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
@@ -119,7 +119,7 @@ class AuthOrchSerializationServicesIntegrationTest {
     void authCanReadSessionAfterSessionIdIsUpdated() {
         var oldSessionId = SESSION_ID;
         var newSessionId = "new-session-id";
-        var orchSession = orchSessionService.generateSession(oldSessionId);
+        var orchSession = orchSessionService.generateSession();
         orchSessionService.storeOrUpdateSession(orchSession, oldSessionId);
         var authSession = authSessionService.getSession(oldSessionId).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
@@ -132,7 +132,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void authCanResetSharedFieldsWithoutOverridingUnsharedFields() {
-        var orchSession = orchSessionService.generateSession(SESSION_ID);
+        var orchSession = orchSessionService.generateSession();
         orchSession.addClientSession(CLIENT_SESSION_ID);
         orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -191,7 +191,7 @@ class IPVCallbackHandlerTest {
             new CaptureLoggingExtension(IPVCallbackHandler.class);
 
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(TEST_EMAIL_ADDRESS)
                     .setInternalCommonSubjectIdentifier(TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER);
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -94,7 +94,7 @@ public class IdentityProgressFrontendHandlerTest {
             mock(AuthenticationUserInfoStorageService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
     private final Session session =
-            new Session(SESSION_ID).setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
+            new Session().setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
     private final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID).withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID);
     private final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -109,7 +109,7 @@ class ProcessingIdentityHandlerTest {
             mock(CloudwatchMetricsService.class);
     private final LogoutService logoutService = mock(LogoutService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
-    private final Session session = new Session(SESSION_ID);
+    private final Session session = new Session();
     private final OrchSessionItem orchSession = new OrchSessionItem(SESSION_ID);
     private final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
     protected final Json objectMapper = SerializationService.getInstance();

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -783,7 +783,7 @@ public class AuthorisationHandler
             String newSessionId) {
         sessionService.updateWithNewSessionId(
                 previousSession, previousSessionId, newSessionIdForPreviousSession);
-        var newSession = sessionService.copySessionForMaxAge(previousSession, newSessionId);
+        var newSession = sessionService.copySessionForMaxAge(previousSession);
         sessionService.storeOrUpdateSession(newSession, newSessionId);
         return newSession;
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -517,7 +517,7 @@ public class AuthorisationHandler
         var newBrowserSessionId = IdGenerator.generate();
         var existingSession = existingSessionId.flatMap(sessionService::getSession);
         if (existingSessionId.isEmpty() || existingSession.isEmpty()) {
-            session = sessionService.generateSession(newSessionId);
+            session = sessionService.generateSession();
             updateAttachedSessionIdToLogs(newSessionId);
             LOG.info("Created new session with ID {}", newSessionId);
         } else {
@@ -639,7 +639,7 @@ public class AuthorisationHandler
         if (existingSessionId.isEmpty()
                 || existingSession.isEmpty()
                 || existingOrchSessionOptional.isEmpty()) {
-            session = sessionService.generateSession(newSessionId);
+            session = sessionService.generateSession();
             orchSession = createNewOrchSession(newSessionId, newBrowserSessionId);
             LOG.info("Created session with id: {}", newSessionId);
         } else {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
@@ -464,7 +464,7 @@ class LogoutRequestTest {
     }
 
     private Session generateSession() {
-        return new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID);
+        return new Session().addClientSession(CLIENT_SESSION_ID);
     }
 
     private void generateSessionFromCookie(Session session, OrchSessionItem orchSession) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -140,7 +140,7 @@ class AuthCodeHandlerTest {
     private static final Json objectMapper = SerializationService.getInstance();
     private AuthCodeHandler handler;
 
-    private final Session session = new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID);
+    private final Session session = new Session().addClientSession(CLIENT_SESSION_ID);
     private final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID)
                     .withAccountState(OrchSessionItem.AccountState.NEW)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -145,7 +145,7 @@ class AuthenticationCallbackHandlerTest {
     private static final String SESSION_ID = "a-session-id";
 
     private static final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setVerifiedMfaMethodType(MFAMethodType.EMAIL)
                     .setAuthenticated(false)
                     .setCurrentCredentialStrength(null)
@@ -626,7 +626,7 @@ class AuthenticationCallbackHandlerTest {
     void shouldAuditMediumCredentialTrustLevelOn1FARequestWhenPreviously2FA()
             throws UnsuccessfulCredentialResponseException {
         Session mediumLevelSession =
-                new Session(SESSION_ID)
+                new Session()
                         .setVerifiedMfaMethodType(MFAMethodType.EMAIL)
                         .setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
         when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(mediumLevelSession));
@@ -1245,7 +1245,7 @@ class AuthenticationCallbackHandlerTest {
         }
 
         private void withPreviousSharedSessionDueToMaxAge() {
-            var previousSharedSession = new Session(PREVIOUS_SESSION_ID);
+            var previousSharedSession = new Session();
             PREVIOUS_CLIENT_SESSIONS.forEach(previousSharedSession::addClientSession);
             previousSharedSession.setEmailAddress(TEST_EMAIL_ADDRESS);
             when(sessionService.getSession(PREVIOUS_SESSION_ID))
@@ -1270,7 +1270,7 @@ class AuthenticationCallbackHandlerTest {
         }
 
         private Session withMaxAgeSharedSession() {
-            var session = new Session(SESSION_ID);
+            var session = new Session();
             when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
             return session;
         }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -311,10 +311,10 @@ class AuthorisationHandlerTest {
                         tokenValidationService,
                         authFrontend,
                         authorisationService);
-        session = new Session(SESSION_ID);
-        newSession = new Session(NEW_SESSION_ID);
+        session = new Session();
+        newSession = new Session();
         orchSession = new OrchSessionItem(SESSION_ID);
-        when(sessionService.generateSession(anyString())).thenReturn(newSession);
+        when(sessionService.generateSession()).thenReturn(newSession);
         when(clientSessionService.generateClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(clientSessionService.generateClientSession(any(), any(), any(), any()))
                 .thenReturn(clientSession);
@@ -1687,7 +1687,7 @@ class AuthorisationHandlerTest {
 
         @Test
         void shouldAddPreviousSessionIdClaimIfThereIsAnExistingSession() throws ParseException {
-            when(sessionService.getSession(any())).thenReturn(Optional.of(new Session(SESSION_ID)));
+            when(sessionService.getSession(any())).thenReturn(Optional.of(new Session()));
 
             var requestParams =
                     buildRequestParams(
@@ -2011,8 +2011,7 @@ class AuthorisationHandlerTest {
 
             @BeforeEach
             void setup() {
-                when(sessionService.generateSession(anyString()))
-                        .thenReturn(new Session(NEW_SESSION_ID));
+                when(sessionService.generateSession()).thenReturn(new Session());
             }
 
             @Test
@@ -2021,7 +2020,7 @@ class AuthorisationHandlerTest {
                 withExistingOrchSession(null);
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
-                verify(sessionService).generateSession(NEW_SESSION_ID);
+                verify(sessionService).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
@@ -2051,7 +2050,7 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
-                verify(sessionService).generateSession(NEW_SESSION_ID);
+                verify(sessionService).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
@@ -2080,7 +2079,7 @@ class AuthorisationHandlerTest {
                 withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
-                verify(sessionService).generateSession(NEW_SESSION_ID);
+                verify(sessionService).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
@@ -2109,7 +2108,7 @@ class AuthorisationHandlerTest {
                 withExistingOrchSession(orchSession.withBrowserSessionId(null));
                 var response = makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
-                verify(sessionService, never()).generateSession(anyString());
+                verify(sessionService, never()).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
@@ -2144,7 +2143,7 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
-                verify(sessionService, never()).generateSession(anyString());
+                verify(sessionService, never()).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
@@ -2174,7 +2173,7 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(DIFFERENT_BROWSER_SESSION_ID);
 
-                verify(sessionService).generateSession(NEW_SESSION_ID);
+                verify(sessionService).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -322,12 +322,7 @@ class AuthorisationHandlerTest {
         when(clientService.getClient(anyString()))
                 .thenReturn(Optional.of(generateClientRegistry()));
         when(sessionService.updateWithNewSessionId(any(Session.class), anyString(), anyString()))
-                .then(
-                        invocation -> {
-                            Session sessionToUpdate = invocation.getArgument(0);
-                            sessionToUpdate.setSessionId(invocation.getArgument(2));
-                            return sessionToUpdate;
-                        });
+                .then(invocation -> invocation.<Session>getArgument(0));
     }
 
     @Nested
@@ -2592,8 +2587,7 @@ class AuthorisationHandlerTest {
             when(configService.supportMaxAgeEnabled()).thenReturn(true);
             when(configService.getSessionExpiry()).thenReturn(3600L);
             withExistingSession(session);
-            when(sessionService.copySessionForMaxAge(any(Session.class), anyString()))
-                    .thenCallRealMethod();
+            when(sessionService.copySessionForMaxAge(any(Session.class))).thenCallRealMethod();
         }
 
         @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -244,7 +244,7 @@ class LogoutHandlerTest {
     }
 
     private Session generateSession() {
-        return new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID);
+        return new Session().addClientSession(CLIENT_SESSION_ID);
     }
 
     private void saveSession(Session session) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -126,7 +126,7 @@ public class InitiateIPVAuthorisationServiceTest {
     private final AuthenticationRequest authenticationRequest = mock(AuthenticationRequest.class);
     private final UserInfo userInfo = generateUserInfo();
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(EMAIL_ADDRESS)
                     .setInternalCommonSubjectIdentifier(expectedCommonSubject);
     private final ClientRegistry client = generateClientRegistry();

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -49,7 +49,7 @@ public class RedisExtension
 
     private String createSession(String sessionId, boolean isAuthenticated, Optional<String> email)
             throws Json.JsonException {
-        Session session = new Session(sessionId).setAuthenticated(isAuthenticated);
+        Session session = new Session().setAuthenticated(isAuthenticated);
         email.ifPresent(session::setEmailAddress);
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
         return sessionId;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -40,7 +40,7 @@ public class Session {
 
     @Expose private String internalCommonSubjectIdentifier;
 
-    public Session(String sessionId) {
+    public Session() {
         this.clientSessions = new ArrayList<>();
         this.isNewAccount = AccountState.UNKNOWN;
         this.processingIdentityAttempts = 0;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -66,10 +66,6 @@ public class Session {
         initializeCodeRequestMap();
     }
 
-    public void setSessionId(String sessionId) {
-        this.sessionId = sessionId;
-    }
-
     public List<String> getClientSessions() {
         return clientSessions;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -20,8 +20,6 @@ public class Session {
         UNKNOWN
     }
 
-    @Expose private String sessionId;
-
     @Expose private List<String> clientSessions;
 
     @Expose private String emailAddress;
@@ -43,7 +41,6 @@ public class Session {
     @Expose private String internalCommonSubjectIdentifier;
 
     public Session(String sessionId) {
-        this.sessionId = sessionId;
         this.clientSessions = new ArrayList<>();
         this.isNewAccount = AccountState.UNKNOWN;
         this.processingIdentityAttempts = 0;
@@ -52,7 +49,6 @@ public class Session {
     }
 
     public Session(Session session) {
-        this.sessionId = session.sessionId;
         this.clientSessions = session.clientSessions;
         this.isNewAccount = session.isNewAccount;
         this.processingIdentityAttempts = session.processingIdentityAttempts;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -30,8 +30,8 @@ public class SessionService {
                         configurationService.getRedisPassword()));
     }
 
-    public Session generateSession(String sessionId) {
-        return new Session(sessionId);
+    public Session generateSession() {
+        return new Session();
     }
 
     public Session copySessionForMaxAge(Session previousSession) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -34,9 +34,8 @@ public class SessionService {
         return new Session(sessionId);
     }
 
-    public Session copySessionForMaxAge(Session previousSession, String newSessionId) {
+    public Session copySessionForMaxAge(Session previousSession) {
         var copiedSession = new Session(previousSession);
-        copiedSession.setSessionId(newSessionId);
         copiedSession.setAuthenticated(false).setCurrentCredentialStrength(null);
         copiedSession.resetClientSessions();
         return copiedSession;
@@ -64,7 +63,6 @@ public class SessionService {
     public Session updateWithNewSessionId(
             Session session, String oldSessionId, String newSessionId) {
         try {
-            session.setSessionId(newSessionId);
             session.resetProcessingIdentityAttempts();
             storeOrUpdateSession(session, oldSessionId, newSessionId);
             redisConnectionService.deleteValue(oldSessionId);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelperTest.java
@@ -43,7 +43,7 @@ class DocAppUserHelperTest {
     private static final ClientID CLIENT_ID = new ClientID("client-id");
     private static final String CLIENT_NAME = "test-client";
     private static final String SESSION_ID = "a-session-id";
-    private static final Session SESSION = new Session(SESSION_ID);
+    private static final Session SESSION = new Session();
     private static final String AUDIENCE = "oidc-audience";
     private static final Scope VALID_SCOPE =
             new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/TestClientHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/TestClientHelperTest.java
@@ -136,7 +136,7 @@ class TestClientHelperTest {
                         .withTestClient(isTestClient)
                         .withTestClientEmailAllowlist(allowedEmails);
         var sessionId = IdGenerator.generate();
-        return UserContext.builder(new Session(sessionId).setEmailAddress(TEST_EMAIL_ADDRESS))
+        return UserContext.builder(new Session().setEmailAddress(TEST_EMAIL_ADDRESS))
                 .withSessionId(sessionId)
                 .withClient(clientRegistry)
                 .build();

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
@@ -48,7 +48,7 @@ class AuthCodeResponseGenerationServiceTest {
                 new OrchSessionItem(SESSION_ID)
                         .withAccountState(NEW)
                         .withVerifiedMfaMethodType(AUTH_APP.toString());
-        session = new Session(SESSION_ID);
+        session = new Session();
         authCodeResponseGenerationService =
                 new AuthCodeResponseGenerationService(configurationService, dynamoService);
         clientSession =

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -180,7 +180,7 @@ class LogoutServiceTest {
         rpPairwiseId = Optional.of(idToken.getJWTClaimsSet().getSubject());
 
         session =
-                new Session(SESSION_ID)
+                new Session()
                         .setEmailAddress(EMAIL)
                         .setInternalCommonSubjectIdentifier(SUBJECT.getValue());
         setUpClientSession(CLIENT_SESSION_ID, CLIENT_ID);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
@@ -24,7 +24,7 @@ class SessionServiceTest {
     void shouldPersistSessionToRedisWithExpiry() throws Json.JsonException {
         when(configuration.getSessionExpiry()).thenReturn(1234L);
 
-        var session = new Session("session-id").addClientSession("client-session-id");
+        var session = new Session().addClientSession("client-session-id");
 
         sessionService.storeOrUpdateSession(session, "session-id");
 
@@ -34,7 +34,7 @@ class SessionServiceTest {
 
     @Test
     void shouldUpdateSessionIdInRedisAndDeleteOldKey() {
-        var session = new Session("session-id").addClientSession("client-session-id");
+        var session = new Session().addClientSession("client-session-id");
 
         sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.updateWithNewSessionId(session, "session-id", "new-session-id");
@@ -46,7 +46,7 @@ class SessionServiceTest {
 
     @Test
     void shouldDeleteSessionIdFromRedis() {
-        var session = new Session("session-id").addClientSession("client-session-id");
+        var session = new Session().addClientSession("client-session-id");
 
         sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.deleteStoredSession("session-id");


### PR DESCRIPTION
### Wider context of change

In a previous PR, we removed use of the shared session session id getter.

### What’s changed

This PR is to remove the session id field from the shared session, which also includes the setter and session id constructor.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
