### PR TITLE
ATO-1450: Filter keys by algorithm in JwkCache

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/JwkCacheEntry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/JwkCacheEntry.java
@@ -14,9 +14,9 @@ import java.util.List;
 
 public class JwkCacheEntry {
     private static final Logger LOG = LogManager.getLogger(JwkCacheEntry.class);
-    private final KeyUse keyUse;
     private final URL jwksUrl;
     private final int expirationInSeconds;
+    private final KeyUse keyUse;
     private JWK latestKey;
     private Date expireTime;
 
@@ -28,12 +28,12 @@ public class JwkCacheEntry {
         this.latestKey = getKeyFromUrl();
     }
 
-    public static JwkCacheEntry forKeyUse(KeyUse keyUse, URL url, int expirationInSeconds) {
+    public static JwkCacheEntry forKeyUse(URL url, int expirationInSeconds, KeyUse keyUse) {
         return new JwkCacheEntry(url, expirationInSeconds, keyUse);
     }
 
     public static JwkCacheEntry forEncryptionKeys(URL url, int expirationInSeconds) {
-        return new JwkCacheEntry(url, expirationInSeconds, KeyUse.ENCRYPTION);
+        return forKeyUse(url, expirationInSeconds, KeyUse.ENCRYPTION);
     }
 
     public JWK getKey() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/JwkCacheEntry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/JwkCacheEntry.java
@@ -11,29 +11,43 @@ import java.net.URL;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 public class JwkCacheEntry {
     private static final Logger LOG = LogManager.getLogger(JwkCacheEntry.class);
     private final URL jwksUrl;
     private final int expirationInSeconds;
     private final KeyUse keyUse;
+    private final Set<String> algs;
     private JWK latestKey;
     private Date expireTime;
 
-    private JwkCacheEntry(URL jwksUrl, int expirationInSeconds, KeyUse keyUse) {
+    private JwkCacheEntry(URL jwksUrl, int expirationInSeconds, KeyUse keyUse, Set<String> algs) {
         this.jwksUrl = jwksUrl;
         this.expirationInSeconds = expirationInSeconds;
         this.expireTime = NowHelper.nowPlus(this.expirationInSeconds, ChronoUnit.SECONDS);
         this.keyUse = keyUse;
+        this.algs = algs;
         this.latestKey = getKeyFromUrl();
     }
 
-    public static JwkCacheEntry forKeyUse(URL url, int expirationInSeconds, KeyUse keyUse) {
-        return new JwkCacheEntry(url, expirationInSeconds, keyUse);
+    public static JwkCacheEntry forEncryptionKeys(URL url, int expirationInSeconds) {
+        // TODO This set of algs is temporary. At the moment IPV is sending up RSA-OAEP-256 keys
+        // with the alg RS256.
+        // Once they update this, we can remove the algs set and just have a single alg string here.
+        // See https://datatracker.ietf.org/doc/html/rfc7518#section-4.1 for more info
+        return forKeyUse(
+                url, expirationInSeconds, KeyUse.ENCRYPTION, Set.of("RS256", "RSA-OAEP-256"));
     }
 
-    public static JwkCacheEntry forEncryptionKeys(URL url, int expirationInSeconds) {
-        return forKeyUse(url, expirationInSeconds, KeyUse.ENCRYPTION);
+    public static JwkCacheEntry forKeyUse(
+            URL url, int expirationInSeconds, KeyUse keyUse, String alg) {
+        return new JwkCacheEntry(url, expirationInSeconds, keyUse, Set.of(alg));
+    }
+
+    public static JwkCacheEntry forKeyUse(
+            URL url, int expirationInSeconds, KeyUse keyUse, Set<String> algs) {
+        return new JwkCacheEntry(url, expirationInSeconds, keyUse, algs);
     }
 
     public JWK getKey() {
@@ -51,6 +65,7 @@ public class JwkCacheEntry {
             LOG.info("Found {} {} JWKs at {}", jwks.size(), keyUse, jwksUrl);
             return jwks.stream()
                     .filter(key -> keyUse.equals(key.getKeyUse()))
+                    .filter(key -> algs.contains(key.getAlgorithm().getName()))
                     .findFirst()
                     .orElse(null);
         } catch (KeySourceException e) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/JwkCacheEntryTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/JwkCacheEntryTest.java
@@ -127,10 +127,10 @@ class JwkCacheEntryTest {
     }
 
     private JwkCacheEntry createCacheWithExpiration(int expiration) {
-        return JwkCacheEntry.forKeyUse(KeyUse.ENCRYPTION, testJwksUrl, expiration);
+        return JwkCacheEntry.forKeyUse(testJwksUrl, expiration, KeyUse.ENCRYPTION);
     }
 
     private JwkCacheEntry createCacheWithExpiration(KeyUse keyUse, int expiration) {
-        return JwkCacheEntry.forKeyUse(keyUse, testJwksUrl, expiration);
+        return JwkCacheEntry.forKeyUse(testJwksUrl, expiration, keyUse);
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/JwkCacheEntryTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/JwkCacheEntryTest.java
@@ -1,5 +1,7 @@
 package uk.gov.di.orchestration.shared.helpers;
 
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyUse;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +30,8 @@ class JwkCacheEntryTest {
         testJwksUrl = new URL("http://localhost/.well-known/jwks.json");
         when(TEST_KEY_1.getKeyUse()).thenReturn(KeyUse.ENCRYPTION);
         when(TEST_KEY_2.getKeyUse()).thenReturn(KeyUse.ENCRYPTION);
+        when(TEST_KEY_1.getAlgorithm()).thenReturn(JWEAlgorithm.RSA_OAEP_256);
+        when(TEST_KEY_2.getAlgorithm()).thenReturn(JWEAlgorithm.RSA_OAEP_256);
     }
 
     @Test
@@ -80,6 +84,19 @@ class JwkCacheEntryTest {
     }
 
     @Test
+    void shouldIgnoreFirstKeyIfKeyHasDifferentAlg() {
+        try (var mockJwksUtils = mockStatic(JwksUtils.class)) {
+            when(TEST_KEY_1.getAlgorithm()).thenReturn(JWEAlgorithm.ECDH_1PU);
+            mockJwksUtils
+                    .when(() -> JwksUtils.retrieveJwksFromUrl(testJwksUrl))
+                    .thenReturn(List.of(TEST_KEY_1, TEST_KEY_2));
+
+            var cacheEntry = createCacheWithNoExpiration();
+            assertEquals(TEST_KEY_2, cacheEntry.getKey());
+        }
+    }
+
+    @Test
     void shouldRefreshCacheIfExpirationHasPassed() {
         try (var mockJwksUtils = mockStatic(JwksUtils.class);
                 var mockNowHelper = mockStatic(NowHelper.class)) {
@@ -122,15 +139,32 @@ class JwkCacheEntryTest {
         }
     }
 
+    @Test
+    void shouldGetEncryptionKeyIfKeyAlgIsRS256() {
+        // This test is temporary. At the moment IPV is sending up RSA-OAEP-256 keys with the alg
+        // RS256.
+        // Once they send us the correct alg, we can remove this test
+        try (var mockJwksUtils = mockStatic(JwksUtils.class)) {
+            when(TEST_KEY_1.getAlgorithm()).thenReturn(JWSAlgorithm.RS256);
+            mockJwksUtils
+                    .when(() -> JwksUtils.retrieveJwksFromUrl(testJwksUrl))
+                    .thenReturn(List.of(TEST_KEY_1, TEST_KEY_2));
+
+            var cacheEntry = JwkCacheEntry.forEncryptionKeys(testJwksUrl, Integer.MAX_VALUE);
+            assertEquals(TEST_KEY_1, cacheEntry.getKey());
+        }
+    }
+
     private JwkCacheEntry createCacheWithNoExpiration() {
         return createCacheWithExpiration(KeyUse.ENCRYPTION, Integer.MAX_VALUE);
     }
 
     private JwkCacheEntry createCacheWithExpiration(int expiration) {
-        return JwkCacheEntry.forKeyUse(testJwksUrl, expiration, KeyUse.ENCRYPTION);
+        return createCacheWithExpiration(KeyUse.ENCRYPTION, expiration);
     }
 
     private JwkCacheEntry createCacheWithExpiration(KeyUse keyUse, int expiration) {
-        return JwkCacheEntry.forKeyUse(testJwksUrl, expiration, keyUse);
+        return JwkCacheEntry.forKeyUse(
+                testJwksUrl, expiration, keyUse, JWEAlgorithm.RSA_OAEP_256.getName());
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.orchestration.shared.services;
 
+import com.nimbusds.jose.JWEAlgorithm;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyUse;
@@ -101,6 +102,7 @@ class JwksServiceTest {
         try (var mockJwksUtils = mockStatic(JwksUtils.class)) {
             JWK testKey1 = mock(JWK.class);
             when(testKey1.getKeyUse()).thenReturn(KeyUse.ENCRYPTION);
+            when(testKey1.getAlgorithm()).thenReturn(JWEAlgorithm.RSA_OAEP_256);
             mockJwksUtils
                     .when(() -> JwksUtils.retrieveJwksFromUrl(testJwksUrl))
                     .thenReturn(List.of(testKey1));


### PR DESCRIPTION
### Wider context of change

Previously, the JwkCache did not consider the algorithm of the keys. We use the cache to get an pubic encryption JWK and expect it to be using the algorithm `RSA-OAEP-256`, so if we get an encryption key with a different algorithm, the code would likely break. 

### What’s changed

This PR adds an `algs` field to the JwkCacheEntry, which is used to fetch keys with the right algorithms. 

It's worth noting that this just ensures that if a key with a different algorithm is added, then the code wont break. This PR does not add support for encryption keys using a different algorithm to `RSA-OAEP-256` or `RS256`.

This PR also temporarily looks for encryption keys with the `RS256` alg and the `RSA-OAEP-256` alg. Currently IPV are sending us encryption keys with the `RS256` alg, so once they fix this and send us encryption keys with the correct `RSA-OAEP-256` alg, we can remove the extra test for this, and think about whether we still need a set of `algs` in the cache. 

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

