### PR TITLE
ATO-1419: Verify client session databases are in sync

### DIFF
--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -10,7 +10,8 @@ module "identity_progress_role_1" {
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     ], var.is_orch_stubbed ? [] : [
-    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn
+    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_cross_account_read_access_policy[0].arn
   ])
   extra_tags = {
     Service = "identity-progress"

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -34,6 +34,7 @@ import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.api.DocAppCriAPI;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.NoSessionEntity;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
@@ -46,6 +47,7 @@ import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
+import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
@@ -86,6 +88,8 @@ class DocAppCallbackHandlerTest {
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final OrchClientSessionService orchClientSessionService =
+            mock(OrchClientSessionService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final DynamoDocAppService dynamoDocAppService = mock(DynamoDocAppService.class);
     private final NoSessionOrchestrationService noSessionOrchestrationService =
@@ -127,6 +131,13 @@ class DocAppCallbackHandlerTest {
 
     private final ClientSession clientSession =
             new ClientSession(generateAuthRequest().toParameters(), null, emptyList(), null);
+    private final OrchClientSessionItem orchClientSession =
+            new OrchClientSessionItem(
+                    CLIENT_SESSION_ID,
+                    generateAuthRequest().toParameters(),
+                    null,
+                    emptyList(),
+                    null);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =
@@ -144,6 +155,7 @@ class DocAppCallbackHandlerTest {
                         tokenService,
                         sessionService,
                         clientSessionService,
+                        orchClientSessionService,
                         auditService,
                         dynamoDocAppService,
                         authorisationCodeService,
@@ -602,6 +614,9 @@ class DocAppCallbackHandlerTest {
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(clientSession));
         clientSession.setDocAppSubjectId(PAIRWISE_SUBJECT_ID);
+        when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(orchClientSession));
+        orchClientSession.setDocAppSubjectId(PAIRWISE_SUBJECT_ID.getValue());
     }
 
     private static AuthenticationRequest generateAuthRequest() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -1361,7 +1361,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
         redis.createClientSession(clientSessionId, clientSession);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
+                        clientSessionId,
                         authRequestBuilder.build().toParameters(),
                         creationDate,
                         vtrList,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -30,12 +30,14 @@ import uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler;
 import uk.gov.di.authentication.testsupport.helpers.SpotQueueAssertionHelper;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.MFAMethodType;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.ServiceType;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -43,6 +45,7 @@ import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationT
 import uk.gov.di.orchestration.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.IPVStubExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
@@ -50,6 +53,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -84,6 +88,10 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
     @RegisterExtension
     public static final OrchSessionExtension orchSessionExtension = new OrchSessionExtension();
+
+    @RegisterExtension
+    public static final OrchClientSessionExtension orchClientSessionExtension =
+            new OrchClientSessionExtension();
 
     @RegisterExtension
     protected static final AuthenticationCallbackUserInfoStoreExtension userInfoStorageExtension =
@@ -149,8 +157,19 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                         .nonce(new Nonce())
                         .state(RP_STATE);
         redis.createSession(SESSION_ID);
+        var clientCreationTime = LocalDateTime.now();
         redis.createClientSession(
-                CLIENT_SESSION_ID, CLIENT_NAME, authRequestBuilder.build().toParameters());
+                CLIENT_SESSION_ID,
+                CLIENT_NAME,
+                authRequestBuilder.build().toParameters(),
+                clientCreationTime);
+        orchClientSessionExtension.storeClientSession(
+                new OrchClientSessionItem(
+                        CLIENT_SESSION_ID,
+                        authRequestBuilder.build().toParameters(),
+                        clientCreationTime,
+                        List.of(VectorOfTrust.getDefaults()),
+                        CLIENT_NAME));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
         redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
@@ -276,8 +295,19 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 URI.create(REDIRECT_URI))
                         .nonce(new Nonce())
                         .state(RP_STATE);
+        var clientCreationTime = LocalDateTime.now();
         redis.createClientSession(
-                CLIENT_SESSION_ID, CLIENT_NAME, authRequestBuilder.build().toParameters());
+                CLIENT_SESSION_ID,
+                CLIENT_NAME,
+                authRequestBuilder.build().toParameters(),
+                clientCreationTime);
+        orchClientSessionExtension.storeClientSession(
+                new OrchClientSessionItem(
+                        CLIENT_SESSION_ID,
+                        authRequestBuilder.build().toParameters(),
+                        clientCreationTime,
+                        List.of(VectorOfTrust.getDefaults()),
+                        CLIENT_NAME));
         redis.addClientSessionAndStateToRedis(ORCHESTRATION_STATE, CLIENT_SESSION_ID);
 
         var response =
