### PR TITLE
BAU: try to prevent modules from being renamed or removed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,32 @@ repos:
 
   - repo: local
     hooks:
+      - id: check-module-renamed
+        name: Check if any module has been renamed
+        stages:
+          - pre-commit
+        language: python
+        pass_filenames: false
+        additional_dependencies:
+          - GitPython~=3.1
+          - python-hcl2~=6.1
+        types: [terraform]
+        entry: scripts/prevent-module-renaming.py
+      - id: check-module-renamed-manual
+        name: Check if any module has been renamed (manually)
+        stages:
+          - manual
+        language: python
+        pass_filenames: false
+        additional_dependencies:
+          - GitPython~=3.1
+          - python-hcl2~=6.1
+        types: [terraform]
+        entry: scripts/prevent-module-renaming.py
+        args: ["--manual"]
+
+  - repo: local
+    hooks:
       - id: tflint
         name: Init tflint (hack)
         files: ^ci/terraform/

--- a/deploy-dev.sh
+++ b/deploy-dev.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 
+pushd "${DIR}" > /dev/null
+pre-commit run check-module-renamed-manual --all-files --hook-stage manual
+popd > /dev/null
+
 environments=("authdev1" "authdev2" "sandpit")
 
 function usage() {

--- a/scripts/prevent-module-renaming.py
+++ b/scripts/prevent-module-renaming.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+
+import hcl2
+from git import Repo
+
+FROM_REF = os.getenv("PRE_COMMIT_FROM_REF", "HEAD")
+TO_REF = os.getenv("PRE_COMMIT_TO_REF", None)
+
+
+def get_removed_modules(called_manually: bool = True) -> dict[str, str]:
+    repo = Repo(os.getcwd())
+    if called_manually:
+        try:
+            merge_base = repo.merge_base(repo.head.commit, "main")[0]
+            diffs = merge_base.diff(None)
+            diffs += repo.head.commit.diff(None)
+        except Exception:
+            diffs = repo.index.diff(None)
+            diffs += repo.head.commit.diff(None)
+    else:
+        diffs = repo.commit(FROM_REF).diff(TO_REF)
+
+    modules_and_origin: dict[str, str] = {}
+    before = set()
+    after = set()
+    for diff in diffs:
+        if not diff.a_path.endswith(".tf"):
+            continue
+        if diff.change_type not in ["M", "D"]:
+            continue
+        before_modules = extract_module_names(
+            hcl2.loads(diff.a_blob.data_stream.read().decode())
+        )
+        for module_name in before_modules:
+            modules_and_origin[module_name] = diff.a_path
+        before.update(before_modules)
+        try:
+            after.update(
+                extract_module_names(
+                    hcl2.loads(diff.b_blob.data_stream.read().decode())
+                )
+            )
+        except AttributeError:
+            pass
+
+    return {module: modules_and_origin[module] for module in before - after}
+
+
+def extract_module_names(hcldict: dict) -> set[str]:
+    modules = hcldict.get("module", [])
+    module_names = set()
+    for module in modules:
+        for module_name, config in module.items():
+            if "endpoint-module-v2" in config.get("source", ""):
+                module_names.add(module_name)
+    return module_names
+
+
+if __name__ == "__main__":
+    if os.getenv("PRE_COMMIT", "0") == "0":
+        print("This script is meant to be run by pre-commit.", file=sys.stderr)
+        sys.exit(1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manual", action="store_true", default=False)
+    args = parser.parse_args()
+
+    removed_modules = get_removed_modules(args.manual)
+
+    if removed_modules:
+        print(
+            "The following 'endpoint-module-v2' terraform modules were removed (or renamed). This causes problems and should not be done.",
+            file=sys.stderr,
+        )
+        for module_name, original_path in removed_modules.items():
+            print(f"{module_name} ({original_path})", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print("No modules were removed.", file=sys.stderr)


### PR DESCRIPTION
## What

Because of circular dependencies, we cannot rename or remove modules.

- Add a pre-commit check to ensure that no deletion / rename has happened
- Add a manual check to the deploy script to prevent deploy

This is probably possible to work around (ie. if you don't rebase before merge) but it's a simple footcanon prevention for most cases.

## How to review

1. code review
2. rename a module, try to run `deploy-dev.sh` and observe that it errors out
3. remove a module, try to run `deploy-dev.sh` and observe that it errors out
4. attempt to commit the change, observe that it's blocked
5. commit with `--no-verify`, add another change (`git commit --allow-empty -m 'test'`), observe that it errors in CI
