### PR TITLE
ATO-1406: Remove session id setters from shared sessions

### DIFF
--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
@@ -60,7 +60,7 @@ class UserInfoHandlerTest {
     private static final UserInfo TEST_SUBJECT_USER_INFO = new UserInfo(TEST_SUBJECT);
     private final AuditService auditService = mock(AuditService.class);
     private final String sessionId = "a-session-id";
-    private final Session testSession = new Session(sessionId);
+    private final Session testSession = new Session();
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(sessionId);
     private final SerializationService objectMapper = SerializationService.getInstance();
     private final String testVerifiedMfaMethodType = MFAMethodType.AUTH_APP.getValue();

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -120,7 +120,7 @@ class DocAppCallbackHandlerTest {
     private static final State RP_STATE = new State();
     private static final Nonce NONCE = new Nonce();
 
-    private final Session session = new Session(SESSION_ID).setEmailAddress(TEST_EMAIL_ADDRESS);
+    private final Session session = new Session().setEmailAddress(TEST_EMAIL_ADDRESS);
     private final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID)
                     .withAccountState(OrchSessionItem.AccountState.EXISTING_DOC_APP_JOURNEY);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -60,7 +60,7 @@ public class StartService {
     public Session createNewSessionWithExistingIdAndClientSession(
             String sessionId, String clientSessionId) {
         LOG.info("Creating new session with existing sessionID");
-        Session session = new Session(sessionId);
+        Session session = new Session();
         session.addClientSession(clientSessionId);
         sessionService.storeOrUpdateSession(session, sessionId);
         return session;

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -120,7 +120,6 @@ class AccountInterventionsHandlerTest {
     private final Session session =
             new Session(SESSION_ID)
                     .setEmailAddress(EMAIL)
-                    .setSessionId(SESSION_ID)
                     .setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
     private final AuthSessionItem authSession =
             new AuthSessionItem()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -118,7 +118,7 @@ class AccountInterventionsHandlerTest {
 
     private static final ClientSession clientSession = getClientSession();
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
     private final AuthSessionItem authSession =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
@@ -62,7 +62,7 @@ class AccountRecoveryHandlerTest {
     private final String internalCommonSubjectId =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT_ID.getValue(), "test.account.gov.uk", SALT);
-    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private final Session session = new Session().setEmailAddress(EMAIL);
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
 
     private final AuditContext auditContext =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -117,7 +117,7 @@ class AuthenticationAuthCodeHandlerTest {
 
     @BeforeEach
     void setUp() throws Json.JsonException {
-        session = new Session(SESSION_ID).setEmailAddress(CommonTestVariables.EMAIL);
+        session = new Session().setEmailAddress(CommonTestVariables.EMAIL);
         authSession = new AuthSessionItem().withSessionId(SESSION_ID);
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
@@ -72,7 +72,7 @@ class CheckEmailFraudBlockHandlerTest {
     private static UserContext userContext;
     private static AuthSessionService authSessionServiceMock;
 
-    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private final Session session = new Session().setEmailAddress(EMAIL);
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
     private CheckEmailFraudBlockHandler handler;
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -90,7 +90,7 @@ class CheckReAuthUserHandlerTest {
             apiRequestEventWithHeadersAndBody(VALID_HEADERS, null);
 
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(EMAIL_USED_TO_SIGN_IN)
                     .setInternalCommonSubjectIdentifier(TEST_SUBJECT_ID);
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -98,7 +98,7 @@ class CheckUserExistsHandlerTest {
     private CheckUserExistsHandler handler;
     private static final Json objectMapper = SerializationService.getInstance();
     private final Session session =
-            new Session(SESSION_ID).setInternalCommonSubjectIdentifier("test-subject-id");
+            new Session().setInternalCommonSubjectIdentifier("test-subject-id");
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
     private static final String CLIENT_ID = "test-client-id";
     private static final String CLIENT_NAME = "test-client-name";

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -105,7 +105,7 @@ class LoginHandlerReauthenticationRedisTest {
                     .withMfaMethodType(MFAMethodType.AUTH_APP.getValue())
                     .withMethodVerified(true)
                     .withEnabled(true);
-    private static final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private static final Session session = new Session().setEmailAddress(EMAIL);
     private LoginHandler handler;
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -125,7 +125,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     .withMfaMethodType(MFAMethodType.AUTH_APP.getValue())
                     .withMethodVerified(true)
                     .withEnabled(true);
-    private static final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private static final Session session = new Session().setEmailAddress(EMAIL);
     private final Context context = mock(Context.class);
     private final Subject subject = mock(Subject.class);
     private final String expectedCommonSubject =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -117,7 +117,7 @@ class LoginHandlerTest {
                     .withMethodVerified(true)
                     .withEnabled(true);
     private static final Json objectMapper = SerializationService.getInstance();
-    private static final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private static final Session session = new Session().setEmailAddress(EMAIL);
     private LoginHandler handler;
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -123,7 +123,7 @@ class MfaHandlerTest {
                     Optional.of(ENCODED_DEVICE_DETAILS));
 
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
     private final AuthSessionItem authSession =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
@@ -67,7 +67,7 @@ class MfaResetAuthorizeHandlerTest {
     private static final SessionService sessionService = mock(SessionService.class);
     private static final UserContext userContext = mock(UserContext.class);
     private static final Session session =
-            new Session(SESSION_ID).setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
+            new Session().setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
     private static final AuditService auditService = mock(AuditService.class);
     private static final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -134,7 +134,7 @@ class ResetPasswordHandlerTest {
                     Optional.of(ENCODED_DEVICE_DETAILS));
 
     private ResetPasswordHandler handler;
-    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private final Session session = new Session().setEmailAddress(EMAIL);
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
 
     private final ClientRegistry testClientRegistry =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -36,7 +36,6 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
-import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -135,7 +134,7 @@ class ResetPasswordRequestHandlerTest {
                                     "jb2@digital.cabinet-office.gov.uk"));
 
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(CommonTestVariables.EMAIL)
                     .setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
     private final AuthSessionItem authSession =
@@ -478,7 +477,7 @@ class ResetPasswordRequestHandlerTest {
             when(authenticationService.getPhoneNumber(CommonTestVariables.EMAIL))
                     .thenReturn(Optional.of(CommonTestVariables.UK_MOBILE_NUMBER));
             when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                    .thenReturn(Optional.of(new Session(IdGenerator.generate())));
+                    .thenReturn(Optional.of(new Session()));
 
             APIGatewayProxyResponseEvent result = handler.handleRequest(validEvent, context);
 
@@ -556,7 +555,7 @@ class ResetPasswordRequestHandlerTest {
     }
 
     private void usingSessionWithPasswordResetCount(int passwordResetCount) {
-        Session session = new Session(SESSION_ID).setEmailAddress(EMAIL);
+        Session session = new Session().setEmailAddress(EMAIL);
         IntStream.range(0, passwordResetCount)
                 .forEach((i) -> session.incrementPasswordResetCount());
         when(sessionService.getSessionFromRequestHeaders(anyMap()))

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -80,7 +80,6 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.DI_PERSISTENT_SESSION_ID;
-import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.EMAIL;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.ENCODED_DEVICE_DETAILS;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.INTERNAL_COMMON_SUBJECT_ID;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.IP_ADDRESS;
@@ -555,7 +554,7 @@ class ResetPasswordRequestHandlerTest {
     }
 
     private void usingSessionWithPasswordResetCount(int passwordResetCount) {
-        Session session = new Session().setEmailAddress(EMAIL);
+        session.resetPasswordResetCount();
         IntStream.range(0, passwordResetCount)
                 .forEach((i) -> session.incrementPasswordResetCount());
         when(sessionService.getSessionFromRequestHeaders(anyMap()))

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
@@ -86,9 +86,7 @@ class ReverificationResultHandlerTest {
             mock(CloudwatchMetricsService.class);
     private final String subjectId = "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
     private final Session session =
-            new Session(SESSION_ID)
-                    .setEmailAddress(EMAIL)
-                    .setInternalCommonSubjectIdentifier(subjectId);
+            new Session().setEmailAddress(EMAIL).setInternalCommonSubjectIdentifier(subjectId);
     private final AuditContext auditContextWithAllUserInfo =
             new AuditContext(
                     CLIENT_ID,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -136,7 +136,7 @@ class SendNotificationHandlerTest {
     private static final Json objectMapper = SerializationService.getInstance();
 
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
     private final AuthSessionItem authSession =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -106,7 +106,7 @@ class SignUpHandlerTest {
 
     private SignUpHandler handler;
 
-    private final Session session = new Session(SESSION_ID);
+    private final Session session = new Session();
     private final ClientSession clientSession =
             new ClientSession(
                     generateAuthRequest().toParameters(), null, (VectorOfTrust) null, CLIENT_NAME);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -126,7 +126,7 @@ class StartHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
-    private final Session session = new Session(SESSION_ID);
+    private final Session session = new Session();
     private final ClientSession clientSession = getClientSession();
     private final ClientSession docAppClientSession = getDocAppClientSession();
     private static final AuditContext AUDIT_CONTEXT =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -92,7 +92,7 @@ class UpdateProfileHandlerTest {
     private final String TERMS_AND_CONDITIONS_VERSION =
             configurationService.getTermsAndConditionsVersion();
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
     private final AuthSessionItem authSession =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -131,11 +131,10 @@ class VerifyCodeHandlerTest {
             ClientSubjectHelper.calculatePairwiseIdentifier(TEST_SUBJECT_ID, SECTOR_HOST, SALT);
     // TODO do we need both session and sessionForTestClient here?
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(expectedCommonSubject);
-    private final Session sessionForTestClient =
-            new Session(SESSION_ID_FOR_TEST_CLIENT).setEmailAddress(TEST_CLIENT_EMAIL);
+    private final Session sessionForTestClient = new Session().setEmailAddress(TEST_CLIENT_EMAIL);
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final ClientService clientService = mock(ClientService.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -125,7 +125,7 @@ class VerifyMfaCodeHandlerTest {
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(TEST_SUBJECT_ID, SECTOR_HOST, SALT);
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(expectedCommonSubject);
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -69,7 +69,7 @@ class StartServiceTest {
     private static final ClientID CLIENT_ID = new ClientID("client-id");
     private static final String CLIENT_NAME = "test-client";
     private static final String SESSION_ID = "a-session-id";
-    private static final Session SESSION = new Session(SESSION_ID).setEmailAddress(EMAIL);
+    private static final Session SESSION = new Session().setEmailAddress(EMAIL);
     private static final AuthSessionItem AUTH_SESSION =
             new AuthSessionItem().withSessionId(SESSION_ID);
     private static final Scope SCOPES =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -84,7 +84,7 @@ class AuthAppCodeProcessorTest {
     @BeforeEach
     void setUp() {
         this.session =
-                new Session(SESSION_ID)
+                new Session()
                         .setEmailAddress(EMAIL)
                         .setInternalCommonSubjectIdentifier(INTERNAL_SUB_ID);
         this.mockSession = mock(Session.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -54,7 +54,7 @@ class PhoneNumberCodeProcessorTest {
 
     private PhoneNumberCodeProcessor phoneNumberCodeProcessor;
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(EMAIL)
                     .setInternalCommonSubjectIdentifier(INTERNAL_SUB_ID);
     private final AuthSessionItem authSession = mock(AuthSessionItem.class);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -928,7 +928,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         private void setupPreviousSessions(String internalCommonSubjectId)
                 throws Json.JsonException {
-            var session = new Session(PREVIOUS_SESSION_ID).setEmailAddress(TEST_EMAIL_ADDRESS);
+            var session = new Session().setEmailAddress(TEST_EMAIL_ADDRESS);
             PREVIOUS_CLIENT_SESSIONS.forEach(session::addClientSession);
             redis.addSessionWithId(session, PREVIOUS_SESSION_ID);
             redis.addStateToRedis(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -58,7 +58,7 @@ class AuthOrchSerializationServicesIntegrationTest {
     @Test
     void orchCanReadFromSessionCreatedByAuth() {
         var sessionId = "some-existing-session-id";
-        var authSession = new Session(sessionId);
+        var authSession = new Session();
         authSession.addClientSession(CLIENT_SESSION_ID);
         authSessionService.storeOrUpdateSession(authSession, sessionId);
         var orchSession = orchSessionService.getSession(sessionId).get();
@@ -79,7 +79,7 @@ class AuthOrchSerializationServicesIntegrationTest {
     @Test
     void orchCanUpdateSharedFieldInSessionCreatedByAuth() {
         var sessionId = "some-existing-session-id";
-        var authSession = new Session(sessionId);
+        var authSession = new Session();
         authSessionService.storeOrUpdateSession(authSession, sessionId);
         var orchSession = orchSessionService.getSession(sessionId).get();
         orchSession.addClientSession(CLIENT_SESSION_ID);
@@ -103,7 +103,7 @@ class AuthOrchSerializationServicesIntegrationTest {
     @Test
     void authCanReadUnsharedFieldAfterOrchUpdatesSession() {
         var sessionId = "some-existing-session-id";
-        var authSession = new Session(sessionId);
+        var authSession = new Session();
         authSession.incrementPasswordResetCount();
         authSession.incrementPasswordResetCount();
         authSession.incrementPasswordResetCount();
@@ -136,7 +136,7 @@ class AuthOrchSerializationServicesIntegrationTest {
         orchSession.addClientSession(CLIENT_SESSION_ID);
         orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
-        var authSession = new Session(SESSION_ID);
+        var authSession = new Session();
         authSessionService.storeOrUpdateSession(authSession, SESSION_ID);
         orchSession = orchSessionService.getSession(SESSION_ID).get();
         assertThat(orchSession.getClientSessions(), is(empty()));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -48,7 +48,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void authCanReadFromSessionCreatedByOrch() {
-        var orchSession = orchSessionService.generateSession(SESSION_ID);
+        var orchSession = orchSessionService.generateSession();
         orchSession.addClientSession(CLIENT_SESSION_ID);
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
@@ -67,7 +67,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void authCanUpdateSharedFieldInSessionCreatedByOrch() {
-        var orchSession = orchSessionService.generateSession(SESSION_ID);
+        var orchSession = orchSessionService.generateSession();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
@@ -90,7 +90,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void orchCanReadUnsharedFieldAfterAuthUpdatesSession() {
-        var orchSession = orchSessionService.generateSession(SESSION_ID);
+        var orchSession = orchSessionService.generateSession();
         orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
@@ -119,7 +119,7 @@ class AuthOrchSerializationServicesIntegrationTest {
     void authCanReadSessionAfterSessionIdIsUpdated() {
         var oldSessionId = SESSION_ID;
         var newSessionId = "new-session-id";
-        var orchSession = orchSessionService.generateSession(oldSessionId);
+        var orchSession = orchSessionService.generateSession();
         orchSessionService.storeOrUpdateSession(orchSession, oldSessionId);
         var authSession = authSessionService.getSession(oldSessionId).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
@@ -132,7 +132,7 @@ class AuthOrchSerializationServicesIntegrationTest {
 
     @Test
     void authCanResetSharedFieldsWithoutOverridingUnsharedFields() {
-        var orchSession = orchSessionService.generateSession(SESSION_ID);
+        var orchSession = orchSessionService.generateSession();
         orchSession.addClientSession(CLIENT_SESSION_ID);
         orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -191,7 +191,7 @@ class IPVCallbackHandlerTest {
             new CaptureLoggingExtension(IPVCallbackHandler.class);
 
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(TEST_EMAIL_ADDRESS)
                     .setInternalCommonSubjectIdentifier(TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER);
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -94,7 +94,7 @@ public class IdentityProgressFrontendHandlerTest {
             mock(AuthenticationUserInfoStorageService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
     private final Session session =
-            new Session(SESSION_ID).setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
+            new Session().setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
     private final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID).withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID);
     private final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -109,7 +109,7 @@ class ProcessingIdentityHandlerTest {
             mock(CloudwatchMetricsService.class);
     private final LogoutService logoutService = mock(LogoutService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
-    private final Session session = new Session(SESSION_ID);
+    private final Session session = new Session();
     private final OrchSessionItem orchSession = new OrchSessionItem(SESSION_ID);
     private final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
     protected final Json objectMapper = SerializationService.getInstance();

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -783,7 +783,7 @@ public class AuthorisationHandler
             String newSessionId) {
         sessionService.updateWithNewSessionId(
                 previousSession, previousSessionId, newSessionIdForPreviousSession);
-        var newSession = sessionService.copySessionForMaxAge(previousSession, newSessionId);
+        var newSession = sessionService.copySessionForMaxAge(previousSession);
         sessionService.storeOrUpdateSession(newSession, newSessionId);
         return newSession;
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -517,7 +517,7 @@ public class AuthorisationHandler
         var newBrowserSessionId = IdGenerator.generate();
         var existingSession = existingSessionId.flatMap(sessionService::getSession);
         if (existingSessionId.isEmpty() || existingSession.isEmpty()) {
-            session = sessionService.generateSession(newSessionId);
+            session = sessionService.generateSession();
             updateAttachedSessionIdToLogs(newSessionId);
             LOG.info("Created new session with ID {}", newSessionId);
         } else {
@@ -639,7 +639,7 @@ public class AuthorisationHandler
         if (existingSessionId.isEmpty()
                 || existingSession.isEmpty()
                 || existingOrchSessionOptional.isEmpty()) {
-            session = sessionService.generateSession(newSessionId);
+            session = sessionService.generateSession();
             orchSession = createNewOrchSession(newSessionId, newBrowserSessionId);
             LOG.info("Created session with id: {}", newSessionId);
         } else {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
@@ -464,7 +464,7 @@ class LogoutRequestTest {
     }
 
     private Session generateSession() {
-        return new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID);
+        return new Session().addClientSession(CLIENT_SESSION_ID);
     }
 
     private void generateSessionFromCookie(Session session, OrchSessionItem orchSession) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -140,7 +140,7 @@ class AuthCodeHandlerTest {
     private static final Json objectMapper = SerializationService.getInstance();
     private AuthCodeHandler handler;
 
-    private final Session session = new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID);
+    private final Session session = new Session().addClientSession(CLIENT_SESSION_ID);
     private final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID)
                     .withAccountState(OrchSessionItem.AccountState.NEW)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -145,7 +145,7 @@ class AuthenticationCallbackHandlerTest {
     private static final String SESSION_ID = "a-session-id";
 
     private static final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setVerifiedMfaMethodType(MFAMethodType.EMAIL)
                     .setAuthenticated(false)
                     .setCurrentCredentialStrength(null)
@@ -626,7 +626,7 @@ class AuthenticationCallbackHandlerTest {
     void shouldAuditMediumCredentialTrustLevelOn1FARequestWhenPreviously2FA()
             throws UnsuccessfulCredentialResponseException {
         Session mediumLevelSession =
-                new Session(SESSION_ID)
+                new Session()
                         .setVerifiedMfaMethodType(MFAMethodType.EMAIL)
                         .setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
         when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(mediumLevelSession));
@@ -1245,7 +1245,7 @@ class AuthenticationCallbackHandlerTest {
         }
 
         private void withPreviousSharedSessionDueToMaxAge() {
-            var previousSharedSession = new Session(PREVIOUS_SESSION_ID);
+            var previousSharedSession = new Session();
             PREVIOUS_CLIENT_SESSIONS.forEach(previousSharedSession::addClientSession);
             previousSharedSession.setEmailAddress(TEST_EMAIL_ADDRESS);
             when(sessionService.getSession(PREVIOUS_SESSION_ID))
@@ -1270,7 +1270,7 @@ class AuthenticationCallbackHandlerTest {
         }
 
         private Session withMaxAgeSharedSession() {
-            var session = new Session(SESSION_ID);
+            var session = new Session();
             when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
             return session;
         }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -2586,8 +2586,7 @@ class AuthorisationHandlerTest {
             when(configService.supportMaxAgeEnabled()).thenReturn(true);
             when(configService.getSessionExpiry()).thenReturn(3600L);
             withExistingSession(session);
-            when(sessionService.copySessionForMaxAge(any(Session.class), anyString()))
-                    .thenCallRealMethod();
+            when(sessionService.copySessionForMaxAge(any(Session.class))).thenCallRealMethod();
         }
 
         @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -311,10 +311,10 @@ class AuthorisationHandlerTest {
                         tokenValidationService,
                         authFrontend,
                         authorisationService);
-        session = new Session(SESSION_ID);
-        newSession = new Session(NEW_SESSION_ID);
+        session = new Session();
+        newSession = new Session();
         orchSession = new OrchSessionItem(SESSION_ID);
-        when(sessionService.generateSession(anyString())).thenReturn(newSession);
+        when(sessionService.generateSession()).thenReturn(newSession);
         when(clientSessionService.generateClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(clientSessionService.generateClientSession(any(), any(), any(), any()))
                 .thenReturn(clientSession);
@@ -1687,7 +1687,7 @@ class AuthorisationHandlerTest {
 
         @Test
         void shouldAddPreviousSessionIdClaimIfThereIsAnExistingSession() throws ParseException {
-            when(sessionService.getSession(any())).thenReturn(Optional.of(new Session(SESSION_ID)));
+            when(sessionService.getSession(any())).thenReturn(Optional.of(new Session()));
 
             var requestParams =
                     buildRequestParams(
@@ -2011,8 +2011,7 @@ class AuthorisationHandlerTest {
 
             @BeforeEach
             void setup() {
-                when(sessionService.generateSession(anyString()))
-                        .thenReturn(new Session(NEW_SESSION_ID));
+                when(sessionService.generateSession()).thenReturn(new Session());
             }
 
             @Test
@@ -2021,7 +2020,7 @@ class AuthorisationHandlerTest {
                 withExistingOrchSession(null);
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
-                verify(sessionService).generateSession(NEW_SESSION_ID);
+                verify(sessionService).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
@@ -2051,7 +2050,7 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
-                verify(sessionService).generateSession(NEW_SESSION_ID);
+                verify(sessionService).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
@@ -2080,7 +2079,7 @@ class AuthorisationHandlerTest {
                 withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
                 APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
-                verify(sessionService).generateSession(NEW_SESSION_ID);
+                verify(sessionService).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
@@ -2109,7 +2108,7 @@ class AuthorisationHandlerTest {
                 withExistingOrchSession(orchSession.withBrowserSessionId(null));
                 var response = makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
-                verify(sessionService, never()).generateSession(anyString());
+                verify(sessionService, never()).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
@@ -2144,7 +2143,7 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
-                verify(sessionService, never()).generateSession(anyString());
+                verify(sessionService, never()).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
@@ -2174,7 +2173,7 @@ class AuthorisationHandlerTest {
                 APIGatewayProxyResponseEvent response =
                         makeRequestWithBSIDInCookie(DIFFERENT_BROWSER_SESSION_ID);
 
-                verify(sessionService).generateSession(NEW_SESSION_ID);
+                verify(sessionService).generateSession();
                 verify(sessionService)
                         .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -322,12 +322,7 @@ class AuthorisationHandlerTest {
         when(clientService.getClient(anyString()))
                 .thenReturn(Optional.of(generateClientRegistry()));
         when(sessionService.updateWithNewSessionId(any(Session.class), anyString(), anyString()))
-                .then(
-                        invocation -> {
-                            Session sessionToUpdate = invocation.getArgument(0);
-                            sessionToUpdate.setSessionId(invocation.getArgument(2));
-                            return sessionToUpdate;
-                        });
+                .then(invocation -> invocation.<Session>getArgument(0));
     }
 
     @Nested

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -244,7 +244,7 @@ class LogoutHandlerTest {
     }
 
     private Session generateSession() {
-        return new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID);
+        return new Session().addClientSession(CLIENT_SESSION_ID);
     }
 
     private void saveSession(Session session) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -126,7 +126,7 @@ public class InitiateIPVAuthorisationServiceTest {
     private final AuthenticationRequest authenticationRequest = mock(AuthenticationRequest.class);
     private final UserInfo userInfo = generateUserInfo();
     private final Session session =
-            new Session(SESSION_ID)
+            new Session()
                     .setEmailAddress(EMAIL_ADDRESS)
                     .setInternalCommonSubjectIdentifier(expectedCommonSubject);
     private final ClientRegistry client = generateClientRegistry();

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -49,7 +49,7 @@ public class RedisExtension
 
     private String createSession(String sessionId, boolean isAuthenticated, Optional<String> email)
             throws Json.JsonException {
-        Session session = new Session(sessionId).setAuthenticated(isAuthenticated);
+        Session session = new Session().setAuthenticated(isAuthenticated);
         email.ifPresent(session::setEmailAddress);
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
         return sessionId;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -66,10 +66,6 @@ public class Session {
         initializeCodeRequestMap();
     }
 
-    public void setSessionId(String sessionId) {
-        this.sessionId = sessionId;
-    }
-
     public List<String> getClientSessions() {
         return clientSessions;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -21,7 +21,6 @@ public class Session {
     }
 
     @Expose private String sessionId;
-
     @Expose private List<String> clientSessions;
 
     @Expose private String emailAddress;
@@ -42,8 +41,7 @@ public class Session {
 
     @Expose private String internalCommonSubjectIdentifier;
 
-    public Session(String sessionId) {
-        this.sessionId = sessionId;
+    public Session() {
         this.clientSessions = new ArrayList<>();
         this.isNewAccount = AccountState.UNKNOWN;
         this.processingIdentityAttempts = 0;
@@ -52,7 +50,6 @@ public class Session {
     }
 
     public Session(Session session) {
-        this.sessionId = session.sessionId;
         this.clientSessions = session.clientSessions;
         this.isNewAccount = session.isNewAccount;
         this.processingIdentityAttempts = session.processingIdentityAttempts;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -30,8 +30,8 @@ public class SessionService {
                         configurationService.getRedisPassword()));
     }
 
-    public Session generateSession(String sessionId) {
-        return new Session(sessionId);
+    public Session generateSession() {
+        return new Session();
     }
 
     public Session copySessionForMaxAge(Session previousSession, String newSessionId) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -36,7 +36,6 @@ public class SessionService {
 
     public Session copySessionForMaxAge(Session previousSession, String newSessionId) {
         var copiedSession = new Session(previousSession);
-        copiedSession.setSessionId(newSessionId);
         copiedSession.setAuthenticated(false).setCurrentCredentialStrength(null);
         copiedSession.resetClientSessions();
         return copiedSession;
@@ -64,7 +63,6 @@ public class SessionService {
     public Session updateWithNewSessionId(
             Session session, String oldSessionId, String newSessionId) {
         try {
-            session.setSessionId(newSessionId);
             session.resetProcessingIdentityAttempts();
             storeOrUpdateSession(session, oldSessionId, newSessionId);
             redisConnectionService.deleteValue(oldSessionId);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -34,7 +34,7 @@ public class SessionService {
         return new Session();
     }
 
-    public Session copySessionForMaxAge(Session previousSession, String newSessionId) {
+    public Session copySessionForMaxAge(Session previousSession) {
         var copiedSession = new Session(previousSession);
         copiedSession.setAuthenticated(false).setCurrentCredentialStrength(null);
         copiedSession.resetClientSessions();

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelperTest.java
@@ -43,7 +43,7 @@ class DocAppUserHelperTest {
     private static final ClientID CLIENT_ID = new ClientID("client-id");
     private static final String CLIENT_NAME = "test-client";
     private static final String SESSION_ID = "a-session-id";
-    private static final Session SESSION = new Session(SESSION_ID);
+    private static final Session SESSION = new Session();
     private static final String AUDIENCE = "oidc-audience";
     private static final Scope VALID_SCOPE =
             new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/TestClientHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/TestClientHelperTest.java
@@ -136,7 +136,7 @@ class TestClientHelperTest {
                         .withTestClient(isTestClient)
                         .withTestClientEmailAllowlist(allowedEmails);
         var sessionId = IdGenerator.generate();
-        return UserContext.builder(new Session(sessionId).setEmailAddress(TEST_EMAIL_ADDRESS))
+        return UserContext.builder(new Session().setEmailAddress(TEST_EMAIL_ADDRESS))
                 .withSessionId(sessionId)
                 .withClient(clientRegistry)
                 .build();

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
@@ -48,7 +48,7 @@ class AuthCodeResponseGenerationServiceTest {
                 new OrchSessionItem(SESSION_ID)
                         .withAccountState(NEW)
                         .withVerifiedMfaMethodType(AUTH_APP.toString());
-        session = new Session(SESSION_ID);
+        session = new Session();
         authCodeResponseGenerationService =
                 new AuthCodeResponseGenerationService(configurationService, dynamoService);
         clientSession =

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -180,7 +180,7 @@ class LogoutServiceTest {
         rpPairwiseId = Optional.of(idToken.getJWTClaimsSet().getSubject());
 
         session =
-                new Session(SESSION_ID)
+                new Session()
                         .setEmailAddress(EMAIL)
                         .setInternalCommonSubjectIdentifier(SUBJECT.getValue());
         setUpClientSession(CLIENT_SESSION_ID, CLIENT_ID);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
@@ -24,7 +24,7 @@ class SessionServiceTest {
     void shouldPersistSessionToRedisWithExpiry() throws Json.JsonException {
         when(configuration.getSessionExpiry()).thenReturn(1234L);
 
-        var session = new Session("session-id").addClientSession("client-session-id");
+        var session = new Session().addClientSession("client-session-id");
 
         sessionService.storeOrUpdateSession(session, "session-id");
 
@@ -34,7 +34,7 @@ class SessionServiceTest {
 
     @Test
     void shouldUpdateSessionIdInRedisAndDeleteOldKey() {
-        var session = new Session("session-id").addClientSession("client-session-id");
+        var session = new Session().addClientSession("client-session-id");
 
         sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.updateWithNewSessionId(session, "session-id", "new-session-id");
@@ -46,7 +46,7 @@ class SessionServiceTest {
 
     @Test
     void shouldDeleteSessionIdFromRedis() {
-        var session = new Session("session-id").addClientSession("client-session-id");
+        var session = new Session().addClientSession("client-session-id");
 
         sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.deleteStoredSession("session-id");

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -56,7 +56,7 @@ public class RedisExtension
 
     private String createSession(String sessionId, boolean isAuthenticated, Optional<String> email)
             throws Json.JsonException {
-        Session session = new Session(sessionId).setAuthenticated(isAuthenticated);
+        Session session = new Session().setAuthenticated(isAuthenticated);
         email.ifPresent(session::setEmailAddress);
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
         return sessionId;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -21,7 +21,6 @@ public class Session {
     }
 
     @Expose private String sessionId;
-
     @Expose private List<String> clientSessions;
 
     @Expose private String emailAddress;
@@ -44,8 +43,7 @@ public class Session {
 
     @Expose private String internalCommonSubjectIdentifier;
 
-    public Session(String sessionId) {
-        this.sessionId = sessionId;
+    public Session() {
         this.clientSessions = new ArrayList<>();
         this.isNewAccount = AccountState.UNKNOWN;
         this.codeRequestCountMap = new HashMap<>();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -52,11 +52,6 @@ public class Session {
         initializeCodeRequestMap();
     }
 
-    public Session setSessionId(String sessionId) {
-        this.sessionId = sessionId;
-        return this;
-    }
-
     public List<String> getClientSessions() {
         return clientSessions;
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelperTest.java
@@ -40,7 +40,7 @@ class DocAppUserHelperTest {
 
     private static final ClientID CLIENT_ID = new ClientID("client-id");
     private static final String CLIENT_NAME = "test-client";
-    private static final Session SESSION = new Session("a-session-id");
+    private static final Session SESSION = new Session();
     private static final String AUDIENCE = "oidc-audience";
     private static final Scope VALID_SCOPE =
             new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/SessionTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/SessionTest.java
@@ -4,7 +4,6 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -17,7 +16,7 @@ class SessionTest {
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     new Subject().getValue(), "test.account.gov.uk", SaltHelper.generateNewSalt());
     private final Session session =
-            new Session(IdGenerator.generate())
+            new Session()
                     .setEmailAddress("joe.bloggs@test.com")
                     .setInternalCommonSubjectIdentifier(expectedCommonSubject);
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
@@ -135,8 +135,7 @@ class TestClientHelperTest {
                         .withClientName("some-client")
                         .withTestClient(isTestClient)
                         .withTestClientEmailAllowlist(allowedEmails);
-        return UserContext.builder(
-                        new Session(IdGenerator.generate()).setEmailAddress(TEST_EMAIL_ADDRESS))
+        return UserContext.builder(new Session().setEmailAddress(TEST_EMAIL_ADDRESS))
                 .withClient(clientRegistry)
                 .build();
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
@@ -33,7 +33,7 @@ class SessionServiceTest {
     void shouldPersistSessionToRedisWithExpiry() throws Json.JsonException {
         when(configuration.getSessionExpiry()).thenReturn(1234L);
 
-        var session = new Session(SESSION_ID).addClientSession("client-session-id");
+        var session = new Session().addClientSession("client-session-id");
 
         sessionService.storeOrUpdateSession(session, SESSION_ID);
 
@@ -138,7 +138,7 @@ class SessionServiceTest {
 
     @Test
     void shouldDeleteSessionIdFromRedis() {
-        var session = new Session(SESSION_ID).addClientSession("client-session-id");
+        var session = new Session().addClientSession("client-session-id");
 
         sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.deleteSessionFromRedis(SESSION_ID);
@@ -147,7 +147,7 @@ class SessionServiceTest {
     }
 
     private String generateSearlizedSession() throws Json.JsonException {
-        var session = new Session(SESSION_ID).addClientSession("client-session-id");
+        var session = new Session().addClientSession("client-session-id");
 
         return objectMapper.writeValueAsString(session);
     }


### PR DESCRIPTION
### Wider context of change

This PR is the final step in migrating away from using shared sessions to store session IDs. At this point both orch and auth shared sessions have a session ID field that isn't used, but is set in multiple places.

### What’s changed

This PR removes all usage of the session ID setters, and updates constructors to not set the session ID.

A lot of the changes in this PR have been done by Safe Deleting unused methods/parameters using IntelliJ.

I've left the session ID field in both shared sessions, just in case something is expecting it there. We can always remove it later if we need to.

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required - Ran through multiple journeys and all seemed ok
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
