### PR TITLE
ATO-1469: add log to verify if clientSessionId is defined

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -71,6 +71,11 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                                 .withSessionId(logIds.getSessionId())
                                 .withPersistentSessionId(logIds.getPersistentSessionId());
 
+                LOG.info(
+                        "is clientSessionId defined: {}",
+                        logIds.getClientSessionId() != null
+                                && !logIds.getClientSessionId().isBlank());
+
                 if (spotResponse.getStatus().equals(SPOTStatus.ACCEPTED)) {
                     LOG.info(
                             "SPOTResponse Status is {}. Adding CoreIdentityJWT to Dynamo",


### PR DESCRIPTION
### Wider context of change
Part of the identity credentials migration

### What’s changed
Adds a log to verify that clientSessionId is always defined. We need it to access the entry in the IdentityCredentials table

### Manual testing
N/A

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required**
- [x] Changes have been made to the simulator or not required. **Not required**
- [x] Changes have been made to stubs or not required. **Not required**
- [x] Successfully deployed to authdev or not required. **Not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required**