### PR TITLE
Aut 3976/add details to reverification info received event

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/IpvReverificationFailureCode.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/IpvReverificationFailureCode.java
@@ -1,0 +1,27 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+public enum IpvReverificationFailureCode {
+    NO_IDENTITY_AVAILABLE("no_identity_available"),
+    IDENTITY_CHECK_INCOMPLETE("identity_check_incomplete"),
+    IDENTITY_CHECK_FAILED("identity_check_failed"),
+    IDENTITY_DID_NOT_MATCH("identity_did_not_match");
+
+    private String value;
+
+    IpvReverificationFailureCode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static IpvReverificationFailureCode fromValue(String value) {
+        for (IpvReverificationFailureCode e : IpvReverificationFailureCode.values()) {
+            if (e.getValue().equals(value)) {
+                return e;
+            }
+        }
+        throw new IllegalArgumentException("No enum constant with value " + value);
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.ReverificationResultRequest;
 import uk.gov.di.authentication.frontendapi.services.ReverificationResultService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulReverificationResponseException;
 import uk.gov.di.authentication.shared.helpers.ConstructUriHelper;
 import uk.gov.di.authentication.shared.helpers.InstrumentationHelper;
@@ -138,7 +139,11 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
                                             .getBearerAccessToken()));
 
             LOG.info("Successful IPV ReverificationResult");
-            auditService.submitAuditEvent(AUTH_REVERIFY_VERIFICATION_INFO_RECEIVED, auditContext);
+            var pairs =
+                    AuditService.MetadataPair.pair(
+                            "journey_type", JourneyType.ACCOUNT_RECOVERY.getValue());
+            auditService.submitAuditEvent(
+                    AUTH_REVERIFY_VERIFICATION_INFO_RECEIVED, auditContext, pairs);
             return generateApiGatewayProxyResponse(200, reverificationResult.getContent());
         } catch (UnsuccessfulReverificationResponseException e) {
             LOG.error("Error getting reverification result", e);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
@@ -142,7 +142,7 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
                                             .getTokens()
                                             .getBearerAccessToken()));
 
