### PR TITLE
ATO-1123: always add local_account_id claim

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -1030,13 +1030,13 @@ public class AuthorisationHandler
 
         var claimsSet = new HashSet<AuthUserInfoClaims>();
         claimsSet.add(AuthUserInfoClaims.EMAIL);
+        claimsSet.add(AuthUserInfoClaims.LOCAL_ACCOUNT_ID);
         claimsSet.add(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE);
         claimsSet.add(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH);
         claimsSet.add(AuthUserInfoClaims.UPLIFT_REQUIRED);
         if (identityRequired) {
             LOG.info(
-                    "Identity is required. Adding the local_account_id, salt, email_verified and phone_number claims");
-            claimsSet.add(AuthUserInfoClaims.LOCAL_ACCOUNT_ID);
+                    "Identity is required. Adding the salt, email_verified and phone_number claims");
             claimsSet.add(AuthUserInfoClaims.SALT);
             // Email required for ID journeys for use in Face-to-Face flows
             claimsSet.add(AuthUserInfoClaims.EMAIL_VERIFIED);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -400,7 +400,7 @@ class AuthorisationHandlerTest {
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
             var expectedClaimSetRequest =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"email_verified\":null,\"current_credential_strength\":null,\"verified_mfa_method_type\":null,\"email\":null, \"uplift_required\":null}}");
+                            "{\"userinfo\":{\"local_account_id\":null, \"email_verified\":null,\"current_credential_strength\":null,\"verified_mfa_method_type\":null,\"email\":null, \"uplift_required\":null}}");
             var actualClaimSetRequest =
                     ClaimsSetRequest.parse(captor.getValue().getStringClaim("claim"));
             assertEquals(
@@ -439,7 +439,7 @@ class AuthorisationHandlerTest {
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
             var expectedClaimSetRequest =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"phone_number_verified\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null,\"current_credential_strength\":null, \"uplift_required\":null}}");
+                            "{\"userinfo\":{\"local_account_id\":null, \"phone_number_verified\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null,\"current_credential_strength\":null, \"uplift_required\":null}}");
             var actualClaimSetRequest =
                     ClaimsSetRequest.parse(captor.getValue().getStringClaim("claim"));
             assertEquals(
@@ -1727,7 +1727,7 @@ class AuthorisationHandlerTest {
 
             var expectedClaim =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"verified_mfa_method_type\":null,\"current_credential_strength\":null,\"public_subject_id\":null,\"email\":null, \"uplift_required\":null}}");
+                            "{\"userinfo\":{\"local_account_id\":null, \"verified_mfa_method_type\":null,\"current_credential_strength\":null,\"public_subject_id\":null,\"email\":null, \"uplift_required\":null}}");
             var actualClaim = ClaimsSetRequest.parse(argument.getValue().getStringClaim("claim"));
             assertEquals(actualClaim.toJSONObject(), expectedClaim.toJSONObject());
         }
@@ -1750,7 +1750,7 @@ class AuthorisationHandlerTest {
 
             var expectedClaim =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"legacy_subject_id\":null,\"current_credential_strength\":null,\"verified_mfa_method_type\":null,\"email\":null, \"uplift_required\":null}}");
+                            "{\"userinfo\":{\"legacy_subject_id\":null,\"local_account_id\":null,\"current_credential_strength\":null,\"verified_mfa_method_type\":null,\"email\":null, \"uplift_required\":null}}");
             var actualClaim = ClaimsSetRequest.parse(argument.getValue().getStringClaim("claim"));
             assertEquals(actualClaim.toJSONObject(), expectedClaim.toJSONObject());
         }


### PR DESCRIPTION
### Wider context of change
This is part of the email migration work. In order to stop using UserProfile, we need to have the subjectId on the authUserInfo, even for auth-only journeys.

### What’s changed
Always add local_account_id claim to request

### Manual testing
n/a

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not needed**
- [x] Changes have been made to the simulator or not required. **Not needed**
- [x] Changes have been made to stubs or not required. **Not needed**
- [x] Successfully deployed to authdev or not required. **Not needed**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not needed**
