### PR TITLE
AUT-4047: Remove additional logging.

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationService.java
@@ -85,8 +85,6 @@ public class IPVReverificationService {
         JWTClaimsSet mfaResetAuthorizationClaims =
                 createMfaResetAuthorizationClaims(state, subject, claims, clientSessionId);
 
-        LOG.info("Claim set: {}", mfaResetAuthorizationClaims);
-
         SignedJWT signedJWT =
                 jwtService.signJWT(
                         SIGNING_ALGORITHM,


### PR DESCRIPTION
We were logging the claim set which was useful in lower environments and initial production checking but not needed long term.

# authentication-api PR template picker

> [!TIP]
> Please go to the `Preview` tab and select the appropriate sub-template

## Templates

- [Auth Team](?expand=1&template=auth_template.md)
- [Orchestration Team](?expand=1&template=orch_template.md)