@@ -319,8 +349,19 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 URI.create(REDIRECT_URI))
                         .nonce(new Nonce())
                         .state(RP_STATE);
+        var clientCreationTime = LocalDateTime.now();
         redis.createClientSession(
-                CLIENT_SESSION_ID, CLIENT_NAME, authRequestBuilder.build().toParameters());
+                CLIENT_SESSION_ID,
+                CLIENT_NAME,
+                authRequestBuilder.build().toParameters(),
+                clientCreationTime);
+        orchClientSessionExtension.storeClientSession(
+                new OrchClientSessionItem(
+                        CLIENT_SESSION_ID,
+                        authRequestBuilder.build().toParameters(),
+                        clientCreationTime,
+                        List.of(VectorOfTrust.getDefaults()),
+                        CLIENT_NAME));
 
         var response =
                 makeRequest(
@@ -364,8 +405,19 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                         .state(RP_STATE)
                         .claims(oidcValidClaimsRequest);
         redis.createSession(SESSION_ID);
+        var clientCreationTime = LocalDateTime.now();
         redis.createClientSession(
-                CLIENT_SESSION_ID, CLIENT_NAME, authRequestBuilder.build().toParameters());
+                CLIENT_SESSION_ID,
+                CLIENT_NAME,
+                authRequestBuilder.build().toParameters(),
+                clientCreationTime);
+        orchClientSessionExtension.storeClientSession(
+                new OrchClientSessionItem(
+                        CLIENT_SESSION_ID,
+                        authRequestBuilder.build().toParameters(),
+                        clientCreationTime,
+                        List.of(VectorOfTrust.getDefaults()),
+                        CLIENT_NAME));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
         redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
@@ -450,8 +502,19 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                         .claims(oidcValidClaimsRequest);
 
         redis.createSession(SESSION_ID);
+        var clientCreationTime = LocalDateTime.now();
         redis.createClientSession(
-                CLIENT_SESSION_ID, CLIENT_NAME, authRequestBuilder.build().toParameters());
+                CLIENT_SESSION_ID,
+                CLIENT_NAME,
+                authRequestBuilder.build().toParameters(),
+                clientCreationTime);
+        orchClientSessionExtension.storeClientSession(
+                new OrchClientSessionItem(
+                        CLIENT_SESSION_ID,
+                        authRequestBuilder.build().toParameters(),
+                        clientCreationTime,
+                        List.of(VectorOfTrust.getDefaults()),
+                        CLIENT_NAME));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
         redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
@@ -498,8 +561,19 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                         .state(RP_STATE);
 
         redis.createSession(sessionId);
+        var clientCreationTime = LocalDateTime.now();
         redis.createClientSession(
-                CLIENT_SESSION_ID, CLIENT_NAME, authRequestBuilder.build().toParameters());
+                CLIENT_SESSION_ID,
+                CLIENT_NAME,
+                authRequestBuilder.build().toParameters(),
+                clientCreationTime);
+        orchClientSessionExtension.storeClientSession(
+                new OrchClientSessionItem(
+                        CLIENT_SESSION_ID,
+                        authRequestBuilder.build().toParameters(),
+                        clientCreationTime,
+                        List.of(VectorOfTrust.getDefaults()),
+                        CLIENT_NAME));
         redis.addStateToRedis(ORCHESTRATION_STATE, sessionId);
         redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -724,17 +724,14 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             singletonList(JsonArrayHelper.jsonArrayOf(vtr.get())));
         }
         var creationDate = LocalDateTime.now();
+        var authRequestParams = generateAuthRequest(scope, vtr, oidcClaimsRequest).toParameters();
         var clientSession =
-                new ClientSession(
-                        generateAuthRequest(scope, vtr, oidcClaimsRequest).toParameters(),
-                        creationDate,
-                        vtrList,
-                        "client-name");
+                new ClientSession(authRequestParams, creationDate, vtrList, "client-name");
         redis.createClientSession(CLIENT_SESSION_ID, clientSession);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
                         CLIENT_SESSION_ID,
