### PR TITLE
ATO-1123: migrate email in authcodehandler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -94,7 +94,6 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setupOrchSession();
         var clientSessionId = "some-client-session-id";
         setupAuthUserInfo(clientSessionId);
-        redis.addEmailToSession(sessionID, EMAIL);
         redis.setVerifiedMfaMethodType(sessionID, MFAMethodType.AUTH_APP);
         var creationDate = LocalDateTime.now();
         var authRequestParams = generateAuthRequest().toParameters();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -79,6 +79,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final Nonce NONCE = new Nonce();
     public static final String ENCODED_DEVICE_INFORMATION =
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
+    private static final String SUBJECT = "subject";
     private static final String INTERNAL_COMMON_SUBJECT_ID = "internalCommonSubjectId";
     private String sessionID;
 
@@ -256,7 +257,9 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                         "client_session_id",
                                         clientSessionId,
                                         "email",
-                                        EMAIL)));
+                                        EMAIL,
+                                        "local_account_id",
+                                        SUBJECT)));
         authUserInfoExtension.addAuthenticationUserInfoData(
                 INTERNAL_COMMON_SUBJECT_ID, clientSessionId, authUserInfo);
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -14,6 +14,8 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -29,6 +31,7 @@ import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.orchestration.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
@@ -62,6 +65,10 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     public static final OrchClientSessionExtension orchClientSessionExtension =
             new OrchClientSessionExtension();
 
+    @RegisterExtension
+    public static final AuthenticationCallbackUserInfoStoreExtension authUserInfoExtension =
+            new AuthenticationCallbackUserInfoStoreExtension(180);
+
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final URI REDIRECT_URI =
             URI.create(System.getenv("STUB_RELYING_PARTY_REDIRECT_URI"));
@@ -72,6 +79,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final Nonce NONCE = new Nonce();
     public static final String ENCODED_DEVICE_INFORMATION =
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
+    private static final String INTERNAL_COMMON_SUBJECT_ID = "internalCommonSubjectId";
     private String sessionID;
 
     @BeforeEach
