### PR TITLE
ATO-1371: validate pkce challenge code and method on the `/authorize` endpoint

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
@@ -7,6 +7,8 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.pkce.CodeChallenge;
+import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
@@ -31,6 +33,7 @@ public class RequestObjectToAuthRequestHelper {
 
     private RequestObjectToAuthRequestHelper() {}
 
+    @SuppressWarnings("deprecation")
     public static AuthenticationRequest transform(AuthenticationRequest authRequest) {
         if (Objects.isNull(authRequest.getRequestObject())) {
             return authRequest;
@@ -82,6 +85,17 @@ public class RequestObjectToAuthRequestHelper {
 
             if (Objects.nonNull(jwtClaimsSet.getClaim("max_age"))) {
                 builder.maxAge(getMaxAge(jwtClaimsSet));
+            }
+
+            var codeChallenge = jwtClaimsSet.getStringClaim("code_challenge");
+
+            if (Objects.nonNull(codeChallenge)) {
+                var parsedCodeChallenge = CodeChallenge.parse(codeChallenge);
+                var parsedCodeChallengeMethod =
+                        CodeChallengeMethod.parse(
+                                jwtClaimsSet.getStringClaim("code_challenge_method"));
+
+                builder.codeChallenge(parsedCodeChallenge, parsedCodeChallengeMethod);
             }
 
             return builder.build();

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.oidc.validators;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.id.Identifier;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
 import uk.gov.di.authentication.oidc.services.IPVCapacityService;
@@ -14,6 +15,7 @@ import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -102,13 +104,20 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
                             state));
         }
 
-        // TODO: ATO-1371: Delete the following log once we have verified that
-        //  no RPs are using the code challenge method "plain" AND we have
-        //  checked which RPs, if any, are using PKCE already.
-        if (authRequest.getCodeChallengeMethod() != null) {
-            LOG.info(
-                    "authRequest code challenge method is '{}'",
-                    authRequest.getCodeChallengeMethod());
+        if (configurationService.isPkceEnabled()
+                && Objects.nonNull(authRequest.getCodeChallenge())) {
+            var codeChallenge = authRequest.getCodeChallenge().getValue();
+            var codeChallengeMethod =
+                    Optional.ofNullable(authRequest.getCodeChallengeMethod())
+                            .map(Identifier::getValue)
+                            .orElse(null);
+
+            var codeChallengeError =
+                    validateCodeChallengeAndMethod(codeChallenge, codeChallengeMethod);
+            if (codeChallengeError.isPresent()) {
+                return Optional.of(
+                        new AuthRequestError(codeChallengeError.get(), redirectURI, state));
+            }
         }
 
         List<String> authRequestVtr = authRequest.getCustomParameter(VTR_PARAM);


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

We wish to add PKCE support to the `/authorize` endpoint behind a feature flag.

PKCE should be optional to be backward compatible.

If a code challenge is provided, we wish to perform validation on both it and the code challenge method.

Code challenge validation:
- Non-blank if provided
- (We'll perform additional validation on the code verifier - not implemented at present)

Code challenge method validation:
- We wish to only support the "S256" code challenge method as "plain" offers lower security.
- A value must be provided if a code challenge value is provided
  - (Otherwise the method will default to "plain" if not in the request - which we don't want to support (https://datatracker.ietf.org/doc/html/rfc7636#section-4.3))

Validation needs to be performed on the query params (if the request object is null), and otherwise on the request object.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Added base validation method to the base validator
- Added call from the query param validator
- Added call from the request object validator
- Added unit tests for both validators
- Added integration tests

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to Orch dev, tested:
- Query param cases:
  - No code challenge provided, validation successful
  - Code challenge provided, no method, fails with expected validation error
  - Code challenge provided, method set to "plain", fails with expected validation error
  - Code challenge provided, method set to another invalid value (e.g., "abc"), fails with expected validation error
  - Code challenge provided, method set to "S256", validation successful
- Request object cases
  - Same as above, worked as expected

### Checklist

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

PKCE FF - https://github.com/govuk-one-login/authentication-api/pull/6010