### PR TITLE
AUT-4046: Enable DynamoDB tables backup for Prod

### DIFF
--- a/ci/terraform/interventions-api-stub/dynamodb.tf
+++ b/ci/terraform/interventions-api-stub/dynamodb.tf
@@ -16,7 +16,7 @@ resource "aws_dynamodb_table" "stub_account_interventions_table" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -77,7 +77,7 @@ resource "aws_dynamodb_table" "user_credentials_table" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -169,7 +169,7 @@ resource "aws_dynamodb_table" "user_profile_table" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -218,7 +218,7 @@ resource "aws_dynamodb_table" "client_registry_table" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -259,7 +259,7 @@ resource "aws_dynamodb_table" "identity_credentials_table" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -300,7 +300,7 @@ resource "aws_dynamodb_table" "doc_app_credential_table" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -360,7 +360,7 @@ resource "aws_dynamodb_table" "common_passwords_table" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -396,7 +396,7 @@ resource "aws_dynamodb_table" "account_modifiers_table" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -437,7 +437,7 @@ resource "aws_dynamodb_table" "access_token_store" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -478,7 +478,7 @@ resource "aws_dynamodb_table" "auth_code_store" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -542,7 +542,7 @@ resource "aws_dynamodb_table" "bulk_email_users" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -596,7 +596,7 @@ resource "aws_dynamodb_table" "authentication_callback_userinfo" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -638,7 +638,7 @@ resource "aws_dynamodb_table" "email-check-result" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -681,7 +681,7 @@ resource "aws_dynamodb_table" "authentication_attempt_table" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -780,7 +780,7 @@ resource "aws_dynamodb_table" "auth_session_table" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}
@@ -817,7 +817,7 @@ resource "aws_dynamodb_table" "id_reverification_state" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}

--- a/ci/terraform/ticf-cri-stub/dynamodb.tf
+++ b/ci/terraform/ticf-cri-stub/dynamodb.tf
@@ -16,7 +16,7 @@ resource "aws_dynamodb_table" "stub_ticf_cri_table" {
   }
 
   tags = (
-    var.environment == "integration" ?
+    var.environment == "integration" || var.environment == "production" ?
     {
       "BackupFrequency" = "Bihourly"
     } : {}


### PR DESCRIPTION
##What

AUT-4046 : Added tags for AWS Automated backup for dynamo db table in PROD  according to RTO & RPO for AUTH https://govukverify.atlassian.net/wiki/spaces/Architecture/pages/3834384121/ADR+0048+ADR+Recovery+Time+Objective+RTO+and+Recovery+Point+Objective+RPO.

This persistent data backup is requirement for Backup as service initiative disaster recovery exercise.

## How to review
Code Review
Deploy to dev env it should not add additional tags to dynamo DB tables