### PR TITLE
ATO-1469: write to new identity credentials table

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -28,7 +28,7 @@ import uk.gov.di.authentication.ipv.entity.LogIds;
 import uk.gov.di.authentication.ipv.entity.SPOTRequest;
 import uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler;
 import uk.gov.di.authentication.testsupport.helpers.SpotQueueAssertionHelper;
-import uk.gov.di.orchestration.shared.entity.IdentityCredentials;
+import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.MFAMethodType;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
@@ -207,22 +207,22 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
         assertTrue(
                 identityCredentials
-                        .map(IdentityCredentials::getAdditionalClaims)
+                        .map(AuthIdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.ADDRESS.getValue()))
                         .isPresent());
         assertTrue(
                 identityCredentials
-                        .map(IdentityCredentials::getAdditionalClaims)
+                        .map(AuthIdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.PASSPORT.getValue()))
                         .isPresent());
         assertTrue(
                 identityCredentials
-                        .map(IdentityCredentials::getAdditionalClaims)
+                        .map(AuthIdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.DRIVING_PERMIT.getValue()))
                         .isPresent());
         assertTrue(
                 identityCredentials
-                        .map(IdentityCredentials::getAdditionalClaims)
+                        .map(AuthIdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.RETURN_CODE.getValue()))
                         .isPresent());
 
@@ -416,7 +416,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
         assertTrue(
                 identityCredentials
-                        .map(IdentityCredentials::getAdditionalClaims)
+                        .map(AuthIdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.RETURN_CODE.getValue()))
                         .isPresent());
         var returnCode =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
@@ -79,7 +79,8 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
         var signedCredential = SignedCredentialHelper.generateCredential();
         var pairwiseIdentifier =
                 calculatePairwiseIdentifier(INTERNAL_SUBJECT.getValue(), "test.com", salt);
-        identityStore.addCoreIdentityJWT(pairwiseIdentifier, signedCredential.serialize());
+        identityStore.addCoreIdentityJWT(
+                CLIENT_SESSION_ID, pairwiseIdentifier, signedCredential.serialize());
 
         Map<String, String> headers = new HashMap<>();
         headers.put("Session-Id", SESSION_ID);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
