### PR TITLE
ATO-1456: add email address to AuthSessionItem

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -132,6 +132,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             var userProfile = authenticationService.getUserProfileByEmailMaybe(emailAddress);
             var userExists = userProfile.isPresent();
             userContext.getSession().setEmailAddress(emailAddress);
+            userContext.getAuthSession().setEmailAddress(emailAddress);
 
             var session = userContext.getSession();
             var sessionId = userContext.getAuthSession().getSessionId();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -178,6 +178,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
             authSessionService.updateSession(
                     authSessionItem
                             .withAccountState(AuthSessionItem.AccountState.NEW)
+                            .withEmailAddress(request.getEmail())
                             .withInternalCommonSubjectId(internalCommonSubjectId.getValue()));
             LOG.info("Successfully processed request");
             return generateApiGatewayProxyResponse(200, "");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -13,6 +13,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
     public static final String ATTRIBUTE_UPLIFT_REQUIRED = "UpliftRequired";
+    public static final String ATTRIBUTE_EMAIL = "Email";
 
     public enum AccountState {
         NEW,
@@ -28,6 +29,7 @@ public class AuthSessionItem {
     private CredentialTrustLevel currentCredentialStrength;
     private String internalCommonSubjectId;
     private boolean upliftRequired;
+    private String emailAddress;
 
     public AuthSessionItem() {}
 
@@ -128,6 +130,20 @@ public class AuthSessionItem {
 
     public AuthSessionItem withUpliftRequired(boolean upliftRequired) {
         this.upliftRequired = upliftRequired;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_EMAIL)
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    public void setEmailAddress(String emailAddress) {
+        this.emailAddress = emailAddress;
+    }
+
+    public AuthSessionItem withEmailAddress(String emailAddress) {
+        this.emailAddress = emailAddress;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -14,6 +14,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
     public static final String ATTRIBUTE_UPLIFT_REQUIRED = "UpliftRequired";
     public static final String ATTRIBUTE_EMAIL = "Email";
+    public static final String ATTRIBUTE_TTL = "ttl";
 
     public enum AccountState {
         NEW,
@@ -76,7 +77,7 @@ public class AuthSessionItem {
         return this;
     }
 
-    @DynamoDbAttribute("ttl")
+    @DynamoDbAttribute(ATTRIBUTE_TTL)
     public long getTimeToLive() {
         return timeToLive;
     }


### PR DESCRIPTION
### Wider context of change

This is part of the session migration work, specifically the email migration. User is fetched from the email address, meaning we need to have the email address to check the user, to then check the email address.

### What’s changed

Added email address to AuthSessionItem

### Manual testing

TBD

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **not required**
- [x] Changes have been made to the simulator or not required. **not required**
- [x] Changes have been made to stubs or not required. **not required**
- [x] Successfully deployed to authdev or not required. **not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **not required**
