### PR TITLE
ATO-1470: read from new identity credentials table

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -203,7 +203,8 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                         CLIENT_SESSION_ID),
                                 CLIENT_ID)));
 
-        var identityCredentials = identityStore.getIdentityCredentials(internalCommonSubjectId);
+        var identityCredentials =
+                identityStore.getIdentityCredentials(CLIENT_SESSION_ID, internalCommonSubjectId);
 
         assertTrue(
                 identityCredentials
@@ -384,7 +385,8 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                         "code",
                                         new AuthorizationCode().getValue())));
 
-        var identityCredentials = identityStore.getIdentityCredentials(internalCommonSubjectId);
+        var identityCredentials =
+                identityStore.getIdentityCredentials(CLIENT_SESSION_ID, internalCommonSubjectId);
 
         assertThat(response, hasStatus(302));
         if (validLoC) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -28,9 +28,9 @@ import uk.gov.di.authentication.ipv.entity.LogIds;
 import uk.gov.di.authentication.ipv.entity.SPOTRequest;
 import uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler;
 import uk.gov.di.authentication.testsupport.helpers.SpotQueueAssertionHelper;
-import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.MFAMethodType;
+import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.ServiceType;
@@ -208,22 +208,22 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
         assertTrue(
                 identityCredentials
-                        .map(AuthIdentityCredentials::getAdditionalClaims)
+                        .map(OrchIdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.ADDRESS.getValue()))
                         .isPresent());
         assertTrue(
                 identityCredentials
-                        .map(AuthIdentityCredentials::getAdditionalClaims)
+                        .map(OrchIdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.PASSPORT.getValue()))
                         .isPresent());
         assertTrue(
                 identityCredentials
-                        .map(AuthIdentityCredentials::getAdditionalClaims)
+                        .map(OrchIdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.DRIVING_PERMIT.getValue()))
                         .isPresent());
         assertTrue(
                 identityCredentials
-                        .map(AuthIdentityCredentials::getAdditionalClaims)
+                        .map(OrchIdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.RETURN_CODE.getValue()))
                         .isPresent());
 
@@ -418,7 +418,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
         assertTrue(
                 identityCredentials
-                        .map(AuthIdentityCredentials::getAdditionalClaims)
+                        .map(OrchIdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.RETURN_CODE.getValue()))
                         .isPresent());
         var returnCode =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -203,8 +203,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                         CLIENT_SESSION_ID),
                                 CLIENT_ID)));
 
-        var identityCredentials =
-                identityStore.getIdentityCredentials(CLIENT_SESSION_ID, internalCommonSubjectId);
+        var identityCredentials = identityStore.getIdentityCredentials(CLIENT_SESSION_ID);
 
         assertTrue(
                 identityCredentials
@@ -385,8 +384,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                         "code",
                                         new AuthorizationCode().getValue())));
 
-        var identityCredentials =
-                identityStore.getIdentityCredentials(CLIENT_SESSION_ID, internalCommonSubjectId);
+        var identityCredentials = identityStore.getIdentityCredentials(CLIENT_SESSION_ID);
 
         assertThat(response, hasStatus(302));
         if (validLoC) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -80,8 +80,7 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
         handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
         Optional<OrchIdentityCredentials> identityCredentials =
-                identityStore.getIdentityCredentials(
-                        CLIENT_SESSION_ID, pairwiseIdentifier.getValue());
+                identityStore.getIdentityCredentials(CLIENT_SESSION_ID);
         assertTrue(identityCredentials.isPresent());
         assertThat(
                 identityCredentials.get().getIpvVot(),
@@ -113,8 +112,7 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
         handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
         Optional<OrchIdentityCredentials> identityCredentials =
-                identityStore.getIdentityCredentials(
-                        CLIENT_SESSION_ID, pairwiseIdentifier.getValue());
+                identityStore.getIdentityCredentials(CLIENT_SESSION_ID);
         assertTrue(identityCredentials.isPresent());
         assertNull(identityCredentials.get().getAdditionalClaims());
         assertNull(identityCredentials.get().getIpvVot());
@@ -147,10 +145,7 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
                 CORE_IDENTITY_CLAIM);
         handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
