### PR TITLE
Aut 3848/mfa methods retrieve hello world

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
@@ -1,0 +1,19 @@
+package uk.gov.di.accountmanagement.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+
+public class GetMfaMethodsHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+    public GetMfaMethodsHandler() {}
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent, Context context) {
+        return generateApiGatewayProxyResponse(200, "{\"hello\": \"world\"}");
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
@@ -50,7 +50,14 @@ public class GetMfaMethodsHandler
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1063);
         }
 
-        if (input.getPathParameters().get("publicSubjectId").equals(DUMMY_UNKNOWN_SUBJECT_ID)) {
+        var publicSubjectId = input.getPathParameters().get("publicSubjectId");
+
+        if (publicSubjectId.isEmpty()) {
+            LOG.error("Request does not include public subject id");
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1056);
+        }
+
+        if (publicSubjectId.equals(DUMMY_UNKNOWN_SUBJECT_ID)) {
             LOG.error("Unknown public subject ID");
             return generateApiGatewayProxyErrorResponse(404, ErrorResponse.ERROR_1056);
         }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
@@ -24,6 +24,7 @@ public class GetMfaMethodsHandler
 
     private static final String PRODUCTION = "production";
     private static final String INTEGRATION = "integration";
+    private static final String DUMMY_UNKNOWN_SUBJECT_ID = "unknown-public-subject-id";
 
     private static final Logger LOG = LogManager.getLogger(GetMfaMethodsHandler.class);
 
@@ -37,8 +38,9 @@ public class GetMfaMethodsHandler
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent, Context context) {
-        addSessionIdToLogs(apiGatewayProxyRequestEvent);
+            APIGatewayProxyRequestEvent input, Context context) {
+
+        addSessionIdToLogs(input);
 
         var disabledEnvironments = List.of(PRODUCTION, INTEGRATION);
         if (disabledEnvironments.contains(configurationService.getEnvironment())) {
@@ -46,6 +48,11 @@ public class GetMfaMethodsHandler
                     "Request to create MFA method in {} environment but feature is switched off.",
                     configurationService.getEnvironment());
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1063);
+        }
+
+        if (input.getPathParameters().get("publicSubjectId").equals(DUMMY_UNKNOWN_SUBJECT_ID)) {
+            LOG.error("Unknown public subject ID");
+            return generateApiGatewayProxyErrorResponse(404, ErrorResponse.ERROR_1056);
         }
 
         return generateApiGatewayProxyResponse(200, "{\"hello\": \"world\"}");

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -16,6 +17,7 @@ import java.util.Map;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 
 public class GetMfaMethodsHandler
@@ -38,6 +40,14 @@ public class GetMfaMethodsHandler
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        ThreadContext.clearMap();
+        return segmentedFunctionCall(
+                "account-management-api::" + getClass().getSimpleName(),
+                () -> getMfaMethodsHandler(input, context));
+    }
+
+    public APIGatewayProxyResponseEvent getMfaMethodsHandler(
             APIGatewayProxyRequestEvent input, Context context) {
 
         addSessionIdToLogs(input);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandler.java
@@ -4,16 +4,56 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.util.List;
+import java.util.Map;
+
+import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 
 public class GetMfaMethodsHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-    public GetMfaMethodsHandler() {}
+    private final ConfigurationService configurationService;
+
+    private static final String PRODUCTION = "production";
+    private static final String INTEGRATION = "integration";
+
+    private static final Logger LOG = LogManager.getLogger(GetMfaMethodsHandler.class);
+
+    public GetMfaMethodsHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public GetMfaMethodsHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent, Context context) {
+        addSessionIdToLogs(apiGatewayProxyRequestEvent);
+
+        var disabledEnvironments = List.of(PRODUCTION, INTEGRATION);
+        if (disabledEnvironments.contains(configurationService.getEnvironment())) {
+            LOG.error(
+                    "Request to create MFA method in {} environment but feature is switched off.",
+                    configurationService.getEnvironment());
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1063);
+        }
+
         return generateApiGatewayProxyResponse(200, "{\"hello\": \"world\"}");
