### PR TITLE
ATO-1431: Remove auth shared session id getter

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -52,10 +52,6 @@ public class Session {
         initializeCodeRequestMap();
     }
 
-    public String getSessionId() {
-        return sessionId;
-    }
-
     public Session setSessionId(String sessionId) {
         this.sessionId = sessionId;
         return this;


### PR DESCRIPTION
### Wider context of change

Part of the work to migrate to using AuthSessionItem for getting the session ID.

### What’s changed

There are now no more usages of the session ID getter in the auth shared session. This (tiny) PR is for removing the getter.

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