-                        generateAuthRequest(scope, vtr, oidcClaimsRequest).toParameters(),
+                        authRequestParams,
                         creationDate,
                         vtrList,
                         "client-name"));

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
+import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.shared.state.OrchestrationUserSession;
@@ -63,8 +64,14 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
             SessionService sessionService,
             AuthenticationUserInfoStorageService userInfoStorageService,
             ClientSessionService clientSessionService,
-            OrchSessionService orchSessionService) {
-        super(configurationService, sessionService, clientSessionService, orchSessionService);
+            OrchSessionService orchSessionService,
+            OrchClientSessionService orchClientSessionService) {
+        super(
+                configurationService,
+                sessionService,
+                clientSessionService,
+                orchSessionService,
+                orchClientSessionService);
         this.dynamoIdentityService = dynamoIdentityService;
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -30,6 +30,7 @@ import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
+import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SessionService;
@@ -92,7 +93,8 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             AuditService auditService,
             CloudwatchMetricsService cloudwatchMetricsService,
             LogoutService logoutService,
-            OrchSessionService orchSessionService) {
+            OrchSessionService orchSessionService,
+            OrchClientSessionService orchClientSessionService) {
         super(
                 ProcessingIdentityRequest.class,
                 configurationService,
@@ -100,7 +102,8 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                 clientSessionService,
                 dynamoClientService,
                 dynamoService,
-                orchSessionService);
+                orchSessionService,
+                orchClientSessionService);
         this.dynamoIdentityService = dynamoIdentityService;
         this.accountInterventionService = accountInterventionService;
         this.auditService = auditService;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -98,6 +98,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFiel
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.orchestration.shared.services.AuditService.UNKNOWN;
+import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.logIfClientSessionsAreNotEqual;
 
 public class AuthenticationCallbackHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -299,6 +300,8 @@ public class AuthenticationCallbackHandler
                                     () ->
                                             new AuthenticationCallbackException(
                                                     "OrchClientSession not found"));
+
+            logIfClientSessionsAreNotEqual(clientSession, orchClientSession);
 
             String persistentSessionId =
                     PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders());

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -115,6 +115,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.updateAttache
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.updateAttachedSessionIdToLogs;
 import static uk.gov.di.orchestration.shared.helpers.RequestBodyHelper.parseRequestBody;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
+import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.logIfClientSessionsAreNotEqual;
 
 public class AuthorisationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -439,6 +440,8 @@ public class AuthorisationHandler
                         creationDate,
                         vtrList,
                         client.getClientName());
+
+        logIfClientSessionsAreNotEqual(clientSession, orchClientSession);
 
         if (DocAppUserHelper.isDocCheckingAppUser(
                 authRequest.toParameters(), Optional.of(client))) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -68,6 +68,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.updateAttachedLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.RequestBodyHelper.parseRequestBody;
+import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.logIfClientSessionsAreNotEqual;
 
 public class TokenHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -261,9 +262,11 @@ public class TokenHandler
 
         var idTokenHint = tokenResponse.getOIDCTokens().getIDToken().serialize();
         var clientSessionId = authCodeExchangeData.getClientSessionId();
+        var orchClientSession = orchClientSessionService.getClientSession(clientSessionId);
+        logIfClientSessionsAreNotEqual(clientSession, orchClientSession.orElse(null));
         clientSessionService.updateStoredClientSession(
                 clientSessionId, clientSession.setIdTokenHint(idTokenHint));
