### PR TITLE
ATO-1391: duplicate roles to remove auth user info policies

### DIFF
--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -1,3 +1,6 @@
+// There are two roles here. Only the "old" one is in use, but I need to deploy the new role
+// before using it, as I have removed a policy from part way through the policies_to_attach
+
 module "oidc_api_authentication_callback_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -1,4 +1,4 @@
-module "oidc_api_authentication_callback_role" {
+module "oidc_api_authentication_callback_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "oidc-api-authentication-callback-role"

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -23,6 +23,31 @@ module "oidc_api_authentication_callback_role" {
   }
 }
 
+module "oidc_api_authentication_callback_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "oidc-api-authentication-callback-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.storage_token_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
+    aws_iam_policy.dynamo_authentication_callback_userinfo_write_access_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.ipv_token_auth_kms_policy.arn,
+    aws_iam_policy.ipv_public_encryption_key_parameter_policy.arn,
+    aws_iam_policy.orch_to_auth_kms_policy.arn,
+    aws_iam_policy.authentication_callback_userinfo_encryption_key_kms_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn
+  ]
+  extra_tags = {
+    Service = "orchestration-redirect"
+  }
+}
+
 
 module "authentication_callback" {
   source = "../modules/endpoint-module-v2"

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -7,13 +7,10 @@ module "oidc_api_authentication_callback_role_1" {
   policies_to_attach = [
     aws_iam_policy.storage_token_kms_signing_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
-    aws_iam_policy.dynamo_authentication_callback_userinfo_write_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.ipv_token_auth_kms_policy.arn,
     aws_iam_policy.ipv_public_encryption_key_parameter_policy.arn,
     aws_iam_policy.orch_to_auth_kms_policy.arn,
-    aws_iam_policy.authentication_callback_userinfo_encryption_key_kms_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -6,9 +6,7 @@ module "identity_progress_role_1" {
 
   policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
     aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
-    aws_iam_policy.authentication_callback_userinfo_encryption_key_kms_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     ], var.is_orch_stubbed ? [] : [

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -1,3 +1,6 @@
+// There are two roles here. Only the "old" one is in use, but I need to deploy the new role
+// before using it, as I have removed a policy from part way through the policies_to_attach
+
 module "identity_progress_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -1,4 +1,4 @@
-module "identity_progress_role" {
+module "identity_progress_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "identity-progress-role"

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -19,6 +19,27 @@ module "identity_progress_role" {
   }
 }
 
+module "identity_progress_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "identity-progress-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = concat([
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
+    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
+    aws_iam_policy.authentication_callback_userinfo_encryption_key_kms_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    ], var.is_orch_stubbed ? [] : [
+    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn
+  ])
+  extra_tags = {
+    Service = "identity-progress"
+  }
+}
+
 module "identity_progress" {
   source = "../modules/endpoint-module-v2"
 

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -1,3 +1,6 @@
+// There are two roles here. Only the "old" one is in use, but I need to deploy the new role
+// before using it, as I have removed a policy from part way through the policies_to_attach
+
 module "oidc_userinfo_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -12,8 +12,6 @@ module "oidc_userinfo_role_1" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
-    aws_iam_policy.authentication_callback_userinfo_encryption_key_kms_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.identity_credentials_encryption_policy_arn,

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -25,6 +25,33 @@ module "oidc_userinfo_role" {
   }
 }
 
+module "oidc_userinfo_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "oidc-userinfo-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
+    aws_iam_policy.oidc_token_kms_signing_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
+    aws_iam_policy.authentication_callback_userinfo_encryption_key_kms_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    local.identity_credentials_encryption_policy_arn,
+    local.doc_app_credential_encryption_policy_arn,
+    local.user_credentials_encryption_policy_arn
+  ]
+  extra_tags = {
+    Service = "userinfo"
+  }
+}
+
 module "userinfo" {
   source = "../modules/endpoint-module-v2"
 

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -1,4 +1,4 @@
-module "oidc_userinfo_role" {
+module "oidc_userinfo_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment
   role_name   = "oidc-userinfo-role"


### PR DESCRIPTION
### Wider context of change
We are deleting the authUserInfo table. In order to remove it, we need to delete the polices associated with it, but these exist part way through `policies_to_attach` already. Hence, we first need to define and deploy a new role first.

### What’s changed
Creates a new role for each lambda that needs it

### Manual testing
tbd: deploy to auth dev

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not Needed**
- [x] Changes have been made to the simulator or not required. **Not Needed**
- [x] Changes have been made to stubs or not required. **Not Needed**
- [ ] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not Needed**

### Related PRs
https://github.com/govuk-one-login/authentication-api/pull/5928