### PR TITLE
ATO-1429: Remove use of session id getter in SessionService

### DIFF
--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -210,7 +211,7 @@ class UserInfoHandlerTest {
         assertEquals(objectMapper.writeValueAsString(ErrorResponse.ERROR_1000), response.getBody());
         verify(sessionService).getSessionFromRequestHeaders(request.getHeaders());
         verifyNoInteractions(accessTokenService, userInfoService, auditService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(), anyString());
     }
 
     @Test
@@ -231,7 +232,7 @@ class UserInfoHandlerTest {
         assertEquals(objectMapper.writeValueAsString(ErrorResponse.ERROR_1000), response.getBody());
         verify(sessionService).getSessionFromRequestHeaders(request.getHeaders());
         verifyNoInteractions(accessTokenService, userInfoService, auditService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -256,7 +257,7 @@ class UserInfoHandlerTest {
         assertEquals(objectMapper.writeValueAsString(ErrorResponse.ERROR_1000), response.getBody());
         verify(sessionService).getSessionFromRequestHeaders(request.getHeaders());
         verifyNoInteractions(accessTokenService, userInfoService, auditService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -281,7 +282,7 @@ class UserInfoHandlerTest {
         assertTrue(authChallengeHeader.get(0).contains("\"Invalid access token\""));
 
         verify(accessTokenService, never()).setAccessTokenStoreUsed(any(), anyBoolean());
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -307,7 +308,7 @@ class UserInfoHandlerTest {
         assertTrue(authChallengeHeader.get(0).contains("\"Invalid access token\""));
 
         verify(accessTokenService, never()).setAccessTokenStoreUsed(any(), anyBoolean());
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -337,7 +338,7 @@ class UserInfoHandlerTest {
         assertTrue(authChallengeHeader.get(0).contains("\"Invalid access token\""));
 
         verify(accessTokenService, never()).setAccessTokenStoreUsed(any(), anyBoolean());
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -364,7 +365,7 @@ class UserInfoHandlerTest {
         assertTrue(authChallengeHeader.get(0).contains("\"Invalid access token\""));
 
         verify(accessTokenService, never()).setAccessTokenStoreUsed(any(), anyBoolean());
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     private void withAuthSession() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
@@ -24,6 +24,7 @@ public class SessionHelper {
             ConfigurationService configurationService) {
         LOG.info("Calculating internal common subject identifier");
         var session = userContext.getSession();
+        var sessionId = userContext.getAuthSession().getSessionId();
         UserProfile userProfile =
                 userContext.getUserProfile().isPresent()
                         ? userContext.getUserProfile().get()
@@ -38,7 +39,7 @@ public class SessionHelper {
                                 .getValue();
         LOG.info("Setting internal common subject identifier in user session");
         session.setInternalCommonSubjectIdentifier(internalCommonSubjectId);
-        sessionService.storeOrUpdateSession(session);
+        sessionService.storeOrUpdateSession(session, sessionId);
         authSession.setInternalCommonSubjectId(internalCommonSubjectId);
         authSessionService.updateSession(authSession);
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -162,7 +162,8 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                         Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
                 LOG.info("reauthentication successful");
                 sessionService.storeOrUpdateSession(
-                        userContext.getSession().setPreservedReauthCountsForAudit(null));
+                        userContext.getSession().setPreservedReauthCountsForAudit(null),
+                        userContext.getAuthSession().getSessionId());
             }
 
             return generateApiGatewayProxyResponse(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -48,8 +48,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(CheckUserExistsHandler.class);
-    public static final int NUMBER_OF_LAST_DIGITS = 3;
-
     private final AuditService auditService;
     private final CodeStorageService codeStorageService;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -135,11 +135,14 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             var userExists = userProfile.isPresent();
             userContext.getSession().setEmailAddress(emailAddress);
 
+            var session = userContext.getSession();
+            var sessionId = userContext.getAuthSession().getSessionId();
+
             if (codeStorageService.isBlockedForEmail(
                     emailAddress,
                     CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.PASSWORD_RESET)) {
                 LOG.info("User account is locked");
-                sessionService.storeOrUpdateSession(userContext.getSession());
+                sessionService.storeOrUpdateSession(session, sessionId);
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.AUTH_ACCOUNT_TEMPORARILY_LOCKED,
@@ -154,7 +157,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             AuditableEvent auditableEvent;
             var rpPairwiseId = AuditService.UNKNOWN;
             var userMfaDetail = new UserMfaDetail();
-            var session = userContext.getSession();
 
             AuthSessionItem authSession = userContext.getAuthSession();
 
@@ -222,7 +224,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                             userMfaDetail.getMfaMethodType(),
                             getLastDigitsOfPhoneNumber(userMfaDetail),
                             lockoutInformation);
-            sessionService.storeOrUpdateSession(session);
+            sessionService.storeOrUpdateSession(session, sessionId);
             authSessionService.updateSession(authSession);
 
             LOG.info("Successfully processed request");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -295,7 +295,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         sessionService.storeOrUpdateSession(
                 userContext
                         .getSession()
-                        .setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier));
+                        .setInternalCommonSubjectIdentifier(internalCommonSubjectIdentifier),
+                userContext.getAuthSession().getSessionId());
 
         authSessionService.updateSession(
                 authSessionItem

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -199,7 +199,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             sessionService.storeOrUpdateSession(
                     userContext
                             .getSession()
-                            .incrementCodeRequestCount(NotificationType.MFA_SMS, journeyType));
+                            .incrementCodeRequestCount(NotificationType.MFA_SMS, journeyType),
+                    userContext.getAuthSession().getSessionId());
 
             Optional<ErrorResponse> thisRequestExceedsMaximumAllowedRequests =
                     validateCodeRequestAttempts(email, journeyType, userContext);
@@ -274,7 +275,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             blockUsersOnAllJourneysOtherThanReauthenticatingUsers(
                     email, journeyType, newCodeRequestBlockPrefix);
 
-            clearCountOfFailedCodeRequests(journeyType, session);
+            clearCountOfFailedCodeRequests(
+                    journeyType, session, userContext.getAuthSession().getSessionId());
 
             return Optional.of(ErrorResponse.ERROR_1025);
         }
@@ -316,9 +318,10 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         }
     }
 
-    private void clearCountOfFailedCodeRequests(JourneyType journeyType, Session session) {
+    private void clearCountOfFailedCodeRequests(
+            JourneyType journeyType, Session session, String sessionId) {
         LOG.info("Resetting code request count");
         sessionService.storeOrUpdateSession(
-                session.resetCodeRequestCount(NotificationType.MFA_SMS, journeyType));
+                session.resetCodeRequestCount(NotificationType.MFA_SMS, journeyType), sessionId);
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -150,7 +150,8 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
             emitPasswordResetRequestedAuditEvent(input, request, userContext, isTestClient);
 
             sessionService.storeOrUpdateSession(
-                    userContext.getSession().incrementPasswordResetCount());
+                    userContext.getSession().incrementPasswordResetCount(),
+                    userContext.getAuthSession().getSessionId());
 
             var userIsNewlyLockedOutOfPasswordReset =
                     hasUserExceededMaxAllowedRequests(request.getEmail(), userContext);
@@ -181,7 +182,9 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                 userContext.getSession().getEmailAddress(),
                 codeRequestBlockedKeyPrefix,
                 configurationService.getLockoutDuration());
-        sessionService.storeOrUpdateSession(userContext.getSession().resetPasswordResetCount());
+        sessionService.storeOrUpdateSession(
+                userContext.getSession().resetPasswordResetCount(),
+                userContext.getAuthSession().getSessionId());
     }
 
     private void emitPasswordResetRequestedAuditEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -172,8 +172,8 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                     userContext
                             .getSession()
                             .setEmailAddress(request.getEmail())
-                            .setInternalCommonSubjectIdentifier(
-                                    internalCommonSubjectId.getValue()));
+                            .setInternalCommonSubjectIdentifier(internalCommonSubjectId.getValue()),
+                    userContext.getAuthSession().getSessionId());
 
             authSessionService.updateSession(
                     authSessionItem

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -177,7 +177,7 @@ public class StartHandler
             if (startRequest.authenticated() && isUserProfileEmpty) {
                 session =
                         startService.createNewSessionWithExistingIdAndClientSession(
-                                session,
+                                sessionId,
                                 getHeaderValueFromHeaders(
                                         input.getHeaders(),
                                         CLIENT_SESSION_ID_HEADER,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -152,6 +152,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             LOG.info("Processing request");
 
             var session = userContext.getSession();
+            var sessionId = userContext.getAuthSession().getSessionId();
             AuthSessionItem authSession = userContext.getAuthSession();
 
             attachAuthSessionIdToLogs(authSession);
@@ -206,7 +207,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
             }
 
-            sessionService.storeOrUpdateSession(session);
+            sessionService.storeOrUpdateSession(session, sessionId);
 
             if (errorResponse.isPresent()) {
                 handleInvalidVerificationCode(
@@ -382,6 +383,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             ClientRegistry client,
             Optional<String> maybePairwiseId) {
         var session = userContext.getSession();
+        var sessionId = userContext.getAuthSession().getSessionId();
         var notificationType = codeRequest.notificationType();
         int loginFailureCount =
                 codeStorageService.getIncorrectMfaCodeAttemptsCount(session.getEmailAddress());
@@ -398,7 +400,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     MFAMethodType.SMS.getValue(),
                     false);
             sessionService.storeOrUpdateSession(
-                    session.setVerifiedMfaMethodType(MFAMethodType.SMS));
+                    session.setVerifiedMfaMethodType(MFAMethodType.SMS), sessionId);
             authSessionService.updateSession(
                     authSession.withVerifiedMfaMethodType(MFAMethodType.SMS.getValue()));
             clearAccountRecoveryBlockIfPresent(session, auditContext);
@@ -413,7 +415,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
         if (configurationService.isAuthenticationAttemptsServiceEnabled() && subjectId != null) {
             preserveReauthCountsForAuditIfJourneyIsReauth(
-                    journeyType, subjectId, session, maybePairwiseId);
+                    journeyType, subjectId, session, sessionId, maybePairwiseId);
             clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
             maybePairwiseId.ifPresentOrElse(
                     this::clearReauthErrorCountsForSuccessfullyAuthenticatedUser,
@@ -432,6 +434,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             JourneyType journeyType,
             String subjectId,
             Session session,
+            String sessionId,
             Optional<String> maybePairwiseId) {
         if (journeyType == JourneyType.REAUTHENTICATION
                 && configurationService.supportReauthSignoutEnabled()
@@ -446,7 +449,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             : authenticationAttemptsService.getCountsByJourney(
                                     subjectId, JourneyType.REAUTHENTICATION);
             var updatedSession = session.setPreservedReauthCountsForAudit(counts);
-            sessionService.storeOrUpdateSession(updatedSession);
+            sessionService.storeOrUpdateSession(updatedSession, sessionId);
         }
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -58,11 +58,11 @@ public class StartService {
     }
 
     public Session createNewSessionWithExistingIdAndClientSession(
-            Session session, String clientSessionId) {
+            String sessionId, String clientSessionId) {
         LOG.info("Creating new session with existing sessionID");
-        session = new Session(session.getSessionId());
+        Session session = new Session(sessionId);
         session.addClientSession(clientSessionId);
-        sessionService.storeOrUpdateSession(session);
+        sessionService.storeOrUpdateSession(session, sessionId);
         return session;
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -305,7 +305,8 @@ class AuthenticationAuthCodeHandlerTest {
                             Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
             verify(sessionService, atLeastOnce())
                     .storeOrUpdateSession(
-                            argThat(s -> Objects.isNull(s.getPreservedReauthCountsForAudit())));
+                            argThat(s -> Objects.isNull(s.getPreservedReauthCountsForAudit())),
+                            eq(SESSION_ID));
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -64,6 +64,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -279,7 +280,7 @@ class CheckUserExistsHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.ERROR_1045));
-            verify(sessionService, times(1)).storeOrUpdateSession(any());
+            verify(sessionService, times(1)).storeOrUpdateSession(any(Session.class), anyString());
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_ACCOUNT_TEMPORARILY_LOCKED,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -62,6 +62,7 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -228,7 +229,7 @@ class LoginHandlerReauthenticationRedisTest {
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -289,7 +289,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
             verify(cloudwatchMetricsService, never())
                     .incrementAuthenticationSuccess(
                             any(), any(), any(), any(), anyBoolean(), anyBoolean());
-            verify(sessionService, never()).storeOrUpdateSession(any());
+            verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -70,6 +70,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -455,7 +456,7 @@ class LoginHandlerTest {
 
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1028));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
 
         verify(codeStorageService).getIncorrectPasswordCount(EMAIL);
         verify(codeStorageService).deleteIncorrectPasswordCount(EMAIL);
@@ -513,7 +514,7 @@ class LoginHandlerTest {
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @ParameterizedTest
@@ -551,7 +552,7 @@ class LoginHandlerTest {
                                 configurationService.getMaxPasswordRetries()));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @ParameterizedTest
@@ -606,7 +607,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1008));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @ParameterizedTest
@@ -659,7 +660,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1008));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -675,7 +676,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -690,7 +691,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1000));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any());
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -724,7 +725,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class));
+        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -906,7 +907,8 @@ class LoginHandlerTest {
                         argThat(
                                 t ->
                                         t.getInternalCommonSubjectIdentifier()
-                                                .equals(expectedCommonSubject)));
+                                                .equals(expectedCommonSubject)),
+                        eq(SESSION_ID));
     }
 
     private void verifyAuthSessionIsSaved() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -64,6 +64,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -406,7 +407,8 @@ class MfaHandlerTest {
                                 sessionForTestUser ->
                                         sessionForTestUser.getCodeRequestCount(
                                                         NotificationType.MFA_SMS, journeyType)
-                                                == 0));
+                                                == 0),
+                        eq(SESSION_ID));
 
         verify(auditService)
                 .submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -253,7 +253,8 @@ class ResetPasswordRequestHandlerTest {
                             TEST_SIX_DIGIT_CODE,
                             CODE_EXPIRY_TIME,
                             RESET_PASSWORD_WITH_CODE);
