### PR TITLE
ATO-1491: Add missing key permissions to dynamo policies

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -4521,10 +4521,15 @@ Resources:
               - dynamodb:DescribeTable
               - dynamodb:Get*
             Resource: !GetAtt ClientSessionTable.Arn
-          - Sid: AllowClientSessionTableDecryption
+          - Sid: AllowClientSessionTableKeyAccess
             Effect: Allow
             Action:
+              - kms:Encrypt
               - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
             Resource: !GetAtt ClientSessionTableEncryptionKey.Arn
 
   ClientSessionTableWriteAccessPolicy:
@@ -4539,10 +4544,15 @@ Resources:
               - dynamodb:PutItem
               - dynamodb:UpdateItem
             Resource: !GetAtt ClientSessionTable.Arn
-          - Sid: AllowClientSessionTableEncryption
+          - Sid: AllowClientSessionTableKeyAccess
             Effect: Allow
             Action:
               - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
             Resource: !GetAtt ClientSessionTableEncryptionKey.Arn
 
   ClientSessionTableDeleteAccessPolicy:
@@ -4556,6 +4566,16 @@ Resources:
             Action:
               - dynamodb:DeleteItem
             Resource: !GetAtt ClientSessionTable.Arn
+          - Sid: AllowClientSessionTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: !GetAtt ClientSessionTableEncryptionKey.Arn
 
   # This combined read, write and delete policy is required because we've reached the managed polices per role quota limit.
   ClientSessionTableReadWriteAndDeleteAccessPolicy:
@@ -4581,15 +4601,15 @@ Resources:
             Action:
               - dynamodb:DeleteItem
             Resource: !GetAtt ClientSessionTable.Arn
-          - Sid: AllowClientSessionTableEncryption
+          - Sid: AllowClientSessionTableKeyAccess
             Effect: Allow
             Action:
               - kms:Encrypt
-            Resource: !GetAtt ClientSessionTableEncryptionKey.Arn
-          - Sid: AllowClientSessionTableDecryption
-            Effect: Allow
-            Action:
               - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
             Resource: !GetAtt ClientSessionTableEncryptionKey.Arn
 
   IdentityCredentialsTableReadAccessPolicy:

--- a/template.yaml
+++ b/template.yaml
@@ -4342,10 +4342,15 @@ Resources:
               - dynamodb:DescribeTable
               - dynamodb:Get*
             Resource: !GetAtt OrchSessionTable.Arn
-          - Sid: AllowOrchSessionTableDecryption
+          - Sid: AllowOrchSessionTableKeyAccess
             Effect: Allow
             Action:
+              - kms:Encrypt
               - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
             Resource: !GetAtt OrchSessionTableEncryptionKey.Arn
 
   OrchSessionTableWriteAccessPolicy:
@@ -4364,6 +4369,11 @@ Resources:
             Effect: Allow
             Action:
               - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
             Resource: !GetAtt OrchSessionTableEncryptionKey.Arn
 
   # This combined read and write policy is required because we've reached the managed polices per role quota limit (20). Ticket raised to requst quota increase (ATO-1056)
@@ -4379,11 +4389,6 @@ Resources:
               - dynamodb:DescribeTable
               - dynamodb:Get*
             Resource: !GetAtt OrchSessionTable.Arn
-          - Sid: AllowOrchSessionTableDecryption
-            Effect: Allow
-            Action:
-              - kms:Decrypt
-            Resource: !GetAtt OrchSessionTableEncryptionKey.Arn
           - Sid: AllowOrchSessionTableWriteAccess
             Effect: Allow
             Action:
@@ -4394,6 +4399,11 @@ Resources:
             Effect: Allow
             Action:
               - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
             Resource: !GetAtt OrchSessionTableEncryptionKey.Arn
 
   # This combined read, write and delete policy is required because we've reached the managed polices per role quota limit (20). Ticket raised to requst quota increase (ATO-1056)
