### PR TITLE
Ato 1372/update token endpoint support pkce

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -11,6 +11,9 @@ import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.pkce.CodeChallenge;
+import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
+import com.nimbusds.oauth2.sdk.pkce.CodeVerifier;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
@@ -267,6 +270,14 @@ public class TokenHandler
                     400, e.getErrorObject().toJSONObject().toJSONString());
         }
 
+        if (configurationService.isPkceEnabled()) {
+            if (!isPKCEValid(
+                    Optional.ofNullable(authRequest.getCodeChallenge()),
+                    Optional.ofNullable(requestBody.get("code_verifier")))) {
+                return generateInvalidGrantPKCEVerificationCodeApiGatewayProxyResponse();
+            }
+        }
+
         var tokenResponse =
                 getTokenResponse(
                         clientSession,
@@ -292,6 +303,36 @@ public class TokenHandler
 
         LOG.info("Successfully generated tokens");
         return generateApiGatewayProxyResponse(200, tokenResponse.toJSONObject().toJSONString());
+    }
+
+    private static boolean isPKCEValid(
+            Optional<CodeChallenge> codeChallengeOpt, Optional<String> codeVerifierOpt) {
+
+        if (codeChallengeOpt.isEmpty() && codeVerifierOpt.isEmpty()) {
+            LOG.info("No PKCE parameters in request");
+            return true;
+        } else if (codeChallengeOpt.isEmpty()) {
+            LOG.warn("Code verifier present in request but no code_challenge in auth request");
+            return false;
+        } else if (codeVerifierOpt.isEmpty()) {
+            LOG.warn("Code challenge in auth request but no code verifier in token request");
+            return false;
+        }
+
+        CodeVerifier codeVerifier;
+        CodeChallenge codeChallenge = codeChallengeOpt.get();
+        try {
+            // Throws IllegalArgumentException for invalid verifier
+            // Validates the verifier according to spec:
+            // https://datatracker.ietf.org/doc/html/rfc7636#section-4.1
+            codeVerifier = new CodeVerifier(codeVerifierOpt.get());
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Invalid Code Verifier: {}", e.getMessage());
+            return false;
+        }
+
+        var computedCodeChallenge = CodeChallenge.compute(CodeChallengeMethod.S256, codeVerifier);
+        return computedCodeChallenge.getValue().equals(codeChallenge.getValue());
     }
 
     private static boolean refreshTokenRequest(Map<String, String> requestBody) {
@@ -329,7 +370,7 @@ public class TokenHandler
             jti = signedJwt.getJWTClaimsSet().getJWTID();
         } catch (java.text.ParseException e) {
             LOG.warn("Unable to parse RefreshToken");
-            return generateInvalidGrantCodeApiGatewayProxyResponse();
+            return generateInvalidGrantCodeRefreshTokenApiGatewayProxyResponse();
         }
         boolean areScopesValid =
                 tokenValidationService.validateRefreshTokenScopes(clientScopes, scopes);
@@ -346,11 +387,11 @@ public class TokenHandler
             tokenStore = objectMapper.readValue(refreshToken.get(), RefreshTokenStore.class);
         } catch (JsonException | NoSuchElementException | IllegalArgumentException e) {
             LOG.warn("Refresh token not found with given key");
-            return generateInvalidGrantCodeApiGatewayProxyResponse();
+            return generateInvalidGrantCodeRefreshTokenApiGatewayProxyResponse();
         }
         if (!tokenStore.getRefreshToken().equals(currentRefreshToken.getValue())) {
             LOG.warn("Refresh token store does not contain Refresh token in request");
-            return generateInvalidGrantCodeApiGatewayProxyResponse();
+            return generateInvalidGrantCodeRefreshTokenApiGatewayProxyResponse();
         }
 
         OIDCTokenResponse tokenResponse =
@@ -489,10 +530,21 @@ public class TokenHandler
         return tokenResponse;
     }
 
-    private APIGatewayProxyResponseEvent generateInvalidGrantCodeApiGatewayProxyResponse() {
+    private APIGatewayProxyResponseEvent
+            generateInvalidGrantCodeRefreshTokenApiGatewayProxyResponse() {
+        return generateInvalidGrantCodeApiGatewayProxyResponse("Invalid Refresh token");
+    }
+
+    private APIGatewayProxyResponseEvent
+            generateInvalidGrantPKCEVerificationCodeApiGatewayProxyResponse() {
+        return generateInvalidGrantCodeApiGatewayProxyResponse("PKCE code verification failed");
+    }
+
+    private APIGatewayProxyResponseEvent generateInvalidGrantCodeApiGatewayProxyResponse(
+            String description) {
         return generateApiGatewayProxyResponse(
                 400,
-                new ErrorObject(OAuth2Error.INVALID_GRANT_CODE, "Invalid Refresh token")
+                new ErrorObject(OAuth2Error.INVALID_GRANT_CODE, description)
                         .toJSONObject()
                         .toJSONString());
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -270,10 +270,24 @@ public class TokenHandler
                     400, e.getErrorObject().toJSONObject().toJSONString());
         }
 
+        // ATO-1372: add logging to see how many RPs are sending the correct code verifiers
+        var codeChallenge = authRequest.getCodeChallenge();
+        var codeVerifierString = requestBody.get("code_verifier");
+
+        try {
+            if (!isPKCEValid(
+                    Optional.ofNullable(codeChallenge), Optional.ofNullable(codeVerifierString))) {
+                LOG.info("PKCE validation failed");
+            } else {
+                LOG.info("PKCE validation passed");
+            }
+        } catch (Exception e) {
+            LOG.info("PKCE FAILED {}", e.getMessage());
+        }
+
         if (configurationService.isPkceEnabled()) {
             if (!isPKCEValid(
-                    Optional.ofNullable(authRequest.getCodeChallenge()),
-                    Optional.ofNullable(requestBody.get("code_verifier")))) {
+                    Optional.ofNullable(codeChallenge), Optional.ofNullable(codeVerifierString))) {
                 return generateInvalidGrantPKCEVerificationCodeApiGatewayProxyResponse();
             }
         }

--- a/template.yaml
+++ b/template.yaml
@@ -1618,6 +1618,10 @@ Resources:
             - IsReturnAuthTimeInIdTokenEnabled
             - true
             - false
+          PKCE_ENABLED: !If
+            - PkceEnabled
+            - true
+            - false
 
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy


### PR DESCRIPTION
### Wider context of change

As part of the PKCE work , at the token endpoint we take the code challenge from the authRequestParams and validated by the code verifier passed through the request

### What’s changed

Added logic in Validating code challenge and verifier
Wrapped in feature flag and code verifier non null check

### Manual testing

Ran through RP stub 

### How to review

 - Look at validation logic
 - Error response
 - enabling PKCE logic
