### PR TITLE
AUT-2913: Switch on calls to the TICF CRI in prod

### DIFF
--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -9,7 +9,7 @@ shared_state_bucket                  = "digital-identity-prod-tfstate"
 # App-specific
 internal_sector_uri  = "https://identity.account.gov.uk"
 test_clients_enabled = false
-
+call_ticf_cri        = true
 
 auth_to_orch_token_signing_public_key = <<-EOT
 -----BEGIN PUBLIC KEY-----


### PR DESCRIPTION
## What

Switch on calls to the TICF CRI in prod.

The call is enabled in all other environments and has been running without issue for many weeks.

Switching on as requested by TICF.

## How to review

1. Code Review
