### PR TITLE
ATO-1469: add cross acount access to identity credentials

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -45,11 +45,12 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-dev-tfstate"
 
-orch_account_id                              = "767397776536"
-is_orch_stubbed                              = false
-orch_environment                             = "build"
-orch_session_table_encryption_key_arn        = "arn:aws:kms:eu-west-2:767397776536:key/b7cb6340-0d22-4b6a-8702-b5ec17d4f979"
-orch_client_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:767397776536:key/7a1d86fe-1ca0-499c-95e9-ee8593a850f9"
+orch_account_id                                    = "767397776536"
+is_orch_stubbed                                    = false
+orch_environment                                   = "build"
+orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:767397776536:key/b7cb6340-0d22-4b6a-8702-b5ec17d4f979"
+orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:767397776536:key/7a1d86fe-1ca0-499c-95e9-ee8593a850f9"
+orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:767397776536:key/e284a04a-bac2-42b0-b723-ef0d32722ad5"
 
 orch_storage_token_jwk_enabled              = true
 orch_trustmark_enabled                      = true

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -34,11 +34,12 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-dev-tfstate"
 
-orch_account_id                              = "058264132019"
-is_orch_stubbed                              = false
-orch_environment                             = "integration"
-orch_session_table_encryption_key_arn        = "arn:aws:kms:eu-west-2:058264132019:key/1b5c001b-ed53-4a7b-bfbe-5d0f596110b5"
-orch_client_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:058264132019:key/fdf1686f-2d4d-4c7b-b3be-324b6ebba370"
+orch_account_id                                    = "058264132019"
+is_orch_stubbed                                    = false
+orch_environment                                   = "integration"
+orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:058264132019:key/1b5c001b-ed53-4a7b-bfbe-5d0f596110b5"
+orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:058264132019:key/fdf1686f-2d4d-4c7b-b3be-324b6ebba370"
+orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:058264132019:key/808a8c1e-82d8-487e-abb8-e13d6564b426"
 
 orch_trustmark_enabled               = true
 orch_openid_configuration_enabled    = true

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -48,6 +48,7 @@ module "ipv_processing_identity_role_with_orch_session_table_access" {
     aws_iam_policy.dynamo_orch_session_cross_account_read_and_delete_access_policy[0].arn,
     aws_iam_policy.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy[0].arn,
     aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn
   ]
 }
 moved {

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -49,11 +49,12 @@ authorize_protected_subnet_enabled = true
 
 contra_state_bucket = "digital-identity-prod-tfstate"
 
-orch_account_id                              = "533266965190"
-is_orch_stubbed                              = false
-orch_environment                             = "production"
-orch_session_table_encryption_key_arn        = "arn:aws:kms:eu-west-2:533266965190:key/7ad27a55-9d21-47f2-be03-b61f2c9a8ce6"
-orch_client_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:533266965190:key/9b57120e-3bcd-4fce-ada8-89ea9d1412d6"
+orch_account_id                                    = "533266965190"
+is_orch_stubbed                                    = false
+orch_environment                                   = "production"
+orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:533266965190:key/7ad27a55-9d21-47f2-be03-b61f2c9a8ce6"
+orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:533266965190:key/9b57120e-3bcd-4fce-ada8-89ea9d1412d6"
+orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:533266965190:key/b2979629-c62f-458d-992b-ac4239c2cf81"
 
 orch_trustmark_enabled               = true
 orch_openid_configuration_enabled    = true

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -66,9 +66,11 @@ orch_userinfo_enabled                = true
 orch_storage_token_jwk_enabled       = true
 orch_ipv_jwks_enabled                = true
 
-orch_account_id                              = "816047645251"
-is_orch_stubbed                              = false
-orch_environment                             = "dev"
-orch_session_table_encryption_key_arn        = "arn:aws:kms:eu-west-2:816047645251:key/645669ba-b288-4b63-bfe1-9d8bde9956ec"
-orch_client_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:816047645251:key/4cd7c551-128f-4579-99c2-a7f1bff64fb7"
-cmk_for_back_channel_logout_enabled          = true
+orch_account_id                                    = "816047645251"
+is_orch_stubbed                                    = false
+orch_environment                                   = "dev"
+orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:816047645251:key/645669ba-b288-4b63-bfe1-9d8bde9956ec"
+orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:816047645251:key/4cd7c551-128f-4579-99c2-a7f1bff64fb7"
+orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:816047645251:key/443e90d8-5a3b-43f1-99de-59ad9ca1ef26"
+
+cmk_for_back_channel_logout_enabled = true

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -26,12 +26,13 @@ authentication_attempts_service_enabled = true
 ipv_auth_authorize_callback_uri = "https://signin.staging.account.gov.uk/ipv/callback/authorize"
 ipv_auth_authorize_client_id    = "auth"
 
-orch_account_id                              = "590183975515"
-is_orch_stubbed                              = false
-orch_environment                             = "staging"
-orch_session_table_encryption_key_arn        = "arn:aws:kms:eu-west-2:590183975515:key/156f87e0-001a-4ae8-a6c1-23f8f68b6e84"
-orch_client_session_table_encryption_key_arn = "arn:aws:kms:eu-west-2:590183975515:key/b94d81a1-a41f-4e61-859c-87dcacb32e51"
-cmk_for_back_channel_logout_enabled          = true
+orch_account_id                                    = "590183975515"
+is_orch_stubbed                                    = false
+orch_environment                                   = "staging"
+orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:590183975515:key/156f87e0-001a-4ae8-a6c1-23f8f68b6e84"
+orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:590183975515:key/b94d81a1-a41f-4e61-859c-87dcacb32e51"
+orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:590183975515:key/d0bdb864-8478-4411-a44a-a4232fc97cf3"
+cmk_for_back_channel_logout_enabled                = true
 
 contra_state_bucket = "di-auth-staging-tfstate"
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -669,6 +669,11 @@ variable "orch_client_session_table_encryption_key_arn" {
   default = ""
 }
 
+variable "orch_identity_credentials_table_encryption_key_arn" {
+  type    = string
+  default = ""
+}
+
 variable "cmk_for_back_channel_logout_enabled" {
   default     = false
   type        = bool


### PR DESCRIPTION
### Wider context of change
This is part of the identity credentials migration work.

### What’s changed
In this PR, we add a new policy to processing identity handler to access the identity credentials table in orch accounts

### Manual testing
TBD: deploy to sandpit

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not Needed**
- [x] Changes have been made to the simulator or not required. **Not Needed**
- [x] Changes have been made to stubs or not required. **Not Needed**
- [x] Successfully deployed to authdev or not required. **Not Needed**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not Needed**
