### PR TITLE
ATO-1322: swap getter in verifycode/verifyMfa code handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
@@ -30,8 +30,8 @@ public class SessionHelper {
                         ? userContext.getUserProfile().get()
                         : authenticationService.getUserProfileByEmail(session.getEmailAddress());
         var internalCommonSubjectId =
-                session.getInternalCommonSubjectIdentifier() != null
-                        ? session.getInternalCommonSubjectIdentifier()
+                authSession.getInternalCommonSubjectId() != null
+                        ? authSession.getInternalCommonSubjectId()
                         : ClientSubjectHelper.getSubjectWithSectorIdentifier(
                                         userProfile,
                                         configurationService.getInternalSectorUri(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -163,7 +163,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             var auditContext =
                     auditContextFromUserContext(
                             userContext,
-                            session.getInternalCommonSubjectIdentifier(),
+                            authSession.getInternalCommonSubjectId(),
                             session.getEmailAddress(),
                             IpAddressHelper.extractIpAddress(input),
                             AuditService.UNKNOWN,
@@ -408,7 +408,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     session.setVerifiedMfaMethodType(MFAMethodType.SMS), sessionId);
             authSessionService.updateSession(
                     authSession.withVerifiedMfaMethodType(MFAMethodType.SMS.getValue()));
-            clearAccountRecoveryBlockIfPresent(session, auditContext);
+            clearAccountRecoveryBlockIfPresent(authSession, auditContext);
             cloudwatchMetricsService.incrementAuthenticationSuccess(
                     authSession.getIsNewAccount(),
                     clientId,
@@ -538,14 +538,15 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         };
     }
 
-    private void clearAccountRecoveryBlockIfPresent(Session session, AuditContext auditContext) {
+    private void clearAccountRecoveryBlockIfPresent(
+            AuthSessionItem authSession, AuditContext auditContext) {
         var accountRecoveryBlockPresent =
                 accountModifiersService.isAccountRecoveryBlockPresent(
-                        session.getInternalCommonSubjectIdentifier());
+                        authSession.getInternalCommonSubjectId());
         if (accountRecoveryBlockPresent) {
             LOG.info("AccountRecovery block is present. Removing block");
             accountModifiersService.removeAccountRecoveryBlockIfPresent(
-                    session.getInternalCommonSubjectIdentifier());
+                    authSession.getInternalCommonSubjectId());
             auditService.submitAuditEvent(
                     FrontendAuditableEvent.AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED,
                     auditContext,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -386,7 +386,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             JourneyType journeyType,
             AuditContext auditContext,
             ClientRegistry client,
-            Optional<String> maybePairwiseId) {
+            Optional<String> maybeRpPairwiseId) {
         var session = userContext.getSession();
         var sessionId = userContext.getAuthSession().getSessionId();
         var notificationType = codeRequest.notificationType();
@@ -420,9 +420,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
         if (configurationService.isAuthenticationAttemptsServiceEnabled() && subjectId != null) {
             preserveReauthCountsForAuditIfJourneyIsReauth(
-                    journeyType, subjectId, session, sessionId, maybePairwiseId);
+                    journeyType, subjectId, session, sessionId, maybeRpPairwiseId);
             clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
-            maybePairwiseId.ifPresentOrElse(
+            maybeRpPairwiseId.ifPresentOrElse(
                     this::clearReauthErrorCountsForSuccessfullyAuthenticatedUser,
                     () -> LOG.warn("Unable to clear rp pairwise id reauth counts"));
         }
@@ -440,16 +440,16 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             String subjectId,
             Session session,
             String sessionId,
-            Optional<String> maybePairwiseId) {
+            Optional<String> maybeRpPairwiseId) {
         if (journeyType == JourneyType.REAUTHENTICATION
                 && configurationService.supportReauthSignoutEnabled()
                 && configurationService.isAuthenticationAttemptsServiceEnabled()) {
             var counts =
-                    maybePairwiseId.isPresent()
+                    maybeRpPairwiseId.isPresent()
                             ? authenticationAttemptsService
                                     .getCountsByJourneyForSubjectIdAndRpPairwiseId(
                                             subjectId,
-                                            maybePairwiseId.get(),
+                                            maybeRpPairwiseId.get(),
                                             JourneyType.REAUTHENTICATION)
                             : authenticationAttemptsService.getCountsByJourney(
                                     subjectId, JourneyType.REAUTHENTICATION);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -176,7 +176,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
-                        userContext.getSession().getInternalCommonSubjectIdentifier(),
+                        authSession.getInternalCommonSubjectId(),
                         userContext.getSession().getEmailAddress(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
@@ -357,7 +357,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
-                        session.getInternalCommonSubjectIdentifier(),
+                        authSession.getInternalCommonSubjectId(),
                         session.getEmailAddress(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
@@ -72,7 +72,7 @@ public abstract class MfaCodeProcessor {
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
-                        userContext.getSession().getInternalCommonSubjectIdentifier(),
+                        userContext.getAuthSession().getInternalCommonSubjectId(),
                         emailAddress,
                         ipAddress,
                         phoneNumber,
@@ -89,15 +89,15 @@ public abstract class MfaCodeProcessor {
             MFAMethodType mfaMethodType, String ipAddress, String persistentSessionId) {
         var accountRecoveryBlockPresent =
                 accountModifiersService.isAccountRecoveryBlockPresent(
-                        userContext.getSession().getInternalCommonSubjectIdentifier());
+                        userContext.getAuthSession().getInternalCommonSubjectId());
         if (accountRecoveryBlockPresent) {
             LOG.info("AccountRecovery block is present. Removing block");
             accountModifiersService.removeAccountRecoveryBlockIfPresent(
-                    userContext.getSession().getInternalCommonSubjectIdentifier());
+                    userContext.getAuthSession().getInternalCommonSubjectId());
             var auditContext =
                     auditContextFromUserContext(
                             userContext,
-                            userContext.getSession().getInternalCommonSubjectIdentifier(),
+                            userContext.getAuthSession().getInternalCommonSubjectId(),
                             emailAddress,
                             ipAddress,
                             AuditService.UNKNOWN,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -5,13 +5,13 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.PhoneNumberRequest;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
@@ -178,9 +178,9 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
 
         if (configurationService.isPhoneCheckerWithReplyEnabled()
                 && (journeyType != JourneyType.ACCOUNT_RECOVERY || updatedPhoneNumber)) {
-            Session session = userContext.getSession();
+            AuthSessionItem authSession = userContext.getAuthSession();
             String internalCommonSubjectIdentifier =
-                    session != null ? session.getInternalCommonSubjectIdentifier() : "";
+                    authSession != null ? authSession.getInternalCommonSubjectId() : "";
 
             var phoneNumberRequest =
                     new PhoneNumberRequest(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -111,6 +111,7 @@ class VerifyCodeHandlerTest {
     private static final String CLIENT_ID = "client-id";
     private static final String CLIENT_NAME = "client-name";
     private static final String TEST_CLIENT_ID = "test-client-id";
+    private static final String CLIENT_SECTOR_HOST = "client.test.account.gov.uk";
     private static final String TEST_CLIENT_CODE = "654321";
     private static final String TEST_CLIENT_EMAIL =
             "testclient.user1@digital.cabinet-office.gov.uk";
@@ -129,6 +130,9 @@ class VerifyCodeHandlerTest {
     private final UserProfile userProfile = mock(UserProfile.class);
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(TEST_SUBJECT_ID, SECTOR_HOST, SALT);
+    private final String expectedPairwiseId =
+            ClientSubjectHelper.calculatePairwiseIdentifier(
+                    TEST_SUBJECT_ID, CLIENT_SECTOR_HOST, SALT);
     // TODO do we need both session and sessionForTestClient here?
     private final Session session =
             new Session()
@@ -154,7 +158,7 @@ class VerifyCodeHandlerTest {
                     .withTestClient(false)
                     .withClientID(CLIENT_ID)
                     .withClientName(CLIENT_NAME)
-                    .withSectorIdentifierUri("https://" + SECTOR_HOST);
+                    .withSectorIdentifierUri("https://" + CLIENT_SECTOR_HOST);
     private final ClientRegistry testClientRegistry =
             new ClientRegistry()
                     .withTestClient(true)
@@ -774,7 +778,7 @@ class VerifyCodeHandlerTest {
         when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
         var result = makeCallWithCode(CODE, MFA_SMS.toString(), journeyType);
 
-        List.of(TEST_SUBJECT_ID, expectedCommonSubject)
+        List.of(TEST_SUBJECT_ID, expectedPairwiseId)
                 .forEach(
                         identifier ->
                                 verify(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -91,6 +91,7 @@ import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.C
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.DI_PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.EMAIL;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.ENCODED_DEVICE_DETAILS;
+import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.INTERNAL_COMMON_SUBJECT_ID;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.SESSION_ID;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.VALID_HEADERS;
@@ -123,16 +124,17 @@ class VerifyMfaCodeHandlerTest {
     private static final String TEST_SUBJECT_ID = "test-subject-id";
     private static final int MAX_RETRIES = 6;
 
-    private final String expectedCommonSubject =
-            ClientSubjectHelper.calculatePairwiseIdentifier(TEST_SUBJECT_ID, SECTOR_HOST, SALT);
     private final String expectedRpPairwiseSubjectId =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     TEST_SUBJECT_ID, CLIENT_SECTOR_HOST, SALT);
     private final Session session =
             new Session()
                     .setEmailAddress(EMAIL)
-                    .setInternalCommonSubjectIdentifier(expectedCommonSubject);
-    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
+                    .setInternalCommonSubjectIdentifier(INTERNAL_COMMON_SUBJECT_ID);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID);
     private final Json objectMapper = SerializationService.getInstance();
     public VerifyMfaCodeHandler handler;
 
@@ -167,7 +169,7 @@ class VerifyMfaCodeHandlerTest {
                     CLIENT_ID,
                     CLIENT_SESSION_ID,
                     SESSION_ID,
-                    expectedCommonSubject,
+                    INTERNAL_COMMON_SUBJECT_ID,
                     EMAIL,
                     IP_ADDRESS,
                     AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -118,12 +118,16 @@ class VerifyMfaCodeHandlerTest {
     private static final String AUTH_APP_SECRET =
             "JZ5PYIOWNZDAOBA65S5T77FEEKYCCIT2VE4RQDAJD7SO73T3LODA";
     private static final String SECTOR_HOST = "test.account.gov.uk";
+    private static final String CLIENT_SECTOR_HOST = "client.test.account.gov.uk";
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final String TEST_SUBJECT_ID = "test-subject-id";
     private static final int MAX_RETRIES = 6;
 
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(TEST_SUBJECT_ID, SECTOR_HOST, SALT);
+    private final String expectedRpPairwiseSubjectId =
+            ClientSubjectHelper.calculatePairwiseIdentifier(
+                    TEST_SUBJECT_ID, CLIENT_SECTOR_HOST, SALT);
     private final Session session =
             new Session()
                     .setEmailAddress(EMAIL)
@@ -886,7 +890,7 @@ class VerifyMfaCodeHandlerTest {
         when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
                         eq(SUBJECT_ID), any(), eq(JourneyType.REAUTHENTICATION)))
                 .thenReturn(existingCounts);
-        when(clientRegistry.getSectorIdentifierUri()).thenReturn("http://" + SECTOR_HOST);
+        when(clientRegistry.getSectorIdentifierUri()).thenReturn("http://" + CLIENT_SECTOR_HOST);
         when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
 
         var codeRequest =
@@ -894,7 +898,7 @@ class VerifyMfaCodeHandlerTest {
                         MFAMethodType.AUTH_APP, CODE, JourneyType.REAUTHENTICATION, null);
         makeCallWithCode(codeRequest);
 
-        List.of(TEST_SUBJECT_ID, expectedCommonSubject)
+        List.of(TEST_SUBJECT_ID, expectedRpPairwiseSubjectId)
                 .forEach(
                         identifier ->
                                 verify(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -50,7 +50,7 @@ import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_B
 class AuthAppCodeProcessorTest {
     AuthAppCodeProcessor authAppCodeProcessor;
     Session mockSession;
-    AuthSessionItem mockAuthSession;
+    AuthSessionItem authSession;
     CodeStorageService mockCodeStorageService;
     ConfigurationService mockConfigurationService;
     DynamoService mockDynamoService;
@@ -88,7 +88,10 @@ class AuthAppCodeProcessorTest {
                         .setEmailAddress(EMAIL)
                         .setInternalCommonSubjectIdentifier(INTERNAL_SUB_ID);
         this.mockSession = mock(Session.class);
-        this.mockAuthSession = mock(AuthSessionItem.class);
+        this.authSession =
+                new AuthSessionItem()
+                        .withSessionId(SESSION_ID)
+                        .withInternalCommonSubjectId(INTERNAL_SUB_ID);
         this.mockCodeStorageService = mock(CodeStorageService.class);
         this.mockConfigurationService = mock(ConfigurationService.class);
         this.mockDynamoService = mock(DynamoService.class);
@@ -283,10 +286,9 @@ class AuthAppCodeProcessorTest {
     }
 
     private void setUpSuccessfulCodeRequest(CodeRequest codeRequest) {
-        when(mockAuthSession.getSessionId()).thenReturn(SESSION_ID);
         when(mockUserContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(mockUserContext.getSession()).thenReturn(session);
-        when(mockUserContext.getAuthSession()).thenReturn(mockAuthSession);
+        when(mockUserContext.getAuthSession()).thenReturn(authSession);
         when(mockUserContext.getClientId()).thenReturn(CLIENT_ID);
         when(mockUserContext.getTxmaAuditEncoded()).thenReturn(TXMA_ENCODED_HEADER_VALUE);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -398,6 +398,7 @@ class PhoneNumberCodeProcessorTest {
     public void setupPhoneNumberCode(CodeRequest codeRequest, CodeRequestType codeRequestType) {
         var differentPhoneNumber = CommonTestVariables.UK_MOBILE_NUMBER.replace("789", "987");
         when(authSession.getSessionId()).thenReturn(SESSION_ID);
+        when(authSession.getInternalCommonSubjectId()).thenReturn(INTERNAL_SUB_ID);
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(userContext.getClientId()).thenReturn(CLIENT_ID);
         when(userContext.getSession()).thenReturn(session);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -353,6 +353,8 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 ClientSubjectHelper.calculatePairwiseIdentifier(
                         SUBJECT.getValue(), INTERNAl_SECTOR_HOST, SaltHelper.generateNewSalt());
         redis.addInternalCommonSubjectIdToSession(sessionId, internalCommonSubjectId);
+        authSessionExtension.addInternalCommonSubjectIdToSession(
+                this.sessionId, internalCommonSubjectId);
         setUpTestWithoutSignUp(sessionId, withScope());
         userStore.signUp(EMAIL_ADDRESS, "password", SUBJECT);
         userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");
@@ -384,6 +386,8 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         SUBJECT.getValue(), INTERNAl_SECTOR_HOST, SaltHelper.generateNewSalt());
         accountModifiersStore.setAccountRecoveryBlock(internalCommonSubjectId);
         redis.addInternalCommonSubjectIdToSession(sessionId, internalCommonSubjectId);
+        authSessionExtension.addInternalCommonSubjectIdToSession(
+                this.sessionId, internalCommonSubjectId);
         setUpTestWithoutSignUp(sessionId, withScope());
         userStore.signUp(EMAIL_ADDRESS, "password", SUBJECT);
         userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");
@@ -442,6 +446,8 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         SUBJECT.getValue(), INTERNAl_SECTOR_HOST, SaltHelper.generateNewSalt());
         accountModifiersStore.setAccountRecoveryBlock(internalCommonSubjectId);
         redis.addInternalCommonSubjectIdToSession(sessionId, internalCommonSubjectId);
+        authSessionExtension.addInternalCommonSubjectIdToSession(
+                this.sessionId, internalCommonSubjectId);
         setUpTestWithSignUp(sessionId, withScope());
         userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -109,6 +109,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         this.sessionId = redis.createSession();
         authSessionExtension.addSession(this.sessionId);
         redis.addInternalCommonSubjectIdToSession(this.sessionId, internalCommonSubjectId);
+        authSessionExtension.addInternalCommonSubjectIdToSession(
+                this.sessionId, internalCommonSubjectId);
         setUpTest(sessionId, withScope());
     }
 


### PR DESCRIPTION
## What: 
- Swaps the shared session getter for internalCommonSubjectId for the AuthSession one in the verifyCode and VerifyMfaCode lambda
- Renames some variables and re-jigs some test setup to make clearer that reauth counts are stored against RP pairwise id, not internalCommonSubjectId (Auth dev confirmed this makes sense)
- These lambdas are done together as they shared a service which used a getter

## How to review:
- Code review commit by commit
- Deployed to sandpit and ran auth acceptance tests

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs: 
- I borked my last branch, so this one replaces it 😆 
