### PR TITLE
ATO-1472: Write to and delete from new client session store

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -47,6 +47,7 @@ import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.extensions.DocAppJwksExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.RpPublicKeyCacheExtension;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
@@ -130,6 +131,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @RegisterExtension
     public static final OrchSessionExtension orchSessionExtension = new OrchSessionExtension();
+
+    @RegisterExtension
+    public static final OrchClientSessionExtension orchClientSessionExtention =
+            new OrchClientSessionExtension();
 
     private static final String ENCRYPTION_KEY_ID = UUID.randomUUID().toString();
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -71,6 +71,7 @@ import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
@@ -89,6 +90,7 @@ import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
+import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
@@ -165,6 +167,9 @@ class AuthorisationHandlerTest {
             mock(DocAppAuthorisationService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final ClientSession clientSession = mock(ClientSession.class);
+    private final OrchClientSessionService orchClientSessionService =
+            mock(OrchClientSessionService.class);
+    private final OrchClientSessionItem orchClientSession = mock(OrchClientSessionItem.class);
     private final OrchestrationAuthorizationService orchestrationAuthorizationService =
             mock(OrchestrationAuthorizationService.class);
     private final UserContext userContext = mock(UserContext.class);
@@ -300,6 +305,7 @@ class AuthorisationHandlerTest {
                         sessionService,
                         orchSessionService,
                         clientSessionService,
+                        orchClientSessionService,
                         orchestrationAuthorizationService,
                         auditService,
                         queryParamsAuthorizeValidator,
@@ -318,6 +324,8 @@ class AuthorisationHandlerTest {
         when(clientSessionService.generateClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(clientSessionService.generateClientSession(any(), any(), any(), any()))
                 .thenReturn(clientSession);
+        when(orchClientSessionService.generateClientSession(any(), any(), any(), any(), any()))
+                .thenReturn(orchClientSession);
         when(clientSession.getDocAppSubjectId()).thenReturn(new Subject("test-subject-id"));
         when(clientService.getClient(anyString()))
                 .thenReturn(Optional.of(generateClientRegistry()));
@@ -354,6 +362,7 @@ class AuthorisationHandlerTest {
             verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
+            verify(orchClientSessionService).storeClientSession(orchClientSession);
 
             inOrder.verify(auditService)
                     .submitAuditEvent(
@@ -638,6 +647,7 @@ class AuthorisationHandlerTest {
 
             verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
+            verify(orchClientSessionService).storeClientSession(orchClientSession);
 
             inOrder.verify(auditService)
                     .submitAuditEvent(
@@ -680,6 +690,7 @@ class AuthorisationHandlerTest {
             verify(orchSessionService).addSession(any());
             verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
+            verify(orchClientSessionService).storeClientSession(orchClientSession);
 
             inOrder.verify(auditService)
                     .submitAuditEvent(
@@ -752,6 +763,7 @@ class AuthorisationHandlerTest {
             verify(orchSessionService).addSession(any());
             verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
+            verify(orchClientSessionService).storeClientSession(orchClientSession);
 
             inOrder.verify(auditService)
                     .submitAuditEvent(
@@ -794,6 +806,7 @@ class AuthorisationHandlerTest {
             verify(orchSessionService).addSession(any());
             verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
+            verify(orchClientSessionService).storeClientSession(orchClientSession);
 
             verifyAuthorisationRequestParsedAuditEvent(
                     AuditService.UNKNOWN, false, false, "LOW_LEVEL");
@@ -841,6 +854,7 @@ class AuthorisationHandlerTest {
             verify(orchSessionService).addSession(any());
             verify(orchSessionService).deleteSession(SESSION_ID);
             verify(clientSessionService).storeClientSession(CLIENT_SESSION_ID, clientSession);
+            verify(orchClientSessionService).storeClientSession(orchClientSession);
 
             inOrder.verify(auditService)
                     .submitAuditEvent(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -60,6 +60,7 @@ import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
+import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.TokenService;
@@ -162,6 +163,8 @@ public class TokenHandlerTest {
     private final AuthorisationCodeService authorisationCodeService =
             mock(AuthorisationCodeService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final OrchClientSessionService orchClientSessionService =
+            mock(OrchClientSessionService.class);
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
@@ -182,6 +185,7 @@ public class TokenHandlerTest {
                         configurationService,
                         authorisationCodeService,
                         clientSessionService,
+                        orchClientSessionService,
                         tokenValidationService,
                         redisConnectionService,
                         tokenClientAuthValidatorFactory,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -37,6 +37,7 @@ public class LogoutService {
     private final OrchSessionService orchSessionService;
     private final DynamoClientService dynamoClientService;
     private final ClientSessionService clientSessionService;
+    private final OrchClientSessionService orchClientSessionService;
     private final AuditService auditService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final BackChannelLogoutService backChannelLogoutService;
@@ -52,6 +53,7 @@ public class LogoutService {
                 new OrchSessionService(configurationService),
                 new DynamoClientService(configurationService),
                 new ClientSessionService(configurationService),
+                new OrchClientSessionService(configurationService),
                 new AuditService(configurationService),
                 new CloudwatchMetricsService(),
                 new BackChannelLogoutService(configurationService),
@@ -66,6 +68,7 @@ public class LogoutService {
                 new OrchSessionService(configurationService),
                 new DynamoClientService(configurationService),
                 new ClientSessionService(configurationService, redis),
+                new OrchClientSessionService(configurationService),
                 new AuditService(configurationService),
                 new CloudwatchMetricsService(),
                 new BackChannelLogoutService(configurationService),
@@ -79,6 +82,7 @@ public class LogoutService {
             OrchSessionService orchSessionService,
             DynamoClientService dynamoClientService,
             ClientSessionService clientSessionService,
+            OrchClientSessionService orchClientSessionService,
             AuditService auditService,
             CloudwatchMetricsService cloudwatchMetricsService,
             BackChannelLogoutService backChannelLogoutService,
@@ -89,6 +93,7 @@ public class LogoutService {
         this.orchSessionService = orchSessionService;
         this.dynamoClientService = dynamoClientService;
         this.clientSessionService = clientSessionService;
+        this.orchClientSessionService = orchClientSessionService;
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.backChannelLogoutService = backChannelLogoutService;
@@ -127,6 +132,8 @@ public class LogoutService {
                                             configurationService.getInternalSectorURI()));
             LOG.info("Deleting Client Session");
             clientSessionService.deleteStoredClientSession(clientSessionId);
+            LOG.info("Deleting Orch Client session");
+            orchClientSessionService.deleteStoredClientSession(clientSessionId);
         }
         LOG.info("Deleting Session");
         sessionService.deleteStoredSession(request.getSessionId());


### PR DESCRIPTION
### Wider context of change

A previous PR added a new dynamo client session store, as well as a service to interact with the store. We would like to migrate away from using the shared redis store and use this dynamo store instead.

### What’s changed

This PR writes to the dynamo client session store wherever we write to the redis client session store. Since there was only 1 instance of the delete method being used, i've also included deleting from the dynamo client session store in this ticket.

### Manual testing

Deployed to dev and sandpit:
- Did a basic auth journey, saw the client session was created in the new dynamo table. 
- Logged out and saw the client session was deleted from the new dynamo table.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

