### PR TITLE
AUT-4030: un-split test-services tfvars

### DIFF
--- a/ci/terraform/test-services/authdev1.tfvars
+++ b/ci/terraform/test-services/authdev1.tfvars
@@ -1,8 +1,3 @@
-environment         = "authdev1"
 shared_state_bucket = "di-auth-development-tfstate"
-vpc_environment     = "dev"
 
 synthetics_users = "any.user@digital.cabinet-office.gov.uk"
-
-logging_endpoint_enabled = false
-logging_endpoint_arns    = []

--- a/ci/terraform/test-services/authdev2.tfvars
+++ b/ci/terraform/test-services/authdev2.tfvars
@@ -1,8 +1,3 @@
-environment         = "authdev2"
 shared_state_bucket = "di-auth-development-tfstate"
-vpc_environment     = "dev"
 
 synthetics_users = "any.user@digital.cabinet-office.gov.uk"
-
-logging_endpoint_enabled = false
-logging_endpoint_arns    = []

--- a/ci/terraform/test-services/build-overrides.tfvars
+++ b/ci/terraform/test-services/build-overrides.tfvars
@@ -1,3 +1,0 @@
-logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-]

--- a/ci/terraform/test-services/build.tfvars
+++ b/ci/terraform/test-services/build.tfvars
@@ -1,4 +1,5 @@
-logging_endpoint_arn              = ""
-logging_endpoint_arns             = []
-shared_state_bucket               = "digital-identity-dev-tfstate"
 test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"
+shared_state_bucket               = "digital-identity-dev-tfstate"
+
+# Logging
+logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]

--- a/ci/terraform/test-services/dev.tfvars
+++ b/ci/terraform/test-services/dev.tfvars
@@ -1,4 +1,2 @@
-logging_endpoint_arn              = ""
-logging_endpoint_arns             = []
-shared_state_bucket               = "di-auth-development-tfstate"
 test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"
+shared_state_bucket               = "di-auth-development-tfstate"

--- a/ci/terraform/test-services/integration-overrides.tfvars
+++ b/ci/terraform/test-services/integration-overrides.tfvars
@@ -1,3 +1,0 @@
-logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-]

--- a/ci/terraform/test-services/integration.tfvars
+++ b/ci/terraform/test-services/integration.tfvars
@@ -1,4 +1,5 @@
-logging_endpoint_arn              = ""
-logging_endpoint_arns             = []
-shared_state_bucket               = "digital-identity-dev-tfstate"
 test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"
+shared_state_bucket               = "digital-identity-dev-tfstate"
+
+# Logging
+logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]

--- a/ci/terraform/test-services/production-overrides.tfvars
+++ b/ci/terraform/test-services/production-overrides.tfvars
@@ -1,5 +1,0 @@
-logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-]
-
-shared_state_bucket = "digital-identity-prod-tfstate"

--- a/ci/terraform/test-services/production.tfvars
+++ b/ci/terraform/test-services/production.tfvars
@@ -1,4 +1,5 @@
-logging_endpoint_arn              = ""
-logging_endpoint_arns             = []
-shared_state_bucket               = "digital-identity-prod-tfstate"
 test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"
+shared_state_bucket               = "digital-identity-prod-tfstate"
+
+# Logging
+logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]

--- a/ci/terraform/test-services/sandpit.tfvars
+++ b/ci/terraform/test-services/sandpit.tfvars
@@ -1,5 +1,1 @@
-environment         = "sandpit"
 shared_state_bucket = "digital-identity-dev-tfstate"
-
-logging_endpoint_enabled = false
-logging_endpoint_arns    = []

--- a/ci/terraform/test-services/staging-overrides.tfvars
+++ b/ci/terraform/test-services/staging-overrides.tfvars
@@ -1,4 +1,0 @@
-shared_state_bucket = "di-auth-staging-tfstate"
-logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-]

--- a/ci/terraform/test-services/staging.tfvars
+++ b/ci/terraform/test-services/staging.tfvars
@@ -1,4 +1,5 @@
-logging_endpoint_arn              = ""
-logging_endpoint_arns             = []
-shared_state_bucket               = "di-auth-staging-tfstate"
 test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"
+shared_state_bucket               = "di-auth-staging-tfstate"
+
+# Logging
+logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]


### PR DESCRIPTION
## What

- **AUT-4030: set `var.environment` via envar**
- **AUT-4030: ts: Unsplit and organise tfvars**

## How to review

- check i've not missed anything
- check it deploys sensibly

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
