### PR TITLE
ATO-1469: add policies for new identity credentials table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -3785,8 +3785,7 @@ Resources:
             - false
           IPV_JWK_CACHE_EXPIRATION_IN_SECONDS: 300
       Policies:
-        - !Ref AuthIdentityCredentialsTableReadAccessPolicy
-        - !Ref AuthIdentityCredentialsTableWriteAccessPolicy
+        - !Ref AuthIdentityCredentialsTableReadAndWriteAccessPolicy
         - !Ref OrchIdentityCredentialsTableReadAndWriteAccessPolicy
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy
@@ -4736,6 +4735,70 @@ Resources:
             Effect: Allow
             Action:
               - dynamodb:DeleteItem
+            Resource: !Sub
+              - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-identity-credentials
+              - AccountId:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    authAccountId,
+                  ]
+                AuthEnvironment:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    authEnvironment,
+                  ]
+          - Sid: AllowAuthIdentityCredentialsTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                authIdentityCredentialsTableKeyArn,
+              ]
+
+  # This combined read and write policy is required because we've reached the managed polices per role quota limit (20).
+  AuthIdentityCredentialsTableReadAndWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowAuthIdentityCredentialsTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:BatchGetItem
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+              - dynamodb:Query
+              - dynamodb:Scan
+            Resource: !Sub
+              - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-identity-credentials
+              - AccountId:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    authAccountId,
+                  ]
+                AuthEnvironment:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    authEnvironment,
+                  ]
+          - Sid: AllowAuthIdentityCredentialsTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:UpdateItem
+              - dynamodb:PutItem
             Resource: !Sub
               - arn:aws:dynamodb:eu-west-2:${AccountId}:table/${AuthEnvironment}-identity-credentials
               - AccountId:

--- a/template.yaml
+++ b/template.yaml
@@ -2949,6 +2949,7 @@ Resources:
                 ]
       Policies:
         - !Ref AuthIdentityCredentialsTableReadAccessPolicy
+        - !Ref OrchIdentityCredentialsTableReadAccessPolicy
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref DocAppCredentialTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy
@@ -3786,6 +3787,7 @@ Resources:
       Policies:
         - !Ref AuthIdentityCredentialsTableReadAccessPolicy
         - !Ref AuthIdentityCredentialsTableWriteAccessPolicy
+        - !Ref OrchIdentityCredentialsTableReadAccessPolicy
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy
         - !Ref UserProfileTableWriteAccessPolicy
@@ -3995,6 +3997,7 @@ Resources:
         - !Ref AuthIdentityCredentialsTableReadAccessPolicy
         - !Ref AuthIdentityCredentialsTableWriteAccessPolicy
         - !Ref AuthIdentityCredentialsTableDeleteAccessPolicy
+        - !Ref OrchIdentityCredentialsTableReadAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref SpotResponseQueueConsumePolicy
       Tags:

--- a/template.yaml
+++ b/template.yaml
@@ -3788,6 +3788,7 @@ Resources:
         - !Ref AuthIdentityCredentialsTableReadAccessPolicy
         - !Ref AuthIdentityCredentialsTableWriteAccessPolicy
         - !Ref OrchIdentityCredentialsTableReadAccessPolicy
+        - !Ref OrchIdentityCredentialsTableWriteAccessPolicy
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy
         - !Ref UserProfileTableWriteAccessPolicy
@@ -3998,6 +3999,7 @@ Resources:
         - !Ref AuthIdentityCredentialsTableWriteAccessPolicy
         - !Ref AuthIdentityCredentialsTableDeleteAccessPolicy
         - !Ref OrchIdentityCredentialsTableReadAccessPolicy
+        - !Ref OrchIdentityCredentialsTableWriteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref SpotResponseQueueConsumePolicy
       Tags:

--- a/template.yaml
+++ b/template.yaml
@@ -4000,6 +4000,7 @@ Resources:
         - !Ref AuthIdentityCredentialsTableDeleteAccessPolicy
         - !Ref OrchIdentityCredentialsTableReadAccessPolicy
         - !Ref OrchIdentityCredentialsTableWriteAccessPolicy
+        - !Ref OrchIdentityCredentialsTableDeleteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref SpotResponseQueueConsumePolicy
       Tags:

--- a/template.yaml
+++ b/template.yaml
@@ -4557,6 +4557,55 @@ Resources:
               - kms:Decrypt
             Resource: !GetAtt ClientSessionTableEncryptionKey.Arn
 
+  OrchIdentityCredentialsTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowOrchIdentityCredentialsTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt OrchIdentityCredentialsTable.Arn
+          - Sid: AllowOrchIdentityCredentialsTableDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: !GetAtt OrchIdentityCredentialsTableEncryptionKey.Arn
+
+  OrchIdentityCredentialsTableWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowOrchIdentityCredentialsTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+            Resource: !GetAtt OrchIdentityCredentialsTable.Arn
+          - Sid: AllowOrchIdentityCredentialsTableDecryptionAndEncryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+            Resource: !GetAtt OrchIdentityCredentialsTableEncryptionKey.Arn
+
+  OrchIdentityCredentialsTableDeleteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowOrchIdentityCredentialsTableDeleteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DeleteItem
+            Resource: !GetAtt OrchIdentityCredentialsTable.Arn
+
   AuthIdentityCredentialsTableReadAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -3787,8 +3787,7 @@ Resources:
       Policies:
         - !Ref AuthIdentityCredentialsTableReadAccessPolicy
         - !Ref AuthIdentityCredentialsTableWriteAccessPolicy
-        - !Ref OrchIdentityCredentialsTableReadAccessPolicy
-        - !Ref OrchIdentityCredentialsTableWriteAccessPolicy
+        - !Ref OrchIdentityCredentialsTableReadAndWriteAccessPolicy
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy
         - !Ref UserProfileTableWriteAccessPolicy
@@ -4611,6 +4610,36 @@ Resources:
             Action:
               - dynamodb:DeleteItem
             Resource: !GetAtt OrchIdentityCredentialsTable.Arn
+
+  # This combined read and write policy is required because we've reached the managed polices per role quota limit (20).
+  OrchIdentityCredentialsTableReadAndWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowOrchIdentityCredentialsTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt OrchIdentityCredentialsTable.Arn
+          - Sid: AllowOrchIdentityCredentialsTableDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: !GetAtt OrchIdentityCredentialsTableEncryptionKey.Arn
+          - Sid: AllowOrchIdentityCredentialsTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+            Resource: !GetAtt OrchIdentityCredentialsTable.Arn
+          - Sid: AllowOrchIdentityCredentialsTableEncryption
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+            Resource: !GetAtt OrchIdentityCredentialsTableEncryptionKey.Arn
 
   AuthIdentityCredentialsTableReadAccessPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
### Wider context of change
Part of the identity credentials migration

### What’s changed
Refactors the now unused identity credentials policies to instead access the table on Orch accounts, and adds those policies to the lambdas in the same places the Auth equivalent currently exist

### Manual testing
Deploying to dev now

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required**
- [x] Changes have been made to the simulator or not required. **Not required**
- [x] Changes have been made to stubs or not required. **Not required**
- [x] Successfully deployed to authdev or not required. **Not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required**