### PR TITLE
ATO-1468 VerifyMfaCodeHandler read email AuthSessionItem

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
@@ -21,12 +21,12 @@ public class SessionHelper {
             AuthenticationService authenticationService,
             ConfigurationService configurationService) {
         LOG.info("Calculating internal common subject identifier");
-        var session = userContext.getSession();
         var authSession = userContext.getAuthSession();
         UserProfile userProfile =
                 userContext.getUserProfile().isPresent()
                         ? userContext.getUserProfile().get()
-                        : authenticationService.getUserProfileByEmail(session.getEmailAddress());
+                        : authenticationService.getUserProfileByEmail(
+                                authSession.getEmailAddress());
         var internalCommonSubjectId =
                 authSession.getInternalCommonSubjectId() != null
                         ? authSession.getInternalCommonSubjectId()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.frontendapi.helpers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler;
-import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
@@ -17,13 +16,13 @@ public class SessionHelper {
 
     public static void updateSessionWithSubject(
             UserContext userContext,
-            AuthSessionItem authSession,
             SessionService sessionService,
             AuthSessionService authSessionService,
             AuthenticationService authenticationService,
             ConfigurationService configurationService) {
         LOG.info("Calculating internal common subject identifier");
         var session = userContext.getSession();
+        var authSession = userContext.getAuthSession();
         UserProfile userProfile =
                 userContext.getUserProfile().isPresent()
                         ? userContext.getUserProfile().get()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -228,7 +228,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             if (codeRequestType.equals(CodeRequestType.PW_RESET_MFA_SMS)) {
                 SessionHelper.updateSessionWithSubject(
                         userContext,
-                        authSession,
                         sessionService,
                         authSessionService,
                         authenticationService,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -194,13 +194,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         try {
             String subjectID = userProfileMaybe.map(UserProfile::getSubjectID).orElse(null);
             return verifyCode(
-                    input,
-                    codeRequest,
-                    userContext,
-                    subjectID,
-                    authSession,
-                    maybeRpPairwiseId,
-                    client);
+                    input, codeRequest, userContext, subjectID, maybeRpPairwiseId, client);
         } catch (Exception e) {
             LOG.error("Unexpected exception thrown");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
@@ -279,12 +273,12 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             VerifyMfaCodeRequest codeRequest,
             UserContext userContext,
             String subjectId,
-            AuthSessionItem authSession,
             Optional<String> maybeRpPairwiseId,
             ClientRegistry client) {
 
         var session = userContext.getSession();
-        var sessionId = userContext.getAuthSession().getSessionId();
+        var authSession = userContext.getAuthSession();
+        var sessionId = authSession.getSessionId();
         var mfaCodeProcessor =
                 mfaCodeProcessorFactory
                         .getMfaCodeProcessor(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -174,7 +174,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 auditContextFromUserContext(
                         userContext,
                         authSession.getInternalCommonSubjectId(),
-                        userContext.getSession().getEmailAddress(),
+                        authSession.getEmailAddress(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         extractPersistentIdFromHeaders(input.getHeaders()));
@@ -310,7 +310,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             if (errorResponse.equals(ErrorResponse.ERROR_1034)
                     || errorResponse.equals(ErrorResponse.ERROR_1042)) {
                 blockCodeForSessionAndResetCountIfBlockDoesNotExist(
-                        userContext.getSession().getEmailAddress(),
+                        userContext.getAuthSession().getEmailAddress(),
                         codeRequest.getMfaMethodType(),
                         codeRequest.getJourneyType());
             }
@@ -349,13 +349,13 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 auditContextFromUserContext(
                         userContext,
                         authSession.getInternalCommonSubjectId(),
-                        session.getEmailAddress(),
+                        authSession.getEmailAddress(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         extractPersistentIdFromHeaders(input.getHeaders()));
 
         var metadataPairs =
-                metadataPairsForEvent(auditableEvent, session.getEmailAddress(), codeRequest);
+                metadataPairsForEvent(auditableEvent, authSession.getEmailAddress(), codeRequest);
 
         auditService.submitAuditEvent(auditableEvent, auditContext, metadataPairs);
 
@@ -416,7 +416,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 clientId,
                 userContext.getClientName(),
                 levelOfConfidence.getValue(),
-                clientService.isTestJourney(clientId, session.getEmailAddress()),
+                clientService.isTestJourney(clientId, authSession.getEmailAddress()),
                 true);
 
         return ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -299,7 +299,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         if (JourneyType.PASSWORD_RESET_MFA.equals(codeRequest.getJourneyType())) {
             SessionHelper.updateSessionWithSubject(
                     userContext,
-                    authSession,
                     sessionService,
                     authSessionService,
                     authenticationService,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
@@ -34,7 +34,7 @@ public abstract class MfaCodeProcessor {
             AuthenticationService dynamoService,
             AuditService auditService,
             DynamoAccountModifiersService accountModifiersService) {
-        this.emailAddress = userContext.getSession().getEmailAddress();
+        this.emailAddress = userContext.getAuthSession().getEmailAddress();
         this.userContext = userContext;
         this.codeStorageService = codeStorageService;
         this.maxRetries = maxRetries;

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -118,7 +118,10 @@ class AuthenticationAuthCodeHandlerTest {
     @BeforeEach
     void setUp() throws Json.JsonException {
         session = new Session().setEmailAddress(CommonTestVariables.EMAIL);
-        authSession = new AuthSessionItem().withSessionId(SESSION_ID);
+        authSession =
+                new AuthSessionItem()
+                        .withSessionId(SESSION_ID)
+                        .withEmailAddress(CommonTestVariables.EMAIL);
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(clientSession));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -131,6 +131,7 @@ class VerifyMfaCodeHandlerTest {
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
+                    .withEmailAddress(EMAIL)
                     .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID);
     private final Json objectMapper = SerializationService.getInstance();
     public VerifyMfaCodeHandler handler;

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -49,7 +49,6 @@ import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_B
 
 class AuthAppCodeProcessorTest {
     AuthAppCodeProcessor authAppCodeProcessor;
-    Session mockSession;
     AuthSessionItem authSession;
     CodeStorageService mockCodeStorageService;
     ConfigurationService mockConfigurationService;
@@ -83,11 +82,11 @@ class AuthAppCodeProcessorTest {
 
     @BeforeEach
     void setUp() {
-        this.session = new Session().setEmailAddress(EMAIL);
-        this.mockSession = mock(Session.class);
+        this.session = new Session();
         this.authSession =
                 new AuthSessionItem()
                         .withSessionId(SESSION_ID)
+                        .withEmailAddress(EMAIL)
                         .withInternalCommonSubjectId(INTERNAL_SUB_ID);
         this.mockCodeStorageService = mock(CodeStorageService.class);
         this.mockConfigurationService = mock(ConfigurationService.class);
@@ -96,7 +95,7 @@ class AuthAppCodeProcessorTest {
         this.mockUserContext = mock(UserContext.class);
         this.mockAccountModifiersService = mock(DynamoAccountModifiersService.class);
         when(mockUserContext.getSession()).thenReturn(session);
-        when(mockUserContext.getAuthSession()).thenReturn(mock(AuthSessionItem.class));
+        when(mockUserContext.getAuthSession()).thenReturn(authSession);
     }
 
     private static Stream<Arguments> validatorParams() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
@@ -3,12 +3,11 @@ package uk.gov.di.authentication.frontendapi.validation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
-import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
@@ -24,8 +23,7 @@ class MfaCodeProcessorFactoryTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final UserContext userContext = mock(UserContext.class);
-    private final Session session = mock(Session.class);
-    private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
+    private final AuthSessionItem authSession = mock(AuthSessionItem.class);
     private final DynamoAccountModifiersService accountModifiersService =
             mock(DynamoAccountModifiersService.class);
     private final MfaCodeProcessorFactory mfaCodeProcessorFactory =
@@ -41,13 +39,12 @@ class MfaCodeProcessorFactoryTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(configurationService.getIncreasedCodeMaxRetries()).thenReturn(999999);
 
-        when(userContext.getSession()).thenReturn(session);
+        when(authSession.getEmailAddress()).thenReturn("test@test.com");
+        when(userContext.getAuthSession()).thenReturn(authSession);
     }
 
     @Test
     void whenMfaMethodGeneratesAuthAppCodeProcessor() {
-        when(session.getEmailAddress()).thenReturn("test@test.com");
-        when(userContext.getSession()).thenReturn(session);
 
         var mfaCodeProcessor =
                 mfaCodeProcessorFactory.getMfaCodeProcessor(
@@ -61,8 +58,6 @@ class MfaCodeProcessorFactoryTest {
 
     @Test
     void whenMfaMethodGeneratesPhoneNumberCodeProcessor() {
-        when(session.getEmailAddress()).thenReturn("test@test.com");
-        when(userContext.getSession()).thenReturn(session);
         when(configurationService.getAwsRegion()).thenReturn("eu-west-2");
         var mfaCodeProcessor =
                 mfaCodeProcessorFactory.getMfaCodeProcessor(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -54,7 +54,11 @@ class PhoneNumberCodeProcessorTest {
 
     private PhoneNumberCodeProcessor phoneNumberCodeProcessor;
     private final Session session = new Session().setEmailAddress(EMAIL);
-    private final AuthSessionItem authSession = mock(AuthSessionItem.class);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withEmailAddress(EMAIL)
+                    .withInternalCommonSubjectId(INTERNAL_SUB_ID);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final UserContext userContext = mock(UserContext.class);
     private final UserProfile userProfile = mock(UserProfile.class);
@@ -394,8 +398,6 @@ class PhoneNumberCodeProcessorTest {
 
     public void setupPhoneNumberCode(CodeRequest codeRequest, CodeRequestType codeRequestType) {
         var differentPhoneNumber = CommonTestVariables.UK_MOBILE_NUMBER.replace("789", "987");
-        when(authSession.getSessionId()).thenReturn(SESSION_ID);
-        when(authSession.getInternalCommonSubjectId()).thenReturn(INTERNAL_SUB_ID);
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(userContext.getClientId()).thenReturn(CLIENT_ID);
         when(userContext.getSession()).thenReturn(session);
@@ -428,6 +430,7 @@ class PhoneNumberCodeProcessorTest {
         when(codeStorageService.getIncorrectMfaCodeAttemptsCount(CommonTestVariables.EMAIL))
                 .thenReturn(6);
         when(userContext.getSession()).thenReturn(session);
+        when(userContext.getAuthSession()).thenReturn(authSession);
         when(configurationService.isTestClientsEnabled()).thenReturn(false);
         when(codeStorageService.getOtpCode(
                         CommonTestVariables.EMAIL, NotificationType.VERIFY_PHONE_NUMBER))
@@ -450,6 +453,7 @@ class PhoneNumberCodeProcessorTest {
     public void setUpBlockedPhoneNumberCode(
             CodeRequest codeRequest, CodeRequestType codeRequestType) {
         when(userContext.getSession()).thenReturn(session);
+        when(userContext.getAuthSession()).thenReturn(authSession);
         when(configurationService.isTestClientsEnabled()).thenReturn(false);
         when(codeStorageService.getOtpCode(
                         CommonTestVariables.EMAIL, NotificationType.VERIFY_PHONE_NUMBER))


### PR DESCRIPTION
### Wider context of change

This is part of the session migration work, specifically the email migration. Use AuthSessionItem email address instead of Session's email address.

### What’s changed

VerifyMfaCodeHandler uses AuthSessionItem. Minor refactoring in code and tests.

### Manual testing

Ran tests and checked logs

### Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required.**
- [x] Changes have been made to the simulator or not required. **Not required.**
- [x] Changes have been made to stubs or not required. **Not required.**
- [x] Successfully deployed to authdev or not required. **Not required.**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required.**

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/6069
https://github.com/govuk-one-login/authentication-api/pull/6070
https://github.com/govuk-one-login/authentication-api/pull/6076
https://github.com/govuk-one-login/authentication-api/pull/6077
https://github.com/govuk-one-login/authentication-api/pull/6078
https://github.com/govuk-one-login/authentication-api/pull/6080