### PR TITLE
ATO-1417: Add code to write to new client session store

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchClientSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchClientSessionServiceIntegrationTest.java
@@ -1,0 +1,158 @@
+package uk.gov.di.authentication.services;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
+import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
+import uk.gov.di.orchestration.shared.exceptions.OrchClientSessionException;
+import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+
+import static java.time.Clock.fixed;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OrchClientSessionServiceIntegrationTest {
+    private static final String CLIENT_SESSION_ID = "test-client-session-id";
+    private static final List<VectorOfTrust> VTR_LIST =
+            List.of(VectorOfTrust.of(CredentialTrustLevel.LOW_LEVEL, LevelOfConfidence.LOW_LEVEL));
+    private final OrchClientSessionItem clientSession =
+            new OrchClientSessionItem(CLIENT_SESSION_ID).withVtrList(VTR_LIST);
+
+    @RegisterExtension
+    protected static final OrchClientSessionExtension clientSessionExtension =
+            new OrchClientSessionExtension();
+
+    @BeforeEach
+    void setup() {
+        clientSessionExtension.setClock(Clock.systemUTC());
+    }
+
+    @Test
+    void shouldStoreClientSessionWithAllFieldsSet() {
+        var creationInstant = Instant.parse("2025-02-20T14:38:30.547Z");
+        var creationDate = LocalDateTime.ofInstant(creationInstant, ZoneId.systemDefault());
+        var docAppSubjectId = new Subject("test-doc-app-subject-id");
+        var rpPairwiseId = "test-rp-pairwise-id";
+        var clientName = "test-client";
+        var authRequestParams = Map.of("test-param", List.of("val1", "val2"));
+        var idTokenHint = "token-hint";
+        var clientSessionWithAllFields =
+                new OrchClientSessionItem(
+                                CLIENT_SESSION_ID,
+                                authRequestParams,
+                                creationDate,
+                                VTR_LIST,
+                                clientName)
+                        .withIdTokenHint(idTokenHint)
+                        .withRpPairwiseId(rpPairwiseId)
+                        .withDocAppSubjectId(docAppSubjectId.getValue());
+
+        // clientSessionService sets TTL when storing a client session
+        // If we fix the time we can assert against the TTL
+        fixTime(creationInstant);
+        clientSessionExtension.storeClientSession(clientSessionWithAllFields);
+
+        var session = clientSessionExtension.getClientSession(CLIENT_SESSION_ID);
+        assertTrue(session.isPresent());
+        assertThat(session.get().getClientSessionId(), equalTo(CLIENT_SESSION_ID));
+        assertThat(session.get().getAuthRequestParams(), equalTo(authRequestParams));
+        assertThat(session.get().getIdTokenHint(), equalTo(idTokenHint));
+        assertThat(session.get().getCreationDate(), equalTo(creationDate));
+        assertThat(session.get().getVtrList(), equalTo(VTR_LIST));
+        assertThat(session.get().getRpPairwiseId(), equalTo(rpPairwiseId));
+        assertThat(session.get().getDocAppSubjectId(), equalTo(docAppSubjectId.getValue()));
+        assertThat(session.get().getClientName(), equalTo(clientName));
+        // Default expiry is 1 hour (3600 seconds)
+        var expectedTimeToLive = creationInstant.plusSeconds(3600).getEpochSecond();
+        assertThat(session.get().getTimeToLive(), equalTo(expectedTimeToLive));
+    }
+
+    @Test
+    void shouldThrowWhenFailingToStoreClientSession() {
+        var invalidClientSession = new OrchClientSessionItem(null);
+        assertThrows(
+                OrchClientSessionException.class,
+                () -> clientSessionExtension.storeClientSession(invalidClientSession));
+    }
+
+    @Test
+    void shouldReturnEmptyOptionalWhenSessionWithIdDoesNotExist() {
+        var session = clientSessionExtension.getClientSession("not-a-client-session-id");
+        assertTrue(session.isEmpty());
+    }
+
+    @Test
+    void shouldThrowWhenFailingToGetClientSessionById() {
+        assertThrows(
+                OrchClientSessionException.class,
+                () -> clientSessionExtension.getClientSession(null));
+    }
+
+    @Test
+    void shouldNotGetClientSessionByIdWhenClientSessionExistsButTimeToLiveExpired() {
+        fixTime(Instant.parse("2025-02-18T11:00:00Z"));
+        clientSessionExtension.storeClientSession(clientSession);
+
+        // Default expiry is 1 hour (3600 seconds)
+        fixTime(Instant.parse("2025-02-18T12:00:01Z"));
+        var clientSessionOpt = clientSessionExtension.getClientSession(CLIENT_SESSION_ID);
+
+        assertTrue(clientSessionOpt.isEmpty());
+    }
+
+    @Test
+    void shouldUpdateClientSession() {
+        clientSessionExtension.storeClientSession(clientSession);
+
+        clientSession.setClientName("new-client-name");
+        clientSessionExtension.updateStoredClientSession(clientSession);
+
+        var actualSession = clientSessionExtension.getClientSession(CLIENT_SESSION_ID);
+        assertTrue(actualSession.isPresent());
+        assertThat(actualSession.get().getClientName(), equalTo("new-client-name"));
+    }
+
+    @Test
+    void shouldThrowWhenUpdatingClientSessionFails() {
+        var clientSessionWithNoId = new OrchClientSessionItem(null);
+        assertThrows(
+                OrchClientSessionException.class,
+                () -> clientSessionExtension.updateStoredClientSession(clientSessionWithNoId));
+    }
+
+    @Test
+    void shouldDeleteClientSession() {
+        clientSessionExtension.storeClientSession(clientSession);
+        var beforeDeletion = clientSessionExtension.getClientSession(CLIENT_SESSION_ID);
+        assertTrue(beforeDeletion.isPresent());
+
+        clientSessionExtension.deleteStoredClientSession(CLIENT_SESSION_ID);
+
+        var afterDeletion = clientSessionExtension.getClientSession(CLIENT_SESSION_ID);
+        assertTrue(afterDeletion.isEmpty());
+    }
+
+    @Test
+    void shouldThrowWhenDeletingClientSessionFails() {
+        assertThrows(
+                OrchClientSessionException.class,
+                () -> clientSessionExtension.deleteStoredClientSession(null));
+    }
+
+    private static void fixTime(Instant time) {
+        clientSessionExtension.setClock(fixed(time, ZoneId.systemDefault()));
+    }
+}

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchClientSessionExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchClientSessionExtension.java
@@ -1,0 +1,90 @@
+package uk.gov.di.orchestration.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
+import uk.gov.di.orchestration.sharedtest.basetest.DynamoTestConfiguration;
+
+import java.time.Clock;
+import java.util.Optional;
+
+public class OrchClientSessionExtension extends DynamoExtension implements AfterEachCallback {
+
+    public static final String TABLE_NAME = "local-Client-Session";
+    public static final String CLIENT_SESSION_ID_FIELD = "ClientSessionId";
+    private OrchClientSessionService orchClientSessionService;
+    private final ConfigurationService configurationService;
+
+    public OrchClientSessionExtension() {
+        createInstance();
+        this.configurationService =
+                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT);
+        orchClientSessionService = new OrchClientSessionService(configurationService);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+
+        orchClientSessionService = new OrchClientSessionService(configurationService);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, TABLE_NAME, CLIENT_SESSION_ID_FIELD);
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(TABLE_NAME)) {
+            createOrchSessionTable();
+        }
+    }
+
+    private void createOrchSessionTable() {
+        CreateTableRequest request =
+                CreateTableRequest.builder()
+                        .tableName(TABLE_NAME)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.HASH)
+                                        .attributeName(CLIENT_SESSION_ID_FIELD)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(CLIENT_SESSION_ID_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .build();
+        dynamoDB.createTable(request);
+    }
+
+    public void storeClientSession(OrchClientSessionItem clientSession) {
+        orchClientSessionService.storeClientSession(clientSession);
+    }
+
+    public void updateStoredClientSession(OrchClientSessionItem clientSession) {
+        orchClientSessionService.updateStoredClientSession(clientSession);
+    }
+
+    public Optional<OrchClientSessionItem> getClientSession(String clientSessionId) {
+        return orchClientSessionService.getClientSession(clientSessionId);
+    }
+
+    public void deleteStoredClientSession(String clientSessionId) {
+        orchClientSessionService.deleteStoredClientSession(clientSessionId);
+    }
+
+    public void setClock(Clock clock) {
+        orchClientSessionService = new OrchClientSessionService(configurationService, clock);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/converters/VtrListConverter.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/converters/VtrListConverter.java
@@ -1,0 +1,43 @@
+package uk.gov.di.orchestration.shared.converters;
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
+import uk.gov.di.orchestration.shared.services.SerializationService;
+
+import java.util.List;
+
+public class VtrListConverter implements AttributeConverter<List<VectorOfTrust>> {
+    private final SerializationService serializationService = SerializationService.getInstance();
+
+    @Override
+    public AttributeValue transformFrom(List<VectorOfTrust> input) {
+        return AttributeValue.fromL(
+                input.stream()
+                        .map(serializationService::writeValueAsString)
+                        .map(AttributeValue::fromS)
+                        .toList());
+    }
+
+    @Override
+    public List<VectorOfTrust> transformTo(AttributeValue input) {
+        return input.l().stream()
+                .map(
+                        value ->
+                                serializationService.readValueUnchecked(
+                                        value.s(), VectorOfTrust.class))
+                .toList();
+    }
+
+    @Override
+    public EnhancedType<List<VectorOfTrust>> type() {
+        return EnhancedType.listOf(VectorOfTrust.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.L;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
@@ -1,0 +1,187 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import uk.gov.di.orchestration.shared.converters.VtrListConverter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@DynamoDbBean
+public class OrchClientSessionItem {
+    private static final String ATTRIBUTE_CLIENT_SESSION_ID = "ClientSessionId";
+    private static final String ATTRIBUTE_AUTH_REQUEST_PARAMS = "AuthRequestParams";
+    private static final String ATTRIBUTE_ID_TOKEN_HINT = "IdTokenHint";
+    private static final String ATTRIBUTE_CREATION_DATE = "CreationDate";
+    private static final String ATTRIBUTE_VTR_LIST = "VtrList";
+    private static final String ATTRIBUTE_RP_PAIRWISE_ID = "RpPairwiseId";
+    private static final String ATTRIBUTE_DOC_APP_SUBJECT_ID = "DocAppSubjectId";
+    private static final String ATTRIBUTE_CLIENT_NAME = "ClientName";
+    private static final String ATTRIBUTE_TTL = "ttl";
+    private String clientSessionId;
+    private Map<String, List<String>> authRequestParams;
+    private String idTokenHint;
+    private LocalDateTime creationDate;
+    private List<VectorOfTrust> vtrList;
+    private String rpPairwiseId;
+    private String docAppSubjectId;
+    private String clientName;
+    private long timeToLive;
+
+    public OrchClientSessionItem() {}
+
+    public OrchClientSessionItem(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+    }
+
+    public OrchClientSessionItem(
+            String clientSessionId,
+            Map<String, List<String>> authRequestParams,
+            LocalDateTime creationDate,
+            List<VectorOfTrust> vtrList,
+            String clientName) {
+        this.clientSessionId = clientSessionId;
+        this.authRequestParams = authRequestParams;
+        this.creationDate = creationDate;
+        this.vtrList = vtrList;
+        this.clientName = clientName;
+    }
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute(ATTRIBUTE_CLIENT_SESSION_ID)
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
+    public void setClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+    }
+
+    public OrchClientSessionItem withClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_AUTH_REQUEST_PARAMS)
+    public Map<String, List<String>> getAuthRequestParams() {
+        return authRequestParams;
+    }
+
+    public void setAuthRequestParams(Map<String, List<String>> authRequestParams) {
+        this.authRequestParams = authRequestParams;
+    }
+
+    public OrchClientSessionItem withAuthRequestParams(
+            Map<String, List<String>> authRequestParams) {
+        this.authRequestParams = authRequestParams;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_ID_TOKEN_HINT)
+    public String getIdTokenHint() {
+        return idTokenHint;
+    }
+
+    public void setIdTokenHint(String idTokenHint) {
+        this.idTokenHint = idTokenHint;
+    }
+
+    public OrchClientSessionItem withIdTokenHint(String idTokenHint) {
+        this.idTokenHint = idTokenHint;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_CREATION_DATE)
+    public LocalDateTime getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(LocalDateTime creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    public OrchClientSessionItem withCreationDate(LocalDateTime creationDate) {
+        this.creationDate = creationDate;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_VTR_LIST)
+    @DynamoDbConvertedBy(VtrListConverter.class)
+    public List<VectorOfTrust> getVtrList() {
+        return vtrList;
+    }
+
+    public void setVtrList(List<VectorOfTrust> vtrList) {
+        this.vtrList = vtrList;
+    }
+
+    public OrchClientSessionItem withVtrList(List<VectorOfTrust> vtrList) {
+        this.vtrList = vtrList;
+        return this;
+    }
+
+    // TODO: I've added this method in case we still need it during the migration.
+    // We should probably remove it if we're not using it after the migration though.
+    public VectorOfTrust getEffectiveVectorOfTrust() {
+        return VectorOfTrust.orderVtrList(vtrList).stream().findFirst().orElse(null);
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_RP_PAIRWISE_ID)
+    public String getRpPairwiseId() {
+        return rpPairwiseId;
+    }
+
+    public void setRpPairwiseId(String rpPairwiseId) {
+        this.rpPairwiseId = rpPairwiseId;
+    }
+
+    public OrchClientSessionItem withRpPairwiseId(String rpPairwiseId) {
+        this.rpPairwiseId = rpPairwiseId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_DOC_APP_SUBJECT_ID)
+    public String getDocAppSubjectId() {
+        return docAppSubjectId;
+    }
+
+    public void setDocAppSubjectId(String docAppSubjectId) {
+        this.docAppSubjectId = docAppSubjectId;
+    }
+
+    public OrchClientSessionItem withDocAppSubjectId(String docAppSubjectId) {
+        this.docAppSubjectId = docAppSubjectId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_CLIENT_NAME)
+    public String getClientName() {
+        return clientName;
+    }
+
+    public void setClientName(String clientName) {
+        this.clientName = clientName;
+    }
+
+    public OrchClientSessionItem withClientName(String clientName) {
+        this.clientName = clientName;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_TTL)
+    public long getTimeToLive() {
+        return timeToLive;
+    }
+
+    public void setTimeToLive(long timeToLive) {
+        this.timeToLive = timeToLive;
+    }
+
+    public OrchClientSessionItem withTimeToLive(long timeToLive) {
+        this.timeToLive = timeToLive;
+        return this;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/OrchClientSessionException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/OrchClientSessionException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.orchestration.shared.exceptions;
+
+public class OrchClientSessionException extends RuntimeException {
+
+    public OrchClientSessionException(String message) {
+        super(message);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchClientSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchClientSessionService.java
@@ -1,0 +1,122 @@
+package uk.gov.di.orchestration.shared.services;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
+import uk.gov.di.orchestration.shared.exceptions.OrchClientSessionException;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static uk.gov.di.orchestration.shared.helpers.NowHelper.NowClock;
+
+public class OrchClientSessionService extends BaseDynamoService<OrchClientSessionItem> {
+    private static final Logger LOG = LogManager.getLogger(OrchClientSessionService.class);
+
+    private final long timeToLive;
+    private final NowClock nowClock;
+
+    public OrchClientSessionService(ConfigurationService configurationService) {
+        this(configurationService, Clock.systemUTC());
+    }
+
+    public OrchClientSessionService(ConfigurationService configurationService, Clock clock) {
+        super(OrchClientSessionItem.class, "Client-Session", configurationService, true);
+        this.timeToLive = configurationService.getSessionExpiry();
+        this.nowClock = new NowClock(clock);
+    }
+
+    public OrchClientSessionService(
+            DynamoDbClient dynamoDbClient,
+            DynamoDbTable<OrchClientSessionItem> dynamoDbTable,
+            ConfigurationService configurationService) {
+        super(dynamoDbTable, dynamoDbClient);
+        this.timeToLive = configurationService.getSessionExpiry();
+        this.nowClock = new NowClock(Clock.systemUTC());
+    }
+
+    public OrchClientSessionItem generateClientSession(
+            String clientSessionId,
+            Map<String, List<String>> authRequestParams,
+            LocalDateTime creationDate,
+            List<VectorOfTrust> vtrList,
+            String clientName) {
+
+        return new OrchClientSessionItem(
+                clientSessionId, authRequestParams, creationDate, vtrList, clientName);
+    }
+
+    public void storeClientSession(OrchClientSessionItem clientSession) {
+        var item =
+                clientSession.withTimeToLive(
+                        nowClock.nowPlus(timeToLive, ChronoUnit.SECONDS)
+                                .toInstant()
+                                .getEpochSecond());
+        try {
+            put(item);
+        } catch (Exception e) {
+            logAndThrowOrchClientSessionException(
+                    "Failed to add Orch client session item",
+                    clientSession.getClientSessionId(),
+                    e);
+        }
+    }
+
+    public Optional<OrchClientSessionItem> getClientSession(String clientSessionId) {
+        Optional<OrchClientSessionItem> clientSession = Optional.empty();
+        try {
+            clientSession = get(clientSessionId);
+        } catch (Exception e) {
+            logAndThrowOrchClientSessionException(
+                    "Failed to get Orch client session item", clientSessionId, e);
+        }
+        if (clientSession.isEmpty()) {
+            LOG.info("No Orch client session item found with clientSessionId {}", clientSessionId);
+            return clientSession;
+        }
+
+        Optional<OrchClientSessionItem> validOrchSession =
+                clientSession.filter(
+                        s -> s.getTimeToLive() > nowClock.now().toInstant().getEpochSecond());
+        if (validOrchSession.isEmpty()) {
+            LOG.info(
+                    "Orch client session item with expired TTL found. Client Session ID: {}",
+                    clientSessionId);
+        }
+        return validOrchSession;
+    }
+
+    public void updateStoredClientSession(OrchClientSessionItem clientSession) {
+        try {
+            update(clientSession);
+        } catch (Exception e) {
+            logAndThrowOrchClientSessionException(
+                    "Error updating Orch client session item",
+                    clientSession.getClientSessionId(),
+                    e);
+        }
+    }
+
+    public void deleteStoredClientSession(String clientSessionId) {
+        try {
+            delete(clientSessionId);
+        } catch (Exception e) {
+            logAndThrowOrchClientSessionException(
+                    "Error deleting orch client session item", clientSessionId, e);
+        }
+    }
+
+    private void logAndThrowOrchClientSessionException(
+            String message, String sessionId, Exception e) {
+        LOG.error(
+                "{}. Client Session ID: {}. Error message: {}", message, sessionId, e.getMessage());
+        throw new OrchClientSessionException(message);
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
@@ -1,0 +1,162 @@
+package uk.gov.di.orchestration.shared.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
+import uk.gov.di.orchestration.shared.exceptions.OrchClientSessionException;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OrchClientSessionServiceTest {
+    private static final String CLIENT_SESSION_ID = "test-client-session-id";
+    private static final String CLIENT_NAME = "test-client-name";
+    private static final long VALID_TTL = Instant.now().plusSeconds(100).getEpochSecond();
+    private static final long EXPIRED_TTL = Instant.now().minusSeconds(100).getEpochSecond();
+    private static final Key CLIENT_SESSION_ID_PARTITION_KEY =
+            Key.builder().partitionValue(CLIENT_SESSION_ID).build();
+
+    private final DynamoDbTable<OrchClientSessionItem> table = mock(DynamoDbTable.class);
+    private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private OrchClientSessionService clientSessionService;
+
+    @BeforeEach
+    void setup() {
+        when(configurationService.getSessionExpiry()).thenReturn(86400L);
+        clientSessionService =
+                new OrchClientSessionService(dynamoDbClient, table, configurationService);
+    }
+
+    @Test
+    void shouldStoreClientSession() {
+        var clientSession = withValidClientSession();
+        clientSessionService.storeClientSession(clientSession);
+        verify(table).putItem(clientSession);
+    }
+
+    @Test
+    void shouldThrowWhenFailingToStoreClientSession() {
+        withFailedPut();
+        var clientSession = new OrchClientSessionItem(CLIENT_SESSION_ID);
+        assertThrows(
+                OrchClientSessionException.class,
+                () -> clientSessionService.storeClientSession(clientSession));
+    }
+
+    @Test
+    void shouldGetClientSessionById() {
+        withValidClientSession();
+        var clientSession = clientSessionService.getClientSession(CLIENT_SESSION_ID);
+        assertTrue(clientSession.isPresent());
+        assertEquals(CLIENT_SESSION_ID, clientSession.get().getClientSessionId());
+    }
+
+    @Test
+    void shouldThrowWhenFailingToGetClientSessionById() {
+        withFailedGet();
+        assertThrows(
+                OrchClientSessionException.class,
+                () -> clientSessionService.getClientSession(CLIENT_SESSION_ID));
+    }
+
+    @Test
+    void shouldNotGetClientSessionByIdWhenNoClientSessionExists() {
+        var clientSession = clientSessionService.getClientSession("not-a-client-session");
+        assertTrue(clientSession.isEmpty());
+    }
+
+    @Test
+    void shouldNotGetClientSessionByIdWhenClientSessionExistsButTimeToLiveExpired() {
+        withExpiredClientSession();
+        var clientSession = clientSessionService.getClientSession(CLIENT_SESSION_ID);
+        assertTrue(clientSession.isEmpty());
+    }
+
+    @Test
+    void shouldUpdateClientSession() {
+        var existingSession = withValidClientSession();
+        var sessionToBeUpdated = existingSession.withClientName("new-client-name");
+        clientSessionService.updateStoredClientSession(sessionToBeUpdated);
+        verify(table).updateItem(sessionToBeUpdated);
+    }
+
+    @Test
+    void shouldThrowWhenUpdatingClientSessionFails() {
+        withFailedUpdate();
+        var sessionToBeUpdated = new OrchClientSessionItem(CLIENT_SESSION_ID);
+        assertThrows(
+                OrchClientSessionException.class,
+                () -> clientSessionService.updateStoredClientSession(sessionToBeUpdated));
+    }
+
+    @Test
+    void shouldDeleteClientSession() {
+        var existingClientSession = withValidClientSession();
+        clientSessionService.deleteStoredClientSession(CLIENT_SESSION_ID);
+        verify(table).getItem(CLIENT_SESSION_ID_PARTITION_KEY);
+        verify(table).deleteItem(existingClientSession);
+    }
+
+    @Test
+    void shouldThrowWhenDeletingClientSessionFails() {
+        withValidClientSession();
+        withFailedDelete();
+        assertThrows(
+                OrchClientSessionException.class,
+                () -> clientSessionService.deleteStoredClientSession(CLIENT_SESSION_ID));
+    }
+
+    private OrchClientSessionItem withValidClientSession() {
+        OrchClientSessionItem existingSession =
+                new OrchClientSessionItem(CLIENT_SESSION_ID)
+                        .withClientName(CLIENT_NAME)
+                        .withTimeToLive(VALID_TTL);
+        when(table.getItem(CLIENT_SESSION_ID_PARTITION_KEY)).thenReturn(existingSession);
+        return existingSession;
+    }
+
+    private void withExpiredClientSession() {
+        OrchClientSessionItem existingSession =
+                new OrchClientSessionItem(CLIENT_SESSION_ID)
+                        .withClientName(CLIENT_NAME)
+                        .withTimeToLive(EXPIRED_TTL);
+        when(table.getItem(CLIENT_SESSION_ID_PARTITION_KEY)).thenReturn(existingSession);
+    }
+
+    private void withFailedPut() {
+        doThrow(DynamoDbException.builder().message("Failed to put item in table").build())
+                .when(table)
+                .putItem(any(OrchClientSessionItem.class));
+    }
+
+    private void withFailedGet() {
+        doThrow(DynamoDbException.builder().message("Failed to get from table").build())
+                .when(table)
+                .getItem(any(Key.class));
+    }
+
+    private void withFailedUpdate() {
+        doThrow(DynamoDbException.builder().message("Failed to update table").build())
+                .when(table)
+                .updateItem(any(OrchClientSessionItem.class));
+    }
+
+    private void withFailedDelete() {
+        doThrow(DynamoDbException.builder().message("Failed to delete from table").build())
+                .when(table)
+                .deleteItem(any(OrchClientSessionItem.class));
+    }
+}


### PR DESCRIPTION
### Wider context of change

In a previous PR, we added a dynamoDB table for storing client sessions. We would like to migrate away from using redis to store client sessions and use this dynamo table in the orch account.

### What’s changed

This PR creates a DynamoDB version of `ClientSession` called `OrchClientSessionItem`, and also creates a service to store, retrieve, and delete instances of `OrchClientSessionItem` to the DynamoDB table, called `OrchClientSessionService`. 

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

