### PR TITLE
ATO-1469: rename table with Orch prefix

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -616,11 +616,11 @@ Resources:
           Value: ClientSessionTable
   #endregion
 
-  #region IdentityCredentials DynamoDB Table
-  IdentityCredentialsTableEncryptionKey:
+  #region OrchIdentityCredentials DynamoDB Table
+  OrchIdentityCredentialsTableEncryptionKey:
     Type: AWS::KMS::Key
     Properties:
-      Description: KMS encryption key for IdentityCredentials DynamoDB table
+      Description: KMS encryption key for OrchIdentityCredentials DynamoDB table
       EnableKeyRotation: true
       KeyPolicy:
         Version: 2012-10-17
@@ -646,10 +646,10 @@ Resources:
               ArnLike:
                 kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
 
-  IdentityCredentialsTable:
+  OrchIdentityCredentialsTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-Identity-Credentials
+      TableName: !Sub ${Environment}-Orch-Identity-Credentials
       AttributeDefinitions:
         - AttributeName: ClientSessionId
           AttributeType: S
@@ -659,7 +659,7 @@ Resources:
       BillingMode: PAY_PER_REQUEST
       SSESpecification:
         SSEEnabled: true
-        KMSMasterKeyId: !GetAtt IdentityCredentialsTableEncryptionKey.Arn
+        KMSMasterKeyId: !GetAtt OrchIdentityCredentialsTableEncryptionKey.Arn
         SSEType: KMS
       TimeToLiveSpecification:
         AttributeName: ttl
@@ -668,7 +668,7 @@ Resources:
         PointInTimeRecoveryEnabled: true
       Tags:
         - Key: Name
-          Value: IdentityCredentialsTable
+          Value: OrchIdentityCredentialsTable
   #endregion
 
   #region RP Public Key DynamoDB Table


### PR DESCRIPTION
### Wider context of change
Part of the identity credentials table migration

### What’s changed
Previously, I had planned to just name the table <env>-Identity-Credentials. However, in tests, this overlaps with the auth table. There is an urgency to get this migrated, so rather than bothering with figuring out a clever fix in tests, just rename this table to have orch prefix

### Manual testing
Successfully deployed the dev. Deleted the old table and created a table called `dev-Orch-Identity-Credentials`

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
