### PR TITLE
AUT-4030: Un-split ticf-cri-stub tfvars

### DIFF
--- a/ci/terraform/ticf-cri-stub/authdev1.tfvars
+++ b/ci/terraform/ticf-cri-stub/authdev1.tfvars
@@ -1,6 +1,2 @@
-environment         = "authdev1"
 shared_state_bucket = "di-auth-development-tfstate"
 vpc_environment     = "dev"
-
-lambda_max_concurrency = 0
-lambda_min_concurrency = 0

--- a/ci/terraform/ticf-cri-stub/authdev2.tfvars
+++ b/ci/terraform/ticf-cri-stub/authdev2.tfvars
@@ -1,6 +1,2 @@
-environment         = "authdev2"
 shared_state_bucket = "di-auth-development-tfstate"
 vpc_environment     = "dev"
-
-lambda_max_concurrency = 0
-lambda_min_concurrency = 0

--- a/ci/terraform/ticf-cri-stub/build.tfvars
+++ b/ci/terraform/ticf-cri-stub/build.tfvars
@@ -1,5 +1,8 @@
 ticf_cri_stub_release_zip_file = "./artifacts/ticf-cri-stub.zip"
 shared_state_bucket            = "digital-identity-dev-tfstate"
-logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-]
+
+# Logging
+logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]
+
+# Sizing
+lambda_min_concurrency = 1

--- a/ci/terraform/ticf-cri-stub/dev.tfvars
+++ b/ci/terraform/ticf-cri-stub/dev.tfvars
@@ -1,3 +1,5 @@
 ticf_cri_stub_release_zip_file = "./artifacts/ticf-cri-stub.zip"
-logging_endpoint_arns          = []
-shared_state_bucket            = "di-auth-development-tfstate"
+shared_state_bucket            = "digital-identity-dev-tfstate"
+
+# Sizing
+lambda_min_concurrency = 1

--- a/ci/terraform/ticf-cri-stub/sandpit.tfvars
+++ b/ci/terraform/ticf-cri-stub/sandpit.tfvars
@@ -1,2 +1,4 @@
-environment         = "sandpit"
 shared_state_bucket = "digital-identity-dev-tfstate"
+
+# Sizing
+lambda_min_concurrency = 1

--- a/ci/terraform/ticf-cri-stub/variables.tf
+++ b/ci/terraform/ticf-cri-stub/variables.tf
@@ -47,7 +47,7 @@ variable "scaling_trigger" {
 }
 
 variable "lambda_min_concurrency" {
-  default     = 1
+  default     = 0
   type        = number
   description = "The number of lambda instance to keep 'warm'"
 }


### PR DESCRIPTION
## What

- **AUT-4030: set `var.environment` via envar**
- **AUT-4030: tifc: Organise tfvars**

## How to review

- check i've not missed anything
- check it deploys sensibly

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