-            LOG.info("Successful IPV ReverificationResult");
+            LOG.info("ReverificationResult response received from IPV");
 
             var reverificationResultJson = reverificationResult.getContentAsJSONObject();
             var success = reverificationResultJson.get("success");

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
@@ -136,18 +136,21 @@ class ReverificationResultHandlerTest {
     @Nested
     class SuccessfulRequest {
 
-        @Test
-        void shouldReturn200AndIPVResponseOnValidRequest()
-                throws ParseException, UnsuccessfulReverificationResponseException {
-            HTTPResponse userInfo = new HTTPResponse(200);
-            userInfo.setContentType("application/json");
-            userInfo.setContent(
-                    "{ \"sub\": \"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"success\": true}");
-
+        @BeforeEach
+        void setUp() throws ParseException {
             when(idReverificationStateService.get(any()))
                     .thenReturn(Optional.ofNullable(ID_REVERIFICATION_STATE));
             when(reverificationResultService.getToken(any()))
                     .thenReturn(getSuccessfulTokenResponse());
+        }
+
+        @Test
+        void shouldReturn200AndIPVResponseOnValidRequest()
+                throws ParseException, UnsuccessfulReverificationResponseException {
+            var userInfo =
+                    successfulResponseWithBody(
+                            "{ \"sub\": \"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"success\": true}");
+
             when(reverificationResultService.sendIpvReverificationRequest(any()))
                     .thenReturn(userInfo);
 
@@ -156,7 +159,7 @@ class ReverificationResultHandlerTest {
 
             var result =
                     handler.handleRequestWithUserContext(
-                            apiRequestEventWithEmail("1234", AUTHENTICATION_STATE, EMAIL),
+                            apiRequestEventWithHeadersAndBody(VALID_HEADERS, "{}"),
                             context,
                             request,
                             USER_CONTEXT);
@@ -168,14 +171,10 @@ class ReverificationResultHandlerTest {
         @Test
         void shouldSubmitSuccessfulTokenReceivedAuditEvent()
                 throws ParseException, UnsuccessfulReverificationResponseException {
-            HTTPResponse userInfo = new HTTPResponse(200);
-            userInfo.setContentType("application/json");
-            userInfo.setContent(
-                    "{ \"sub\": \"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"success\": true}");
-            when(idReverificationStateService.get(any()))
-                    .thenReturn(Optional.ofNullable(ID_REVERIFICATION_STATE));
-            when(reverificationResultService.getToken(any()))
-                    .thenReturn(getSuccessfulTokenResponse());
+            var userInfo =
+                    successfulResponseWithBody(
+                            "{ \"sub\": \"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"success\": true}");
+
             when(reverificationResultService.sendIpvReverificationRequest(any()))
                     .thenReturn(userInfo);
 
@@ -196,14 +195,10 @@ class ReverificationResultHandlerTest {
         @Test
         void shouldSubmitReverificationInfoAuditEventForReverificationSuccessResponse()
                 throws ParseException, UnsuccessfulReverificationResponseException {
-            HTTPResponse userInfo = new HTTPResponse(200);
-            userInfo.setContentType("application/json");
-            userInfo.setContent(
-                    "{ \"sub\": \"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"success\": true}");
-            when(idReverificationStateService.get(any()))
-                    .thenReturn(Optional.ofNullable(ID_REVERIFICATION_STATE));
-            when(reverificationResultService.getToken(any()))
-                    .thenReturn(getSuccessfulTokenResponse());
+            var userInfo =
+                    successfulResponseWithBody(
+                            "{ \"sub\": \"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"success\": true}");
+
             when(reverificationResultService.sendIpvReverificationRequest(any()))
                     .thenReturn(userInfo);
 
@@ -227,14 +222,9 @@ class ReverificationResultHandlerTest {
         @Test
         void shouldSubmitReverificationInfoAuditEventForReverificationFailureResponse()
                 throws ParseException, UnsuccessfulReverificationResponseException {
-            HTTPResponse userInfo = new HTTPResponse(200);
-            userInfo.setContentType("application/json");
-            userInfo.setContent(
-                    "{ \"sub\": \"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"success\": false, \"failure_code\": \"no_identity_available\"}");
-            when(idReverificationStateService.get(any()))
-                    .thenReturn(Optional.ofNullable(ID_REVERIFICATION_STATE));
-            when(reverificationResultService.getToken(any()))
-                    .thenReturn(getSuccessfulTokenResponse());
+            var userInfo =
+                    successfulResponseWithBody(
+                            "{ \"sub\": \"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"success\": false, \"failure_code\": \"no_identity_available\"}");
             when(reverificationResultService.sendIpvReverificationRequest(any()))
                     .thenReturn(userInfo);
 
@@ -260,16 +250,12 @@ class ReverificationResultHandlerTest {
         void shouldSubmitReverificationInfoAuditEventAndLogWarningWhenFailureCodeUnknown()
                 throws ParseException, UnsuccessfulReverificationResponseException {
             var unknownFailureCode = "foo";
-            HTTPResponse userInfo = new HTTPResponse(200);
-            userInfo.setContentType("application/json");
-            userInfo.setContent(
+            var responseBody =
                     format(
                             "{ \"sub\": \"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"success\": false, \"failure_code\": \"%s\"}",
-                            unknownFailureCode));
-            when(idReverificationStateService.get(any()))
-                    .thenReturn(Optional.ofNullable(ID_REVERIFICATION_STATE));
-            when(reverificationResultService.getToken(any()))
-                    .thenReturn(getSuccessfulTokenResponse());
+                            unknownFailureCode);
+            var userInfo = successfulResponseWithBody(responseBody);
+
             when(reverificationResultService.sendIpvReverificationRequest(any()))
                     .thenReturn(userInfo);
 
@@ -434,6 +420,13 @@ class ReverificationResultHandlerTest {
         tokenHTTPResponse.setContent(tokenResponseContent);
 
         return TokenResponse.parse(tokenHTTPResponse);
+    }
+
+    private HTTPResponse successfulResponseWithBody(String body) throws ParseException {
+        HTTPResponse userInfo = new HTTPResponse(200);
+        userInfo.setContentType("application/json");
+        userInfo.setContent(body);
+        return userInfo;
     }
 
     public TokenResponse getUnsuccessfulTokenResponse() throws ParseException {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.frontendapi.entity.ReverificationResultRequest;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.frontendapi.services.ReverificationResultService;
 import uk.gov.di.authentication.shared.entity.IDReverificationState;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulReverificationResponseException;
@@ -203,7 +204,12 @@ class ReverificationResultHandlerTest {
 
             verify(auditService)
                     .submitAuditEvent(
-                            AUTH_REVERIFY_VERIFICATION_INFO_RECEIVED, auditContextWithAllUserInfo);
+                            eq(AUTH_REVERIFY_VERIFICATION_INFO_RECEIVED),
+                            any(),
+                            eq(
+                                    AuditService.MetadataPair.pair(
+                                            "journey_type",
+                                            JourneyType.ACCOUNT_RECOVERY.getValue())));
         }
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ReverificationResultHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ReverificationResultHandlerIntegrationTest.java
@@ -65,7 +65,7 @@ class ReverificationResultHandlerIntegrationTest extends ApiGatewayHandlerIntegr
             """
             {
                 "sub": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
-                "success": true"
+                "success": true
             }
             """;
 


### PR DESCRIPTION
Updates the reverification info received event with the extensions [defined in the event catalogue](https://github.com/govuk-one-login/event-catalogue/blob/main/schemas/AUTH_REVERIFY_VERIFICATION_INFO_RECEIVED.yaml) (note that the phone number country code should already be populated by the audit service for users with phone numbers).