### PR TITLE
ATO-1123: add permissions to access AuthUserInfo for AuthCodeHandler

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -3128,6 +3128,7 @@ Resources:
         - !Ref OrchSessionTableReadAccessPolicy
         - !Ref OrchSessionTableWriteAccessPolicy
         - !Ref ClientSessionTableReadAccessPolicy
+        - !Ref AuthUserInfoTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 


### PR DESCRIPTION
### Wider context of change
Part of the migration of email work

### What’s changed
Adds permissions for the AuthCodeHandler to read from the AuthUserInfo table

### Manual testing
n/a

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not Required**
- [x] Changes have been made to the simulator or not required. **Not Required**
- [x] Changes have been made to stubs or not required. **Not Required**
- [x] Successfully deployed to authdev or not required. **Not Required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not Required**
