### PR TITLE
BAU: pin golang to 1.23.6 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  golang: 1.23.6
 exclude: |
   (?x)^(
       .*/test/.*/.*\.approved.json


### PR DESCRIPTION
## What

1.24 breaks compat
