### PR TITLE
ATO-1469: create new identity credentials table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -595,6 +595,61 @@ Resources:
           Value: ClientSessionTable
   #endregion
 
+  #region IdentityCredentials DynamoDB Table
+  IdentityCredentialsTableEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS encryption key for IdentityCredentials DynamoDB table
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Sid: AllowDynamodbAccessToEncryptionKey
+            Effect: Allow
+            Principal:
+              Service: dynamodb.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+
+  IdentityCredentialsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${Environment}-Identity-Credentials
+      AttributeDefinitions:
+        - AttributeName: ClientSessionId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: ClientSessionId
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEEnabled: true
+        KMSMasterKeyId: !GetAtt IdentityCredentialsTableEncryptionKey.Arn
+        SSEType: KMS
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - Key: Name
+          Value: IdentityCredentialsTable
+  #endregion
+
   #region RP Public Key DynamoDB Table
 
   RpPublicKeyTableEncryptionKey:


### PR DESCRIPTION
### Wider context of change
Part of the migration of the IdentityCredentials table to Orch accounts. We are using clientSessionId (aka journeyId) as the sort key.

### What’s changed
Added new table in IaC.

### Manual testing
n/a

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not needed**
- [x] Changes have been made to the simulator or not required. **Not needed**
- [x] Changes have been made to stubs or not required. **Not needed**
- [x] Successfully deployed to authdev or not required. **Not needed**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not needed**