-        assertFalse(
-                identityStore
-                        .getIdentityCredentials(CLIENT_SESSION_ID, pairwiseIdentifier.getValue())
-                        .isPresent());
+        assertFalse(identityStore.getIdentityCredentials(CLIENT_SESSION_ID).isPresent());
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 Collections.singletonList(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -80,7 +80,8 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
         handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
         Optional<AuthIdentityCredentials> identityCredentials =
-                identityStore.getIdentityCredentials(pairwiseIdentifier.getValue());
+                identityStore.getIdentityCredentials(
+                        CLIENT_SESSION_ID, pairwiseIdentifier.getValue());
         assertTrue(identityCredentials.isPresent());
         assertThat(
                 identityCredentials.get().getIpvVot(),
@@ -112,7 +113,8 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
         handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
         Optional<AuthIdentityCredentials> identityCredentials =
-                identityStore.getIdentityCredentials(pairwiseIdentifier.getValue());
+                identityStore.getIdentityCredentials(
+                        CLIENT_SESSION_ID, pairwiseIdentifier.getValue());
         assertTrue(identityCredentials.isPresent());
         assertNull(identityCredentials.get().getAdditionalClaims());
         assertNull(identityCredentials.get().getIpvVot());
@@ -146,7 +148,9 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
         handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
         assertFalse(
-                identityStore.getIdentityCredentials(pairwiseIdentifier.getValue()).isPresent());
+                identityStore
+                        .getIdentityCredentials(CLIENT_SESSION_ID, pairwiseIdentifier.getValue())
+                        .isPresent());
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 Collections.singletonList(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler;
-import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
+import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.sharedtest.basetest.IntegrationTest;
 
@@ -79,7 +79,7 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
                         CLIENT_ID);
         handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
-        Optional<AuthIdentityCredentials> identityCredentials =
+        Optional<OrchIdentityCredentials> identityCredentials =
                 identityStore.getIdentityCredentials(
                         CLIENT_SESSION_ID, pairwiseIdentifier.getValue());
         assertTrue(identityCredentials.isPresent());
@@ -112,7 +112,7 @@ public class SpotResponseIntegrationTest extends IntegrationTest {
                         CLIENT_ID);
         handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
-        Optional<AuthIdentityCredentials> identityCredentials =
+        Optional<OrchIdentityCredentials> identityCredentials =
                 identityStore.getIdentityCredentials(
                         CLIENT_SESSION_ID, pairwiseIdentifier.getValue());
         assertTrue(identityCredentials.isPresent());

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -131,7 +131,8 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
                     "Attempting to find identity credentials in dynamo. Attempt: {}",
                     processingAttempts);
             var identityCredentials =
-                    dynamoIdentityService.getIdentityCredentials(pairwiseSubjectId);
+                    dynamoIdentityService.getIdentityCredentials(
+                            userSession.getClientSessionId(), pairwiseSubjectId);
 
             var processingStatus = IdentityProgressStatus.PROCESSING;
             if (identityCredentials.isEmpty()

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -131,8 +131,7 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
                     "Attempting to find identity credentials in dynamo. Attempt: {}",
                     processingAttempts);
             var identityCredentials =
-                    dynamoIdentityService.getIdentityCredentials(
-                            userSession.getClientSessionId(), pairwiseSubjectId);
+                    dynamoIdentityService.getIdentityCredentials(userSession.getClientSessionId());
 
             var processingStatus = IdentityProgressStatus.PROCESSING;
             if (identityCredentials.isEmpty()

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -142,7 +142,8 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                     processingAttempts);
 
             var identityCredentials =
-                    dynamoIdentityService.getIdentityCredentials(rpPairwiseSubject.getValue());
+                    dynamoIdentityService.getIdentityCredentials(
+                            userContext.getClientSessionId(), rpPairwiseSubject.getValue());
             var processingStatus = ProcessingIdentityStatus.PROCESSING;
             if (identityCredentials.isEmpty()
                     && userContext.getSession().getProcessingIdentityAttempts() == 1) {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -142,8 +142,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                     processingAttempts);
 
             var identityCredentials =
