### PR TITLE
AUT-4001: Add runbook links for MFA reset alarms

### DIFF
--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -40,6 +40,7 @@ module "account_recovery" {
     INTERNAl_SECTOR_URI      = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AccountRecoveryHandler::handleRequest"
+  runbook_link          = "https://govukverify.atlassian.net/l/cp/LfLKwP4s"
 
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id

--- a/ci/terraform/oidc/id-reverification-state.tf
+++ b/ci/terraform/oidc/id-reverification-state.tf
@@ -27,6 +27,7 @@ module "id_reverification_state" {
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.IDReverificationStateHandler::handleRequest"
+  runbook_link          = "https://govukverify.atlassian.net/l/cp/LfLKwP4s"
 
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id

--- a/ci/terraform/oidc/mfa-reset-authorize.tf
+++ b/ci/terraform/oidc/mfa-reset-authorize.tf
@@ -46,6 +46,7 @@ module "mfa_reset_authorize" {
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetAuthorizeHandler::handleRequest"
+  runbook_link          = "https://govukverify.atlassian.net/l/cp/LfLKwP4s"
 
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id

--- a/ci/terraform/oidc/mfa-reset-jar-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-jar-jwk.tf
@@ -32,6 +32,7 @@ module "mfa_reset_jar_signing_jwk" {
     IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS = aws_kms_alias.ipv_reverification_request_signing_key_alias.name
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetJarJwkHandler::handleRequest"
+  runbook_link          = "https://govukverify.atlassian.net/l/cp/LfLKwP4s"
 
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_resource.auth_frontend_wellknown_resource.id

--- a/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-storage-token-jwk.tf
@@ -28,6 +28,7 @@ module "mfa_reset_storage_token_jwk" {
     MFA_RESET_STORAGE_TOKEN_SIGNING_KEY_ALIAS = aws_kms_alias.mfa_reset_token_signing_key_alias.arn
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetStorageTokenJwkHandler::handleRequest"
+  runbook_link          = "https://govukverify.atlassian.net/l/cp/LfLKwP4s"
 
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_resource.auth_frontend_wellknown_resource.id

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -40,6 +40,7 @@ module "reverification_result" {
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ReverificationResultHandler::handleRequest"
+  runbook_link          = "https://govukverify.atlassian.net/l/cp/LfLKwP4s"
 
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id


### PR DESCRIPTION
## What

These lambdas are used as part of the MFA reset journey. They are all linked to the same runbook, which 2nd-line can use to determine what to do when alarms are raised for the lambdas.

## How to review

1. Code Review
2. Read the linked runbook

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.