-            verify(sessionService).storeOrUpdateSession(argThat(this::isSessionWithEmailSent));
+            verify(sessionService)
+                    .storeOrUpdateSession(argThat(this::isSessionWithEmailSent), eq(SESSION_ID));
         }
 
         @Test
@@ -343,7 +344,8 @@ class ResetPasswordRequestHandlerTest {
                             TEST_SIX_DIGIT_CODE,
                             CODE_EXPIRY_TIME,
                             RESET_PASSWORD_WITH_CODE);
-            verify(sessionService).storeOrUpdateSession(argThat(this::isSessionWithEmailSent));
+            verify(sessionService)
+                    .storeOrUpdateSession(argThat(this::isSessionWithEmailSent), eq(SESSION_ID));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -500,7 +502,7 @@ class ResetPasswordRequestHandlerTest {
             verify(awsSqsClient, never()).send(anyString());
             verify(codeStorageService, never())
                     .saveOtpCode(anyString(), anyString(), anyLong(), any(NotificationType.class));
-            verify(sessionService, never()).storeOrUpdateSession(any());
+            verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
             verifyNoInteractions(awsSqsClient);
         }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -70,6 +70,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -287,7 +288,8 @@ class SendNotificationHandlerTest {
                                 argThat(
                                         session ->
                                                 isSessionWithEmailSent(
-                                                        session, notificationType, journeyType)));
+                                                        session, notificationType, journeyType)),
+                                eq(SESSION_ID));
                 verify(auditService)
                         .submitAuditEvent(
                                 notificationType.equals(VERIFY_EMAIL)
@@ -477,7 +479,8 @@ class SendNotificationHandlerTest {
                         argThat(
                                 session ->
                                         isSessionWithEmailSent(
-                                                session, notificationType, journeyType)));
+                                                session, notificationType, journeyType)),
+                        eq(SESSION_ID));
 
         var testClientAuditContext = auditContext.withClientId(TEST_CLIENT_ID);
 
