### PR TITLE
Aut 4062/mfa reset metrics

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandler.java
@@ -10,6 +10,7 @@ import uk.gov.di.authentication.frontendapi.entity.IDReverificationStateResponse
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.IDReverificationStateService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -25,17 +26,22 @@ public class IDReverificationStateHandler {
     private final Json objectMapper = SerializationService.getInstance();
     private final AuditService auditService;
     private final IDReverificationStateService idReverificationStateService;
+    private final CloudwatchMetricsService cloudwatchMetricsService;
 
     public IDReverificationStateHandler(
-            AuditService auditService, IDReverificationStateService idReverificationStateService) {
+            AuditService auditService,
+            IDReverificationStateService idReverificationStateService,
+            CloudwatchMetricsService cloudwatchMetricsService) {
         this.auditService = auditService;
         this.idReverificationStateService = idReverificationStateService;
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
     }
 
     public IDReverificationStateHandler(ConfigurationService configurationService) {
         this(
                 new AuditService(configurationService),
-                new IDReverificationStateService(configurationService));
+                new IDReverificationStateService(configurationService),
+                new CloudwatchMetricsService(configurationService));
     }
 
     public IDReverificationStateHandler() {
@@ -70,6 +76,7 @@ public class IDReverificationStateHandler {
                 auditContext,
                 AuditService.MetadataPair.pair(
                         "journey-type", JourneyType.ACCOUNT_RECOVERY.getValue()));
+        cloudwatchMetricsService.incrementReverifyAuthorisationErrorCount();
         var response =
                 new IDReverificationStateResponse(
                         idReverificationState.getOrchestrationRedirectUrl());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
@@ -10,7 +10,8 @@ public enum CloudwatchMetricDimensions {
     CLIENT_NAME("ClientName"),
     CREDENTIAL_TYPE("CredentialType"),
     JOURNEY_TYPE("JourneyType"),
-    FAILURE_REASON("FailureReason");
+    FAILURE_REASON("FailureReason"),
+    IPV_RESPONSE("IpvResponse");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -19,7 +19,8 @@ public enum CloudwatchMetrics {
             "AccessTokenServiceConsistentReadQueryAttempt"),
     ACCESS_TOKEN_SERVICE_CONSISTENT_READ_QUERY_SUCCESS(
             "AccessTokenServiceConsistentReadQueryAttemptSuccess"),
-    USER_SUBMITTED_CREDENTIAL("UserSubmittedCredential");
+    USER_SUBMITTED_CREDENTIAL("UserSubmittedCredential"),
+    MFA_RESET_IPV_RESPONSE("MfaResetIpvResponse");
     private String value;
 
     CloudwatchMetrics(String value) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -20,7 +20,8 @@ public enum CloudwatchMetrics {
     ACCESS_TOKEN_SERVICE_CONSISTENT_READ_QUERY_SUCCESS(
             "AccessTokenServiceConsistentReadQueryAttemptSuccess"),
     USER_SUBMITTED_CREDENTIAL("UserSubmittedCredential"),
-    MFA_RESET_IPV_RESPONSE("MfaResetIpvResponse");
+    MFA_RESET_IPV_RESPONSE("MfaResetIpvResponse"),
+    MFA_RESET_AUTHORISATION_ERROR("ReverifyAuthorisationError");
     private String value;
 
     CloudwatchMetrics(String value) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -13,6 +13,7 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.CLIENT_NAME;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.IPV_RESPONSE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.IS_TEST;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_REQUIRED;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.REQUESTED_LEVEL_OF_CONFIDENCE;
@@ -21,6 +22,7 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTIC
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_NEW_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.EMAIL_CHECK_DURATION;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_HANDOFF;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_IPV_RESPONSE;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
 public class CloudwatchMetricsService {
@@ -121,6 +123,16 @@ public class CloudwatchMetricsService {
         incrementCounter(
                 MFA_RESET_HANDOFF.getValue(),
                 Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
+    }
+
+    public void incrementMfaResetIpvResponseCount(String ipvResponse) {
+        incrementCounter(
+                MFA_RESET_IPV_RESPONSE.getValue(),
+                Map.of(
+                        ENVIRONMENT.getValue(),
+                        configurationService.getEnvironment(),
+                        IPV_RESPONSE.getValue(),
+                        ipvResponse));
     }
 
     public DimensionSet getDimensions(Map<String, String> dimensions) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -21,6 +21,7 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTIC
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_EXISTING_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_NEW_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.EMAIL_CHECK_DURATION;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_AUTHORISATION_ERROR;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_HANDOFF;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.MFA_RESET_IPV_RESPONSE;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -133,6 +134,12 @@ public class CloudwatchMetricsService {
                         configurationService.getEnvironment(),
                         IPV_RESPONSE.getValue(),
                         ipvResponse));
+    }
+
+    public void incrementReverifyAuthorisationErrorCount() {
+        incrementCounter(
+                MFA_RESET_AUTHORISATION_ERROR.getValue(),
+                Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
     }
 
     public DimensionSet getDimensions(Map<String, String> dimensions) {


### PR DESCRIPTION
## What

Added metrics for MFA reset with IPV:
- Metric in ReverificationResultHandler to count the different responses returned from IPV.
- Metric in IDReverificationStateHandler to count the number of error responses returned from IPV.

Following this PR being merged an additional panel will be added on the ‘Sign In/Sign Up’ [dashboard](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-7d%20to%20now;gf=all;id=1588f7b7-0df7-4730-b726-6b9320bc7cc7) to track these metrics

## How to review

1. Code Review
2. Go through mfa reset journey, see metrics in cloudwatch: 
    - "MfaResetIpvResponse" for regular journey and "MfaResetError" for cross brower journey
