### PR TITLE
AUT-4030: Un-split auth-ext-api tfvars

### DIFF
--- a/ci/terraform/auth-external-api/authdev1.tfvars
+++ b/ci/terraform/auth-external-api/authdev1.tfvars
@@ -1,13 +1,9 @@
-environment         = "authdev1"
 shared_state_bucket = "di-auth-development-tfstate"
 vpc_environment     = "dev"
 
-logging_endpoint_arns  = []
-internal_sector_uri    = "https://identity.authdev1.sandpit.account.gov.uk"
-lambda_max_concurrency = 0
-lambda_min_concurrency = 0
-endpoint_memory_size   = 1536
+# URIs
+internal_sector_uri = "https://identity.authdev1.sandpit.account.gov.uk"
 
-orch_client_id                       = "orchestrationAuth"
+# Signing Keys
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENB3csRUIdoaTHNn079Jl7JpiXzxF0p2ZIddCErxtIhGMTTqtbQZJCPesSKUVE/DQbpIko3mLoisuFgmQfFouCw=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM0ZehmrdDd89uYEFMTakbS7JgwCGXK7CAYMcVvy1pP5yV4O2mnDjYmvjZpvio2ctgOPxDuBb38QP1HD9WAOR2w=="

--- a/ci/terraform/auth-external-api/authdev2.tfvars
+++ b/ci/terraform/auth-external-api/authdev2.tfvars
@@ -1,13 +1,9 @@
-environment         = "authdev2"
 shared_state_bucket = "di-auth-development-tfstate"
 vpc_environment     = "dev"
 
-logging_endpoint_arns  = []
-internal_sector_uri    = "https://identity.authdev2.sandpit.account.gov.uk"
-lambda_max_concurrency = 0
-lambda_min_concurrency = 0
-endpoint_memory_size   = 1536
+# URIs
+internal_sector_uri = "https://identity.authdev2.sandpit.account.gov.uk"
 
-orch_client_id                       = "orchestrationAuth"
+# Signing Keys
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/Yz722IDLN1mPqkPTihkwAkp/rUmBhnWynwAkE/YZlskX+N7VmwIjupla7O6hczlIOqkmPdQ1ayDqI8yY2QOiw=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwe8ey1GnTbH6E69EJFUkt4WQc1KltJwzOYNWUmK/+GxooRp+j9i9KWQ0WlV4gVI0iQkHY3ZKq+RWk94tSDHbyQ=="

--- a/ci/terraform/auth-external-api/build.tfvars
+++ b/ci/terraform/auth-external-api/build.tfvars
@@ -1,16 +1,19 @@
 auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
 shared_state_bucket      = "digital-identity-dev-tfstate"
-logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-]
-internal_sector_uri    = "https://identity.build.account.gov.uk"
-lambda_max_concurrency = 0
-lambda_min_concurrency = 1
-endpoint_memory_size   = 1536
-scaling_trigger        = 0.6
 
-orch_client_id                       = "orchestrationAuth"
+# URIs
+internal_sector_uri = "https://identity.build.account.gov.uk"
+
+# Signing Keys
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPrCBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmzWAucozlF6eykmgikXj2kI03O7VWwuA51+3Ak+stF2dddC60WXEKhrFumKBUnE5GhJNg4v0iN948Mwl+vz5Xw=="
-orch_api_vpc_endpoint_id             = "vpce-0867442e4d95fb43e"
-new_auth_api_vpc_endpoint_id         = "vpce-042c5d3d97d7438d9"
+
+# VPC
+orch_api_vpc_endpoint_id     = "vpce-0867442e4d95fb43e"
+new_auth_api_vpc_endpoint_id = "vpce-042c5d3d97d7438d9"
+
+# Logging
+logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]
+
+# Sizing
+lambda_min_concurrency = 1

--- a/ci/terraform/auth-external-api/dev.tfvars
+++ b/ci/terraform/auth-external-api/dev.tfvars
@@ -1,11 +1,12 @@
 auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
 shared_state_bucket      = "di-auth-development-tfstate"
-internal_sector_uri      = "https://identity.dev.account.gov.uk"
-lambda_max_concurrency   = 0
-lambda_min_concurrency   = 1
-endpoint_memory_size     = 1536
-scaling_trigger          = 0.6
 
-orch_client_id                       = "orchestrationAuth"
+# URIs
+internal_sector_uri = "https://identity.dev.account.gov.uk"
+
+# Signing Keys
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHzG8IFx1jE1+Ul44jQk96efPknCXVxWS4PqLrKfR/31UQovFQLfyxA46uiMOvr7+0hRwFX1fQhagsIK+dfB5PA=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1P2vcnCdqx+MDwMTrJy47tV5ryTfkRaZYTpLsfCpC79ZgKSYEBcguuOUP4DvJpyHomBEnxeUs7s5KRgyMQjY4g=="
+
+# Sizing
+lambda_min_concurrency = 1

--- a/ci/terraform/auth-external-api/integration.tfvars
+++ b/ci/terraform/auth-external-api/integration.tfvars
@@ -1,14 +1,17 @@
 auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
 shared_state_bucket      = "digital-identity-dev-tfstate"
-logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-]
-internal_sector_uri    = "https://identity.integration.account.gov.uk"
-lambda_max_concurrency = 0
-lambda_min_concurrency = 1
-endpoint_memory_size   = 1536
-scaling_trigger        = 0.6
 
-orch_client_id                  = "orchestrationAuth"
+# URIs
+internal_sector_uri = "https://identity.integration.account.gov.uk"
+
+# Signing Keys
 orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzzwKLypUL89WVaeTbfBZu0Fws8T7ppx89XLVfgXIoCs2P//N5qdghvzgNIgVehQ7CkzyorO/lnRlWPfjCG4Oxw=="
