### PR TITLE
AUT-3484: Update the openapi spec with new names

### DIFF
--- a/ci/terraform/account-management/mfa-mm-create-backup.tf
+++ b/ci/terraform/account-management/mfa-mm-create-backup.tf
@@ -16,7 +16,7 @@ module "account_management_api_mfa_mm_create_backup_role" {
 module "mfa-mm-create-backup" {
   source = "../modules/endpoint-lambda"
 
-  endpoint_name = "mfa-methods-create-backup"
+  endpoint_name = "mfa-mm-create-backup"
   handler_environment_variables = {
     ENVIRONMENT          = var.environment
     REDIS_KEY            = local.redis_key

--- a/ci/terraform/account-management/openapi_v2.yaml
+++ b/ci/terraform/account-management/openapi_v2.yaml
@@ -77,7 +77,7 @@ paths:
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
-        uri: "${endpoint_modules.mfa-methods-create-backup.integration_uri}"
+        uri: "${endpoint_modules.mfa-mm-create-backup.integration_uri}"
         passthroughBehavior: "when_no_match"
         timeoutInMillis: 29000
       description: "Retrieve mfaMethods that for the given public subject id"
@@ -156,7 +156,7 @@ paths:
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
-        uri: "${endpoint_modules.mfa-methods-create-backup.integration_uri}"
+        uri: "${endpoint_modules.mfa-mm-create-backup.integration_uri}"
         passthroughBehavior: "when_no_match"
         timeoutInMillis: 29000
       tags:
@@ -206,7 +206,7 @@ paths:
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
-        uri: "${endpoint_modules.mfa-methods-create-backup.integration_uri}"
+        uri: "${endpoint_modules.mfa-mm-create-backup.integration_uri}"
         passthroughBehavior: "when_no_match"
         timeoutInMillis: 29000
       tags:
@@ -244,7 +244,7 @@ paths:
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
-        uri: "${endpoint_modules.mfa-methods-create-backup.integration_uri}"
+        uri: "${endpoint_modules.mfa-mm-create-backup.integration_uri}"
         passthroughBehavior: "when_no_match"
         timeoutInMillis: 29000
       tags:


### PR DESCRIPTION

## What
The OpenAPI spec needs updating to use the names changed in the previous change for this ticket.

<!-- Describe what you have changed and why -->

## How to review
1. Code Review

<!-- Describe the steps required to review this PR.
For example:

1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
