### PR TITLE
ATO-1311: Add regex pattern for orch acceptance test emails

### DIFF
--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -20,7 +20,9 @@ locals {
     pattern = "test-user+${var.environment}-$${instantiationMillis}-$${counter}@test.null.local" # '$${' = literal '${' (escaped)
     regex   = "^test-user\\+${var.environment}-\\d+-\\d+@test\\.null\\.local$"
   }
-  simulator_acceptance_test_rp_client_email = "orch-test-user@digital.cabinet-office.gov.uk"
+  orch_acceptance_test_rp_client_emails = {
+    regex = "^orch-test-user\\d*@digital.cabinet-office.gov.uk$"
+  }
 }
 
 resource "aws_dynamodb_table_item" "stub_relying_party_client" {
@@ -106,7 +108,7 @@ resource "aws_dynamodb_table_item" "stub_relying_party_client" {
       N = each.value.test_client
     }
     TestClientEmailAllowlist = {
-      L = [for email in concat(split(",", var.test_client_email_allowlist), [local.acceptance_test_rp_client_emails.regex], [local.simulator_acceptance_test_rp_client_email]) : {
+      L = [for email in concat(split(",", var.test_client_email_allowlist), [local.acceptance_test_rp_client_emails.regex], [local.orch_acceptance_test_rp_client_emails.regex]) : {
         S = email
       }]
     }


### PR DESCRIPTION
### Wider context of change

We would like to add acceptance tests for identity journeys in the orchestration-acceptance-tests repo. The simulator already has acceptance tests for this, and used an account with an email address defined in the stub-rp-clients file. 

It would be nice to use a different email for the orchestration acceptance tests.

### What’s changed

This PR replaces the definition of the simulator acceptance test email for a more general orch acceptance test email regex. The existing simulator acceptance test email matches the regex pattern, so the definition for it has been removed. 

### Checklist
- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] Changes have been made to contract tests or not required.
- [ ] Changes have been made to the simulator or not required.
- [ ] Changes have been made to stubs or not required.
- [ ] Successfully deployed to authdev or not required.
- [ ] Successfully run Authentication acceptance tests against sandpit or not required.