-                    dynamoIdentityService.getIdentityCredentials(
-                            userContext.getClientSessionId(), rpPairwiseSubject.getValue());
+                    dynamoIdentityService.getIdentityCredentials(userContext.getClientSessionId());
             var processingStatus = ProcessingIdentityStatus.PROCESSING;
             if (identityCredentials.isEmpty()
                     && userContext.getSession().getProcessingIdentityAttempts() == 1) {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -19,9 +19,9 @@ import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.IdentityProgressResponse;
 import uk.gov.di.authentication.ipv.entity.IdentityProgressStatus;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
-import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
+import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
@@ -165,7 +165,7 @@ public class IdentityProgressFrontendHandlerTest {
     void shouldReturnCOMPLETEDStatusWhenIdentityCredentialIsPresent() throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new AuthIdentityCredentials()
+                new OrchIdentityCredentials()
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
@@ -204,7 +204,7 @@ public class IdentityProgressFrontendHandlerTest {
             throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new AuthIdentityCredentials()
+                new OrchIdentityCredentials()
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap());
         when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
@@ -313,7 +313,7 @@ public class IdentityProgressFrontendHandlerTest {
     void shouldReturnExpectedResponseBody() {
         usingValidSession();
         var identityCredentials =
-                new AuthIdentityCredentials()
+                new OrchIdentityCredentials()
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -169,7 +169,7 @@ public class IdentityProgressFrontendHandlerTest {
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
-        when(dynamoIdentityService.getIdentityCredentials(anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSession(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -207,7 +207,7 @@ public class IdentityProgressFrontendHandlerTest {
                 new AuthIdentityCredentials()
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap());
-        when(dynamoIdentityService.getIdentityCredentials(anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSession(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -242,7 +242,8 @@ public class IdentityProgressFrontendHandlerTest {
             throws Json.JsonException {
         session.incrementProcessingIdentityAttempts();
         usingValidSession();
-        when(dynamoIdentityService.getIdentityCredentials(INTERNAL_COMMON_SUBJECT_ID))
+        when(dynamoIdentityService.getIdentityCredentials(
+                        CLIENT_SESSION_ID, INTERNAL_COMMON_SUBJECT_ID))
                 .thenReturn(Optional.empty());
         when(clientSessionService.getClientSession(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -276,7 +277,8 @@ public class IdentityProgressFrontendHandlerTest {
     void shouldReturnNO_ENTRYStatusWhenNoEntryIsFoundInDynamoOnFirstAttempt()
             throws Json.JsonException {
         usingValidSession();
-        when(dynamoIdentityService.getIdentityCredentials(INTERNAL_COMMON_SUBJECT_ID))
+        when(dynamoIdentityService.getIdentityCredentials(
+                        CLIENT_SESSION_ID, INTERNAL_COMMON_SUBJECT_ID))
                 .thenReturn(Optional.empty());
         when(clientSessionService.getClientSession(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -315,7 +317,7 @@ public class IdentityProgressFrontendHandlerTest {
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
-        when(dynamoIdentityService.getIdentityCredentials(anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSession(any()))
                 .thenReturn(Optional.of(getClientSession()));

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -169,7 +169,7 @@ public class IdentityProgressFrontendHandlerTest {
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
-        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSession(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -207,7 +207,7 @@ public class IdentityProgressFrontendHandlerTest {
                 new OrchIdentityCredentials()
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap());
-        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSession(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -242,8 +242,7 @@ public class IdentityProgressFrontendHandlerTest {
             throws Json.JsonException {
         session.incrementProcessingIdentityAttempts();
         usingValidSession();
-        when(dynamoIdentityService.getIdentityCredentials(
-                        CLIENT_SESSION_ID, INTERNAL_COMMON_SUBJECT_ID))
+        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
                 .thenReturn(Optional.empty());
         when(clientSessionService.getClientSession(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -277,8 +276,7 @@ public class IdentityProgressFrontendHandlerTest {
     void shouldReturnNO_ENTRYStatusWhenNoEntryIsFoundInDynamoOnFirstAttempt()
             throws Json.JsonException {
         usingValidSession();
-        when(dynamoIdentityService.getIdentityCredentials(
-                        CLIENT_SESSION_ID, INTERNAL_COMMON_SUBJECT_ID))
+        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
                 .thenReturn(Optional.empty());
         when(clientSessionService.getClientSession(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -317,7 +315,7 @@ public class IdentityProgressFrontendHandlerTest {
                         .withSubjectID(INTERNAL_COMMON_SUBJECT_ID)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
-        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSession(any()))
                 .thenReturn(Optional.of(getClientSession()));

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -16,11 +16,11 @@ import uk.gov.di.authentication.ipv.entity.ProcessingIdentityResponse;
 import uk.gov.di.authentication.ipv.entity.ProcessingIdentityStatus;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
-import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
+import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
@@ -171,7 +171,8 @@ class ProcessingIdentityHandlerTest {
     void shouldReturnCOMPLETEDStatusWhenIdentityCredentialIsPresent() throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new AuthIdentityCredentials()
+                new OrchIdentityCredentials()
+                        .withClientSessionId(CLIENT_SESSION_ID)
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
@@ -203,7 +204,8 @@ class ProcessingIdentityHandlerTest {
     void shouldCallAISIfProcessingStatusIsCOMPLETED() throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new AuthIdentityCredentials()
+                new OrchIdentityCredentials()
+                        .withClientSessionId(CLIENT_SESSION_ID)
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
@@ -233,7 +235,7 @@ class ProcessingIdentityHandlerTest {
             throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new AuthIdentityCredentials()
+                new OrchIdentityCredentials()
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
@@ -283,7 +285,7 @@ class ProcessingIdentityHandlerTest {
             throws Json.JsonException {
         usingValidSession();
         var identityCredentials =
-                new AuthIdentityCredentials()
+                new OrchIdentityCredentials()
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap());
         when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -175,7 +175,7 @@ class ProcessingIdentityHandlerTest {
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
-        when(dynamoIdentityService.getIdentityCredentials(anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -207,7 +207,7 @@ class ProcessingIdentityHandlerTest {
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
-        when(dynamoIdentityService.getIdentityCredentials(anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -239,7 +239,7 @@ class ProcessingIdentityHandlerTest {
                         .withCoreIdentityJWT("a-core-identity");
         AccountIntervention intervention =
                 new AccountIntervention(new AccountInterventionState(false, true, false, false));
-        when(dynamoIdentityService.getIdentityCredentials(anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -286,7 +286,7 @@ class ProcessingIdentityHandlerTest {
                 new AuthIdentityCredentials()
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap());
-        when(dynamoIdentityService.getIdentityCredentials(anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -315,7 +315,7 @@ class ProcessingIdentityHandlerTest {
             throws Json.JsonException {
         session.incrementProcessingIdentityAttempts();
         usingValidSession();
-        when(dynamoIdentityService.getIdentityCredentials(PAIRWISE_SUBJECT))
+        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID, PAIRWISE_SUBJECT))
                 .thenReturn(Optional.empty());
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -342,7 +342,7 @@ class ProcessingIdentityHandlerTest {
     void shouldReturnNO_ENTRYStatusWhenNoEntryIsFoundInDynamoOnFirstAttempt()
             throws Json.JsonException {
         usingValidSession();
-        when(dynamoIdentityService.getIdentityCredentials(PAIRWISE_SUBJECT))
+        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID, PAIRWISE_SUBJECT))
                 .thenReturn(Optional.empty());
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -176,7 +176,7 @@ class ProcessingIdentityHandlerTest {
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
-        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -209,7 +209,7 @@ class ProcessingIdentityHandlerTest {
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap())
                         .withCoreIdentityJWT("a-core-identity");
-        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -241,7 +241,7 @@ class ProcessingIdentityHandlerTest {
                         .withCoreIdentityJWT("a-core-identity");
         AccountIntervention intervention =
                 new AccountIntervention(new AccountInterventionState(false, true, false, false));
-        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -288,7 +288,7 @@ class ProcessingIdentityHandlerTest {
                 new OrchIdentityCredentials()
                         .withSubjectID(PAIRWISE_SUBJECT)
                         .withAdditionalClaims(Collections.emptyMap());
-        when(dynamoIdentityService.getIdentityCredentials(anyString(), anyString()))
+        when(dynamoIdentityService.getIdentityCredentials(anyString()))
                 .thenReturn(Optional.of(identityCredentials));
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -317,7 +317,7 @@ class ProcessingIdentityHandlerTest {
             throws Json.JsonException {
         session.incrementProcessingIdentityAttempts();
         usingValidSession();
-        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID, PAIRWISE_SUBJECT))
+        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
                 .thenReturn(Optional.empty());
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));
@@ -344,7 +344,7 @@ class ProcessingIdentityHandlerTest {
     void shouldReturnNO_ENTRYStatusWhenNoEntryIsFoundInDynamoOnFirstAttempt()
             throws Json.JsonException {
         usingValidSession();
-        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID, PAIRWISE_SUBJECT))
+        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
                 .thenReturn(Optional.empty());
         when(clientSessionService.getClientSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(getClientSession()));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -145,7 +145,11 @@ public class UserInfoService {
     private UserInfo populateIdentityInfo(AccessTokenInfo accessTokenInfo, UserInfo userInfo) {
         LOG.info("Populating IdentityInfo");
         var identityCredentials =
-                identityService.getIdentityCredentials(accessTokenInfo.getSubject()).orElse(null);
+                identityService
+                        .getIdentityCredentials(
+                                accessTokenInfo.getAccessTokenStore().getJourneyId(),
+                                accessTokenInfo.getSubject())
+                        .orElse(null);
         if (Objects.isNull(identityCredentials)) {
             LOG.info("No identity credentials present");
             return userInfo;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -147,8 +147,7 @@ public class UserInfoService {
         var identityCredentials =
                 identityService
                         .getIdentityCredentials(
-                                accessTokenInfo.getAccessTokenStore().getJourneyId(),
-                                accessTokenInfo.getSubject())
+                                accessTokenInfo.getAccessTokenStore().getJourneyId())
                         .orElse(null);
         if (Objects.isNull(identityCredentials)) {
             LOG.info("No identity credentials present");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -260,7 +260,7 @@ class UserInfoServiceTest {
                                             RETURN_CODE));
             accessToken = createSignedAccessToken(oidcValidClaimsRequest);
 
-            when(identityService.getIdentityCredentials(SUBJECT.getValue()))
+            when(identityService.getIdentityCredentials(JOURNEY_ID, SUBJECT.getValue()))
                     .thenReturn(Optional.of(identityCredentials));
 
             var accessTokenStore =
@@ -389,7 +389,7 @@ class UserInfoServiceTest {
                             .withCoreIdentityJWT(coreIdentityJWT);
             accessToken = createSignedAccessToken(oidcValidClaimsRequest);
 
-            when(identityService.getIdentityCredentials(SUBJECT.getValue()))
+            when(identityService.getIdentityCredentials(JOURNEY_ID, SUBJECT.getValue()))
                     .thenReturn(Optional.of(identityCredentials));
 
             var accessTokenStore =

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -24,9 +24,9 @@ import uk.gov.di.authentication.app.entity.DocAppCredential;
 import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.orchestration.shared.entity.AccessTokenStore;
-import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
+import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.exceptions.AccessTokenException;
@@ -245,7 +245,8 @@ class UserInfoServiceTest {
                         ParseException {
             when(configurationService.isIdentityEnabled()).thenReturn(true);
             var identityCredentials =
-                    new AuthIdentityCredentials()
+                    new OrchIdentityCredentials()
+                            .withClientSessionId(JOURNEY_ID)
                             .withSubjectID(SUBJECT.getValue())
                             .withCoreIdentityJWT(coreIdentityJWT)
                             .withAdditionalClaims(
@@ -384,7 +385,8 @@ class UserInfoServiceTest {
                         ParseException {
             when(configurationService.isIdentityEnabled()).thenReturn(true);
             var identityCredentials =
-                    new AuthIdentityCredentials()
+                    new OrchIdentityCredentials()
+                            .withClientSessionId(JOURNEY_ID)
                             .withSubjectID(SUBJECT.getValue())
                             .withCoreIdentityJWT(coreIdentityJWT);
             accessToken = createSignedAccessToken(oidcValidClaimsRequest);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -261,7 +261,7 @@ class UserInfoServiceTest {
                                             RETURN_CODE));
             accessToken = createSignedAccessToken(oidcValidClaimsRequest);
 
-            when(identityService.getIdentityCredentials(JOURNEY_ID, SUBJECT.getValue()))
+            when(identityService.getIdentityCredentials(JOURNEY_ID))
                     .thenReturn(Optional.of(identityCredentials));
 
             var accessTokenStore =
@@ -391,7 +391,7 @@ class UserInfoServiceTest {
                             .withCoreIdentityJWT(coreIdentityJWT);
             accessToken = createSignedAccessToken(oidcValidClaimsRequest);
 
-            when(identityService.getIdentityCredentials(JOURNEY_ID, SUBJECT.getValue()))
+            when(identityService.getIdentityCredentials(JOURNEY_ID))
                     .thenReturn(Optional.of(identityCredentials));
 
             var accessTokenStore =

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
@@ -77,8 +77,9 @@ public class IdentityStoreExtension extends DynamoExtension implements AfterEach
                 clientSessionId, subjectID, additionalClaims, ipvVot, ipvCoreIdentity);
     }
 
-    public Optional<AuthIdentityCredentials> getIdentityCredentials(String subjectID) {
-        return dynamoService.getIdentityCredentials(subjectID);
+    public Optional<AuthIdentityCredentials> getIdentityCredentials(
+            String clientSessionId, String subjectID) {
+        return dynamoService.getIdentityCredentials(clientSessionId, subjectID);
     }
 
     private void createAuthIdentityCredentialTable() {

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
@@ -77,9 +77,8 @@ public class IdentityStoreExtension extends DynamoExtension implements AfterEach
                 clientSessionId, subjectID, additionalClaims, ipvVot, ipvCoreIdentity);
     }
 
-    public Optional<OrchIdentityCredentials> getIdentityCredentials(
-            String clientSessionId, String subjectID) {
-        return dynamoService.getIdentityCredentials(clientSessionId, subjectID);
+    public Optional<OrchIdentityCredentials> getIdentityCredentials(String clientSessionId) {
+        return dynamoService.getIdentityCredentials(clientSessionId);
     }
 
     private void createAuthIdentityCredentialTable() {

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/IdentityStoreExtension.java
@@ -8,7 +8,7 @@ import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
-import uk.gov.di.orchestration.shared.entity.AuthIdentityCredentials;
+import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 import uk.gov.di.orchestration.sharedtest.basetest.DynamoTestConfiguration;
@@ -77,7 +77,7 @@ public class IdentityStoreExtension extends DynamoExtension implements AfterEach
                 clientSessionId, subjectID, additionalClaims, ipvVot, ipvCoreIdentity);
     }
 
-    public Optional<AuthIdentityCredentials> getIdentityCredentials(
+    public Optional<OrchIdentityCredentials> getIdentityCredentials(
             String clientSessionId, String subjectID) {
         return dynamoService.getIdentityCredentials(clientSessionId, subjectID);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
@@ -57,8 +57,7 @@ public class DynamoIdentityService {
         orchIdentityCredentialsDynamoService.update(identityCredentials);
     }
 
-    public Optional<OrchIdentityCredentials> getIdentityCredentials(
-            String clientSessionId, String subjectID) {
+    public Optional<OrchIdentityCredentials> getIdentityCredentials(String clientSessionId) {
         return orchIdentityCredentialsDynamoService
                 .get(clientSessionId)
                 .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
@@ -57,7 +57,8 @@ public class DynamoIdentityService {
         orchIdentityCredentialsDynamoService.update(identityCredentials);
     }
 
-    public Optional<AuthIdentityCredentials> getIdentityCredentials(String subjectID) {
+    public Optional<AuthIdentityCredentials> getIdentityCredentials(
+            String clientSessionId, String subjectID) {
         return authIdentityCredentialsDynamoService
                 .get(subjectID)
                 .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoIdentityService.java
@@ -57,10 +57,10 @@ public class DynamoIdentityService {
         orchIdentityCredentialsDynamoService.update(identityCredentials);
     }
 
-    public Optional<AuthIdentityCredentials> getIdentityCredentials(
+    public Optional<OrchIdentityCredentials> getIdentityCredentials(
             String clientSessionId, String subjectID) {
-        return authIdentityCredentialsDynamoService
-                .get(subjectID)
+        return orchIdentityCredentialsDynamoService
+                .get(clientSessionId)
                 .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
     }
 


### PR DESCRIPTION
### Wider context of change
This is part of the identity credentials migration work.

### What’s changed
In this PR, we read from the new table. We continue to write to the old table

### Manual testing
I've done some logging here to verify clientSessionId is always defined:
https://github.com/govuk-one-login/authentication-api/pull/6013

Deployed to dev:
- Ran through an identity journey - no issues observed
- Rebased main to ensure this had the latest changes in

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing. **tbd**
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not Needed**
- [x] Changes have been made to the simulator or not required. **Not Needed**
- [x] Changes have been made to stubs or not required. **Not Needed**
- [x] Successfully deployed to authdev or not required. **Not Needed**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not Needed**
