### PR TITLE
AUT-4048: Updating Auth backend url env variable in Auth token lambda

### DIFF
--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -34,7 +34,7 @@ module "auth_token" {
     TXMA_AUDIT_QUEUE_URL                       = module.auth_ext_txma_audit.queue_url
     AUTHENTICATION_AUTHORIZATION_CALLBACK_URI  = var.authentication_auth_callback_uri
     ORCH_CLIENT_ID                             = var.orch_client_id
-    AUTHENTICATION_BACKEND_URI                 = "https://${aws_api_gateway_rest_api.di_auth_ext_api.id}-${data.aws_vpc_endpoint.auth_api_vpc_endpoint.id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
+    AUTHENTICATION_BACKEND_URI                 = "https://${aws_api_gateway_rest_api.di_auth_ext_api.id}-${var.new_auth_api_vpc_endpoint_id != "" ? var.new_auth_api_vpc_endpoint_id : data.aws_vpc_endpoint.auth_api_vpc_endpoint.id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
     ORCHESTRATION_BACKEND_URI                  = "https://${aws_api_gateway_rest_api.di_auth_ext_api.id}-${var.orch_api_vpc_endpoint_id}.execute-api.${var.aws_region}.amazonaws.com/${var.environment}/"
     ORCH_TO_AUTH_TOKEN_SIGNING_PUBLIC_KEY      = var.orch_to_auth_public_signing_key
     ORCH_STUB_TO_AUTH_TOKEN_SIGNING_PUBLIC_KEY = var.orch_stub_to_auth_public_signing_key


### PR DESCRIPTION
## What

AUT-4048: Updating  Auth backend url env variable in Auth token lambda for new orch stub work , This change will break the Existing orch stub we need to update the RP usr for SP acceptance test in build & Staging 

## How to review

1. Code Review
2. deploy to Authdevs ./deploy-authdevs.sh -x -p     
check the env variable for auth-token-lambda is getting updated 

```
 ~ environment {
          ~ variables = {
              ~ "AUTHENTICATION_BACKEND_URI"                 = "https://8yikw2kek6-**vpce-01a1f8e880d273ec6**.execute-api.eu-west-2.amazonaws.com/authdev2/" -> "https://8yikw2kek6-**vpce-0b907325ae3bfe3ce.**execute-api.eu-west-2.amazonaws.com/authdev2/"
                # (16 unchanged elements hidden)
            }
        }

```
