### PR TITLE
ATO-1456: remove AuthSessionItem email address migration log check

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -29,7 +29,6 @@ import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
@@ -228,11 +227,6 @@ public abstract class BaseFrontendHandler<T>
         clientID.ifPresent(c -> userContextBuilder.withClient(clientService.getClient(c)));
 
         clientSession.ifPresent(userContextBuilder::withClientSession);
-
-        LOG.info(
-                "Auth session email migration check {}",
-                Objects.equals(
-                        session.get().getEmailAddress(), authSession.get().getEmailAddress()));
 
         authSession
                 .map(AuthSessionItem::getEmailAddress)


### PR DESCRIPTION
### Wider context of change

This is part of the session migration work, specifically the email migration.

### What’s changed

Remove logs after check.

### Manual testing

Checked splunk

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required**
- [x] Changes have been made to the simulator or not required. **Not required**
- [x] Changes have been made to stubs or not required. **Not required**
- [x] Successfully deployed to authdev or not required. **Not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required**

