### PR TITLE
BAU: fix for Aws account no starting with zero need a double quote

### DIFF
--- a/ci/terraform/shared/build.tfvars
+++ b/ci/terraform/shared/build.tfvars
@@ -3,7 +3,7 @@ common_state_bucket = "digital-identity-dev-tfstate"
 # Account IDs
 tools_account_id         = 706615647326
 orchestration_account_id = 767397776536
-auth_new_account_id      = 058264536367
+auth_new_account_id      = "058264536367"
 
 # CIDR blocks
 orch_privatesub_cidr_blocks       = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]


### PR DESCRIPTION
## What

Fix for AWS account no starting with zero need a double quote

## How to review
1. Code Review
