### PR TITLE
BAU: Pin io.netty:netty-handler version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ subprojects {
                 classpath('com.google.protobuf:protobuf-java:[3.25.5,)') {
                     because 'CVE-2024-7254 is fixed in 3.25.5 and above'
                 }
+
+                classpath('io.netty:netty-handler:[4.1.118.Final,)') {
+                    because 'CVE-2025-24970 is fixed in io.netty:netty-handler:4.1.118.Final and higher'
+                }
             }
         }
     }


### PR DESCRIPTION
This is a follow up to https://github.com/govuk-one-login/authentication-api/pull/5923, which partially resolved a vulnerability issue, but did not cover the two places in build.gradle that needed updating.

CVE-2025-24970 in https://github.com/govuk-one-login/authentication-api/security/dependabot/30 exposes that io.netty:netty-handler has a vulnerability

> SslHandler doesn't correctly validate packets which can lead to native crash when using native SSLEngine

This is patched in version 4.1.118.Final, which we pin as this is a transitive dependency of a few other direct dependencies we use. Over time our direct dependencies will release patched versions. At such time this pin can be removed.


