### PR TITLE
BAU: add check in PR template for correct permissions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/orch_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/orch_template.md
@@ -28,6 +28,12 @@ Deployed to Orch dev and observed the following succesful test cases:
 
 ### Checklist
 
+<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
+This should be done in a separate PR.
+-->
+
+- [ ] Lambdas have correct permissions for the resources they're accessing.
+
 <!-- Be careful when making changes to code in 'shared' components where each team has a copy.
 Check with counterparts to see if changes need to be made in the other team's code.
 In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.


### PR DESCRIPTION
### Wider context of change
Code wasdeployed to main where a lambda didn't have the right permission. Among other actions, this is a small one to point out to devs that careful consideration must be taken when accessing resources within a lambda.

### What’s changed
Added a checkbox in the PR template

### Manual testing
n/a

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not Needed**
- [x] Changes have been made to the simulator or not required. **Not Needed**
- [x] Changes have been made to stubs or not required. **Not Needed**
- [x] Successfully deployed to authdev or not required. **Not Needed**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not Needed**