@@ -79,12 +87,13 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         handler = new AuthCodeHandler(TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
         txmaAuditQueue.clear();
         sessionID = redis.createSession();
-        setupOrchSession();
     }
 
     @Test
     void shouldReturn200WithSuccessfulAuthResponse() throws Json.JsonException {
+        setupOrchSession();
         var clientSessionId = "some-client-session-id";
+        setupAuthUserInfo(clientSessionId);
         redis.addEmailToSession(sessionID, EMAIL);
         redis.setVerifiedMfaMethodType(sessionID, MFAMethodType.AUTH_APP);
         var creationDate = LocalDateTime.now();
@@ -128,6 +137,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn200WithSuccessfulAuthResponseForDocAppJourney()
             throws Json.JsonException, JOSEException {
+        setupDocAppOrchSession();
         var clientSessionId = "some-client-session-id";
         var creationDate = LocalDateTime.now();
         var authRequestParams = generateDocAppAuthRequest().toParameters();
@@ -227,6 +237,28 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private void setupOrchSession() {
         orchSessionExtension.addSession(
                 new OrchSessionItem(sessionID)
+                        .withVerifiedMfaMethodType(MFAMethodType.AUTH_APP.getValue())
+                        .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID));
+    }
+
+    private void setupDocAppOrchSession() {
+        orchSessionExtension.addSession(
+                new OrchSessionItem(sessionID)
                         .withVerifiedMfaMethodType(MFAMethodType.AUTH_APP.getValue()));
+    }
+
+    private void setupAuthUserInfo(String clientSessionId) {
+        var authUserInfo =
+                new UserInfo(
+                        new JSONObject(
+                                Map.of(
+                                        "sub",
+                                        INTERNAL_COMMON_SUBJECT_ID,
+                                        "client_session_id",
+                                        clientSessionId,
+                                        "email",
+                                        EMAIL)));
+        authUserInfoExtension.addAuthenticationUserInfoData(
+                INTERNAL_COMMON_SUBJECT_ID, clientSessionId, authUserInfo);
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AuthCodeException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AuthCodeException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+public class AuthCodeException extends Exception {
+    public AuthCodeException(String message) {
+        super(message);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.oidc.exceptions.AuthCodeException;
 import uk.gov.di.authentication.oidc.exceptions.ProcessAuthRequestException;
 import uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
+import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
@@ -28,7 +29,6 @@ import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
-import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
@@ -39,7 +39,6 @@ import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
-import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
@@ -87,7 +86,6 @@ public class AuthCodeHandler
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final ConfigurationService configurationService;
     private final DynamoService dynamoService;
-    private final DynamoClientService dynamoClientService;
 
     public AuthCodeHandler(
             SessionService sessionService,
@@ -101,8 +99,7 @@ public class AuthCodeHandler
             AuditService auditService,
             CloudwatchMetricsService cloudwatchMetricsService,
             ConfigurationService configurationService,
-            DynamoService dynamoService,
-            DynamoClientService dynamoClientService) {
+            DynamoService dynamoService) {
         this.sessionService = sessionService;
         this.orchSessionService = orchSessionService;
         this.authUserInfoStorageService = authUserInfoStorageService;
@@ -115,7 +112,6 @@ public class AuthCodeHandler
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.configurationService = configurationService;
         this.dynamoService = dynamoService;
-        this.dynamoClientService = dynamoClientService;
     }
 
     public AuthCodeHandler(ConfigurationService configurationService) {
@@ -131,7 +127,6 @@ public class AuthCodeHandler
         cloudwatchMetricsService = new CloudwatchMetricsService();
         this.configurationService = configurationService;
         dynamoService = new DynamoService(configurationService);
-        dynamoClientService = new DynamoClientService(configurationService);
         authCodeResponseService =
                 new AuthCodeResponseGenerationService(configurationService, dynamoService);
     }
@@ -150,7 +145,6 @@ public class AuthCodeHandler
         cloudwatchMetricsService = new CloudwatchMetricsService();
         this.configurationService = configurationService;
         dynamoService = new DynamoService(configurationService);
-        dynamoClientService = new DynamoClientService(configurationService);
         authCodeResponseService =
                 new AuthCodeResponseGenerationService(configurationService, dynamoService);
     }
@@ -203,6 +197,7 @@ public class AuthCodeHandler
         LOG.info("Processing request");
 
         Optional<String> emailOptional;
+        Optional<String> subjectIdOptional;
         boolean isDocAppJourney;
         AuthenticationRequest authenticationRequest = null;
         ClientSession clientSession;
@@ -236,8 +231,13 @@ public class AuthCodeHandler
                                         clientSessionId)
                                 .orElseThrow(() -> new AuthCodeException("authUserInfo not found"));
                 emailOptional = Optional.of(authUserInfo.getEmailAddress());
+                subjectIdOptional =
+                        Optional.of(
+                                authUserInfo.getStringClaim(
+                                        AuthUserInfoClaims.LOCAL_ACCOUNT_ID.getValue()));
             } else {
                 emailOptional = Optional.empty();
+                subjectIdOptional = Optional.empty();
             }
 
             authCode =
@@ -282,7 +282,6 @@ public class AuthCodeHandler
                             isTestJourney,
                             isDocAppJourney);
 
-            var subjectId = AuditService.UNKNOWN;
             var rpPairwiseId = AuditService.UNKNOWN;
             String internalCommonSubjectId;
             if (isDocAppJourney) {
@@ -291,14 +290,12 @@ public class AuthCodeHandler
             } else {
                 authCodeResponseService.processVectorOfTrust(clientSession, dimensions);
                 internalCommonSubjectId = orchSession.getInternalCommonSubjectId();
-                subjectId = authCodeResponseService.getSubjectId(session);
-                rpPairwiseId =
-                        authCodeResponseService.getRpPairwiseId(
-                                session, clientID, dynamoClientService);
+                rpPairwiseId = clientSession.getRpPairwiseId();
             }
 
             var metadataPairs = new ArrayList<AuditService.MetadataPair>();
