### PR TITLE
AUT-3977: Add extra metadata to reverify authorisation error received audit event

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandler.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.entity.IDReverificationStateRequest;
 import uk.gov.di.authentication.frontendapi.entity.IDReverificationStateResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -64,7 +65,11 @@ public class IDReverificationStateHandler {
 
         var auditContext =
                 baseAuditContext.withClientSessionId(idReverificationState.getClientSessionId());
-        auditService.submitAuditEvent(AUTH_REVERIFY_AUTHORISATION_ERROR_RECEIVED, auditContext);
+        auditService.submitAuditEvent(
+                AUTH_REVERIFY_AUTHORISATION_ERROR_RECEIVED,
+                auditContext,
+                AuditService.MetadataPair.pair(
+                        "journey-type", JourneyType.ACCOUNT_RECOVERY.getValue()));
         var response =
                 new IDReverificationStateResponse(
                         idReverificationState.getOrchestrationRedirectUrl());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandlerTest.java
@@ -23,6 +23,7 @@ import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyReques
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.ENCODED_DEVICE_DETAILS;
 import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class IDReverificationStateHandlerTest {
     public static final String AUTHENTICATION_STATE = "state";
@@ -67,7 +68,8 @@ public class IDReverificationStateHandlerTest {
                         AUTH_REVERIFY_AUTHORISATION_ERROR_RECEIVED,
                         AuditContext.emptyAuditContext()
                                 .withClientSessionId(CLIENT_SESSION_ID)
-                                .withTxmaAuditEncoded(Optional.of(ENCODED_DEVICE_DETAILS)));
+                                .withTxmaAuditEncoded(Optional.of(ENCODED_DEVICE_DETAILS)),
+                        pair("journey-type", "ACCOUNT_RECOVERY"));
     }
 
     private static APIGatewayProxyRequestEvent generateRequest(String authenticationState) {


### PR DESCRIPTION
Add journey-type to this event, which will only be called in the event of an mfa reset via ipv flow.

This reflects the [event schema](https://github.com/govuk-one-login/event-catalogue/blob/af0e3aacde13ba06ea5a3586ec496512d415f3e1/schemas/AUTH_REVERIFY_AUTHORISATION_ERROR_RECEIVED.yaml), although note that not all user fields have been added here, as there is some discussion as to whether they're relevant in this case.