@@ -110,6 +110,7 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
         var pairwiseIdentifier =
                 calculatePairwiseIdentifier(INTERNAL_SUBJECT.getValue(), "test.com", salt);
         identityStore.saveIdentityClaims(
+                CLIENT_SESSION_ID,
                 pairwiseIdentifier,
                 emptyMap(),
                 LevelOfConfidence.MEDIUM_LEVEL.getValue(),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -456,6 +456,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         IdentityStoreExtension identityStore = new IdentityStoreExtension(ttl);
         if (Objects.nonNull(additionalClaims)) {
             identityStore.saveIdentityClaims(
+                    JOURNEY_ID,
                     PUBLIC_SUBJECT.getValue(),
                     additionalClaims,
                     LevelOfConfidence.MEDIUM_LEVEL.getValue(),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -463,7 +463,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     CORE_IDENTITY_CLAIM);
         }
         if (Objects.nonNull(coreIdentityJWT)) {
-            identityStore.addCoreIdentityJWT(PUBLIC_SUBJECT.getValue(), coreIdentityJWT);
+            identityStore.addCoreIdentityJWT(
+                    JOURNEY_ID, PUBLIC_SUBJECT.getValue(), coreIdentityJWT);
         }
         userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, INTERNAL_SUBJECT);
         userStore.addVerifiedPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -56,6 +56,7 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
     void shouldAddSpotCredentialToDBForValidResponseWhenEntryAlreadyExists() {
         var pairwiseIdentifier = new Subject();
         identityStore.saveIdentityClaims(
+                CLIENT_SESSION_ID,
                 pairwiseIdentifier.getValue(),
                 Map.of(
                         ValidClaims.ADDRESS.getValue(),
@@ -137,6 +138,7 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
                         REQUEST_ID,
                         CLIENT_ID);
         identityStore.saveIdentityClaims(
+                CLIENT_SESSION_ID,
                 pairwiseIdentifier.getValue(),
                 emptyMap(),
                 LevelOfConfidence.MEDIUM_LEVEL.getValue(),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler;
-import uk.gov.di.orchestration.shared.entity.IdentityCredentials;
+import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.sharedtest.basetest.IntegrationTest;
@@ -78,7 +78,7 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
                         CLIENT_ID);
         handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
-        Optional<IdentityCredentials> identityCredentials =
+        Optional<AuthIdentityCredentials> identityCredentials =
                 identityStore.getIdentityCredentials(pairwiseIdentifier.getValue());
         assertTrue(identityCredentials.isPresent());
         assertThat(
@@ -110,7 +110,7 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
                         CLIENT_ID);
         handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
-        Optional<IdentityCredentials> identityCredentials =
+        Optional<AuthIdentityCredentials> identityCredentials =
                 identityStore.getIdentityCredentials(pairwiseIdentifier.getValue());
         assertTrue(identityCredentials.isPresent());
         assertNull(identityCredentials.get().getAdditionalClaims());

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -206,7 +206,9 @@ public class IPVCallbackHelper {
         LOG.warn("SPOT will not be invoked due to returnCode. Returning authCode to RP");
         segmentedFunctionCall(
                 "saveIdentityClaims",
-                () -> saveIdentityClaimsToDynamo(rpPairwiseSubject, userIdentityUserInfo));
+                () ->
+                        saveIdentityClaimsToDynamo(
+                                clientSessionId, rpPairwiseSubject, userIdentityUserInfo));
         var authCode =
                 authorisationCodeService.generateAndSaveAuthorisationCode(
                         clientId,
@@ -309,7 +311,7 @@ public class IPVCallbackHelper {
     }
 
     public void saveIdentityClaimsToDynamo(
-            Subject rpPairwiseSubject, UserInfo userIdentityUserInfo) {
+            String clientSessionId, Subject rpPairwiseSubject, UserInfo userIdentityUserInfo) {
         LOG.info("Checking for additional identity claims to save to dynamo");
         var additionalClaims = new HashMap<String, String>();
         ValidClaims.getAllValidClaims().stream()
@@ -330,6 +332,7 @@ public class IPVCallbackHelper {
         String ipvCoreIdentityString =
                 ipvCoreIdentityClaim == null ? "" : ipvCoreIdentityClaim.toString();
         dynamoIdentityService.saveIdentityClaims(
+                clientSessionId,
                 rpPairwiseSubject.getValue(),
                 additionalClaims,
                 (String) userIdentityUserInfo.getClaim(VOT.getValue()),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -522,7 +522,7 @@ public class IPVCallbackHandler
                     "saveIdentityClaims",
                     () ->
                             ipvCallbackHelper.saveIdentityClaimsToDynamo(
-                                    rpPairwiseSubject, userIdentityUserInfo));
+                                    clientSessionId, rpPairwiseSubject, userIdentityUserInfo));
             var redirectURI = frontend.ipvCallbackURI();
             LOG.info("Successful IPV callback. Redirecting to frontend");
             return generateApiGatewayProxyResponse(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -83,6 +83,7 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                     auditService.submitAuditEvent(
                             IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED, logIds.getClientId(), user);
                     dynamoIdentityService.addCoreIdentityJWT(
+                            logIds.getClientSessionId(),
                             spotResponse.getSub(),
                             spotResponse.getClaims().values().stream()
                                     .map(Object::toString)

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -97,7 +97,8 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                             spotResponse.getReason());
                     auditService.submitAuditEvent(
                             IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED, logIds.getClientId(), user);
-                    dynamoIdentityService.deleteIdentityCredentials(spotResponse.getSub());
+                    dynamoIdentityService.deleteIdentityCredentials(
+                            logIds.getClientSessionId(), spotResponse.getSub());
                     return null;
                 }
             } catch (JsonException e) {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -326,7 +326,8 @@ class IPVCallbackHelperTest {
 
     @Test
     void shouldSaveAdditionalIdentityClaimsToDynamo() {
-        helper.saveIdentityClaimsToDynamo(RP_PAIRWISE_SUBJECT, p2VotUserIdentityUserInfo);
+        helper.saveIdentityClaimsToDynamo(
+                CLIENT_SESSION_ID, RP_PAIRWISE_SUBJECT, p2VotUserIdentityUserInfo);
 
         assertThat(
                 logging.events(),
@@ -338,6 +339,7 @@ class IPVCallbackHelperTest {
                 hasItem(withMessageContaining("Additional identity claims present: true")));
         verify(dynamoIdentityService)
                 .saveIdentityClaims(
+                        CLIENT_SESSION_ID,
                         "rp-pairwise-id",
                         Map.of("https://vocab.account.gov.uk/v1/passport", "passport"),
                         "P2",
@@ -354,7 +356,7 @@ class IPVCallbackHelperTest {
                                         "vot", "P2",
                                         "vtm", OIDC_TRUSTMARK_URI.toString(),
                                         "https://vocab.account.gov.uk/v1/passport", "passport")));
-        helper.saveIdentityClaimsToDynamo(RP_PAIRWISE_SUBJECT, userInfo);
+        helper.saveIdentityClaimsToDynamo(CLIENT_SESSION_ID, RP_PAIRWISE_SUBJECT, userInfo);
 
         assertThat(
                 logging.events(),
@@ -366,6 +368,7 @@ class IPVCallbackHelperTest {
                 hasItem(withMessageContaining("Additional identity claims present: true")));
         verify(dynamoIdentityService)
                 .saveIdentityClaims(
+                        CLIENT_SESSION_ID,
                         "rp-pairwise-id",
                         Map.of("https://vocab.account.gov.uk/v1/passport", "passport"),
                         "P2",
@@ -386,7 +389,7 @@ class IPVCallbackHelperTest {
                                         put("https://vocab.account.gov.uk/v1/passport", "passport");
                                     }
                                 }));
-        helper.saveIdentityClaimsToDynamo(RP_PAIRWISE_SUBJECT, userInfo);
+        helper.saveIdentityClaimsToDynamo(CLIENT_SESSION_ID, RP_PAIRWISE_SUBJECT, userInfo);
 
         assertThat(
                 logging.events(),
@@ -398,6 +401,7 @@ class IPVCallbackHelperTest {
                 hasItem(withMessageContaining("Additional identity claims present: true")));
         verify(dynamoIdentityService)
                 .saveIdentityClaims(
+                        CLIENT_SESSION_ID,
                         "rp-pairwise-id",
                         Map.of("https://vocab.account.gov.uk/v1/passport", "passport"),
                         "P2",

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -623,7 +623,8 @@ class IPVCallbackHandlerTest {
                         any(UserInfo.class),
                         eq(CLIENT_ID.getValue()));
         verify(ipvCallbackHelper)
-                .saveIdentityClaimsToDynamo(any(Subject.class), any(UserInfo.class));
+                .saveIdentityClaimsToDynamo(
+                        any(String.class), any(Subject.class), any(UserInfo.class));
 
         verifyAuditEvent(IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED);
         verifyAuditEvent(IPVAuditableEvent.IPV_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -19,9 +19,9 @@ import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.IdentityProgressResponse;
 import uk.gov.di.authentication.ipv.entity.IdentityProgressStatus;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
+import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
-import uk.gov.di.orchestration.shared.entity.IdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
@@ -165,7 +165,7 @@ public class IdentityProgressFrontendHandlerTest {
     void shouldReturnCOMPLETEDStatusWhenIdentityCredentialIsPresent() throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new IdentityCredentials()
+                new AuthIdentityCredentials()
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
@@ -204,7 +204,7 @@ public class IdentityProgressFrontendHandlerTest {
             throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new IdentityCredentials()
+                new AuthIdentityCredentials()
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap());
         when(dynamoIdentityService.getIdentityCredentials(anyString()))
@@ -311,7 +311,7 @@ public class IdentityProgressFrontendHandlerTest {
     void shouldReturnExpectedResponseBody() {
         usingValidSession();
         var identityCredentials =
-                new IdentityCredentials()
+                new AuthIdentityCredentials()
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -16,11 +16,11 @@ import uk.gov.di.authentication.ipv.entity.ProcessingIdentityResponse;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityStatus;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
+import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
-import uk.gov.di.orchestration.shared.entity.IdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
@@ -171,7 +171,7 @@ class ProcessingIdentityHandlerTest {
     void shouldReturnCOMPLETEDStatusWhenIdentityCredentialIsPresent() throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new IdentityCredentials()
+                new AuthIdentityCredentials()
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
@@ -203,7 +203,7 @@ class ProcessingIdentityHandlerTest {
     void shouldCallAISIfProcessingStatusIsCOMPLETED() throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new IdentityCredentials()
+                new AuthIdentityCredentials()
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
@@ -233,7 +233,7 @@ class ProcessingIdentityHandlerTest {
             throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new IdentityCredentials()
+                new AuthIdentityCredentials()
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
@@ -283,7 +283,7 @@ class ProcessingIdentityHandlerTest {
             throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new IdentityCredentials()
+                new AuthIdentityCredentials()
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap());
         when(dynamoIdentityService.getIdentityCredentials(anyString()))

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -94,7 +94,8 @@ class SPOTResponseHandlerTest {
         handler.handleRequest(generateSQSEvent(json), context);
 
         verify(dynamoIdentityService)
-                .deleteIdentityCredentials("urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6");
+                .deleteIdentityCredentials(
+                        CLIENT_SESSION_ID, "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6");
 
         verify(auditService)
                 .submitAuditEvent(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -61,6 +61,7 @@ class SPOTResponseHandlerTest {
 
         verify(dynamoIdentityService)
                 .addCoreIdentityJWT(
+                        CLIENT_SESSION_ID,
                         "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
                         "random-searalized-credential");
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -24,9 +24,9 @@ import uk.gov.di.authentication.app.entity.DocAppCredential;
 import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.orchestration.shared.entity.AccessTokenStore;
+import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
-import uk.gov.di.orchestration.shared.entity.IdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.exceptions.AccessTokenException;
@@ -245,7 +245,7 @@ class UserInfoServiceTest {
                         ParseException {
             when(configurationService.isIdentityEnabled()).thenReturn(true);
             var identityCredentials =
-                    new IdentityCredentials()
+                    new AuthIdentityCredentials()
                             .withSubjectID(SUBJECT.getValue())
                             .withCoreIdentityJWT(coreIdentityJWT)
                             .withAdditionalClaims(
@@ -384,7 +384,7 @@ class UserInfoServiceTest {
                         ParseException {
             when(configurationService.isIdentityEnabled()).thenReturn(true);
             var identityCredentials =
-                    new IdentityCredentials()
+                    new AuthIdentityCredentials()
                             .withSubjectID(SUBJECT.getValue())
                             .withCoreIdentityJWT(coreIdentityJWT);
             accessToken = createSignedAccessToken(oidcValidClaimsRequest);

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
@@ -62,8 +62,9 @@ public class IdentityStoreExtension extends DynamoExtension implements AfterEach
         }
     }
 
-    public void addCoreIdentityJWT(String subjectID, String coreIdentityJWT) {
-        dynamoService.addCoreIdentityJWT(subjectID, coreIdentityJWT);
+    public void addCoreIdentityJWT(
+            String clientSessionId, String subjectID, String coreIdentityJWT) {
+        dynamoService.addCoreIdentityJWT(clientSessionId, subjectID, coreIdentityJWT);
     }
 
     public void saveIdentityClaims(

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
@@ -67,11 +67,13 @@ public class IdentityStoreExtension extends DynamoExtension implements AfterEach
     }
 
     public void saveIdentityClaims(
+            String clientSessionId,
             String subjectID,
             Map<String, String> additionalClaims,
             String ipvVot,
             String ipvCoreIdentity) {
-        dynamoService.saveIdentityClaims(subjectID, additionalClaims, ipvVot, ipvCoreIdentity);
+        dynamoService.saveIdentityClaims(
+                clientSessionId, subjectID, additionalClaims, ipvVot, ipvCoreIdentity);
     }
 
     public Optional<AuthIdentityCredentials> getIdentityCredentials(String subjectID) {

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
@@ -8,7 +8,7 @@ import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
-import uk.gov.di.orchestration.shared.entity.IdentityCredentials;
+import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 import uk.gov.di.orchestration.sharedtest.basetest.DynamoTestConfiguration;
@@ -67,7 +67,7 @@ public class IdentityStoreExtension extends DynamoExtension implements AfterEach
         dynamoService.saveIdentityClaims(subjectID, additionalClaims, ipvVot, ipvCoreIdentity);
     }
 
-    public Optional<IdentityCredentials> getIdentityCredentials(String subjectID) {
+    public Optional<AuthIdentityCredentials> getIdentityCredentials(String subjectID) {
         return dynamoService.getIdentityCredentials(subjectID);
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthIdentityCredentials.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthIdentityCredentials.java
@@ -7,7 +7,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 import java.util.Map;
 
 @DynamoDbBean
-public class IdentityCredentials {
+public class AuthIdentityCredentials {
 
     private String subjectID;
     private String coreIdentityJWT;
@@ -16,7 +16,7 @@ public class IdentityCredentials {
     private String ipvVot;
     private String ipvCoreIdentity;
 
-    public IdentityCredentials() {}
+    public AuthIdentityCredentials() {}
 
     @DynamoDbPartitionKey
     @DynamoDbAttribute("SubjectID")
@@ -28,7 +28,7 @@ public class IdentityCredentials {
         this.subjectID = subjectID;
     }
 
-    public IdentityCredentials withSubjectID(String subjectID) {
+    public AuthIdentityCredentials withSubjectID(String subjectID) {
         this.subjectID = subjectID;
         return this;
     }
@@ -42,7 +42,7 @@ public class IdentityCredentials {
         this.coreIdentityJWT = coreIdentityJWT;
     }
 
-    public IdentityCredentials withCoreIdentityJWT(String coreIdentityJWT) {
+    public AuthIdentityCredentials withCoreIdentityJWT(String coreIdentityJWT) {
         this.coreIdentityJWT = coreIdentityJWT;
         return this;
     }
@@ -56,7 +56,7 @@ public class IdentityCredentials {
         this.timeToExist = timeToExist;
     }
 
-    public IdentityCredentials withTimeToExist(long timeToExist) {
+    public AuthIdentityCredentials withTimeToExist(long timeToExist) {
         this.timeToExist = timeToExist;
         return this;
     }
@@ -70,7 +70,7 @@ public class IdentityCredentials {
         this.additionalClaims = additionalClaims;
     }
 
-    public IdentityCredentials withAdditionalClaims(Map<String, String> additionalClaims) {
+    public AuthIdentityCredentials withAdditionalClaims(Map<String, String> additionalClaims) {
         this.additionalClaims = additionalClaims;
         return this;
     }
@@ -84,7 +84,7 @@ public class IdentityCredentials {
         this.ipvVot = ipvVot;
     }
 
-    public IdentityCredentials withIpvVot(String ipvVot) {
+    public AuthIdentityCredentials withIpvVot(String ipvVot) {
         this.ipvVot = ipvVot;
         return this;
     }
@@ -98,7 +98,7 @@ public class IdentityCredentials {
         this.ipvCoreIdentity = ipvCoreIdentity;
     }
 
-    public IdentityCredentials withIpvCoreIdentity(String ipvCoreIdentity) {
+    public AuthIdentityCredentials withIpvCoreIdentity(String ipvCoreIdentity) {
         this.ipvCoreIdentity = ipvCoreIdentity;
         return this;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchIdentityCredentials.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchIdentityCredentials.java
@@ -1,0 +1,105 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+import java.util.Map;
+
+@DynamoDbBean
+public class OrchIdentityCredentials {
+
+    private String subjectID;
+    private String coreIdentityJWT;
+    private long timeToExist;
+    private Map<String, String> additionalClaims;
+    private String ipvVot;
+    private String ipvCoreIdentity;
+
+    public OrchIdentityCredentials() {}
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("SubjectID")
+    public String getSubjectID() {
+        return subjectID;
+    }
+
+    public void setSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+    }
+
+    public OrchIdentityCredentials withSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+        return this;
+    }
+
+    @DynamoDbAttribute("CoreIdentityJWT")
+    public String getCoreIdentityJWT() {
+        return coreIdentityJWT;
+    }
+
+    public void setCoreIdentityJWT(String coreIdentityJWT) {
+        this.coreIdentityJWT = coreIdentityJWT;
+    }
+
+    public OrchIdentityCredentials withCoreIdentityJWT(String coreIdentityJWT) {
+        this.coreIdentityJWT = coreIdentityJWT;
+        return this;
+    }
+
+    @DynamoDbAttribute("TimeToExist")
+    public long getTimeToExist() {
+        return timeToExist;
+    }
+
+    public void setTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+    }
+
+    public OrchIdentityCredentials withTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+        return this;
+    }
+
+    @DynamoDbAttribute("AdditionalClaims")
+    public Map<String, String> getAdditionalClaims() {
+        return additionalClaims;
+    }
+
+    public void setAdditionalClaims(Map<String, String> additionalClaims) {
+        this.additionalClaims = additionalClaims;
+    }
+
+    public OrchIdentityCredentials withAdditionalClaims(Map<String, String> additionalClaims) {
+        this.additionalClaims = additionalClaims;
+        return this;
+    }
+
+    @DynamoDbAttribute("IpvVot")
+    public String getIpvVot() {
+        return ipvVot;
+    }
+
+    public void setIpvVot(String ipvVot) {
+        this.ipvVot = ipvVot;
+    }
+
+    public OrchIdentityCredentials withIpvVot(String ipvVot) {
+        this.ipvVot = ipvVot;
+        return this;
+    }
+
+    @DynamoDbAttribute("IpvCoreIdentity")
+    public String getIpvCoreIdentity() {
+        return ipvCoreIdentity;
+    }
+
+    public void setIpvCoreIdentity(String ipvCoreIdentity) {
+        this.ipvCoreIdentity = ipvCoreIdentity;
+    }
+
+    public OrchIdentityCredentials withIpvCoreIdentity(String ipvCoreIdentity) {
+        this.ipvCoreIdentity = ipvCoreIdentity;
+        return this;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchIdentityCredentials.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchIdentityCredentials.java
@@ -9,6 +9,7 @@ import java.util.Map;
 @DynamoDbBean
 public class OrchIdentityCredentials {
 
+    private String clientSessionId;
     private String subjectID;
     private String coreIdentityJWT;
     private long timeToExist;
@@ -19,6 +20,20 @@ public class OrchIdentityCredentials {
     public OrchIdentityCredentials() {}
 
     @DynamoDbPartitionKey
+    @DynamoDbAttribute("ClientSessionId")
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
+    public void setClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+    }
+
+    public OrchIdentityCredentials withClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+        return this;
+    }
+
     @DynamoDbAttribute("SubjectID")
     public String getSubjectID() {
         return subjectID;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchIdentityCredentials.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchIdentityCredentials.java
@@ -62,7 +62,7 @@ public class OrchIdentityCredentials {
         return this;
     }
 
-    @DynamoDbAttribute("TimeToExist")
+    @DynamoDbAttribute("ttl")
     public long getTimeToExist() {
         return timeToExist;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
@@ -55,11 +55,12 @@ public class DynamoIdentityService {
     }
 
     public void saveIdentityClaims(
+            String clientSessionId,
             String subjectID,
             Map<String, String> additionalClaims,
             String ipvVot,
             String ipvCoreIdentity) {
-        var identityCredentials =
+        var authIdentityCredentials =
                 new AuthIdentityCredentials()
                         .withSubjectID(subjectID)
                         .withAdditionalClaims(additionalClaims)
@@ -69,7 +70,19 @@ public class DynamoIdentityService {
                                 NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
                                         .toInstant()
                                         .getEpochSecond());
+        authIdentityCredentialsDynamoService.put(authIdentityCredentials);
 
-        authIdentityCredentialsDynamoService.put(identityCredentials);
+        var identityCredentials =
+                new OrchIdentityCredentials()
+                        .withClientSessionId(clientSessionId)
+                        .withSubjectID(subjectID)
+                        .withAdditionalClaims(additionalClaims)
+                        .withIpvVot(ipvVot)
+                        .withIpvCoreIdentity(ipvCoreIdentity)
+                        .withTimeToExist(
+                                NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond());
+        orchIdentityCredentialsDynamoService.put(identityCredentials);
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
@@ -63,8 +63,9 @@ public class DynamoIdentityService {
                 .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
     }
 
-    public void deleteIdentityCredentials(String subjectID) {
+    public void deleteIdentityCredentials(String clientSessionId, String subjectID) {
         authIdentityCredentialsDynamoService.delete(subjectID);
+        orchIdentityCredentialsDynamoService.delete(clientSessionId);
     }
 
     public void saveIdentityClaims(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.orchestration.shared.services;
 
 import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
+import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 
 import java.time.temporal.ChronoUnit;
@@ -11,6 +12,7 @@ public class DynamoIdentityService {
 
     private final long timeToExist;
     private final BaseDynamoService<AuthIdentityCredentials> authIdentityCredentialsDynamoService;
+    private final BaseDynamoService<OrchIdentityCredentials> orchIdentityCredentialsDynamoService;
 
     public DynamoIdentityService(ConfigurationService configurationService) {
         authIdentityCredentialsDynamoService =
@@ -18,6 +20,12 @@ public class DynamoIdentityService {
                         AuthIdentityCredentials.class,
                         "identity-credentials",
                         configurationService);
+        orchIdentityCredentialsDynamoService =
+                new BaseDynamoService<>(
+                        OrchIdentityCredentials.class,
+                        "Orch-Identity-Credentials",
+                        configurationService,
+                        true);
         this.timeToExist = configurationService.getAccessTokenExpiry();
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
@@ -1,25 +1,25 @@
 package uk.gov.di.orchestration.shared.services;
 
-import uk.gov.di.orchestration.shared.entity.IdentityCredentials;
+import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Optional;
 
-public class DynamoIdentityService extends BaseDynamoService<IdentityCredentials> {
+public class DynamoIdentityService extends BaseDynamoService<AuthIdentityCredentials> {
 
     private final long timeToExist;
 
     public DynamoIdentityService(ConfigurationService configurationService) {
-        super(IdentityCredentials.class, "identity-credentials", configurationService);
+        super(AuthIdentityCredentials.class, "identity-credentials", configurationService);
         this.timeToExist = configurationService.getAccessTokenExpiry();
     }
 
     public void addCoreIdentityJWT(String subjectID, String coreIdentityJWT) {
         var identityCredentials =
                 get(subjectID)
-                        .orElse(new IdentityCredentials())
+                        .orElse(new AuthIdentityCredentials())
                         .withSubjectID(subjectID)
                         .withCoreIdentityJWT(coreIdentityJWT)
                         .withTimeToExist(
@@ -30,7 +30,7 @@ public class DynamoIdentityService extends BaseDynamoService<IdentityCredentials
         update(identityCredentials);
     }
 
-    public Optional<IdentityCredentials> getIdentityCredentials(String subjectID) {
+    public Optional<AuthIdentityCredentials> getIdentityCredentials(String subjectID) {
         return get(subjectID)
                 .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
     }
@@ -45,7 +45,7 @@ public class DynamoIdentityService extends BaseDynamoService<IdentityCredentials
             String ipvVot,
             String ipvCoreIdentity) {
         var identityCredentials =
-                new IdentityCredentials()
+                new AuthIdentityCredentials()
                         .withSubjectID(subjectID)
                         .withAdditionalClaims(additionalClaims)
                         .withIpvVot(ipvVot)

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
@@ -29,8 +29,9 @@ public class DynamoIdentityService {
         this.timeToExist = configurationService.getAccessTokenExpiry();
     }
 
-    public void addCoreIdentityJWT(String subjectID, String coreIdentityJWT) {
-        var identityCredentials =
+    public void addCoreIdentityJWT(
+            String clientSessionId, String subjectID, String coreIdentityJWT) {
+        var authIdentityCredentials =
                 authIdentityCredentialsDynamoService
                         .get(subjectID)
                         .orElse(new AuthIdentityCredentials())
@@ -40,8 +41,20 @@ public class DynamoIdentityService {
                                 NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
                                         .toInstant()
                                         .getEpochSecond());
+        authIdentityCredentialsDynamoService.update(authIdentityCredentials);
 
-        authIdentityCredentialsDynamoService.update(identityCredentials);
+        var identityCredentials =
+                orchIdentityCredentialsDynamoService
+                        .get(clientSessionId)
+                        .orElse(new OrchIdentityCredentials())
+                        .withClientSessionId(clientSessionId)
+                        .withSubjectID(subjectID)
+                        .withCoreIdentityJWT(coreIdentityJWT)
+                        .withTimeToExist(
+                                NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond());
+        orchIdentityCredentialsDynamoService.update(identityCredentials);
     }
 
     public Optional<AuthIdentityCredentials> getIdentityCredentials(String subjectID) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IdentityStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IdentityStoreExtension.java
@@ -8,7 +8,7 @@ import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
-import uk.gov.di.authentication.shared.entity.IdentityCredentials;
+import uk.gov.di.authentication.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoIdentityService;
 import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
@@ -67,7 +67,7 @@ public class IdentityStoreExtension extends DynamoExtension implements AfterEach
         dynamoService.saveIdentityClaims(subjectID, additionalClaims, ipvVot, ipvCoreIdentity);
     }
 
-    public Optional<IdentityCredentials> getIdentityCredentials(String subjectID) {
+    public Optional<AuthIdentityCredentials> getIdentityCredentials(String subjectID) {
         return dynamoService.getIdentityCredentials(subjectID);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthIdentityCredentials.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthIdentityCredentials.java
@@ -7,7 +7,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 import java.util.Map;
 
 @DynamoDbBean
-public class IdentityCredentials {
+public class AuthIdentityCredentials {
 
     private String subjectID;
     private String coreIdentityJWT;
@@ -16,7 +16,7 @@ public class IdentityCredentials {
     private String ipvVot;
     private String ipvCoreIdentity;
 
-    public IdentityCredentials() {}
+    public AuthIdentityCredentials() {}
 
     @DynamoDbPartitionKey
     @DynamoDbAttribute("SubjectID")
@@ -28,7 +28,7 @@ public class IdentityCredentials {
         this.subjectID = subjectID;
     }
 
-    public IdentityCredentials withSubjectID(String subjectID) {
+    public AuthIdentityCredentials withSubjectID(String subjectID) {
         this.subjectID = subjectID;
         return this;
     }
@@ -42,7 +42,7 @@ public class IdentityCredentials {
         this.coreIdentityJWT = coreIdentityJWT;
     }
 
-    public IdentityCredentials withCoreIdentityJWT(String coreIdentityJWT) {
+    public AuthIdentityCredentials withCoreIdentityJWT(String coreIdentityJWT) {
         this.coreIdentityJWT = coreIdentityJWT;
         return this;
     }
@@ -56,7 +56,7 @@ public class IdentityCredentials {
         this.timeToExist = timeToExist;
     }
 
-    public IdentityCredentials withTimeToExist(long timeToExist) {
+    public AuthIdentityCredentials withTimeToExist(long timeToExist) {
         this.timeToExist = timeToExist;
         return this;
     }
@@ -70,7 +70,7 @@ public class IdentityCredentials {
         this.additionalClaims = additionalClaims;
     }
 
-    public IdentityCredentials withAdditionalClaims(Map<String, String> additionalClaims) {
+    public AuthIdentityCredentials withAdditionalClaims(Map<String, String> additionalClaims) {
         this.additionalClaims = additionalClaims;
         return this;
     }
@@ -84,7 +84,7 @@ public class IdentityCredentials {
         this.ipvVot = ipvVot;
     }
 
-    public IdentityCredentials withIpvVot(String ipvVot) {
+    public AuthIdentityCredentials withIpvVot(String ipvVot) {
         this.ipvVot = ipvVot;
         return this;
     }
@@ -98,7 +98,7 @@ public class IdentityCredentials {
         this.ipvCoreIdentity = ipvCoreIdentity;
     }
 
-    public IdentityCredentials withIpvCoreIdentity(String ipvCoreIdentity) {
+    public AuthIdentityCredentials withIpvCoreIdentity(String ipvCoreIdentity) {
         this.ipvCoreIdentity = ipvCoreIdentity;
         return this;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoIdentityService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoIdentityService.java
@@ -1,25 +1,25 @@
 package uk.gov.di.authentication.shared.services;
 
-import uk.gov.di.authentication.shared.entity.IdentityCredentials;
+import uk.gov.di.authentication.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Optional;
 
-public class DynamoIdentityService extends BaseDynamoService<IdentityCredentials> {
+public class DynamoIdentityService extends BaseDynamoService<AuthIdentityCredentials> {
 
     private final long timeToExist;
 
     public DynamoIdentityService(ConfigurationService configurationService) {
-        super(IdentityCredentials.class, "identity-credentials", configurationService);
+        super(AuthIdentityCredentials.class, "identity-credentials", configurationService);
         this.timeToExist = configurationService.getAccessTokenExpiry();
     }
 
     public void addCoreIdentityJWT(String subjectID, String coreIdentityJWT) {
         var identityCredentials =
                 get(subjectID)
-                        .orElse(new IdentityCredentials())
+                        .orElse(new AuthIdentityCredentials())
                         .withSubjectID(subjectID)
                         .withCoreIdentityJWT(coreIdentityJWT)
                         .withTimeToExist(
@@ -30,7 +30,7 @@ public class DynamoIdentityService extends BaseDynamoService<IdentityCredentials
         update(identityCredentials);
     }
 
-    public Optional<IdentityCredentials> getIdentityCredentials(String subjectID) {
+    public Optional<AuthIdentityCredentials> getIdentityCredentials(String subjectID) {
         return get(subjectID)
                 .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
     }
@@ -45,7 +45,7 @@ public class DynamoIdentityService extends BaseDynamoService<IdentityCredentials
             String ipvVot,
             String ipvCoreIdentity) {
         var identityCredentials =
-                new IdentityCredentials()
+                new AuthIdentityCredentials()
                         .withSubjectID(subjectID)
                         .withAdditionalClaims(additionalClaims)
                         .withIpvVot(ipvVot)


### PR DESCRIPTION
### Wider context of change
This is part of the identity credentials migration work.

### What’s changed
In this PR, we write to the new table.

### Manual testing
I've done some logging here to verify clientSessionId is always defined:
https://github.com/govuk-one-login/authentication-api/pull/6013

Testing in dev:
 - I've ran through an identity journey in dev and have confirmed that this works
 - Saw the identity credentials in the new table
### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing. **tbd**
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not Needed**
- [x] Changes have been made to the simulator or not required. **Not Needed**
- [x] Changes have been made to stubs or not required. **Not Needed**
- [x] Successfully deployed to authdev or not required. **Not Needed**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not Needed**
