### PR TITLE
AUT-4030: Un-split tfvars (do this one last)

### DIFF
--- a/account-management-api/build.gradle
+++ b/account-management-api/build.gradle
@@ -6,6 +6,8 @@ plugins {
 group "uk.gov.di.authentication.accountmanagement"
 version "unspecified"
 
+File terraformDir = new File(project.rootDir, "ci/terraform/account-management")
+
 dependencies {
     compileOnly configurations.lambda,
             configurations.sqs,
@@ -40,6 +42,9 @@ test {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {

--- a/auth-external-api/build.gradle
+++ b/auth-external-api/build.gradle
@@ -6,6 +6,8 @@ plugins {
 group "uk.gov.di.authentication.external.api"
 version "unspecified"
 
+File terraformDir = new File(project.rootDir, "ci/terraform/auth-external-api")
+
 dependencies {
     compileOnly configurations.lambda,
             configurations.sqs,
@@ -39,6 +41,9 @@ test {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 import com.github.spotbugs.snom.Confidence
 import com.github.spotbugs.snom.Effort
-
 buildscript {
     repositories {
         maven {
@@ -75,6 +74,10 @@ subprojects {
 
     apply plugin: "com.github.spotbugs"
     apply plugin: "java"
+
+    ext {
+        isDevDeployBuild = project.hasProperty("devDeployBuild") ? project.getProperty("devDeployBuild").toBoolean() : false
+    }
 
     spotbugs {
         ignoreFailures = false

--- a/ci/terraform/.gitignore
+++ b/ci/terraform/.gitignore
@@ -1,2 +1,3 @@
 */*_templated.yaml
 /.terraform.lock.hcl
+*/artifacts/

--- a/ci/terraform/account-management/build.tfvars
+++ b/ci/terraform/account-management/build.tfvars
@@ -1,4 +1,3 @@
-lambda_zip_file     = "./artifacts/account-management-api.zip"
 common_state_bucket = "digital-identity-dev-tfstate"
 
 # FMS Flag

--- a/ci/terraform/account-management/dev.tfvars
+++ b/ci/terraform/account-management/dev.tfvars
@@ -1,4 +1,3 @@
-lambda_zip_file     = "./artifacts/account-management-api.zip"
 common_state_bucket = "di-auth-development-tfstate"
 
 # URIs

--- a/ci/terraform/account-management/integration.tfvars
+++ b/ci/terraform/account-management/integration.tfvars
@@ -1,4 +1,3 @@
-lambda_zip_file     = "./artifacts/account-management-api.zip"
 common_state_bucket = "digital-identity-dev-tfstate"
 
 # FMS Flag

--- a/ci/terraform/account-management/production.tfvars
+++ b/ci/terraform/account-management/production.tfvars
@@ -1,4 +1,3 @@
-lambda_zip_file     = "./artifacts/account-management-api.zip"
 common_state_bucket = "digital-identity-prod-tfstate"
 
 # URIs

--- a/ci/terraform/account-management/staging.tfvars
+++ b/ci/terraform/account-management/staging.tfvars
@@ -1,4 +1,3 @@
-lambda_zip_file     = "./artifacts/account-management-api.zip"
 common_state_bucket = "di-auth-staging-tfstate"
 
 # FMS Flag

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -58,7 +58,7 @@ variable "enable_api_gateway_execution_request_tracing" {
 }
 
 variable "lambda_zip_file" {
-  default     = "../../../account-management-api/build/distributions/account-management-api.zip"
+  default     = "./artifacts/account-management-api.zip"
   description = "Location of the Lambda ZIP file"
   type        = string
 }

--- a/ci/terraform/auth-external-api/build.tfvars
+++ b/ci/terraform/auth-external-api/build.tfvars
@@ -1,5 +1,4 @@
-auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
-shared_state_bucket      = "digital-identity-dev-tfstate"
+shared_state_bucket = "digital-identity-dev-tfstate"
 
 # URIs
 internal_sector_uri = "https://identity.build.account.gov.uk"

--- a/ci/terraform/auth-external-api/dev.tfvars
+++ b/ci/terraform/auth-external-api/dev.tfvars
@@ -1,5 +1,4 @@
-auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
-shared_state_bucket      = "di-auth-development-tfstate"
+shared_state_bucket = "di-auth-development-tfstate"
 
 # URIs
 internal_sector_uri = "https://identity.dev.account.gov.uk"

--- a/ci/terraform/auth-external-api/integration.tfvars
+++ b/ci/terraform/auth-external-api/integration.tfvars
@@ -1,5 +1,4 @@
-auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
-shared_state_bucket      = "digital-identity-dev-tfstate"
+shared_state_bucket = "digital-identity-dev-tfstate"
 
 # URIs
 internal_sector_uri = "https://identity.integration.account.gov.uk"

--- a/ci/terraform/auth-external-api/production.tfvars
+++ b/ci/terraform/auth-external-api/production.tfvars
@@ -1,5 +1,4 @@
-auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
-shared_state_bucket      = "digital-identity-prod-tfstate"
+shared_state_bucket = "digital-identity-prod-tfstate"
 
 # URIs
 internal_sector_uri = "https://identity.account.gov.uk"

--- a/ci/terraform/auth-external-api/staging.tfvars
+++ b/ci/terraform/auth-external-api/staging.tfvars
@@ -1,5 +1,4 @@
-auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
-shared_state_bucket      = "di-auth-staging-tfstate"
+shared_state_bucket = "di-auth-staging-tfstate"
 
 # URIs
 internal_sector_uri = "https://identity.staging.account.gov.uk"

--- a/ci/terraform/auth-external-api/variables.tf
+++ b/ci/terraform/auth-external-api/variables.tf
@@ -14,7 +14,7 @@ variable "deployer_role_arn" {
 }
 
 variable "auth_ext_lambda_zip_file" {
-  default     = "../../../auth-external-api/build/distributions/auth-external-api.zip"
+  default     = "./artifacts/auth-external-api.zip"
   description = "Location of the Lambda ZIP file"
   type        = string
 }

--- a/ci/terraform/delivery-receipts/build.tfvars
+++ b/ci/terraform/delivery-receipts/build.tfvars
@@ -1,2 +1,1 @@
-lambda_zip_file     = "./artifacts/delivery-receipts-api.zip"
 common_state_bucket = "digital-identity-dev-tfstate"

--- a/ci/terraform/delivery-receipts/dev.tfvars
+++ b/ci/terraform/delivery-receipts/dev.tfvars
@@ -1,2 +1,1 @@
-lambda_zip_file     = "./artifacts/delivery-receipts-api.zip"
 common_state_bucket = "di-auth-development-tfstate"

--- a/ci/terraform/delivery-receipts/integration.tfvars
+++ b/ci/terraform/delivery-receipts/integration.tfvars
@@ -1,4 +1,3 @@
-lambda_zip_file     = "./artifacts/delivery-receipts-api.zip"
 common_state_bucket = "digital-identity-dev-tfstate"
 
 # Logging

--- a/ci/terraform/delivery-receipts/production.tfvars
+++ b/ci/terraform/delivery-receipts/production.tfvars
@@ -1,4 +1,3 @@
-lambda_zip_file     = "./artifacts/delivery-receipts-api.zip"
 common_state_bucket = "digital-identity-prod-tfstate"
 
 # Notify

--- a/ci/terraform/delivery-receipts/staging.tfvars
+++ b/ci/terraform/delivery-receipts/staging.tfvars
@@ -1,4 +1,3 @@
-lambda_zip_file     = "./artifacts/delivery-receipts-api.zip"
 common_state_bucket = "di-auth-staging-tfstate"
 
 # Logging

--- a/ci/terraform/delivery-receipts/variables.tf
+++ b/ci/terraform/delivery-receipts/variables.tf
@@ -5,7 +5,7 @@ variable "deployer_role_arn" {
 }
 
 variable "lambda_zip_file" {
-  default     = "../../../delivery-receipts-api/build/distributions/delivery-receipts-api.zip"
+  default     = "./artifacts/delivery-receipts-api.zip"
   description = "Location of the Lambda ZIP file"
   type        = string
 }

--- a/ci/terraform/interventions-api-stub/build.tfvars
+++ b/ci/terraform/interventions-api-stub/build.tfvars
@@ -1,5 +1,4 @@
-interventions_api_stub_release_zip_file = "./artifacts/interventions-api-stub.zip"
-shared_state_bucket                     = "digital-identity-dev-tfstate"
+shared_state_bucket = "digital-identity-dev-tfstate"
 
 # VPC
 orchestration_vpc_endpoint_id = "vpce-0867442e4d95fb43e"

--- a/ci/terraform/interventions-api-stub/dev.tfvars
+++ b/ci/terraform/interventions-api-stub/dev.tfvars
@@ -1,5 +1,4 @@
-interventions_api_stub_release_zip_file = "./artifacts/interventions-api-stub.zip"
-shared_state_bucket                     = "di-auth-development-tfstate"
+shared_state_bucket = "di-auth-development-tfstate"
 
 # VPC
 orchestration_vpc_endpoint_id = "vpce-0028f62dad635589a"

--- a/ci/terraform/interventions-api-stub/variables.tf
+++ b/ci/terraform/interventions-api-stub/variables.tf
@@ -58,7 +58,7 @@ variable "endpoint_memory_size" {
 }
 
 variable "interventions_api_stub_release_zip_file" {
-  default     = "../../../interventions-api-stub/build/distributions/interventions-api-stub.zip"
+  default     = "./artifacts/interventions-api-stub.zip"
   description = "Location of the Lambda ZIP file - defaults to build output folder when built locally"
   type        = string
 }

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -1,9 +1,4 @@
-oidc_api_lambda_zip_file             = "./artifacts/oidc-api.zip"
-frontend_api_lambda_zip_file         = "./artifacts/frontend-api.zip"
-client_registry_api_lambda_zip_file  = "./artifacts/client-registry-api.zip"
-ipv_api_lambda_zip_file              = "./artifacts/ipv-api.zip"
-doc_checking_app_api_lambda_zip_file = "./artifacts/doc-checking-app-api.zip"
-shared_state_bucket                  = "digital-identity-dev-tfstate"
+shared_state_bucket = "digital-identity-dev-tfstate"
 
 # FMS Flag
 fms_enabled                = true

--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -1,10 +1,4 @@
-oidc_api_lambda_zip_file             = "./artifacts/oidc-api.zip"
-frontend_api_lambda_zip_file         = "./artifacts/frontend-api.zip"
-client_registry_api_lambda_zip_file  = "./artifacts/client-registry-api.zip"
-ipv_api_lambda_zip_file              = "./artifacts/ipv-api.zip"
-doc_checking_app_api_lambda_zip_file = "./artifacts/doc-checking-app-api.zip"
-shared_state_bucket                  = "di-auth-development-tfstate"
-
+shared_state_bucket = "di-auth-development-tfstate"
 
 # FMS Flag
 fms_enabled                = true

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -1,10 +1,4 @@
-oidc_api_lambda_zip_file             = "./artifacts/oidc-api.zip"
-frontend_api_lambda_zip_file         = "./artifacts/frontend-api.zip"
-client_registry_api_lambda_zip_file  = "./artifacts/client-registry-api.zip"
-ipv_api_lambda_zip_file              = "./artifacts/ipv-api.zip"
-doc_checking_app_api_lambda_zip_file = "./artifacts/doc-checking-app-api.zip"
-shared_state_bucket                  = "digital-identity-prod-tfstate"
-
+shared_state_bucket = "digital-identity-prod-tfstate"
 
 # App-specific
 internal_sector_uri  = "https://identity.account.gov.uk"

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -1,9 +1,4 @@
-oidc_api_lambda_zip_file             = "./artifacts/oidc-api.zip"
-frontend_api_lambda_zip_file         = "./artifacts/frontend-api.zip"
-client_registry_api_lambda_zip_file  = "./artifacts/client-registry-api.zip"
-ipv_api_lambda_zip_file              = "./artifacts/ipv-api.zip"
-doc_checking_app_api_lambda_zip_file = "./artifacts/doc-checking-app-api.zip"
-shared_state_bucket                  = "di-auth-staging-tfstate"
+shared_state_bucket = "di-auth-staging-tfstate"
 
 # FMS Flag
 fms_enabled                = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -1,29 +1,29 @@
 variable "oidc_api_lambda_zip_file" {
-  default     = "../../../oidc-api/build/distributions/oidc-api.zip"
+  default     = "./artifacts/oidc-api.zip"
   description = "Location of the OIDC API Lambda ZIP file"
   type        = string
 }
 
 variable "frontend_api_lambda_zip_file" {
-  default     = "../../../frontend-api/build/distributions/frontend-api.zip"
+  default     = "./artifacts/frontend-api.zip"
   description = "Location of the Frontend API Lambda ZIP file"
   type        = string
 }
 
 variable "client_registry_api_lambda_zip_file" {
-  default     = "../../../client-registry-api/build/distributions/client-registry-api.zip"
+  default     = "./artifacts/client-registry-api.zip"
   description = "Location of the client registry API Lambda ZIP file"
   type        = string
 }
 
 variable "ipv_api_lambda_zip_file" {
-  default     = "../../../ipv-api/build/distributions/ipv-api.zip"
+  default     = "./artifacts/ipv-api.zip"
   description = "Location of the ipv API Lambda ZIP file"
   type        = string
 }
 
 variable "doc_checking_app_api_lambda_zip_file" {
-  default     = "../../../doc-checking-app-api/build/distributions/doc-checking-app-api.zip"
+  default     = "./artifacts/doc-checking-app-api.zip"
   description = "Location of the doc checking app API Lambda ZIP file"
   type        = string
 }

--- a/ci/terraform/test-services/build.tfvars
+++ b/ci/terraform/test-services/build.tfvars
@@ -1,5 +1,4 @@
-test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"
-shared_state_bucket               = "digital-identity-dev-tfstate"
+shared_state_bucket = "digital-identity-dev-tfstate"
 
 # Logging
 logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]

--- a/ci/terraform/test-services/dev.tfvars
+++ b/ci/terraform/test-services/dev.tfvars
@@ -1,2 +1,1 @@
-test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"
-shared_state_bucket               = "di-auth-development-tfstate"
+shared_state_bucket = "di-auth-development-tfstate"

--- a/ci/terraform/test-services/integration.tfvars
+++ b/ci/terraform/test-services/integration.tfvars
@@ -1,5 +1,4 @@
-test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"
-shared_state_bucket               = "digital-identity-dev-tfstate"
+shared_state_bucket = "digital-identity-dev-tfstate"
 
 # Logging
 logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]

--- a/ci/terraform/test-services/production.tfvars
+++ b/ci/terraform/test-services/production.tfvars
@@ -1,5 +1,4 @@
-test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"
-shared_state_bucket               = "digital-identity-prod-tfstate"
+shared_state_bucket = "digital-identity-prod-tfstate"
 
 # Logging
 logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]

--- a/ci/terraform/test-services/staging.tfvars
+++ b/ci/terraform/test-services/staging.tfvars
@@ -1,5 +1,4 @@
-test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"
-shared_state_bucket               = "di-auth-staging-tfstate"
+shared_state_bucket = "di-auth-staging-tfstate"
 
 # Logging
 logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]

--- a/ci/terraform/test-services/variables.tf
+++ b/ci/terraform/test-services/variables.tf
@@ -5,7 +5,7 @@ variable "deployer_role_arn" {
 }
 
 variable "test_services-api-lambda_zip_file" {
-  default     = "../../../test-services-api/build/distributions/test-services-api.zip"
+  default     = "./artifacts/test-services-api.zip"
   description = "Location of the Lambda ZIP file"
   type        = string
 }

--- a/ci/terraform/ticf-cri-stub/build.tfvars
+++ b/ci/terraform/ticf-cri-stub/build.tfvars
@@ -1,5 +1,4 @@
-ticf_cri_stub_release_zip_file = "./artifacts/ticf-cri-stub.zip"
-shared_state_bucket            = "digital-identity-dev-tfstate"
+shared_state_bucket = "digital-identity-dev-tfstate"
 
 # Logging
 logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]

--- a/ci/terraform/ticf-cri-stub/dev.tfvars
+++ b/ci/terraform/ticf-cri-stub/dev.tfvars
@@ -1,5 +1,4 @@
-ticf_cri_stub_release_zip_file = "./artifacts/ticf-cri-stub.zip"
-shared_state_bucket            = "di-auth-development-tfstate"
+shared_state_bucket = "di-auth-development-tfstate"
 
 # Sizing
 lambda_min_concurrency = 1

--- a/ci/terraform/ticf-cri-stub/variables.tf
+++ b/ci/terraform/ticf-cri-stub/variables.tf
@@ -58,7 +58,7 @@ variable "endpoint_memory_size" {
 }
 
 variable "ticf_cri_stub_release_zip_file" {
-  default     = "../../../ticf-cri-stub/build/distributions/ticf-cri-stub.zip"
+  default     = "./artifacts/ticf-cri-stub.zip"
   description = "Location of the Lambda ZIP file - defaults to build output folder when built locally"
   type        = string
 }

--- a/ci/terraform/utils/build.tfvars
+++ b/ci/terraform/utils/build.tfvars
@@ -1,5 +1,4 @@
-utils_release_zip_file = "./artifacts/utils.zip"
-shared_state_bucket    = "digital-identity-dev-tfstate"
+shared_state_bucket = "digital-identity-dev-tfstate"
 
 # App Specific
 internal_sector_uri = "https://identity.build.account.gov.uk"

--- a/ci/terraform/utils/dev.tfvars
+++ b/ci/terraform/utils/dev.tfvars
@@ -1,5 +1,4 @@
-utils_release_zip_file = "./artifacts/utils.zip"
-shared_state_bucket    = "di-auth-development-tfstate"
+shared_state_bucket = "di-auth-development-tfstate"
 
 # App-specific
 internal_sector_uri = "https://identity.dev.account.gov.uk"

--- a/ci/terraform/utils/integration.tfvars
+++ b/ci/terraform/utils/integration.tfvars
@@ -1,5 +1,4 @@
-utils_release_zip_file = "./artifacts/utils.zip"
-shared_state_bucket    = "digital-identity-dev-tfstate"
+shared_state_bucket = "digital-identity-dev-tfstate"
 
 internal_sector_uri                           = "https://identity.integration.account.gov.uk"
 allow_bulk_test_users                         = true

--- a/ci/terraform/utils/production.tfvars
+++ b/ci/terraform/utils/production.tfvars
@@ -1,5 +1,4 @@
-utils_release_zip_file = "./artifacts/utils.zip"
-shared_state_bucket    = "digital-identity-prod-tfstate"
+shared_state_bucket = "digital-identity-prod-tfstate"
 
 # App-specific
 internal_sector_uri = "https://identity.account.gov.uk"

--- a/ci/terraform/utils/staging.tfvars
+++ b/ci/terraform/utils/staging.tfvars
@@ -1,5 +1,4 @@
-utils_release_zip_file = "./artifacts/utils.zip"
-shared_state_bucket    = "di-auth-staging-tfstate"
+shared_state_bucket = "di-auth-staging-tfstate"
 
 # App-specific
 internal_sector_uri         = "https://identity.staging.account.gov.uk"

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -29,7 +29,7 @@ variable "allow_bulk_test_users" {
 }
 
 variable "utils_release_zip_file" {
-  default     = "../../../utils/build/distributions/utils.zip"
+  default     = "./artifacts/utils.zip"
   description = "Location of the Utils distribution ZIP file"
   type        = string
 }

--- a/client-registry-api/build.gradle
+++ b/client-registry-api/build.gradle
@@ -6,6 +6,8 @@ plugins {
 group "uk.gov.di.clientregistry"
 version "unspecified"
 
+File terraformDir = new File(project.rootDir, "ci/terraform/oidc")
+
 dependencies {
 
     compileOnly configurations.lambda,
@@ -37,6 +39,9 @@ test {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {

--- a/delivery-receipts-api/build.gradle
+++ b/delivery-receipts-api/build.gradle
@@ -6,6 +6,8 @@ plugins {
 group "uk.gov.di.authentication.deliveryreceiptsapi"
 version "unspecified"
 
+File terraformDir = new File(project.rootDir, "ci/terraform/delivery-receipts")
+
 dependencies {
     implementation configurations.govuk_notify,
             configurations.lambda,
@@ -32,6 +34,9 @@ test {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {

--- a/deploy-dev.sh
+++ b/deploy-dev.sh
@@ -125,7 +125,7 @@ fi
 if [[ ${O_BUILD} -eq 1 ]]; then
   echo "Building deployment artefacts ... "
   pushd "${DIR}" > /dev/null
-  ./gradlew ${O_CLEAN} build buildZip -x test -x spotlessCheck -x composeDown
+  ./gradlew ${O_CLEAN} buildZip -PdevDeployBuild=1
   popd > /dev/null
   echo "done!"
 fi

--- a/doc-checking-app-api/build.gradle
+++ b/doc-checking-app-api/build.gradle
@@ -7,6 +7,8 @@ plugins {
 group "uk.gov.di.authentication.doccheckingapp"
 version "unspecified"
 
+File terraformDir = new File(project.rootDir, "ci/terraform/oidc")
+
 dependencies {
     compileOnly configurations.lambda,
             configurations.dynamodb,
@@ -63,6 +65,9 @@ pact {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -7,6 +7,8 @@ plugins {
 group "uk.gov.di.authentication.frontendapi"
 version "unspecified"
 
+File terraformDir = new File(project.rootDir, "ci/terraform/oidc")
+
 dependencies {
 
     implementation project(path: ':shared')
@@ -72,6 +74,9 @@ pact {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {

--- a/interventions-api-stub/build.gradle
+++ b/interventions-api-stub/build.gradle
@@ -6,6 +6,8 @@ plugins {
 group = 'uk.gov.di.authentication.interventions-api-stub'
 version = 'unspecified'
 
+File terraformDir = new File(project.rootDir, "ci/terraform/interventions-api-stub")
+
 dependencies {
     compileOnly configurations.lambda,
             configurations.dynamodb
@@ -30,6 +32,9 @@ java {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -7,6 +7,8 @@ plugins {
 group "uk.gov.di.authentication.ipvapi"
 version "unspecified"
 
+File terraformDir = new File(project.rootDir, "ci/terraform/oidc")
+
 dependencies {
     compileOnly configurations.lambda,
             configurations.sqs,
@@ -64,6 +66,9 @@ pact {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -7,6 +7,8 @@ plugins {
 group "uk.gov.di.authentication.oidc"
 version "unspecified"
 
+File terraformDir = new File(project.rootDir, "ci/terraform/oidc")
+
 dependencies {
     compileOnly configurations.kms,
             configurations.lambda,
@@ -69,6 +71,9 @@ pact {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {

--- a/test-services-api/build.gradle
+++ b/test-services-api/build.gradle
@@ -6,6 +6,8 @@ plugins {
 group "uk.gov.di.authentication.testservices"
 version "unspecified"
 
+File terraformDir = new File(project.rootDir, "ci/terraform/test-services")
+
 dependencies {
     compileOnly configurations.lambda,
             configurations.sqs,
@@ -39,6 +41,9 @@ test {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {

--- a/ticf-cri-stub/build.gradle
+++ b/ticf-cri-stub/build.gradle
@@ -6,6 +6,8 @@ plugins {
 group = 'uk.gov.di.authentication.ticf-cri-stub'
 version = 'unspecified'
 
+File terraformDir = new File(project.rootDir, "ci/terraform/ticf-cri-stub")
+
 dependencies {
     compileOnly configurations.lambda
 
@@ -29,6 +31,9 @@ java {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -6,6 +6,8 @@ plugins {
 group 'uk.gov.di.authentication.utils'
 version 'unspecified'
 
+File terraformDir = new File(project.rootDir, "ci/terraform/utils")
+
 dependencies {
     compileOnly configurations.lambda,
             configurations.s3,
@@ -37,6 +39,9 @@ java {
 }
 
 task buildZip(type: Zip) {
+    if (isDevDeployBuild) {
+        destinationDirectory = new File(terraformDir, "artifacts")
+    }
     from compileJava
     from processResources
     into("lib") {


### PR DESCRIPTION
## What

- **AUT-4030: set `var.environment` via envar**
- **AUT-4030: when deploying dev env build into tf dir**

This is rebased against all the other branches for this work, as there were a bunch of merge conflicts, so i've dealt with them early. Hopefully.


## How to review

- Ensure it still deploys correctly
- Ensure that no weird changes have been added 