### PR TITLE
ATO-1447: Remove remaining uses of session id getter

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -104,7 +104,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             CheckUserExistsRequest request,
             UserContext userContext) {
 
-        attachSessionIdToLogs(userContext.getSession());
+        attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
 
         try {
             LOG.info("Processing request");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -172,7 +172,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             SendNotificationRequest request,
             UserContext userContext) {
 
-        attachSessionIdToLogs(userContext.getSession());
+        attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
         var auditContext =
                 auditContextFromUserContext(
                         userContext,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -102,7 +102,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
             SignupRequest request,
             UserContext userContext) {
 
-        attachSessionIdToLogs(userContext.getSession());
+        attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
 
         AuthSessionItem authSessionItem = userContext.getAuthSession();
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -110,7 +110,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
         String persistentSessionId =
                 PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
 
-        LogLineHelper.attachSessionIdToLogs(session);
+        LogLineHelper.attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
 
         LOG.info("Processing request");
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -149,7 +149,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
         } else {
             LOG.error(
                     "Encountered unexpected error while processing session: {}",
-                    session.getSessionId());
+                    userContext.getAuthSession().getSessionId());
             return generateErrorResponse(ErrorResponse.ERROR_1013, auditContext);
         }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -168,7 +168,12 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             AuditService.UNKNOWN,
                             extractPersistentIdFromHeaders(input.getHeaders()));
             var client =
-                    userContext.getClient().orElseThrow(() -> new ClientNotFoundException(session));
+                    userContext
+                            .getClient()
+                            .orElseThrow(
+                                    () ->
+                                            new ClientNotFoundException(
+                                                    "Could not find client in user context"));
 
             Optional<UserProfile> userProfileMaybe = userContext.getUserProfile();
             UserProfile userProfile = userProfileMaybe.orElse(null);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -146,7 +146,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             VerifyCodeRequest codeRequest,
             UserContext userContext) {
 
-        attachSessionIdToLogs(userContext.getSession());
+        attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
 
         try {
             LOG.info("Processing request");

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -58,17 +58,15 @@ public class RedisExtension
             throws Json.JsonException {
         Session session = new Session(sessionId).setAuthenticated(isAuthenticated);
         email.ifPresent(session::setEmailAddress);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
-        return session.getSessionId();
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
+        return sessionId;
     }
 
     public void setVerifiedMfaMethodType(String sessionId, MFAMethodType mfaMethodType)
             throws Json.JsonException {
         var session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.setVerifiedMfaMethodType(mfaMethodType);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public String createSession() throws Json.JsonException {
@@ -122,8 +120,7 @@ public class RedisExtension
             throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.addClientSession(clientSessionId);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public void incrementPasswordCount(String email) {
@@ -146,8 +143,7 @@ public class RedisExtension
             throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.addClientSession(clientSessionId);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
         redis.saveWithExpiry(
                 CLIENT_SESSION_PREFIX.concat(clientSessionId),
                 objectMapper.writeValueAsString(
@@ -171,16 +167,14 @@ public class RedisExtension
     public void addEmailToSession(String sessionId, String emailAddress) throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.setEmailAddress(emailAddress);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public void setSessionCredentialTrustLevel(
             String sessionId, CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.setCurrentCredentialStrength(credentialTrustLevel);
-        redis.saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public Session getSession(String sessionId) throws Json.JsonException {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientNotFoundException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientNotFoundException.java
@@ -1,16 +1,8 @@
 package uk.gov.di.authentication.shared.exceptions;
 
-import uk.gov.di.authentication.shared.entity.Session;
-
-import static java.lang.String.format;
-
 public class ClientNotFoundException extends Exception {
 
     public ClientNotFoundException(String message) {
         super(message);
-    }
-
-    public ClientNotFoundException(Session session) {
-        super(format("No Client found for SessionId: %s", session.getSessionId()));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.shared.helpers;
 
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.Session;
 
 import static uk.gov.di.authentication.shared.helpers.InputSanitiser.sanitiseBase64;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.AUTH_SESSION_ID;
@@ -49,10 +48,6 @@ public class LogLineHelper {
             ThreadContext.remove(logFieldName.getLogFieldName());
         }
         attachLogFieldToLogs(logFieldName, value);
-    }
-
-    public static void attachSessionIdToLogs(Session session) {
-        attachLogFieldToLogs(SESSION_ID, session.getSessionId());
     }
 
     public static void attachSessionIdToLogs(String sessionId) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TestClientHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TestClientHelper.java
@@ -28,7 +28,7 @@ public class TestClientHelper {
         var clientRegistry =
                 userContext
                         .getClient()
-                        .orElseThrow(() -> new ClientNotFoundException(userContext.getSession()));
+                        .orElseThrow(() -> new ClientNotFoundException("Could not find client"));
 
         var isTestClientWithAllowedEmail =
                 (clientRegistry.isTestClient()

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LogLineHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LogLineHelperTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.shared.helpers;
 import org.apache.logging.log4j.ThreadContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.shared.entity.Session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,14 +31,6 @@ class LogLineHelperTest {
     @Test
     void shouldAttachSessionIdToThreadContextUsingString() {
         attachSessionIdToLogs(identifier);
-
-        assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
-        assertEquals(identifier, ThreadContext.get(SESSION_ID.getLogFieldName()));
-    }
-
-    @Test
-    void shouldAttachSessionIdToThreadContextUsingSession() {
-        attachSessionIdToLogs(new Session(identifier));
 
         assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
         assertEquals(identifier, ThreadContext.get(SESSION_ID.getLogFieldName()));


### PR DESCRIPTION
### Wider context of change

Part of the session id migration to AuthSessionItem

### What’s changed

Removes the final few uses of the sessionId getter:
- Removes method signature for `attachSessionIdToLogs` that used the session Id getter
- Use existing sessionId parameter in `RedisExtension` methods.
- Replaces `UpdateProfileHandler` usage of getter with auth session id getter
- Removes the constructor for `ClientNotFoundException` which calls the session id getter.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
