### PR TITLE
ATO-1373: Add backchannel logout config for build stubs

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -12,8 +12,9 @@ stub_rp_clients = [
       "https://rp-build.build.stubs.account.gov.uk/signed-out",
       "http://localhost:8080/signed-out",
     ]
-    test_client = "0"
-    client_type = "web"
+    back_channel_logout_uri = "https://rp-build.build.stubs.account.gov.uk/backchannel-logout"
+    test_client             = "0"
+    client_type             = "web"
     scopes = [
       "openid",
       "email",
@@ -63,8 +64,9 @@ stub_rp_clients = [
       "http://localhost:8080/signed-out",
       "https://rp-build.build.stubs.account.gov.uk/signed-out",
     ]
-    test_client = "1"
-    client_type = "web"
+    back_channel_logout_uri = "https://acceptance-test-rp-build.build.stubs.account.gov.uk/backchannel-logout"
+    test_client             = "1"
+    client_type             = "web"
     scopes = [
       "openid",
       "email",

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -31,105 +31,114 @@ resource "aws_dynamodb_table_item" "stub_relying_party_client" {
   table_name = aws_dynamodb_table.client_registry_table.name
   hash_key   = aws_dynamodb_table.client_registry_table.hash_key
 
-  item = jsonencode({
-    ClientID = {
-      S = random_string.stub_relying_party_client_id[each.value.client_name].result
-    }
-    ClientName = {
-      S = each.value.client_name
-    }
-    Contacts = {
-      L = [{
-        S = "contact+${each.value.client_name}@example.com"
-      }]
-    }
-    SectorIdentifierUri = {
-      S = each.value.sector_identifier_uri
-    }
-    PostLogoutRedirectUrls = {
-      L = [for url in each.value.logout_urls : {
-        S = url
-      }]
-    }
-    RedirectUrls = {
-      L = [for url in each.value.callback_urls : {
-        S = url
-      }]
-    }
-    Scopes = {
-      L = [for scope in each.value.scopes : {
-        S = scope
-      }]
-    }
-    Claims = {
-      L = [
-        {
-          S = "https://vocab.account.gov.uk/v1/coreIdentityJWT"
-        },
-        {
-          S = "https://vocab.account.gov.uk/v1/passport"
-        },
-        {
-          S = "https://vocab.account.gov.uk/v1/address"
-        },
-        {
-          S = "https://vocab.account.gov.uk/v1/drivingPermit"
-        },
-        {
-          S = "https://vocab.account.gov.uk/v1/returnCode"
-        },
-        {
-          S = "https://vocab.account.gov.uk/v1/inheritedIdentityJWT"
-        },
-      ]
-    }
-    PublicKey = {
-      S = replace(replace(
-        replace(
-        tls_private_key.stub_relying_party_client_private_key[each.value.client_name].public_key_pem, "-----BEGIN PUBLIC KEY-----", ""),
-      "-----END PUBLIC KEY-----", ""), "\n", "")
-    }
-    ServiceType = {
-      S = each.value.service_type
-    }
-    SubjectType = {
-      S = "pairwise"
-    }
-    CookieConsentShared = {
-      N = "1"
-    }
-    IdentityVerificationSupported = {
-      N = "1"
-    }
-    ClientType = {
-      S = each.value.client_type
-    }
-    TestClient = {
-      N = each.value.test_client
-    }
-    TestClientEmailAllowlist = {
-      L = [for email in concat(split(",", var.test_client_email_allowlist), [local.acceptance_test_rp_client_emails.regex], [local.orch_acceptance_test_rp_client_emails.regex]) : {
-        S = email
-      }]
-    }
-    OneLoginService = {
-      BOOL = each.value.one_login_service
-    }
-    ClientLoCs = {
-      L = [
-        {
-          S = "P0"
-        },
-        {
-          S = "P1"
-        },
-        {
-          S = "P2"
+  item = jsonencode(
+    merge(
+      {
+        ClientID = {
+          S = random_string.stub_relying_party_client_id[each.value.client_name].result
         }
-      ]
-    }
-    MaxAgeEnabled = {
-      BOOL = each.value.max_age_enabled
-    }
-  })
+        ClientName = {
+          S = each.value.client_name
+        }
+        Contacts = {
+          L = [{
+            S = "contact+${each.value.client_name}@example.com"
+          }]
+        }
+        SectorIdentifierUri = {
+          S = each.value.sector_identifier_uri
+        }
+        PostLogoutRedirectUrls = {
+          L = [for url in each.value.logout_urls : {
+            S = url
+          }]
+        }
+        RedirectUrls = {
+          L = [for url in each.value.callback_urls : {
+            S = url
+          }]
+        }
+        Scopes = {
+          L = [for scope in each.value.scopes : {
+            S = scope
+          }]
+        }
+        Claims = {
+          L = [
+            {
+              S = "https://vocab.account.gov.uk/v1/coreIdentityJWT"
+            },
+            {
+              S = "https://vocab.account.gov.uk/v1/passport"
+            },
+            {
+              S = "https://vocab.account.gov.uk/v1/address"
+            },
+            {
+              S = "https://vocab.account.gov.uk/v1/drivingPermit"
+            },
+            {
+              S = "https://vocab.account.gov.uk/v1/returnCode"
+            },
+            {
+              S = "https://vocab.account.gov.uk/v1/inheritedIdentityJWT"
+            },
+          ]
+        }
+        PublicKey = {
+          S = replace(replace(
+            replace(
+            tls_private_key.stub_relying_party_client_private_key[each.value.client_name].public_key_pem, "-----BEGIN PUBLIC KEY-----", ""),
+          "-----END PUBLIC KEY-----", ""), "\n", "")
+        }
+        ServiceType = {
+          S = each.value.service_type
+        }
+        SubjectType = {
+          S = "pairwise"
+        }
+        CookieConsentShared = {
+          N = "1"
+        }
+        IdentityVerificationSupported = {
+          N = "1"
+        }
+        ClientType = {
+          S = each.value.client_type
+        }
+        TestClient = {
+          N = each.value.test_client
+        }
+        TestClientEmailAllowlist = {
+          L = [for email in concat(split(",", var.test_client_email_allowlist), [local.acceptance_test_rp_client_emails.regex], [local.orch_acceptance_test_rp_client_emails.regex]) : {
+            S = email
+          }]
+        }
+        OneLoginService = {
+          BOOL = each.value.one_login_service
+        }
+        ClientLoCs = {
+          L = [
+            {
+              S = "P0"
+            },
+            {
+              S = "P1"
+            },
+            {
+              S = "P2"
+            }
+          ]
+        }
+        MaxAgeEnabled = {
+          BOOL = each.value.max_age_enabled
+        }
+      }, each.value.back_channel_logout_uri != null ?
+      {
+        BackChannelLogoutUri = {
+          S = each.value.back_channel_logout_uri
+        }
+      } : {}
+    )
+  )
 }

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -31,7 +31,7 @@ variable "logging_endpoint_arns" {
 
 variable "stub_rp_clients" {
   default     = []
-  type        = list(object({ client_name : string, at_client : bool, sector_identifier_uri : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, one_login_service : bool, service_type : string, max_age_enabled : bool }))
+  type        = list(object({ client_name : string, at_client : bool, sector_identifier_uri : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, one_login_service : bool, service_type : string, max_age_enabled : bool, back_channel_logout_uri : optional(string) }))
   description = "The details of RP clients to provision in the Client table"
   validation {
     condition     = length(var.stub_rp_clients) > 0


### PR DESCRIPTION
### Wider context of change

Currently none of our stub clients have backchannel logouts enabled, however the stub does expose an endpoint to handle these. 

### What’s changed

The build rp stub and build acceptance test rp stub now have a BackChannelLogoutUri configured. This points to the rp stub backchannel logout endpoint. 

### Manual testing

I couldn't find another instance of an optional field being used in a type, so I added a backchannel logout uri to the sandpit stub client (`relying-party-stub-sandpit`) and ran a `terraform plan`, to check if the logic was correct. The plan finished successfully and indicated that the only change was updating the client registry to add a backchannel logout uri to the client we expected.

I also updated the build client registry to add the backchannel logout uris to the appropriate clients, and did a simple auth journey with logout. I confirmed that in the build rp stubs the backchannel logout endpoint was hit.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
