### PR TITLE
ATO-1469: add resource policy for cross account access

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -645,6 +645,20 @@ Resources:
             Condition:
               ArnLike:
                 kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+          - Sid: AllowKeyDecryptionAccess
+            Effect: Allow
+            Principal:
+              AWS: !Sub
+                - arn:aws:iam::${AuthAccountId}:root
+                - AuthAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      authAccountId,
+                    ]
+            Action:
+              - kms:Decrypt
+            Resource: "*"
 
   OrchIdentityCredentialsTable:
     Type: AWS::DynamoDB::Table
@@ -669,6 +683,25 @@ Resources:
       Tags:
         - Key: Name
           Value: OrchIdentityCredentialsTable
+      ResourcePolicy:
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Sid: AllowOrchIdentityCredentialsTableCrossAccountReadAccess
+              Effect: Allow
+              Action:
+                - dynamodb:DescribeTable
+                - dynamodb:Get*
+              Resource: "*"
+              Principal:
+                AWS: !Sub
+                  - arn:aws:iam::${AuthAccountId}:root
+                  - AuthAccountId:
+                      !FindInMap [
+                        EnvironmentConfiguration,
+                        !Ref Environment,
+                        authAccountId,
+                      ]
   #endregion
 
   #region RP Public Key DynamoDB Table


### PR DESCRIPTION
### Wider context of change
This is part of the identity credentials migration work.

### What’s changed
In this PR, we add a resource policy onto the table to allow cross account access to it

### Manual testing
Deployed to dev successfully

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not Needed**
- [x] Changes have been made to the simulator or not required. **Not Needed**
- [x] Changes have been made to stubs or not required. **Not Needed**
- [x] Successfully deployed to authdev or not required. **Not Needed**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not Needed**