+    }
+
+    private void addSessionIdToLogs(APIGatewayProxyRequestEvent input) {
+        Map<String, String> headers = input.getHeaders();
+        String sessionId = RequestHeaderHelper.getHeaderValueOrElse(headers, SESSION_ID_HEADER, "");
+        attachSessionIdToLogs(sessionId);
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/CommonTestVariables.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/CommonTestVariables.java
@@ -1,0 +1,20 @@
+package uk.gov.di.accountmanagement.helpers;
+
+import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+
+import java.util.Map;
+
+public class CommonTestVariables {
+    public static final String PERSISTENT_ID = "some-persistent-session-id";
+    public static final String SESSION_ID = "some-session-id";
+    public static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
+    public static final Map<String, String> VALID_HEADERS =
+            Map.of(
+                    PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
+                    PERSISTENT_ID,
+                    ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
+                    SESSION_ID,
+                    AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                    TXMA_ENCODED_HEADER_VALUE);
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
@@ -1,0 +1,52 @@
+package uk.gov.di.accountmanagement.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.accountmanagement.helpers.AuditHelper;
+import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class GetMfaMethodsHandlerTest {
+    private final Context context = mock(Context.class);
+    private static final String PERSISTENT_ID = "some-persistent-session-id";
+    private static final String SESSION_ID = "some-session-id";
+    private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
+    private static final String SUBJECT_ID = "some-subject-id";
+    private static final Map<String, String> VALID_HEADERS =
+            Map.of(
+                    PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
+                    PERSISTENT_ID,
+                    ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
+                    SESSION_ID,
+                    AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                    TXMA_ENCODED_HEADER_VALUE);
+
+    private GetMfaMethodsHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new GetMfaMethodsHandler();
+    }
+
+    @Test
+    void shouldReturn200AndDummyResponse() {
+        var event =
+                new APIGatewayProxyRequestEvent()
+                        .withPathParameters((Map.of("publicSubjectId", SUBJECT_ID)))
+                        .withHeaders(VALID_HEADERS);
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(200));
+        assertEquals("{\"hello\": \"world\"}", result.getBody());
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
@@ -57,4 +57,18 @@ class GetMfaMethodsHandlerTest {
 
         assertThat(result, hasStatus(400));
     }
+
+    @Test
+    void shouldReturn404IfPublicSubjectIdNotFound() {
+        when(configurationService.getEnvironment()).thenReturn("test-environment");
+        var event =
+                new APIGatewayProxyRequestEvent()
+                        .withPathParameters(
+                                (Map.of("publicSubjectId", "unknown-public-subject-id")))
+                        .withHeaders(VALID_HEADERS);
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(404));
+    }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
@@ -4,28 +4,35 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class GetMfaMethodsHandlerTest {
     private final Context context = mock(Context.class);
     private static final String SUBJECT_ID = "some-subject-id";
+    private static final ConfigurationService configurationService =
+            mock(ConfigurationService.class);
 
     private GetMfaMethodsHandler handler;
 
     @BeforeEach
     void setUp() {
-        handler = new GetMfaMethodsHandler();
+        handler = new GetMfaMethodsHandler(configurationService);
     }
 
     @Test
     void shouldReturn200AndDummyResponse() {
+        when(configurationService.getEnvironment()).thenReturn("test-environment");
         var event =
                 new APIGatewayProxyRequestEvent()
                         .withPathParameters((Map.of("publicSubjectId", SUBJECT_ID)))
@@ -35,5 +42,19 @@ class GetMfaMethodsHandlerTest {
 
         assertThat(result, hasStatus(200));
         assertEquals("{\"hello\": \"world\"}", result.getBody());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"production", "integration"})
+    void shouldReturn400IfRequestIsMadeInProductionOrIntegration(String environment) {
+        when(configurationService.getEnvironment()).thenReturn(environment);
+        var event =
+                new APIGatewayProxyRequestEvent()
+                        .withPathParameters((Map.of("publicSubjectId", SUBJECT_ID)))
+                        .withHeaders(VALID_HEADERS);
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
@@ -4,31 +4,18 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
-import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
-import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class GetMfaMethodsHandlerTest {
     private final Context context = mock(Context.class);
-    private static final String PERSISTENT_ID = "some-persistent-session-id";
-    private static final String SESSION_ID = "some-session-id";
-    private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
     private static final String SUBJECT_ID = "some-subject-id";
-    private static final Map<String, String> VALID_HEADERS =
-            Map.of(
-                    PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
-                    PERSISTENT_ID,
-                    ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
-                    SESSION_ID,
-                    AuditHelper.TXMA_ENCODED_HEADER_NAME,
-                    TXMA_ENCODED_HEADER_VALUE);
 
     private GetMfaMethodsHandler handler;
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/GetMfaMethodsHandlerTest.java
@@ -44,6 +44,19 @@ class GetMfaMethodsHandlerTest {
         assertEquals("{\"hello\": \"world\"}", result.getBody());
     }
 
+    @Test
+    void shouldReturn400IfPublicSubjectIdNotIncludedInPath() {
+        when(configurationService.getEnvironment()).thenReturn("test-environment");
+        var event =
+                new APIGatewayProxyRequestEvent()
+                        .withPathParameters((Map.of("publicSubjectId", "")))
+                        .withHeaders(VALID_HEADERS);
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"production", "integration"})
     void shouldReturn400IfRequestIsMadeInProductionOrIntegration(String environment) {


### PR DESCRIPTION
## What

Implements a basic handler in the account management api. In this PR, we just implement a basic hello world dummy lambda. This is also not deployed anywhere at the moment, so actual logic and infrastructure to follow in subsequent PRs.

## How to review

* Code review

## Related PRs
 Similar change done already for the post endpoint: https://github.com/govuk-one-login/authentication-api/pull/5992