### PR TITLE
ATO-1391: remove deletion protection on old AuthUserInfo table

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -489,7 +489,7 @@ resource "aws_dynamodb_table" "authentication_callback_userinfo" {
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
 
-  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
+  deletion_protection_enabled = false
 
   attribute {
     name = "SubjectID"


### PR DESCRIPTION
### Wider context of change
This table is no longer used, so we want to delete it. First, we need to remove deletion protection

### What’s changed
Sets `deletion_protection_enabled` to false

### Manual testing
-