### PR TITLE
ATO-1388: add supported code challenge methods to discovery endpoint

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -11,6 +11,7 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
 import com.nimbusds.openid.connect.sdk.SubjectType;
 import com.nimbusds.openid.connect.sdk.claims.ClaimType;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
@@ -107,6 +108,10 @@ public class WellknownHandler
             oidcMetadata.setEndSessionEndpointURI(oidcApi.logoutURI());
             oidcMetadata.setSupportsBackChannelLogout(true);
             oidcMetadata.setCustomParameter("trustmarks", oidcApi.trustmarkURI().toString());
+
+            if (configService.isPkceEnabled()) {
+                oidcMetadata.setCodeChallengeMethods(List.of(CodeChallengeMethod.S256));
+            }
 
             oidcMetadata.setPolicyURI(authFrontend.privacyNoticeURI());
             oidcMetadata.setTermsOfServiceURI(authFrontend.termsOfServiceURI());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
@@ -5,9 +5,11 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
 import com.nimbusds.openid.connect.sdk.claims.ClaimType;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import org.approvaltests.JsonApprovals;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
@@ -19,6 +21,7 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -30,6 +33,11 @@ class WellknownHandlerTest {
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final AuthFrontend authFrontend = mock(AuthFrontend.class);
     private final OidcAPI oidcApi = mock(OidcAPI.class);
+
+    @BeforeEach
+    public void setUp() {
+        when(configService.isPkceEnabled()).thenReturn(true);
+    }
 
     @Test
     void shouldReturn200WhenRequestIsSuccessful() {
@@ -54,6 +62,24 @@ class WellknownHandlerTest {
 
         assertThat(metadata.getGrantTypes(), equalTo(List.of(GrantType.AUTHORIZATION_CODE)));
         assertThat(metadata.getClaimTypes(), equalTo(List.of(ClaimType.NORMAL)));
+    }
+
+    @Test
+    void shouldContainCorrectCodeChallengeMethods() throws ParseException {
+        APIGatewayProxyResponseEvent result = getWellKnown();
+        var metadata = OIDCProviderMetadata.parse(result.getBody());
+
+        assertThat(metadata.getCodeChallengeMethods(), equalTo(List.of(CodeChallengeMethod.S256)));
+    }
+
+    @Test
+    void shouldNotContainCodeChallengeMethodsWhenPkceNotEnabled() throws ParseException {
+        when(configService.isPkceEnabled()).thenReturn(false);
+
+        APIGatewayProxyResponseEvent result = getWellKnown();
+        var metadata = OIDCProviderMetadata.parse(result.getBody());
+
+        assertNull(metadata.getCodeChallengeMethods());
     }
 
     @Test

--- a/oidc-api/src/test/resources/uk/gov/di/authentication/oidc/lambda/approvals/WellknownHandlerTest.shouldReturnExpectedResponseBody.approved.json
+++ b/oidc-api/src/test/resources/uk/gov/di/authentication/oidc/lambda/approvals/WellknownHandlerTest.shouldReturnExpectedResponseBody.approved.json
@@ -16,6 +16,9 @@
   "grant_types_supported": [
     "authorization_code"
   ],
+  "code_challenge_methods_supported": [
+    "S256"
+  ],
   "token_endpoint_auth_methods_supported": [
     "private_key_jwt",
     "client_secret_post"


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

We wish to add PKCE support behind a feature flag.

The discovery endpoint needs updating to list the PKCE code challenge methods supported by this auth server.

`S256` is the only code challenge method supported.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Supported code challenge methods now returned by discovery endpoint
- Expected endpoint response body updated to include expected `code_challenge_methods_supported` value.

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to Orch dev visited `/.well-known/openid-configuration` on `oidc` subdomain, config contained expected value (below):

```json
"code_challenge_methods_supported": [
  "S256"
],
```

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or **not required**.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or **not required**.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or **not required**.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or **not required**.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or **not required**.