-            metadataPairs.add(pair("internalSubjectId", subjectId));
+            metadataPairs.add(
+                    pair("internalSubjectId", subjectIdOptional.orElse(AuditService.UNKNOWN)));
             metadataPairs.add(pair("isNewAccount", orchSession.getIsNewAccount()));
             metadataPairs.add(pair("rpPairwiseId", rpPairwiseId));
             metadataPairs.add(pair("authCode", authCode));
@@ -340,11 +337,6 @@ public class AuthCodeHandler
                     200,
                     new uk.gov.di.orchestration.entity.AuthCodeResponse(
                             authenticationResponse.toURI().toString()));
-        } catch (ClientNotFoundException e) {
-            return processClientNotFoundException(authenticationRequest);
-        } catch (UserNotFoundException e) {
-            LOG.error(e);
-            throw new RuntimeException(e);
         } catch (JsonException e) {
             throw new RuntimeException(e);
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -32,6 +32,7 @@ import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthCodeResponseGenerationService;
+import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
@@ -74,6 +75,7 @@ public class AuthCodeHandler
 
     private final SessionService sessionService;
     private final OrchSessionService orchSessionService;
+    private final AuthenticationUserInfoStorageService authUserInfoStorageService;
     private final AuthCodeResponseGenerationService authCodeResponseService;
     private final AuthorisationCodeService authorisationCodeService;
     private final OrchestrationAuthorizationService orchestrationAuthorizationService;
@@ -88,6 +90,7 @@ public class AuthCodeHandler
     public AuthCodeHandler(
             SessionService sessionService,
             OrchSessionService orchSessionService,
+            AuthenticationUserInfoStorageService authUserInfoStorageService,
             AuthCodeResponseGenerationService authCodeResponseService,
             AuthorisationCodeService authorisationCodeService,
             OrchestrationAuthorizationService orchestrationAuthorizationService,
@@ -100,6 +103,7 @@ public class AuthCodeHandler
             DynamoClientService dynamoClientService) {
         this.sessionService = sessionService;
         this.orchSessionService = orchSessionService;
+        this.authUserInfoStorageService = authUserInfoStorageService;
         this.authCodeResponseService = authCodeResponseService;
         this.authorisationCodeService = authorisationCodeService;
         this.orchestrationAuthorizationService = orchestrationAuthorizationService;
@@ -115,6 +119,7 @@ public class AuthCodeHandler
     public AuthCodeHandler(ConfigurationService configurationService) {
         sessionService = new SessionService(configurationService);
         orchSessionService = new OrchSessionService(configurationService);
+        authUserInfoStorageService = new AuthenticationUserInfoStorageService(configurationService);
         authorisationCodeService = new AuthorisationCodeService(configurationService);
         orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(configurationService);
@@ -133,6 +138,7 @@ public class AuthCodeHandler
             ConfigurationService configurationService, RedisConnectionService redis) {
         sessionService = new SessionService(configurationService, redis);
         orchSessionService = new OrchSessionService(configurationService);
+        authUserInfoStorageService = new AuthenticationUserInfoStorageService(configurationService);
         authorisationCodeService = new AuthorisationCodeService(configurationService);
         orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(configurationService);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -49,6 +49,7 @@ import uk.gov.di.orchestration.shared.helpers.SaltHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthCodeResponseGenerationService;
+import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
@@ -125,6 +126,8 @@ class AuthCodeHandlerTest {
             mock(OrchestrationAuthorizationService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
+    private final AuthenticationUserInfoStorageService authUserInfoService =
+            mock(AuthenticationUserInfoStorageService.class);
     private final VectorOfTrust vectorOfTrust = mock(VectorOfTrust.class);
 
     private static final String SESSION_ID = IdGenerator.generate();
@@ -176,6 +179,7 @@ class AuthCodeHandlerTest {
                 new AuthCodeHandler(
                         sessionService,
                         orchSessionService,
+                        authUserInfoService,
                         authCodeResponseService,
                         authorisationCodeService,
                         orchestrationAuthorizationService,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -7,6 +7,7 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseMode;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -18,6 +19,8 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,6 +67,7 @@ import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -134,6 +138,7 @@ class AuthCodeHandlerTest {
     private static final String CLIENT_SESSION_ID = IdGenerator.generate();
     private static final String PERSISTENT_SESSION_ID = IdGenerator.generate();
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String PHONE_NUMBER = "012345678902";
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final Subject SUBJECT = new Subject();
@@ -145,6 +150,7 @@ class AuthCodeHandlerTest {
     private static final State STATE = new State();
     private static final Nonce NONCE = new Nonce();
     private static final byte[] SALT = SaltHelper.generateNewSalt();
+    private static final String BASE_64_ENCODED_SALT = Base64.getEncoder().encodeToString(SALT);
     private static final Json objectMapper = SerializationService.getInstance();
     private AuthCodeHandler handler;
 
@@ -237,7 +243,8 @@ class AuthCodeHandlerTest {
             CredentialTrustLevel requestedLevel,
             CredentialTrustLevel finalLevel,
             MFAMethodType mfaMethodType)
-            throws ClientNotFoundException, Json.JsonException, JOSEException {
+            throws ClientNotFoundException, Json.JsonException, JOSEException, ParseException {
+        generateAuthUserInfo();
         var userProfile = new UserProfile().withEmail(EMAIL).withSubjectID(SUBJECT.getValue());
         when(dynamoClientService.getClient(CLIENT_ID.getValue()))
                 .thenReturn(Optional.of(generateClientRegistry()));
@@ -509,8 +516,8 @@ class AuthCodeHandlerTest {
 
     @Test
     void shouldGenerateErrorResponseWhenRedirectUriIsInvalid()
-            throws ClientNotFoundException, JOSEException {
-        session.setEmailAddress(EMAIL);
+            throws ClientNotFoundException, JOSEException, ParseException {
+        generateAuthUserInfo();
         generateValidSessionAndAuthRequest(MEDIUM_LEVEL, false);
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(false);
@@ -524,8 +531,8 @@ class AuthCodeHandlerTest {
 
     @Test
     void shouldGenerateErrorResponseWhenClientIsNotFound()
-            throws ClientNotFoundException, Json.JsonException, JOSEException {
-        session.setEmailAddress(EMAIL);
+            throws ClientNotFoundException, Json.JsonException, JOSEException, ParseException {
+        generateAuthUserInfo();
         AuthenticationErrorResponse authenticationErrorResponse =
                 new AuthenticationErrorResponse(
                         REDIRECT_URI, OAuth2Error.INVALID_CLIENT, null, null);
@@ -549,6 +556,33 @@ class AuthCodeHandlerTest {
                 authCodeResponse.getLocation(),
                 equalTo(
                         "http://localhost/redirect?error=invalid_client&error_description=Client+authentication+failed"));
+
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
+    void shouldGenerateErrorResponseWhenAuthUserInfoIsNotFound()
+            throws Json.JsonException, JOSEException {
+        AuthenticationErrorResponse authenticationErrorResponse =
+                new AuthenticationErrorResponse(
+                        REDIRECT_URI, OAuth2Error.ACCESS_DENIED, null, null);
+        when(orchestrationAuthorizationService.generateAuthenticationErrorResponse(
+                        any(AuthenticationRequest.class),
+                        eq(OAuth2Error.ACCESS_DENIED),
+                        any(URI.class),
+                        any(State.class)))
+                .thenReturn(authenticationErrorResponse);
+        generateValidSessionAndAuthRequest(MEDIUM_LEVEL, false);
+
+        APIGatewayProxyResponseEvent response = generateApiRequest();
+
+        assertThat(response, hasStatus(400));
+        AuthCodeResponse authCodeResponse =
+                objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
+        assertThat(
+                authCodeResponse.getLocation(),
+                equalTo(
+                        "http://localhost/redirect?error=access_denied&error_description=Access+denied+by+resource+owner+or+authorization+server"));
 
         verifyNoInteractions(auditService);
     }
@@ -615,7 +649,8 @@ class AuthCodeHandlerTest {
     }
 
     @Test
-    void shouldUpdateOrchSession() throws JOSEException, ClientNotFoundException {
+    void shouldUpdateOrchSession() throws JOSEException, ClientNotFoundException, ParseException {
+        generateAuthUserInfo();
 
         var authorizationCode = new AuthorizationCode();
         var authRequest = generateValidSessionAndAuthRequest(MEDIUM_LEVEL, false);
@@ -765,5 +800,27 @@ class AuthCodeHandlerTest {
                 .withContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
                 .withTestClient(false)
                 .withScopes(singletonList("openid"));
+    }
+
+    private void generateAuthUserInfo() throws ParseException {
+        var authUserInfo =
+                new UserInfo(
+                        new JSONObject(
+                                Map.of(
+                                        "sub",
+                                        INTERNAL_COMMON_SUBJECT_ID,
+                                        "client_session_id",
+                                        CLIENT_SESSION_ID,
+                                        "email",
+                                        EMAIL,
+                                        "phone_number",
+                                        PHONE_NUMBER,
+                                        "salt",
+                                        BASE_64_ENCODED_SALT,
+                                        "local_account_id",
+                                        SUBJECT.getValue())));
+        when(authUserInfoService.getAuthenticationUserInfo(
+                        INTERNAL_COMMON_SUBJECT_ID, CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(authUserInfo));
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -32,7 +32,6 @@ import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AuthCodeResponse;
 import uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
-import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
@@ -840,16 +839,6 @@ class AuthCodeHandlerTest {
                 .nonce(NONCE)
                 .requestObject(signedJWT)
                 .build();
-    }
-
-    private ClientRegistry generateClientRegistry() {
-        return new ClientRegistry()
-                .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
-                .withClientID(CLIENT_ID.getValue())
-                .withSectorIdentifierUri("https://rp-sector-uri")
-                .withContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
-                .withTestClient(false)
-                .withScopes(singletonList("openid"));
     }
 
     private void generateAuthUserInfo() throws ParseException {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -599,6 +599,46 @@ class AuthCodeHandlerTest {
     }
 
     @Test
+    void shouldGenerateErrorResponseWhenOrchSessionHasNoInternalCommonSubjectId()
+            throws Json.JsonException, JOSEException, ParseException, ClientNotFoundException {
+        generateAuthUserInfo();
+        when(clientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(MEDIUM_LEVEL)));
+        when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
+                .thenReturn(true);
+        when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(clientSession));
+        when(clientSession.getClientName()).thenReturn(CLIENT_NAME);
+        generateValidSessionAndAuthRequest(MEDIUM_LEVEL, false);
+        when(orchSessionService.getSession(anyString()))
+                .thenReturn(
+                        Optional.of(
+                                new OrchSessionItem(SESSION_ID)
+                                        .withAccountState(OrchSessionItem.AccountState.NEW)
+                                        .withAuthTime(12345L)));
+        AuthenticationErrorResponse authenticationErrorResponse =
+                new AuthenticationErrorResponse(
+                        REDIRECT_URI, OAuth2Error.ACCESS_DENIED, null, null);
+        when(orchestrationAuthorizationService.generateAuthenticationErrorResponse(
+                        any(AuthenticationRequest.class),
+                        eq(OAuth2Error.ACCESS_DENIED),
+                        any(URI.class),
+                        any(State.class)))
+                .thenReturn(authenticationErrorResponse);
+
+        APIGatewayProxyResponseEvent response = generateApiRequest();
+
+        assertThat(response, hasStatus(400));
+        AuthCodeResponse authCodeResponse =
+                objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
+        assertThat(
+                authCodeResponse.getLocation(),
+                equalTo(
+                        "http://localhost/redirect?error=access_denied&error_description=Access+denied+by+resource+owner+or+authorization+server"));
+
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
     void shouldGenerateErrorResponseIfUnableToParseAuthRequest() throws Json.JsonException {
         AuthenticationErrorResponse authenticationErrorResponse =
                 new AuthenticationErrorResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -43,7 +43,6 @@ import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
-import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
@@ -56,7 +55,6 @@ import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
-import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
@@ -123,7 +121,6 @@ class AuthCodeHandlerTest {
             mock(CloudwatchMetricsService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final Context context = mock(Context.class);
-    private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
     private final OrchestrationAuthorizationService orchestrationAuthorizationService =
             mock(OrchestrationAuthorizationService.class);
@@ -179,7 +176,7 @@ class AuthCodeHandlerTest {
     }
 
     @BeforeEach
-    void setUp() throws UserNotFoundException, ClientNotFoundException {
+    void setUp() {
         handler =
                 new AuthCodeHandler(
                         sessionService,
@@ -193,16 +190,10 @@ class AuthCodeHandlerTest {
                         auditService,
                         cloudwatchMetricsService,
                         configurationService,
-                        dynamoService,
-                        dynamoClientService);
+                        dynamoService);
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(configurationService.getEnvironment()).thenReturn("unit-test");
         when(configurationService.getInternalSectorURI()).thenReturn(INTERNAL_SECTOR_URI);
-        when(authCodeResponseService.getSubjectId(session)).thenReturn(SUBJECT.getValue());
-        when(authCodeResponseService.getRpPairwiseId(session, CLIENT_ID, dynamoClientService))
-                .thenReturn(
-                        ClientSubjectHelper.calculatePairwiseIdentifier(
-                                SUBJECT.getValue(), "rp-sector-uri", SALT));
         doAnswer(
                         (i) -> {
                             session.setNewAccount(EXISTING_DOC_APP_JOURNEY);
@@ -244,8 +235,6 @@ class AuthCodeHandlerTest {
             MFAMethodType mfaMethodType)
             throws ClientNotFoundException, Json.JsonException, JOSEException, ParseException {
         generateAuthUserInfo();
-        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
-                .thenReturn(Optional.of(generateClientRegistry()));
         if (Objects.nonNull(mfaMethodType)) {
             when(authCodeResponseService.getDimensions(
                             eq(orchSession),
@@ -307,6 +296,11 @@ class AuthCodeHandlerTest {
         when(clientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(requestedLevel)));
         when(clientSession.getVtrLocsAsCommaSeparatedString()).thenReturn("P0");
         when(orchClientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(requestedLevel)));
+        when(clientSession.getRpPairwiseId())
+                .thenReturn(
+                        ClientSubjectHelper.calculatePairwiseIdentifier(
+                                SUBJECT.getValue(), "rp-sector-uri", SALT));
+
         var response = generateApiRequest();
 
         assertThat(response, hasStatus(200));
@@ -572,7 +566,14 @@ class AuthCodeHandlerTest {
 
     @Test
     void shouldGenerateErrorResponseWhenAuthUserInfoIsNotFound()
-            throws Json.JsonException, JOSEException {
+            throws Json.JsonException, JOSEException, ClientNotFoundException {
+        when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
+                .thenReturn(true);
+        when(clientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(MEDIUM_LEVEL)));
+        when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(clientSession));
+        when(clientSession.getClientName()).thenReturn(CLIENT_NAME);
+        when(orchSessionService.getSession(anyString())).thenReturn(Optional.of(orchSession));
         AuthenticationErrorResponse authenticationErrorResponse =
                 new AuthenticationErrorResponse(
                         REDIRECT_URI, OAuth2Error.ACCESS_DENIED, null, null);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -281,7 +281,6 @@ class AuthCodeHandlerTest {
         var authRequest = generateValidSessionAndAuthRequest(requestedLevel, false);
         session.setCurrentCredentialStrength(initialLevel)
                 .setNewAccount(AccountState.NEW)
-                .setEmailAddress(EMAIL)
                 .setVerifiedMfaMethodType(mfaMethodType);
         orchSession.setCurrentCredentialStrength(initialLevel);
         var authSuccessResponse =
@@ -350,6 +349,14 @@ class AuthCodeHandlerTest {
                         pair("rpPairwiseId", expectedRpPairwiseId),
                         pair("authCode", authorizationCode),
                         pair("nonce", NONCE.getValue()));
+
+        verify(authorisationCodeService, times(1))
+                .generateAndSaveAuthorisationCode(
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(EMAIL),
+                        eq(clientSession),
+                        any(Long.class));
 
         var dimensions =
                 Map.of(
@@ -468,6 +475,13 @@ class AuthCodeHandlerTest {
                         pair("rpPairwiseId", AuditService.UNKNOWN),
                         pair("authCode", authorizationCode),
                         pair("nonce", NONCE.getValue()));
+        verify(authorisationCodeService, times(1))
+                .generateAndSaveAuthorisationCode(
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(null),
+                        eq(clientSession),
+                        any(Long.class));
 
         var expectedDimensions =
                 Map.of(
@@ -589,7 +603,6 @@ class AuthCodeHandlerTest {
 
     @Test
     void shouldGenerateErrorResponseIfUnableToParseAuthRequest() throws Json.JsonException {
-        session.setEmailAddress(EMAIL);
         AuthenticationErrorResponse authenticationErrorResponse =
                 new AuthenticationErrorResponse(
                         REDIRECT_URI, OAuth2Error.INVALID_REQUEST, null, null);
@@ -676,7 +689,7 @@ class AuthCodeHandlerTest {
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
-                        eq(null),
+                        eq(EMAIL),
                         eq(clientSession),
                         any(Long.class)))
                 .thenReturn(authorizationCode);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -41,7 +41,6 @@ import uk.gov.di.orchestration.shared.entity.MFAMethodType;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
-import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
@@ -245,10 +244,8 @@ class AuthCodeHandlerTest {
             MFAMethodType mfaMethodType)
             throws ClientNotFoundException, Json.JsonException, JOSEException, ParseException {
         generateAuthUserInfo();
-        var userProfile = new UserProfile().withEmail(EMAIL).withSubjectID(SUBJECT.getValue());
         when(dynamoClientService.getClient(CLIENT_ID.getValue()))
                 .thenReturn(Optional.of(generateClientRegistry()));
-        when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
         if (Objects.nonNull(mfaMethodType)) {
             when(authCodeResponseService.getDimensions(
                             eq(orchSession),
@@ -292,7 +289,6 @@ class AuthCodeHandlerTest {
                         authRequest.getState(),
                         null,
                         authRequest.getResponseMode());
-        when(dynamoService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(Optional.of(userProfile));
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -1,6 +1,5 @@
 package uk.gov.di.orchestration.shared.services;
 
-import com.nimbusds.oauth2.sdk.id.ClientID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
@@ -8,9 +7,7 @@ import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
-import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
-import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -92,28 +89,6 @@ public class AuthCodeResponseGenerationService {
         return Objects.isNull(session.getEmailAddress())
                 ? AuditService.UNKNOWN
                 : userProfile.getSubjectID();
-    }
-
-    public String getRpPairwiseId(
-            Session session, ClientID clientID, DynamoClientService dynamoClientService)
-            throws UserNotFoundException, ClientNotFoundException {
-        var userProfile =
-                dynamoService
-                        .getUserProfileByEmailMaybe(session.getEmailAddress())
-                        .orElseThrow(
-                                () ->
-                                        new UserNotFoundException(
-                                                "Unable to find user with given email address"));
-        var client =
-                dynamoClientService
-                        .getClient(clientID.getValue())
-                        .orElseThrow(() -> new ClientNotFoundException(clientID.getValue()));
-        return ClientSubjectHelper.getSubject(
-                        userProfile,
-                        client,
-                        dynamoService,
-                        configurationService.getInternalSectorURI())
-                .getValue();
     }
 
     public void saveSession(


### PR DESCRIPTION
### Wider context of change
This is part of the session migration work; specifically the email migration. 

### What’s changed
Remove use of `session.getEmailAddress()`, and by extension, use of the UserProfile table.

Also has some performance improvements, as we previously made several dynamoDb calls.

### Manual testing
Deployed to dev and ran a successful identity reuse journey.

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing. **I have added permissions [here](https://github.com/govuk-one-login/authentication-api/pull/6003)**
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not Needed**
- [x] Changes have been made to the simulator or not required. **Not Needed**
- [x] Changes have been made to stubs or not required. **Not Needed**
- [x] Successfully deployed to authdev or not required. **Not Needed**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not Needed**
