### PR TITLE
BAU: Correct metrics for ipv reverification result

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
@@ -258,11 +258,14 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
                 return ValidationResult.failure(
                         "Invalid or missing 'failure_reason'", metadataPairs);
             }
+            LOG.info("Received reverification failure code due to {}", failValue);
             cloudwatchMetricService.incrementMfaResetIpvResponseCount(failValue);
             metadataPairs.add(
                     AuditService.MetadataPair.pair(IPV_REVERIFICATION_FAILURE_CODE, failValue));
+        } else {
+            LOG.info("Received reverification success code");
+            cloudwatchMetricService.incrementMfaResetIpvResponseCount(IPV_REVERIFICATION_SUCCESS);
         }
-        cloudwatchMetricService.incrementMfaResetIpvResponseCount(IPV_REVERIFICATION_SUCCESS);
         return ValidationResult.success(metadataPairs);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
@@ -47,6 +47,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_REVERIFY_SUCCESSFUL_TOKEN_RECEIVED;
@@ -195,6 +196,10 @@ class ReverificationResultHandlerTest {
                             USER_CONTEXT);
 
             verify(cloudwatchMetricsService).incrementMfaResetIpvResponseCount("success");
+
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessageContaining(format("Received reverification success code"))));
             assertThat(result, hasStatus(200));
             assertThat(result, hasBody(userInfo.getContent()));
 
@@ -615,6 +620,15 @@ class ReverificationResultHandlerTest {
                         apiRequestEventWithEmail("1234", AUTHENTICATION_STATE, EMAIL), context);
 
         verify(cloudwatchMetricsService).incrementMfaResetIpvResponseCount(failureCode);
+        verify(cloudwatchMetricsService, never()).incrementMfaResetIpvResponseCount("success");
+
+        assertThat(
+                logging.events(),
+                hasItem(
+                        withMessageContaining(
+                                format(
+                                        "Received reverification failure code due to %s",
+                                        failureCode))));
         assertThat(result, hasStatus(200));
     }
 


### PR DESCRIPTION
We were incrementing success as well as failure metrics in the case of failure codes coming back from ipv.

Also adds some logging for visibility of the code coming back
