### PR TITLE
ATO-1391: delete old table in code from extension

### DIFF
--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
@@ -19,9 +19,7 @@ import java.util.Optional;
 public class AuthenticationCallbackUserInfoStoreExtension extends DynamoExtension
         implements AfterEachCallback {
 
-    public static final String OLD_AUTH_USERINFO_TABLE = "local-authentication-callback-userinfo";
     public static final String AUTH_USERINFO_TABLE = "local-Auth-User-Info";
-    public static final String SUBJECT_ID_FIELD = "SubjectID";
     public static final String INTERNAL_COMMON_SUBJECT_ID_FIELD = "InternalCommonSubjectId";
     public static final String CLIENT_SESSION_ID_FIELD = "ClientSessionId";
 
@@ -49,7 +47,6 @@ public class AuthenticationCallbackUserInfoStoreExtension extends DynamoExtensio
 
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
-        clearDynamoTable(dynamoDB, OLD_AUTH_USERINFO_TABLE, SUBJECT_ID_FIELD);
         clearDynamoTable(
                 dynamoDB,
                 AUTH_USERINFO_TABLE,
@@ -59,31 +56,9 @@ public class AuthenticationCallbackUserInfoStoreExtension extends DynamoExtensio
 
     @Override
     protected void createTables() {
-        if (!tableExists(OLD_AUTH_USERINFO_TABLE)) {
-            createOldUserInfoTable();
-        }
         if (!tableExists(AUTH_USERINFO_TABLE)) {
             createAuthUserInfoTable();
         }
-    }
-
-    private void createOldUserInfoTable() {
-        CreateTableRequest request =
-                CreateTableRequest.builder()
-                        .tableName(OLD_AUTH_USERINFO_TABLE)
-                        .keySchema(
-                                KeySchemaElement.builder()
-                                        .keyType(KeyType.HASH)
-                                        .attributeName(SUBJECT_ID_FIELD)
-                                        .build())
-                        .billingMode(BillingMode.PAY_PER_REQUEST)
-                        .attributeDefinitions(
-                                AttributeDefinition.builder()
-                                        .attributeName(SUBJECT_ID_FIELD)
-                                        .attributeType(ScalarAttributeType.S)
-                                        .build())
-                        .build();
-        dynamoDB.createTable(request);
     }
 
     private void createAuthUserInfoTable() {


### PR DESCRIPTION
### Wider context of change
AuthUserInfo migration

### What’s changed
I missed this table creation in the extension. It isn't used anywhere, so it's just an unused mock table.

### Manual testing
n/a

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required. **Non required**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required. **Non required**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required. **Non required**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required. **Non required**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Non required**