-        var orchClientSession = orchClientSessionService.getClientSession(clientSessionId);
+
         if (orchClientSession.isEmpty()) {
             LOG.warn("No orch client session is present");
         } else {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -329,6 +329,7 @@ class AuthorisationHandlerTest {
         when(clientSession.getDocAppSubjectId()).thenReturn(new Subject("test-subject-id"));
         when(clientService.getClient(anyString()))
                 .thenReturn(Optional.of(generateClientRegistry()));
+        when(orchClientSession.getDocAppSubjectId()).thenReturn("test-subject-id");
         when(sessionService.updateWithNewSessionId(any(Session.class), anyString(), anyString()))
                 .then(invocation -> invocation.<Session>getArgument(0));
     }
@@ -663,8 +664,9 @@ class AuthorisationHandlerTest {
             withExistingSession(session);
             when(userContext.getClientSession()).thenReturn(clientSession);
             when(userContext.getSession()).thenReturn(session);
-            when(clientSession.getAuthRequestParams())
-                    .thenReturn(generateAuthRequest(Optional.empty()).toParameters());
+            var authRequestParams = generateAuthRequest(Optional.empty()).toParameters();
+            when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
+            when(orchClientSession.getAuthRequestParams()).thenReturn(authRequestParams);
 
             Map<String, String> requestParams = buildRequestParams(Map.of("prompt", "login"));
             APIGatewayProxyResponseEvent response =
@@ -708,8 +710,9 @@ class AuthorisationHandlerTest {
             withExistingSession(session);
             when(userContext.getClientSession()).thenReturn(clientSession);
             when(userContext.getSession()).thenReturn(session);
-            when(clientSession.getAuthRequestParams())
-                    .thenReturn(generateAuthRequest(Optional.empty()).toParameters());
+            var authRequestParams = generateAuthRequest(Optional.empty()).toParameters();
+            when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
+            when(orchClientSession.getAuthRequestParams()).thenReturn(authRequestParams);
 
             Map<String, String> requestParams =
                     buildRequestParams(
@@ -735,9 +738,10 @@ class AuthorisationHandlerTest {
             withExistingSession(session);
             when(userContext.getClientSession()).thenReturn(clientSession);
             when(userContext.getSession()).thenReturn(session);
-            when(clientSession.getAuthRequestParams())
-                    .thenReturn(
-                            generateAuthRequest(Optional.of(jsonArrayOf("Cl.Cm"))).toParameters());
+            var authRequestParams =
+                    generateAuthRequest(Optional.of(jsonArrayOf("Cl.Cm"))).toParameters();
+            when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
+            when(orchClientSession.getAuthRequestParams()).thenReturn(authRequestParams);
 
             APIGatewayProxyResponseEvent response =
                     makeHandlerRequest(
@@ -779,8 +783,10 @@ class AuthorisationHandlerTest {
             withExistingSession(session);
             when(userContext.getClientSession()).thenReturn(clientSession);
             when(userContext.getSession()).thenReturn(session);
-            when(clientSession.getAuthRequestParams())
-                    .thenReturn(generateAuthRequest(Optional.of(jsonArrayOf("Cl"))).toParameters());
+            var authRequestParams =
+                    generateAuthRequest(Optional.of(jsonArrayOf("Cl"))).toParameters();
+            when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
+            when(orchClientSession.getAuthRequestParams()).thenReturn(authRequestParams);
 
             APIGatewayProxyResponseEvent response =
                     makeHandlerRequest(
@@ -825,10 +831,10 @@ class AuthorisationHandlerTest {
             withExistingSession(session);
             when(userContext.getClientSession()).thenReturn(clientSession);
             when(userContext.getSession()).thenReturn(session);
-            when(clientSession.getAuthRequestParams())
-                    .thenReturn(
-                            generateAuthRequest(Optional.of(jsonArrayOf("P2.Cl.Cm")))
-                                    .toParameters());
+            var authRequestParams =
+                    generateAuthRequest(Optional.of(jsonArrayOf("P2.Cl.Cm"))).toParameters();
+            when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
+            when(orchClientSession.getAuthRequestParams()).thenReturn(authRequestParams);
 
             APIGatewayProxyResponseEvent response =
                     makeHandlerRequest(
@@ -2933,7 +2939,7 @@ class AuthorisationHandlerTest {
                 new AuthenticationRequest.Builder(
                                 ResponseType.CODE, scope, CLIENT_ID, URI.create(REDIRECT_URI))
                         .state(STATE)
-                        .nonce(new Nonce());
+                        .nonce(NONCE);
         credentialTrustLevel.ifPresent(t -> builder.customParameter("vtr", t));
         return builder.build();
     }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -121,6 +121,17 @@ public class RedisExtension
             Map<String, List<String>> authRequest,
             String clientName)
             throws Json.JsonException {
+        addAuthRequestToSession(
+                clientSessionId, sessionId, authRequest, clientName, LocalDateTime.now());
+    }
+
+    public void addAuthRequestToSession(
+            String clientSessionId,
+            String sessionId,
+            Map<String, List<String>> authRequest,
+            String clientName,
+            LocalDateTime creationDate)
+            throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.addClientSession(clientSessionId);
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
@@ -129,7 +140,7 @@ public class RedisExtension
                 objectMapper.writeValueAsString(
                         new ClientSession(
                                 authRequest,
-                                LocalDateTime.now(),
+                                creationDate,
                                 List.of(VectorOfTrust.getDefaults()),
                                 clientName)),
                 3600);

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -202,12 +202,21 @@ public class RedisExtension
     public void createClientSession(
             String clientSessionId, String clientName, Map<String, List<String>> authRequest)
             throws Json.JsonException {
+        createClientSession(clientSessionId, clientName, authRequest, LocalDateTime.now());
+    }
+
+    public void createClientSession(
+            String clientSessionId,
+            String clientName,
+            Map<String, List<String>> authRequest,
+            LocalDateTime localDateTime)
+            throws Json.JsonException {
         redis.saveWithExpiry(
                 CLIENT_SESSION_PREFIX.concat(clientSessionId),
                 objectMapper.writeValueAsString(
                         new ClientSession(
                                 authRequest,
-                                LocalDateTime.now(),
+                                localDateTime,
                                 List.of(VectorOfTrust.getDefaults()),
                                 clientName)),
                 300);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/ClientSessionMigrationUtils.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/ClientSessionMigrationUtils.java
@@ -1,0 +1,74 @@
+package uk.gov.di.orchestration.shared.utils;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class ClientSessionMigrationUtils {
+    private static final Logger LOG = LogManager.getLogger(ClientSessionMigrationUtils.class);
+
+    private ClientSessionMigrationUtils() {}
+
+    public static void logIfClientSessionsAreNotEqual(
+            ClientSession clientSession, OrchClientSessionItem orchClientSession) {
+        if (!areClientSessionsEqual(clientSession, orchClientSession)) {
+            LOG.warn("Client sessions are not equal");
+        }
+    }
+
+    public static boolean areClientSessionsEqual(
+            ClientSession clientSession, OrchClientSessionItem orchClientSession) {
+        if (clientSession == null && orchClientSession != null) {
+            LOG.warn("Redis client session is null but orch client session is not");
+            return false;
+        }
+        if (clientSession != null && orchClientSession == null) {
+            LOG.warn("Orch client session is null but redis client session is not");
+            return false;
+        }
+        if (clientSession == null) {
+            LOG.warn("Client sessions are both null");
+            return true;
+        }
+        var equal = true;
+        if (!Objects.equals(clientSession.getClientName(), orchClientSession.getClientName())) {
+            LOG.warn("Client sessions do not have matching clientName");
+            equal = false;
+        }
+        if (!Objects.equals(
+                clientSession.getAuthRequestParams(), orchClientSession.getAuthRequestParams())) {
+            LOG.warn("Client sessions do not have matching authRequestParams");
+            equal = false;
+        }
+        var clientSessionDocAppSubjectId =
+                Optional.ofNullable(clientSession.getDocAppSubjectId())
+                        .map(Subject::getValue)
+                        .orElse(null);
+        if (!Objects.equals(clientSessionDocAppSubjectId, orchClientSession.getDocAppSubjectId())) {
+            LOG.warn("Client sessions do not have matching docAppSubjectId");
+            equal = false;
+        }
+        if (!Objects.equals(clientSession.getCreationDate(), orchClientSession.getCreationDate())) {
+            LOG.warn("Client sessions do not have matching creationDate");
+            equal = false;
+        }
+        if (!Objects.equals(clientSession.getVtrList(), orchClientSession.getVtrList())) {
+            LOG.warn("Client sessions do not have matching vtrList");
+            equal = false;
+        }
+        if (!Objects.equals(clientSession.getIdTokenHint(), orchClientSession.getIdTokenHint())) {
+            LOG.warn("Client sessions do not have matching idTokenHint");
+            equal = false;
+        }
+        if (!Objects.equals(clientSession.getRpPairwiseId(), orchClientSession.getRpPairwiseId())) {
+            LOG.warn("Client sessions do not have matching rpPairwiseId");
+            equal = false;
+        }
+        return equal;
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -124,7 +124,6 @@ class LogoutServiceTest {
             URI.create("https://redirect.go.uk?error=access_denied");
 
     private static final String ENVIRONMENT = "test";
-
     private SignedJWT signedIDToken;
     private Optional<String> audience;
     private Optional<String> rpPairwiseId;
@@ -687,7 +686,7 @@ class LogoutServiceTest {
                 new ClientSession(
                         authRequestParams,
                         creationTime,
-                        List.of(mock(VectorOfTrust.class)),
+                        List.of(VectorOfTrust.getDefaults()),
                         "client_name");
         clientSession.setIdTokenHint(idToken.serialize());
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
@@ -696,8 +695,8 @@ class LogoutServiceTest {
                 new OrchClientSessionItem(
                         clientId,
                         authRequestParams,
-                        LocalDateTime.now(),
-                        List.of(mock(VectorOfTrust.class)),
+                        creationTime,
+                        List.of(VectorOfTrust.getDefaults()),
                         "client_name");
         orchClientSession.setIdTokenHint(idToken.serialize());
         when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/utils/ClientSessionMigrationUtilsTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/utils/ClientSessionMigrationUtilsTest.java
@@ -1,0 +1,100 @@
+package uk.gov.di.orchestration.shared.utils;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
+import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.areClientSessionsEqual;
+
+class ClientSessionMigrationUtilsTest {
+    private static final Map<String, List<String>> AUTH_REQUEST_PARAMS =
+            Map.of("testField", List.of("testValue"));
+    private static final LocalDateTime CREATION_DATE =
+            LocalDateTime.ofInstant(
+                    Instant.parse("2025-02-19T14:19:43.590Z"), ZoneId.systemDefault());
+    private static final List<VectorOfTrust> VTR_LIST =
+            List.of(VectorOfTrust.of(CredentialTrustLevel.LOW_LEVEL, LevelOfConfidence.LOW_LEVEL));
+    private static final String CLIENT_NAME = "test-client-name";
+
+    @Test
+    void shouldIdentifyClientSessionsAsEqual() {
+        var clientSession =
+                new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
+        var orchClientSession =
+                new OrchClientSessionItem(
+                        "test-client-session-id",
+                        AUTH_REQUEST_PARAMS,
+                        CREATION_DATE,
+                        VTR_LIST,
+                        CLIENT_NAME);
+
+        assertTrue(areClientSessionsEqual(clientSession, orchClientSession));
+    }
+
+    @Test
+    void shouldIdentifyClientSessionsAsEqualIfBothAreNull() {
+        assertTrue(areClientSessionsEqual(null, null));
+    }
+
+    @Test
+    void shouldIdentifyClientSessionsAsNotEqual() {
+        var clientSession =
+                new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
+        var orchClientSession =
+                new OrchClientSessionItem(
+                        "test-client-session-id",
+                        AUTH_REQUEST_PARAMS,
+                        CREATION_DATE,
+                        VTR_LIST,
+                        "a-different-client-name");
+
+        assertFalse(areClientSessionsEqual(clientSession, orchClientSession));
+    }
+
+    @Test
+    void shouldIdentifyClientSessionsAsNotEqualWhenRedisClientSessionIsNull() {
+        var orchClientSession =
+                new OrchClientSessionItem(
+                        "test-client-session-id",
+                        AUTH_REQUEST_PARAMS,
+                        CREATION_DATE,
+                        VTR_LIST,
+                        CLIENT_NAME);
+
+        assertFalse(areClientSessionsEqual(null, orchClientSession));
+    }
+
+    @Test
+    void shouldIdentifyClientSessionsAsNotEqualWhenOrchClientSessionIsNull() {
+        var clientSession =
+                new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
+
+        assertFalse(areClientSessionsEqual(clientSession, null));
+    }
+
+    @Test
+    void shouldIdentifyClientSessionsAsNotEqualWhenMoreThanOneFieldIsDifferent() {
+        var clientSession =
+                new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
+        var orchClientSession =
+                new OrchClientSessionItem(
+                        "test-client-session-id",
+                        Map.of(),
+                        LocalDateTime.now(),
+                        List.of(),
+                        "different-client-name");
+
+        assertFalse(areClientSessionsEqual(clientSession, orchClientSession));
+    }
+}


### PR DESCRIPTION
### Wider context of change

We are currently writing to the dynamo client session store in addition to the redis client session store. We would like to migrate to only using the dynamo store.

### What’s changed

When the client sessions are read from dynamo, this PR adds logging to compare the sessions from the 2 stores. If they do not match, a log message will be generated. If they match, no log messages will be generated

I've also updated the tests so the test output remains accurate. I've done this by making the logging helper throw an exception, run all the relevant tests, and fix them until none were failing, then remove the runtime exception from the logging helper.

(Reviewing commit-by-commit might help break down this chunky PR)

### Manual testing

Deployed to dev and performed a full identity journey. Ran without issues.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. n/a
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a

