### PR TITLE
ATO-1405: check userInfo from claimsRequest is not null

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -320,7 +320,8 @@ public class TokenService {
                         .subject(rpPairwiseSubject.getValue())
                         .jwtID(jwtID);
 
-        if (Objects.nonNull(claimsRequest)) {
+        if (Objects.nonNull(claimsRequest)
+                && Objects.nonNull(claimsRequest.getUserInfoClaimsRequest())) {
             LOG.info("Populating identity claims in access token");
             claimSetBuilder.claim(
                     "claims",


### PR DESCRIPTION
### Wider context of change

The claimsRequest object is checked to be not null but an RP could attach a claim with a null userinfo, which causes a null pointer exception to be thrown.

### What’s changed

Added a check to ensure the userinfo field is not null before calling it.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **not required**
- [x] Changes have been made to the simulator or not required. **not required**
- [x] Changes have been made to stubs or not required. **not required**
- [x] Successfully deployed to authdev or not required. **not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **not required**
