### PR TITLE
ATO-1418: Add permissions to access new dynamo table

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -44,10 +44,11 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-dev-tfstate"
 
-orch_account_id                       = "767397776536"
-is_orch_stubbed                       = false
-orch_environment                      = "build"
-orch_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:767397776536:key/b7cb6340-0d22-4b6a-8702-b5ec17d4f979"
+orch_account_id                              = "767397776536"
+is_orch_stubbed                              = false
+orch_environment                             = "build"
+orch_session_table_encryption_key_arn        = "arn:aws:kms:eu-west-2:767397776536:key/b7cb6340-0d22-4b6a-8702-b5ec17d4f979"
+orch_client_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:767397776536:key/7a1d86fe-1ca0-499c-95e9-ee8593a850f9"
 
 orch_storage_token_jwk_enabled              = true
 orch_trustmark_enabled                      = true

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -754,6 +754,22 @@ moved {
   to   = data.aws_iam_policy_document.dynamo_orch_session_encryption_key_cross_account_decrypt_policy_document[0]
 }
 
+data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_and_delete_access_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+  statement {
+    sid    = "AllowOrchSessionCrossAccountReadAndDeleteAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:DeleteItem",
+    ]
+    resources = [
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Orch-Session",
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_access_policy_document" {
   count = var.is_orch_stubbed ? 0 : 1
 
@@ -790,6 +806,65 @@ data "aws_iam_policy_document" "dynamo_orch_session_cross_account_delete_access_
 moved {
   from = data.aws_iam_policy_document.dynamo_orch_session_cross_account_delete_access_policy_document
   to   = data.aws_iam_policy_document.dynamo_orch_session_cross_account_delete_access_policy_document[0]
+}
+
+data "aws_iam_policy_document" "dynamo_orch_client_session_cross_account_read_and_delete_access_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+  statement {
+    sid    = "AllowOrchClientSessionCrossAccountReadAndDeleteAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:DeleteItem",
+    ]
+    resources = [
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Client-Session",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_orch_client_session_cross_account_read_access_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+  statement {
+    sid    = "AllowOrchClientSessionCrossAccountReadAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+    ]
+    resources = [
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Client-Session",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_orch_client_session_cross_account_delete_access_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+  statement {
+    sid    = "AllowOrchClientSessionCrossAccountDeleteAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DeleteItem"
+    ]
+    resources = [
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Client-Session",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+  statement {
+    sid    = "AllowOrchClientSessionEncryptionKeyCrossAccountDecryptAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = [
+      var.orch_client_session_table_encryption_key_arn,
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "dynamo_id_reverification_state_write_policy_document" {
@@ -1083,6 +1158,26 @@ moved {
   to   = aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_decrypt_policy[0]
 }
 
+resource "aws_iam_policy" "dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-client-session-encryption-key-cross-account-decrypt-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing decrypt and describe permissions to the orch client session table's KMS encryption key"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy_document[count.index].json
+}
+
+resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_and_delete_access_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-session-cross-account-read-and-delete-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing read and delete permissions to the orch session table"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_and_delete_access_policy_document[count.index].json
+}
+
 resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_access_policy" {
   count = var.is_orch_stubbed ? 0 : 1
 
@@ -1111,6 +1206,43 @@ moved {
   to   = aws_iam_policy.dynamo_orch_session_cross_account_delete_access_policy[0]
 }
 
+resource "aws_iam_policy" "dynamo_orch_client_session_cross_account_read_and_delete_access_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-client-session-cross-account-read-and-delete-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing read and delete permissions to the orch client session table"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_client_session_cross_account_read_and_delete_access_policy_document[count.index].json
+}
+
+resource "aws_iam_policy" "dynamo_orch_client_session_cross_account_read_access_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-client-session-cross-account-read-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing read permissions to the orch client session table"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_client_session_cross_account_read_access_policy_document[count.index].json
+}
+moved {
+  from = aws_iam_policy.dynamo_orch_client_session_cross_account_read_access_policy
+  to   = aws_iam_policy.dynamo_orch_client_session_cross_account_read_access_policy[0]
+}
+
+resource "aws_iam_policy" "dynamo_orch_client_session_cross_account_delete_access_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-client-session-cross-account-delete-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing delete permissions to the orch client session table"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_client_session_cross_account_delete_access_policy_document[count.index].json
+}
+moved {
+  from = aws_iam_policy.dynamo_orch_client_session_cross_account_delete_access_policy
+  to   = aws_iam_policy.dynamo_orch_client_session_cross_account_delete_access_policy[0]
+}
 
 resource "aws_iam_policy" "dynamo_id_reverification_state_write_policy" {
   name_prefix = "dynamo-id-reverification-state-write-policy"

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -12,7 +12,8 @@ module "identity_progress_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     ], var.is_orch_stubbed ? [] : [
-    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn
+    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_cross_account_read_access_policy[0].arn
   ])
   extra_tags = {
     Service = "identity-progress"

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -28,10 +28,11 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-dev-tfstate"
 
-orch_account_id                       = "058264132019"
-is_orch_stubbed                       = false
-orch_environment                      = "integration"
-orch_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:058264132019:key/1b5c001b-ed53-4a7b-bfbe-5d0f596110b5"
+orch_account_id                              = "058264132019"
+is_orch_stubbed                              = false
+orch_environment                             = "integration"
+orch_session_table_encryption_key_arn        = "arn:aws:kms:eu-west-2:058264132019:key/1b5c001b-ed53-4a7b-bfbe-5d0f596110b5"
+orch_client_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:058264132019:key/fdf1686f-2d4d-4c7b-b3be-324b6ebba370"
 
 orch_trustmark_enabled               = true
 orch_openid_configuration_enabled    = true

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -45,8 +45,9 @@ module "ipv_processing_identity_role_with_orch_session_table_access" {
     local.identity_credentials_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_decrypt_policy[0].arn,
-    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn,
-    aws_iam_policy.dynamo_orch_session_cross_account_delete_access_policy[0].arn
+    aws_iam_policy.dynamo_orch_session_cross_account_read_and_delete_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_access_policy[0].arn,
   ]
 }
 moved {

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -26,10 +26,11 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-prod-tfstate"
 
-orch_account_id                       = "533266965190"
-is_orch_stubbed                       = false
-orch_environment                      = "production"
-orch_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:533266965190:key/7ad27a55-9d21-47f2-be03-b61f2c9a8ce6"
+orch_account_id                              = "533266965190"
+is_orch_stubbed                              = false
+orch_environment                             = "production"
+orch_session_table_encryption_key_arn        = "arn:aws:kms:eu-west-2:533266965190:key/7ad27a55-9d21-47f2-be03-b61f2c9a8ce6"
+orch_client_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:533266965190:key/9b57120e-3bcd-4fce-ada8-89ea9d1412d6"
 
 orch_trustmark_enabled               = true
 orch_openid_configuration_enabled    = true

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -66,8 +66,9 @@ orch_userinfo_enabled                = true
 orch_storage_token_jwk_enabled       = true
 orch_ipv_jwks_enabled                = true
 
-orch_account_id                       = "816047645251"
-is_orch_stubbed                       = false
-orch_environment                      = "dev"
-orch_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:816047645251:key/645669ba-b288-4b63-bfe1-9d8bde9956ec"
-cmk_for_back_channel_logout_enabled   = true
+orch_account_id                              = "816047645251"
+is_orch_stubbed                              = false
+orch_environment                             = "dev"
+orch_session_table_encryption_key_arn        = "arn:aws:kms:eu-west-2:816047645251:key/645669ba-b288-4b63-bfe1-9d8bde9956ec"
+orch_client_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:816047645251:key/4cd7c551-128f-4579-99c2-a7f1bff64fb7"
+cmk_for_back_channel_logout_enabled          = true

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -26,11 +26,12 @@ authentication_attempts_service_enabled = true
 ipv_auth_authorize_callback_uri = "https://signin.staging.account.gov.uk/ipv/callback/authorize"
 ipv_auth_authorize_client_id    = "auth"
 
-orch_account_id                       = "590183975515"
-is_orch_stubbed                       = false
-orch_environment                      = "staging"
-orch_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:590183975515:key/156f87e0-001a-4ae8-a6c1-23f8f68b6e84"
-cmk_for_back_channel_logout_enabled   = true
+orch_account_id                              = "590183975515"
+is_orch_stubbed                              = false
+orch_environment                             = "staging"
+orch_session_table_encryption_key_arn        = "arn:aws:kms:eu-west-2:590183975515:key/156f87e0-001a-4ae8-a6c1-23f8f68b6e84"
+orch_client_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:590183975515:key/b94d81a1-a41f-4e61-859c-87dcacb32e51"
+cmk_for_back_channel_logout_enabled          = true
 
 contra_state_bucket = "di-auth-staging-tfstate"
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -664,6 +664,11 @@ variable "orch_session_table_encryption_key_arn" {
   default = ""
 }
 
+variable "orch_client_session_table_encryption_key_arn" {
+  type    = string
+  default = ""
+}
+
 variable "cmk_for_back_channel_logout_enabled" {
   default     = false
   type        = bool

--- a/template.yaml
+++ b/template.yaml
@@ -1345,6 +1345,7 @@ Resources:
         - !Ref RedisParametersAccessPolicy
         - !Ref DocAppSigningKmsAccessPolicy
         - !Ref OrchSessionTableReadAccessPolicy
+        - !Ref ClientSessionTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -1483,6 +1484,8 @@ Resources:
         - !Ref InvokeFetchJwksHandlerPolicy
         - !Ref RpPublicKeyCacheTableReadAccessPolicy
         - !Ref RpPublicKeyCacheTableWriteAccessPolicy
+        - !Ref ClientSessionTableReadAccessPolicy
+        - !Ref ClientSessionTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -1690,6 +1693,8 @@ Resources:
         - !Ref BackChannelLogoutQueueWritePolicy
         - !Ref OrchSessionTableReadAccessPolicy
         - !Ref OrchSessionTableDeleteAccessPolicy
+        - !Ref ClientSessionTableReadAccessPolicy
+        - !Ref ClientSessionTableDeleteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -2019,6 +2024,7 @@ Resources:
         - !Ref IpvPublicEncryptionKeyAccessPolicy
         - !Ref AccountInterventionsServiceUriSecretAccessPolicy
         - !Ref OrchSessionTableReadWriteAndDeleteAccessPolicy
+        - !Ref ClientSessionTableReadWriteAndDeleteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -2662,6 +2668,7 @@ Resources:
         - !Ref RpPublicKeyCacheTableReadAccessPolicy
         - !Ref OrchSessionTableReadAndWriteAccessPolicy
         - !Ref OrchSessionTableDeleteAccessPolicy
+        - !Ref ClientSessionTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -3060,6 +3067,7 @@ Resources:
         - !Ref RedisParametersAccessPolicy
         - !Ref OrchSessionTableReadAccessPolicy
         - !Ref OrchSessionTableWriteAccessPolicy
+        - !Ref ClientSessionTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -3716,6 +3724,8 @@ Resources:
         - !Ref OrchSessionTableWriteAccessPolicy
         - !Ref OrchSessionTableDeleteAccessPolicy
         - !Ref AuthUserInfoTableReadAccessPolicy
+        - !Ref ClientSessionTableReadAccessPolicy
+        - !Ref ClientSessionTableDeleteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -4389,6 +4399,89 @@ Resources:
             Action:
               - kms:Encrypt
             Resource: !GetAtt AuthUserInfoTableEncryptionKey.Arn
+
+  ClientSessionTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowClientSessionTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt ClientSessionTable.Arn
+          - Sid: AllowClientSessionTableDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: !GetAtt ClientSessionTableEncryptionKey.Arn
+
+  ClientSessionTableWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowClientSessionTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+            Resource: !GetAtt ClientSessionTable.Arn
+          - Sid: AllowClientSessionTableEncryption
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+            Resource: !GetAtt ClientSessionTableEncryptionKey.Arn
+
+  ClientSessionTableDeleteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowClientSessionTableDeleteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DeleteItem
+            Resource: !GetAtt ClientSessionTable.Arn
+
+  # This combined read, write and delete policy is required because we've reached the managed polices per role quota limit.
+  ClientSessionTableReadWriteAndDeleteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowClientSessionTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt ClientSessionTable.Arn
+          - Sid: AllowClientSessionTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+            Resource: !GetAtt ClientSessionTable.Arn
+          - Sid: AllowClientSessionTableDeleteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DeleteItem
+            Resource: !GetAtt ClientSessionTable.Arn
+          - Sid: AllowClientSessionTableEncryption
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+            Resource: !GetAtt ClientSessionTableEncryptionKey.Arn
+          - Sid: AllowClientSessionTableDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: !GetAtt ClientSessionTableEncryptionKey.Arn
 
   IdentityCredentialsTableReadAccessPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
### Wider context of change

Part of the work to migrate to storing client sessions in an orch dynamo table

### What’s changed

This PR adds the relevant permissions to lambdas so they can access the new ClientSession dynamo table. Note that the lambdas aren't using the new table yet this is just for adding permissions so they can use it.


### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required 
   - [x] Deployment to orch dev was successful. 
   - [x] Deployment to sandpit was successful.
   - [x] Deployment to authdev1 was successful
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