@@ -4409,27 +4419,27 @@ Resources:
               - dynamodb:DescribeTable
               - dynamodb:Get*
             Resource: !GetAtt OrchSessionTable.Arn
-          - Sid: AllowOrchSessionTableDecryption
-            Effect: Allow
-            Action:
-              - kms:Decrypt
-            Resource: !GetAtt OrchSessionTableEncryptionKey.Arn
           - Sid: AllowOrchSessionTableWriteAccess
             Effect: Allow
             Action:
               - dynamodb:PutItem
               - dynamodb:UpdateItem
             Resource: !GetAtt OrchSessionTable.Arn
-          - Sid: AllowOrchSessionTableKeyAccess
-            Effect: Allow
-            Action:
-              - kms:Encrypt
-            Resource: !GetAtt OrchSessionTableEncryptionKey.Arn
           - Sid: AllowOrchSessionTableDeleteAccess
             Effect: Allow
             Action:
               - dynamodb:DeleteItem
             Resource: !GetAtt OrchSessionTable.Arn
+          - Sid: AllowOrchSessionTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: !GetAtt OrchSessionTableEncryptionKey.Arn
 
   OrchSessionTableDeleteAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -4442,6 +4452,16 @@ Resources:
             Action:
               - dynamodb:DeleteItem
             Resource: !GetAtt OrchSessionTable.Arn
+          - Sid: AllowOrchSessionTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: !GetAtt OrchSessionTableEncryptionKey.Arn
 
   AuthUserInfoTableReadAccessPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -4455,10 +4455,15 @@ Resources:
               - dynamodb:DescribeTable
               - dynamodb:Get*
             Resource: !GetAtt AuthUserInfoTable.Arn
-          - Sid: AllowAuthUserInfoTableDecryption
+          - Sid: AllowAuthUserInfoTableKeyAccess
             Effect: Allow
             Action:
+              - kms:Encrypt
               - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
             Resource: !GetAtt AuthUserInfoTableEncryptionKey.Arn
 
   AuthUserInfoTableWriteAccessPolicy:
@@ -4473,10 +4478,15 @@ Resources:
               - dynamodb:PutItem
               - dynamodb:UpdateItem
             Resource: !GetAtt AuthUserInfoTable.Arn
-          - Sid: AllowAuthUserInfoTableEncryption
+          - Sid: AllowAuthUserInfoTableKeyAccess
             Effect: Allow
             Action:
               - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
             Resource: !GetAtt AuthUserInfoTableEncryptionKey.Arn
 
   ClientSessionTableReadAccessPolicy:

--- a/template.yaml
+++ b/template.yaml
@@ -5151,7 +5151,12 @@ Resources:
           - Sid: AllowRpPublicKeyCacheTableKeyAccess
             Effect: Allow
             Action:
+              - kms:Encrypt
               - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
             Resource: !GetAtt RpPublicKeyTableEncryptionKey.Arn
 
   RpPublicKeyCacheTableWriteAccessPolicy:
@@ -5165,6 +5170,16 @@ Resources:
             Action:
               - dynamodb:PutItem
             Resource: !GetAtt RpPublicKeyCacheTable.Arn
+          - Sid: AllowRpPublicKeyCacheTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: !GetAtt RpPublicKeyTableEncryptionKey.Arn
 
   TxmaQueueSendPermissionPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
### Wider context of change

We had some dynamo policies in cloud formation that, when used without any other related policies, did not have enough permissions to use the AWS managed key associated with the table.

### What’s changed

This PR ensures all dynamo policies have the minimum required permissions as defined by AWS [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption.usagenotes.html#dynamodb-kms-authz):
- `kms:Encrypt`
- `kms:Decrypt`
- `kms:ReEncrypt*`
- `kms:GenerateDataKey*`
- `kms:DescribeKey`
- `kms:CreateGrant`

I've also renamed some of the policy statement `Sid`s to better describe the new permissions changes

### Manual testing

Deployed to dev and did a full auth journey

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