@@ -509,7 +512,8 @@ class SendNotificationHandlerTest {
                         argThat(
                                 session ->
                                         isSessionWithEmailSent(
-                                                session, notificationType, journeyType)));
+                                                session, notificationType, journeyType)),
+                        eq(SESSION_ID));
         verifyNoInteractions(auditService);
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -173,7 +173,8 @@ class SignUpHandlerTest {
         verify(authenticationService)
                 .signUp(eq(EMAIL), eq(PASSWORD), any(Subject.class), any(TermsAndConditions.class));
         verify(sessionService)
-                .storeOrUpdateSession(argThat(s -> s.getEmailAddress().equals(EMAIL)));
+                .storeOrUpdateSession(
+                        argThat(s -> s.getEmailAddress().equals(EMAIL)), eq(SESSION_ID));
 
         assertThat(result, hasStatus(200));
         verify(authenticationService)
@@ -205,7 +206,8 @@ class SignUpHandlerTest {
                         argThat(
                                 t ->
                                         t.getInternalCommonSubjectIdentifier()
-                                                .equals(expectedCommonSubject)));
+                                                .equals(expectedCommonSubject)),
+                        eq(SESSION_ID));
     }
 
     @Test
@@ -225,7 +227,8 @@ class SignUpHandlerTest {
         verify(authenticationService)
                 .signUp(eq(EMAIL), eq(PASSWORD), any(Subject.class), any(TermsAndConditions.class));
         verify(sessionService)
-                .storeOrUpdateSession(argThat(s -> s.getEmailAddress().equals(EMAIL)));
+                .storeOrUpdateSession(
+                        argThat(s -> s.getEmailAddress().equals(EMAIL)), eq(SESSION_ID));
 
         assertThat(result, hasStatus(200));
         verify(authSessionService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -378,8 +378,7 @@ class StartHandlerTest {
         handler.handleRequest(event, context);
 
         verify(startService)
-                .createNewSessionWithExistingIdAndClientSession(
-                        any(Session.class), eq(CLIENT_SESSION_ID));
+                .createNewSessionWithExistingIdAndClientSession(SESSION_ID, CLIENT_SESSION_ID);
         verify(startService)
                 .buildUserStartInfo(
                         any(),
@@ -408,8 +407,7 @@ class StartHandlerTest {
         handler.handleRequest(event, context);
 
         verify(startService, never())
-                .createNewSessionWithExistingIdAndClientSession(
-                        any(Session.class), eq(CLIENT_SESSION_ID));
+                .createNewSessionWithExistingIdAndClientSession(SESSION_ID, CLIENT_SESSION_ID);
         verify(startService)
                 .buildUserStartInfo(
                         any(),
@@ -615,7 +613,7 @@ class StartHandlerTest {
     private void usingValidSession() {
         when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
         when(startService.createNewSessionWithExistingIdAndClientSession(
-                        session, CLIENT_SESSION_ID))
+                        SESSION_ID, CLIENT_SESSION_ID))
                 .thenReturn(session);
         when(authSessionService.getUpdatedPreviousSessionOrCreateNew(any(), any(), any()))
                 .thenReturn(new AuthSessionItem().withSessionId(SESSION_ID));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -280,7 +280,7 @@ class VerifyCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         verify(codeStorageService).deleteOtpCode(EMAIL, emailNotificationType);
-        verify(sessionService).storeOrUpdateSession(session);
+        verify(sessionService).storeOrUpdateSession(session, SESSION_ID);
         verifyNoInteractions(accountModifiersService);
         verify(auditService)
                 .submitAuditEvent(
@@ -559,7 +559,7 @@ class VerifyCodeHandlerTest {
         verify(codeStorageService).deleteOtpCode(EMAIL, MFA_SMS);
         verify(accountModifiersService).removeAccountRecoveryBlockIfPresent(expectedCommonSubject);
         var saveSessionCount = journeyType == JourneyType.PASSWORD_RESET_MFA ? 3 : 2;
-        verify(sessionService, times(saveSessionCount)).storeOrUpdateSession(session);
+        verify(sessionService, times(saveSessionCount)).storeOrUpdateSession(session, SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -604,7 +604,7 @@ class VerifyCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         verify(codeStorageService).deleteOtpCode(EMAIL, MFA_SMS);
         verify(accountModifiersService, never()).removeAccountRecoveryBlockIfPresent(anyString());
-        verify(sessionService, times(2)).storeOrUpdateSession(session);
+        verify(sessionService, times(2)).storeOrUpdateSession(session, SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -790,7 +790,8 @@ class VerifyCodeHandlerTest {
                             argThat(
                                     s ->
                                             s.getPreservedReauthCountsForAudit()
-                                                    .equals(existingCounts)));
+                                                    .equals(existingCounts)),
+                            eq(SESSION_ID));
         } else {
             verify(sessionService, never())
                     .storeOrUpdateSession(
@@ -798,7 +799,8 @@ class VerifyCodeHandlerTest {
                                     s ->
                                             Objects.equals(
                                                     s.getPreservedReauthCountsForAudit(),
-                                                    existingCounts)));
+                                                    existingCounts)),
+                            eq(SESSION_ID));
         }
 
         assertThat(result, hasStatus(204));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -907,7 +907,8 @@ class VerifyMfaCodeHandlerTest {
 
         verify(sessionService, atLeastOnce())
                 .storeOrUpdateSession(
-                        argThat(s -> s.getPreservedReauthCountsForAudit().equals(existingCounts)));
+                        argThat(s -> s.getPreservedReauthCountsForAudit().equals(existingCounts)),
+                        eq(SESSION_ID));
     }
 
     @Test
@@ -940,7 +941,8 @@ class VerifyMfaCodeHandlerTest {
                                 s ->
                                         Objects.equals(
                                                 s.getPreservedReauthCountsForAudit(),
-                                                existingCounts)));
+                                                existingCounts)),
+                        eq(SESSION_ID));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -68,9 +68,10 @@ class StartServiceTest {
     private static final String EMAIL = CommonTestVariables.EMAIL;
     private static final ClientID CLIENT_ID = new ClientID("client-id");
     private static final String CLIENT_NAME = "test-client";
-    private static final Session SESSION = new Session("a-session-id").setEmailAddress(EMAIL);
+    private static final String SESSION_ID = "a-session-id";
+    private static final Session SESSION = new Session(SESSION_ID).setEmailAddress(EMAIL);
     private static final AuthSessionItem AUTH_SESSION =
-            new AuthSessionItem().withSessionId("a-session-id");
+            new AuthSessionItem().withSessionId(SESSION_ID);
     private static final Scope SCOPES =
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
     private static final String AUDIENCE = "oidc-audience";
@@ -110,7 +111,7 @@ class StartServiceTest {
 
         var session =
                 startService.createNewSessionWithExistingIdAndClientSession(
-                        SESSION, currentClientSessionId);
+                        SESSION_ID, currentClientSessionId);
 
         assertFalse(session.isAuthenticated());
         assertThat(session.getCurrentCredentialStrength(), equalTo(null));
@@ -118,7 +119,7 @@ class StartServiceTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         assertTrue(session.getClientSessions().contains("some-client-session-id"));
         assertFalse(session.getClientSessions().contains("previous-session-client-session-id"));
-        verify(sessionService).storeOrUpdateSession(session);
+        verify(sessionService).storeOrUpdateSession(session, SESSION_ID);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -60,7 +60,7 @@ class AuthOrchSerializationServicesIntegrationTest {
         var sessionId = "some-existing-session-id";
         var authSession = new Session(sessionId);
         authSession.addClientSession(CLIENT_SESSION_ID);
-        authSessionService.storeOrUpdateSession(authSession);
+        authSessionService.storeOrUpdateSession(authSession, sessionId);
         var orchSession = orchSessionService.getSession(sessionId).get();
         assertThat(orchSession.getClientSessions(), contains(CLIENT_SESSION_ID));
     }
@@ -71,7 +71,7 @@ class AuthOrchSerializationServicesIntegrationTest {
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
-        authSessionService.storeOrUpdateSession(authSession);
+        authSessionService.storeOrUpdateSession(authSession, SESSION_ID);
         orchSession = orchSessionService.getSession(SESSION_ID).get();
         assertThat(orchSession.getClientSessions(), contains(CLIENT_SESSION_ID));
     }
@@ -80,7 +80,7 @@ class AuthOrchSerializationServicesIntegrationTest {
     void orchCanUpdateSharedFieldInSessionCreatedByAuth() {
         var sessionId = "some-existing-session-id";
         var authSession = new Session(sessionId);
-        authSessionService.storeOrUpdateSession(authSession);
+        authSessionService.storeOrUpdateSession(authSession, sessionId);
         var orchSession = orchSessionService.getSession(sessionId).get();
         orchSession.addClientSession(CLIENT_SESSION_ID);
         orchSessionService.storeOrUpdateSession(orchSession, sessionId);
@@ -95,7 +95,7 @@ class AuthOrchSerializationServicesIntegrationTest {
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
-        authSessionService.storeOrUpdateSession(authSession);
+        authSessionService.storeOrUpdateSession(authSession, SESSION_ID);
         orchSession = orchSessionService.getSession(SESSION_ID).get();
         assertThat(orchSession.getProcessingIdentityAttempts(), is(equalTo(1)));
     }
@@ -107,7 +107,7 @@ class AuthOrchSerializationServicesIntegrationTest {
         authSession.incrementPasswordResetCount();
         authSession.incrementPasswordResetCount();
         authSession.incrementPasswordResetCount();
-        authSessionService.storeOrUpdateSession(authSession);
+        authSessionService.storeOrUpdateSession(authSession, sessionId);
         var orchSession = orchSessionService.getSession(sessionId).get();
         orchSession.addClientSession(CLIENT_SESSION_ID);
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
@@ -123,7 +123,7 @@ class AuthOrchSerializationServicesIntegrationTest {
         orchSessionService.storeOrUpdateSession(orchSession, oldSessionId);
         var authSession = authSessionService.getSession(oldSessionId).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
-        authSessionService.storeOrUpdateSession(authSession);
+        authSessionService.storeOrUpdateSession(authSession, oldSessionId);
         orchSession = orchSessionService.getSession(oldSessionId).get();
         orchSessionService.updateWithNewSessionId(orchSession, oldSessionId, newSessionId);
         authSessionService.getSession(newSessionId).get();
@@ -137,7 +137,7 @@ class AuthOrchSerializationServicesIntegrationTest {
         orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = new Session(SESSION_ID);
-        authSessionService.storeOrUpdateSession(authSession);
+        authSessionService.storeOrUpdateSession(authSession, SESSION_ID);
         orchSession = orchSessionService.getSession(SESSION_ID).get();
         assertThat(orchSession.getClientSessions(), is(empty()));
         assertThat(orchSession.getProcessingIdentityAttempts(), is(equalTo(1)));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -46,7 +46,11 @@ public class SessionService {
         storeOrUpdateSession(session, session.getSessionId());
     }
 
-    private void storeOrUpdateSession(Session session, String oldSessionId) {
+    public void storeOrUpdateSession(Session session, String sessionId) {
+        storeOrUpdateSession(session, sessionId, sessionId);
+    }
+
+    private void storeOrUpdateSession(Session session, String oldSessionId, String newSessionId) {
         try {
             var newSession = OBJECT_MAPPER.writeValueAsString(session);
             if (redisConnectionService.keyExists(oldSessionId)) {
@@ -55,7 +59,7 @@ public class SessionService {
             }
 
             redisConnectionService.saveWithExpiry(
-                    session.getSessionId(), newSession, configurationService.getSessionExpiry());
+                    newSessionId, newSession, configurationService.getSessionExpiry());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -42,24 +42,16 @@ public class SessionService {
                         configurationService.getRedisPassword()));
     }
 
-    public void storeOrUpdateSession(Session session) {
-        storeOrUpdateSession(session, session.getSessionId());
-    }
-
     public void storeOrUpdateSession(Session session, String sessionId) {
-        storeOrUpdateSession(session, sessionId, sessionId);
-    }
-
-    private void storeOrUpdateSession(Session session, String oldSessionId, String newSessionId) {
         try {
             var newSession = OBJECT_MAPPER.writeValueAsString(session);
-            if (redisConnectionService.keyExists(oldSessionId)) {
-                var oldSession = redisConnectionService.getValue(oldSessionId);
+            if (redisConnectionService.keyExists(sessionId)) {
+                var oldSession = redisConnectionService.getValue(sessionId);
                 newSession = JsonUpdateHelper.updateJson(oldSession, newSession);
             }
 
             redisConnectionService.saveWithExpiry(
-                    newSessionId, newSession, configurationService.getSessionExpiry());
+                    sessionId, newSession, configurationService.getSessionExpiry());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
@@ -35,7 +35,7 @@ class SessionServiceTest {
 
         var session = new Session("session-id").addClientSession("client-session-id");
 
-        sessionService.storeOrUpdateSession(session);
+        sessionService.storeOrUpdateSession(session, "session-id");
 
         verify(redis, times(1))
                 .saveWithExpiry("session-id", objectMapper.writeValueAsString(session), 1234L);
@@ -134,7 +134,7 @@ class SessionServiceTest {
     void shouldDeleteSessionIdFromRedis() {
         var session = new Session("session-id").addClientSession("client-session-id");
 
-        sessionService.storeOrUpdateSession(session);
+        sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.deleteSessionFromRedis(session.getSessionId());
 
         verify(redis).deleteValue("session-id");


### PR DESCRIPTION
### Wider context of change

Part of the session id migration to auth session item

### What’s changed

`SessionService.storeOrUpdateSession` no longer calls `Session.getSessionId()`. Instead it supports passing in a session ID.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
