### PR TITLE
ATO-1123: migrate email in AuthCodeHandler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -74,6 +74,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final Nonce NONCE = new Nonce();
     public static final String ENCODED_DEVICE_INFORMATION =
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
+    private static final String SUBJECT = "subject";
     private static final String INTERNAL_COMMON_SUBJECT_ID = "internalCommonSubjectId";
     private String sessionID;
 
@@ -237,7 +238,9 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                         "client_session_id",
                                         clientSessionId,
                                         "email",
-                                        EMAIL)));
+                                        EMAIL,
+                                        "local_account_id",
+                                        SUBJECT)));
         authUserInfoExtension.addAuthenticationUserInfoData(
                 INTERNAL_COMMON_SUBJECT_ID, clientSessionId, authUserInfo);
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -89,7 +89,6 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setupOrchSession();
         var clientSessionId = "some-client-session-id";
         setupAuthUserInfo(clientSessionId);
-        redis.addEmailToSession(sessionID, EMAIL);
         redis.setVerifiedMfaMethodType(sessionID, MFAMethodType.AUTH_APP);
         redis.addAuthRequestToSession(
                 clientSessionId, sessionID, generateAuthRequest().toParameters(), CLIENT_NAME);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AuthCodeException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AuthCodeException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+public class AuthCodeException extends Exception {
+    public AuthCodeException(String message) {
+        super(message);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -32,6 +32,7 @@ import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthCodeResponseGenerationService;
+import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
@@ -72,6 +73,7 @@ public class AuthCodeHandler
 
     private final SessionService sessionService;
     private final OrchSessionService orchSessionService;
+    private final AuthenticationUserInfoStorageService authUserInfoStorageService;
     private final AuthCodeResponseGenerationService authCodeResponseService;
     private final AuthorisationCodeService authorisationCodeService;
     private final OrchestrationAuthorizationService orchestrationAuthorizationService;
@@ -85,6 +87,7 @@ public class AuthCodeHandler
     public AuthCodeHandler(
             SessionService sessionService,
             OrchSessionService orchSessionService,
+            AuthenticationUserInfoStorageService authUserInfoStorageService,
             AuthCodeResponseGenerationService authCodeResponseService,
             AuthorisationCodeService authorisationCodeService,
             OrchestrationAuthorizationService orchestrationAuthorizationService,
@@ -96,6 +99,7 @@ public class AuthCodeHandler
             DynamoClientService dynamoClientService) {
         this.sessionService = sessionService;
         this.orchSessionService = orchSessionService;
+        this.authUserInfoStorageService = authUserInfoStorageService;
         this.authCodeResponseService = authCodeResponseService;
         this.authorisationCodeService = authorisationCodeService;
         this.orchestrationAuthorizationService = orchestrationAuthorizationService;
@@ -110,6 +114,7 @@ public class AuthCodeHandler
     public AuthCodeHandler(ConfigurationService configurationService) {
         sessionService = new SessionService(configurationService);
         orchSessionService = new OrchSessionService(configurationService);
+        authUserInfoStorageService = new AuthenticationUserInfoStorageService(configurationService);
         authorisationCodeService = new AuthorisationCodeService(configurationService);
         orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(configurationService);
@@ -127,6 +132,7 @@ public class AuthCodeHandler
             ConfigurationService configurationService, RedisConnectionService redis) {
         sessionService = new SessionService(configurationService, redis);
         orchSessionService = new OrchSessionService(configurationService);
+        authUserInfoStorageService = new AuthenticationUserInfoStorageService(configurationService);
         authorisationCodeService = new AuthorisationCodeService(configurationService);
         orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(configurationService);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -11,11 +11,13 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AuthCodeResponse;
+import uk.gov.di.authentication.oidc.exceptions.AuthCodeException;
 import uk.gov.di.authentication.oidc.exceptions.ProcessAuthRequestException;
 import uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
@@ -193,6 +195,8 @@ public class AuthCodeHandler
 
         LOG.info("Processing request");
 
+        Optional<String> emailOptional;
+        boolean isDocAppJourney;
         AuthenticationRequest authenticationRequest = null;
         ClientSession clientSession;
         ClientID clientID;
@@ -214,6 +218,21 @@ public class AuthCodeHandler
 
             var redirectUri = authenticationRequest.getRedirectionURI();
             var state = authenticationRequest.getState();
+
+            isDocAppJourney = isDocCheckingAppUserWithSubjectId(clientSession);
+
+            if (!isDocAppJourney) {
+                var authUserInfo =
+                        getAuthUserInfo(
+                                        authUserInfoStorageService,
+                                        orchSession.getInternalCommonSubjectId(),
+                                        clientSessionId)
+                                .orElseThrow(() -> new AuthCodeException("authUserInfo not found"));
+                emailOptional = Optional.of(authUserInfo.getEmailAddress());
+            } else {
+                emailOptional = Optional.empty();
+            }
+
             authCode =
                     generateAuthCode(
                             clientID,
@@ -229,6 +248,8 @@ public class AuthCodeHandler
             return generateApiGatewayProxyErrorResponse(e.getStatusCode(), e.getErrorResponse());
         } catch (ClientNotFoundException e) {
             return processClientNotFoundException(authenticationRequest);
+        } catch (AuthCodeException e) {
+            return processUserNotFoundException(authenticationRequest);
         } catch (ParseException e) {
             return processParseException(e);
         }
@@ -239,19 +260,19 @@ public class AuthCodeHandler
             var isTestJourney =
                     orchestrationAuthorizationService.isTestJourney(
                             clientID, session.getEmailAddress());
-            var docAppJourney = isDocCheckingAppUserWithSubjectId(clientSession);
+
             var dimensions =
                     authCodeResponseService.getDimensions(
                             orchSession,
                             clientSession,
                             clientID.getValue(),
                             isTestJourney,
-                            docAppJourney);
+                            isDocAppJourney);
 
             var subjectId = AuditService.UNKNOWN;
             var rpPairwiseId = AuditService.UNKNOWN;
             String internalCommonSubjectId;
-            if (docAppJourney) {
+            if (isDocAppJourney) {
                 LOG.info("Session not saved for DocCheckingAppUser");
                 internalCommonSubjectId = clientSession.getDocAppSubjectId().getValue();
             } else {
@@ -296,7 +317,7 @@ public class AuthCodeHandler
                     clientSession.getClientName(),
                     isTestJourney);
             authCodeResponseService.saveSession(
-                    docAppJourney,
+                    isDocAppJourney,
                     sessionService,
                     session,
                     sessionId,
@@ -315,6 +336,24 @@ public class AuthCodeHandler
             throw new RuntimeException(e);
         } catch (JsonException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private static Optional<UserInfo> getAuthUserInfo(
+            AuthenticationUserInfoStorageService authUserInfoStorageService,
+            String internalCommonSubjectId,
+            String clientSessionId) {
+
+        if (internalCommonSubjectId == null || internalCommonSubjectId.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            return authUserInfoStorageService.getAuthenticationUserInfo(
+                    internalCommonSubjectId, clientSessionId);
+        } catch (ParseException e) {
+            LOG.warn("error parsing authUserInfo. Message: {}", e.getMessage());
+            return Optional.empty();
         }
     }
 
@@ -381,6 +420,17 @@ public class AuthCodeHandler
                         authenticationRequest.getRedirectionURI(),
                         authenticationRequest.getState());
         return generateResponse(500, new AuthCodeResponse(errorResponse.toURI().toString()));
+    }
+
+    private APIGatewayProxyResponseEvent processUserNotFoundException(
+            AuthenticationRequest authenticationRequest) {
+        var errorResponse =
+                orchestrationAuthorizationService.generateAuthenticationErrorResponse(
+                        authenticationRequest,
+                        OAuth2Error.ACCESS_DENIED,
+                        authenticationRequest.getRedirectionURI(),
+                        authenticationRequest.getState());
+        return generateResponse(400, new AuthCodeResponse(errorResponse.toURI().toString()));
     }
 
     private AuthorizationCode generateAuthCode(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -237,6 +237,7 @@ public class AuthCodeHandler
                     generateAuthCode(
                             clientID,
                             redirectUri,
+                            emailOptional,
                             clientSession,
                             clientSessionId,
                             session,
@@ -257,9 +258,14 @@ public class AuthCodeHandler
         LOG.info("Successfully processed request");
 
         try {
+
             var isTestJourney =
-                    orchestrationAuthorizationService.isTestJourney(
-                            clientID, session.getEmailAddress());
+                    emailOptional
+                            .filter(
+                                    email ->
+                                            orchestrationAuthorizationService.isTestJourney(
+                                                    clientID, email))
+                            .isPresent();
 
             var dimensions =
                     authCodeResponseService.getDimensions(
@@ -300,9 +306,7 @@ public class AuthCodeHandler
                             .withGovukSigninJourneyId(clientSessionId)
                             .withSessionId(sessionId)
                             .withUserId(internalCommonSubjectId)
-                            .withEmail(
-                                    Optional.ofNullable(session.getEmailAddress())
-                                            .orElse(AuditService.UNKNOWN))
+                            .withEmail(emailOptional.orElse(AuditService.UNKNOWN))
                             .withIpAddress(IpAddressHelper.extractIpAddress(input))
                             .withPersistentSessionId(
                                     PersistentIdHelper.extractPersistentIdFromHeaders(
@@ -436,6 +440,7 @@ public class AuthCodeHandler
     private AuthorizationCode generateAuthCode(
             ClientID clientID,
             URI redirectUri,
+            Optional<String> emailOptional,
             ClientSession clientSession,
             String clientSessionId,
             Session session,
@@ -461,7 +466,7 @@ public class AuthCodeHandler
         return authorisationCodeService.generateAndSaveAuthorisationCode(
                 clientID.getValue(),
                 clientSessionId,
-                session.getEmailAddress(),
+                emailOptional.orElse(null),
                 clientSession,
                 orchSession.getAuthTime());
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -275,7 +275,6 @@ class AuthCodeHandlerTest {
         var authRequest = generateValidSessionAndAuthRequest(requestedLevel, false);
         session.setCurrentCredentialStrength(initialLevel)
                 .setNewAccount(AccountState.NEW)
-                .setEmailAddress(EMAIL)
                 .setVerifiedMfaMethodType(mfaMethodType);
         orchSession.setCurrentCredentialStrength(initialLevel);
         var authSuccessResponse =
@@ -344,6 +343,14 @@ class AuthCodeHandlerTest {
                         pair("rpPairwiseId", expectedRpPairwiseId),
                         pair("authCode", authorizationCode),
                         pair("nonce", NONCE.getValue()));
+
+        verify(authorisationCodeService, times(1))
+                .generateAndSaveAuthorisationCode(
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(EMAIL),
+                        eq(clientSession),
+                        any(Long.class));
 
         var dimensions =
                 Map.of(
@@ -460,6 +467,13 @@ class AuthCodeHandlerTest {
                         pair("rpPairwiseId", AuditService.UNKNOWN),
                         pair("authCode", authorizationCode),
                         pair("nonce", NONCE.getValue()));
+        verify(authorisationCodeService, times(1))
+                .generateAndSaveAuthorisationCode(
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(null),
+                        eq(clientSession),
+                        any(Long.class));
 
         var expectedDimensions =
                 Map.of(
@@ -578,7 +592,6 @@ class AuthCodeHandlerTest {
 
     @Test
     void shouldGenerateErrorResponseIfUnableToParseAuthRequest() throws Json.JsonException {
-        session.setEmailAddress(EMAIL);
         AuthenticationErrorResponse authenticationErrorResponse =
                 new AuthenticationErrorResponse(
                         REDIRECT_URI, OAuth2Error.INVALID_REQUEST, null, null);
@@ -663,7 +676,7 @@ class AuthCodeHandlerTest {
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
-                        eq(null),
+                        eq(EMAIL),
                         eq(clientSession),
                         any(Long.class)))
                 .thenReturn(authorizationCode);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -48,6 +48,7 @@ import uk.gov.di.orchestration.shared.helpers.SaltHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthCodeResponseGenerationService;
+import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
@@ -120,6 +121,8 @@ class AuthCodeHandlerTest {
             mock(OrchestrationAuthorizationService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
+    private final AuthenticationUserInfoStorageService authUserInfoService =
+            mock(AuthenticationUserInfoStorageService.class);
     private final VectorOfTrust vectorOfTrust = mock(VectorOfTrust.class);
 
     private static final String SESSION_ID = IdGenerator.generate();
@@ -171,6 +174,7 @@ class AuthCodeHandlerTest {
                 new AuthCodeHandler(
                         sessionService,
                         orchSessionService,
+                        authUserInfoService,
                         authCodeResponseService,
                         authorisationCodeService,
                         orchestrationAuthorizationService,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -40,7 +40,6 @@ import uk.gov.di.orchestration.shared.entity.ErrorResponse;
 import uk.gov.di.orchestration.shared.entity.MFAMethodType;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
-import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
@@ -239,10 +238,8 @@ class AuthCodeHandlerTest {
             MFAMethodType mfaMethodType)
             throws ClientNotFoundException, Json.JsonException, JOSEException, ParseException {
         generateAuthUserInfo();
-        var userProfile = new UserProfile().withEmail(EMAIL).withSubjectID(SUBJECT.getValue());
         when(dynamoClientService.getClient(CLIENT_ID.getValue()))
                 .thenReturn(Optional.of(generateClientRegistry()));
-        when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
         if (Objects.nonNull(mfaMethodType)) {
             when(authCodeResponseService.getDimensions(
                             eq(orchSession),
@@ -286,7 +283,6 @@ class AuthCodeHandlerTest {
                         authRequest.getState(),
                         null,
                         authRequest.getResponseMode());
-        when(dynamoService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(Optional.of(userProfile));
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -1,6 +1,5 @@
 package uk.gov.di.orchestration.shared.services;
 
-import com.nimbusds.oauth2.sdk.id.ClientID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
@@ -8,9 +7,7 @@ import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
-import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
-import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -92,28 +89,6 @@ public class AuthCodeResponseGenerationService {
         return Objects.isNull(session.getEmailAddress())
                 ? AuditService.UNKNOWN
                 : userProfile.getSubjectID();
-    }
-
-    public String getRpPairwiseId(
-            Session session, ClientID clientID, DynamoClientService dynamoClientService)
-            throws UserNotFoundException, ClientNotFoundException {
-        var userProfile =
-                dynamoService
-                        .getUserProfileByEmailMaybe(session.getEmailAddress())
-                        .orElseThrow(
-                                () ->
-                                        new UserNotFoundException(
-                                                "Unable to find user with given email address"));
-        var client =
-                dynamoClientService
-                        .getClient(clientID.getValue())
-                        .orElseThrow(() -> new ClientNotFoundException(clientID.getValue()));
-        return ClientSubjectHelper.getSubject(
-                        userProfile,
-                        client,
-                        dynamoService,
-                        configurationService.getInternalSectorURI())
-                .getValue();
     }
 
     public void saveSession(


### PR DESCRIPTION
### Wider context of change
This is part of the session migration work; specifically the email migration. 

### What’s changed
Remove use of `session.getEmailAddress()`, and by extension, use of the UserProfile table.

Also has some performance improvements, as we previously made several dynamoDb calls.

### Manual testing
Tbd: deploy to dev

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not Needed**
- [x] Changes have been made to the simulator or not required. **Not Needed**
- [x] Changes have been made to stubs or not required. **Not Needed**
- [x] Successfully deployed to authdev or not required. **Not Needed**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not Needed**
