### PR TITLE
BAU: Pin io.netty:netty-handler version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,10 @@ subprojects {
                 add(conf.name, 'com.google.protobuf:protobuf-java:[3.25.5,)') {
                     because 'CVE-2024-7254 is fixed in 3.25.5 and above'
                 }
+
+                add(conf.name, 'io.netty:netty-handler:[4.1.118.Final,)') {
+                    because 'CVE-2025-24970 is fixed in io.netty:netty-handler:4.1.118.Final and higher'
+                }
             }
         }
 


### PR DESCRIPTION
## What

[CVE-2025-24970](https://github.com/govuk-one-login/authentication-api/security/dependabot/30) exposes that io.netty:netty-handler has a vulnerability

> SslHandler doesn't correctly validate packets which can lead to native crash when using native SSLEngine

This is patched in version 4.1.118.Final, which we pin as this is a transitive dependency of a few other direct dependencies we use. Over time our direct dependencies will release patched versions. At such time this pin can be removed.

## How to review

1. Code Review
1. Deploy to an env and run though a sign in journey (already done)