-orch_api_vpc_endpoint_id        = "vpce-0704b783d794cea52"
+
+# VPC
+orch_api_vpc_endpoint_id = "vpce-0704b783d794cea52"
+
+# Logging
+logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]
+
+# Sizing
+lambda_min_concurrency = 1

--- a/ci/terraform/auth-external-api/production.tfvars
+++ b/ci/terraform/auth-external-api/production.tfvars
@@ -1,15 +1,19 @@
 auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
 shared_state_bucket      = "digital-identity-prod-tfstate"
+
+# URIs
+internal_sector_uri = "https://identity.account.gov.uk"
+
+# Signing Keys
+orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5iJXSuxgbfM6ADQVtNNDi7ED5ly5+3VZPbjHv+v0AjQ5Ps+avkXWKwOeScG9sS0cDf0utEXi3fN3cEraa9WuKQ=="
+
+# VPC
+orch_api_vpc_endpoint_id = "vpce-0dd5d6bf9c2a1eade"
+
+# Logging
+logging_endpoint_arns    = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]
 cloudwatch_log_retention = 30
-logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-]
-internal_sector_uri    = "https://identity.account.gov.uk"
+
+# Sizing
 lambda_max_concurrency = 10
 lambda_min_concurrency = 3
-endpoint_memory_size   = 1536
-scaling_trigger        = 0.6
-
-orch_client_id                  = "orchestrationAuth"
-orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5iJXSuxgbfM6ADQVtNNDi7ED5ly5+3VZPbjHv+v0AjQ5Ps+avkXWKwOeScG9sS0cDf0utEXi3fN3cEraa9WuKQ=="
-orch_api_vpc_endpoint_id        = "vpce-0dd5d6bf9c2a1eade"

--- a/ci/terraform/auth-external-api/sandpit.tfvars
+++ b/ci/terraform/auth-external-api/sandpit.tfvars
@@ -1,12 +1,10 @@
-environment         = "sandpit"
 shared_state_bucket = "digital-identity-dev-tfstate"
 
-logging_endpoint_arns  = []
-internal_sector_uri    = "https://identity.sandpit.account.gov.uk"
-lambda_max_concurrency = 0
-lambda_min_concurrency = 0
-endpoint_memory_size   = 1536
+# URIs
+internal_sector_uri = "https://identity.sandpit.account.gov.uk"
 
-orch_client_id                  = "orchestrationAuth"
+# Signing Keys
 orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5Px78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ=="
-orch_api_vpc_endpoint_id        = "vpce-0028f62dad635589a"
+
+# VPC
+orch_api_vpc_endpoint_id = "vpce-0028f62dad635589a"

--- a/ci/terraform/auth-external-api/staging.tfvars
+++ b/ci/terraform/auth-external-api/staging.tfvars
@@ -1,16 +1,20 @@
 auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
 shared_state_bucket      = "di-auth-staging-tfstate"
-logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-]
-internal_sector_uri    = "https://identity.staging.account.gov.uk"
-lambda_max_concurrency = 10
-lambda_min_concurrency = 3
-endpoint_memory_size   = 1536
-scaling_trigger        = 0.6
 
-orch_client_id                       = "orchestrationAuth"
+# URIs
+internal_sector_uri = "https://identity.staging.account.gov.uk"
+
+# Signing Keys
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5PP1PZmhiuHR57ZEfZXARt9/uiG+KKF+S7us4zEEEmEXZFR1H+kWP5RrLHQy9esxsul9X7V4pygDTY1I6QbMGg=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEw3VqLzY6ZFWmqruOpvMpPH8PWuQQ1zSWSgFy2sngA1GKybC0zuZluGHfZMnr/BGo+teQzbDCekLijPvlozXY1g=="
-orch_api_vpc_endpoint_id             = "vpce-0a81481bcd8257f5e"
-new_auth_api_vpc_endpoint_id         = "vpce-07078f5f005fe5efc"
+
+# VPC
+orch_api_vpc_endpoint_id     = "vpce-0a81481bcd8257f5e"
+new_auth_api_vpc_endpoint_id = "vpce-07078f5f005fe5efc"
+
+# Logging
+logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]
+
+# Sizing
+lambda_max_concurrency = 10
+lambda_min_concurrency = 3

--- a/ci/terraform/auth-external-api/variables.tf
+++ b/ci/terraform/auth-external-api/variables.tf
@@ -76,12 +76,12 @@ variable "lambda_max_concurrency" {
 }
 
 variable "scaling_trigger" {
-  default = 0.7
+  default = 0.6
   type    = number
 }
 
 variable "lambda_min_concurrency" {
-  default     = 1
+  default     = 0
   type        = number
   description = "The number of lambda instance to keep 'warm'"
 }
@@ -98,7 +98,7 @@ variable "authentication_auth_callback_uri" {
 }
 
 variable "orch_client_id" {
-  default     = ""
+  default     = "orchestrationAuth"
   type        = string
   description = "The client ID used by the orchestrator in two situations: 1) when passing an authorize request to the authentication frontend - see OIDC module 2) when calling the authentication token endpoint - in this second case there is no real client registry or defined scopes, but it is a part of OAuth2 formalities."
 }


### PR DESCRIPTION
## What

- **AUT-4030: set `var.environment` via envar**
- **AUT-4030: xapi: tidy up variables.tf**
- **AUT-4030: xapi: Deduplicate and tidy devenv tfvars**
- **AUT-4030: xapi: Tidy and deduplicate tfvars files**

## How to review

- Check it deploys without weird changes
- check I've not missed anything

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
