### PR TITLE
BAU: Rename dynamo service to dynamo authentication service

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -22,7 +22,7 @@ import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Optional;
@@ -60,7 +60,7 @@ public class AuthenticateHandler
 
     public AuthenticateHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
-        this.authenticationService = new DynamoService(configurationService);
+        this.authenticationService = new DynamoAuthenticationService(configurationService);
         this.auditService = new AuditService(configurationService);
     }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
@@ -11,7 +11,7 @@ import uk.gov.di.accountmanagement.services.ManualAccountDeletionService;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
@@ -28,7 +28,7 @@ public class ManuallyDeleteAccountHandler implements RequestHandler<String, Stri
     }
 
     public ManuallyDeleteAccountHandler(ConfigurationService configurationService) {
-        this.authenticationService = new DynamoService(configurationService);
+        this.authenticationService = new DynamoAuthenticationService(configurationService);
         var emailSqsClient =
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -24,7 +24,7 @@ import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Map;
@@ -65,7 +65,7 @@ public class RemoveAccountHandler
     }
 
     public RemoveAccountHandler(ConfigurationService configurationService) {
-        this.authenticationService = new DynamoService(configurationService);
+        this.authenticationService = new DynamoAuthenticationService(configurationService);
         this.sqsClient =
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -36,8 +36,8 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Date;
@@ -89,7 +89,8 @@ class SendOtpNotificationHandlerTest {
     private final AwsSqsClient pendingEmailCheckSqsClient = mock(AwsSqsClient.class);
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
-    private final DynamoService dynamoService = mock(DynamoService.class);
+    private final DynamoAuthenticationService dynamoAuthenticationService =
+            mock(DynamoAuthenticationService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
     private final DynamoEmailCheckResultService dynamoEmailCheckResultService =
@@ -119,7 +120,7 @@ class SendOtpNotificationHandlerTest {
                     pendingEmailCheckSqsClient,
                     codeGeneratorService,
                     codeStorageService,
-                    dynamoService,
+                    dynamoAuthenticationService,
                     dynamoEmailCheckResultService,
                     auditService,
                     clientService,
@@ -463,7 +464,7 @@ class SendOtpNotificationHandlerTest {
 
     @Test
     void shouldReturn400IfNewPhoneNumberIsTheSameAsCurrentPhoneNumber() {
-        when(dynamoService.getUserProfileByEmailMaybe(TEST_EMAIL_ADDRESS))
+        when(dynamoAuthenticationService.getUserProfileByEmailMaybe(TEST_EMAIL_ADDRESS))
                 .thenReturn(
                         Optional.of(
                                 new UserProfile()
@@ -534,7 +535,7 @@ class SendOtpNotificationHandlerTest {
 
     @Test
     void shouldReturn400WhenAccountAlreadyExistsWithGivenEmail() {
-        when(dynamoService.userExists(eq(TEST_EMAIL_ADDRESS))).thenReturn(true);
+        when(dynamoAuthenticationService.userExists(eq(TEST_EMAIL_ADDRESS))).thenReturn(true);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of());

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/services/DynamoDeleteServiceIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/services/DynamoDeleteServiceIntegrationTest.java
@@ -7,7 +7,7 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.sharedtest.extensions.AccountModifiersStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 
@@ -31,7 +31,8 @@ class DynamoDeleteServiceIntegrationTest {
 
     DynamoDeleteService dynamoDeleteService =
             new DynamoDeleteService(ConfigurationService.getInstance());
-    DynamoService dynamoService = new DynamoService(ConfigurationService.getInstance());
+    DynamoAuthenticationService dynamoAuthenticationService =
+            new DynamoAuthenticationService(ConfigurationService.getInstance());
     DynamoAccountModifiersService dynamoAccountModifiersService =
             new DynamoAccountModifiersService(ConfigurationService.getInstance());
 
@@ -46,8 +47,8 @@ class DynamoDeleteServiceIntegrationTest {
 
         dynamoDeleteService.deleteAccount(TEST_EMAIL, internalCommonSubjectId);
 
-        var userProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
-        var userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
+        var userProfile = dynamoAuthenticationService.getUserProfileByEmail(TEST_EMAIL);
+        var userCredentials = dynamoAuthenticationService.getUserCredentialsFromEmail(TEST_EMAIL);
         var accountModifiers =
                 dynamoAccountModifiersService.getAccountModifiers(internalCommonSubjectId);
         assertThat(Objects.isNull(userProfile), equalTo(true));
@@ -61,8 +62,8 @@ class DynamoDeleteServiceIntegrationTest {
 
         dynamoDeleteService.deleteAccount(TEST_EMAIL, internalCommonSubjectId);
 
-        var userProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
-        var userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
+        var userProfile = dynamoAuthenticationService.getUserProfileByEmail(TEST_EMAIL);
+        var userCredentials = dynamoAuthenticationService.getUserCredentialsFromEmail(TEST_EMAIL);
         var accountModifiers =
                 dynamoAccountModifiersService.getAccountModifiers(internalCommonSubjectId);
         assertThat(Objects.isNull(userProfile), equalTo(true));

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
@@ -25,7 +25,7 @@ import uk.gov.di.authentication.shared.services.AccessTokenService;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.SystemService;
 
 import java.net.URI;
@@ -49,7 +49,7 @@ public class TokenHandler
     private final TokenService tokenUtilityService;
     private final TokenRequestValidator tokenRequestValidator;
     private final AuditService auditService;
-    private final DynamoService dynamoService;
+    private final DynamoAuthenticationService dynamoAuthenticationService;
 
     public TokenHandler(
             ConfigurationService configurationService,
@@ -58,14 +58,14 @@ public class TokenHandler
             TokenService tokenUtilityService,
             TokenRequestValidator tokenRequestValidator,
             AuditService auditService,
-            DynamoService dynamoService) {
+            DynamoAuthenticationService dynamoAuthenticationService) {
         this.configurationService = configurationService;
         this.authorisationCodeService = authorisationCodeService;
         this.accessTokenStoreService = accessTokenService;
         this.tokenUtilityService = tokenUtilityService;
         this.tokenRequestValidator = tokenRequestValidator;
         this.auditService = auditService;
-        this.dynamoService = dynamoService;
+        this.dynamoAuthenticationService = dynamoAuthenticationService;
     }
 
     public TokenHandler() {
@@ -85,7 +85,7 @@ public class TokenHandler
         this.tokenRequestValidator =
                 new TokenRequestValidator(orchestratorCallbackRedirectUri, orchestratorClientId);
         this.auditService = new AuditService(configurationService);
-        this.dynamoService = new DynamoService(configurationService);
+        this.dynamoAuthenticationService = new DynamoAuthenticationService(configurationService);
     }
 
     @Override
@@ -174,7 +174,8 @@ public class TokenHandler
             authorisationCodeService.updateHasBeenUsed(authCodeStore.getAuthCode(), true);
 
             String subjectID = authCodeStore.getSubjectID();
-            UserProfile userProfile = dynamoService.getUserProfileFromSubject(subjectID);
+            UserProfile userProfile =
+                    dynamoAuthenticationService.getUserProfileFromSubject(subjectID);
             String internalPairwiseId =
                     userProfile.getSalt() == null
                             ? AuditService.UNKNOWN

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -25,7 +25,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.util.Map;
@@ -72,7 +72,9 @@ public class UserInfoHandler
     public UserInfoHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
         this.userInfoService =
-                new UserInfoService(new DynamoService(configurationService), configurationService);
+                new UserInfoService(
+                        new DynamoAuthenticationService(configurationService),
+                        configurationService);
         this.accessTokenService =
                 new AccessTokenService(
                         configurationService, new CloudwatchMetricsService(configurationService));

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
@@ -43,7 +43,8 @@ class TokenHandlerTest {
     private static final ClientSubjectHelper clientSubjectHelper = mock(ClientSubjectHelper.class);
     private static final TokenService tokenUtilityService = mock(TokenService.class);
     private static final AuditService auditService = mock(AuditService.class);
-    private static final DynamoService dynamoService = mock(DynamoService.class);
+    private static final DynamoAuthenticationService DYNAMO_AUTHENTICATION_SERVICE =
+            mock(DynamoAuthenticationService.class);
     private static final BearerAccessToken SUCCESS_TOKEN_RESPONSE_ACCESS_TOKEN =
             new BearerAccessToken();
     private static final AccessTokenResponse SUCCESS_TOKEN_RESPONSE =
@@ -100,7 +101,8 @@ class TokenHandlerTest {
                 .thenReturn(SUCCESS_TOKEN_RESPONSE);
         when(tokenUtilityService.generateTokenErrorResponse(any())).thenCallRealMethod();
 
-        when(dynamoService.getUserProfileFromSubject(any())).thenReturn(USER_PROFILE);
+        when(DYNAMO_AUTHENTICATION_SERVICE.getUserProfileFromSubject(any()))
+                .thenReturn(USER_PROFILE);
     }
 
     @BeforeEach
@@ -125,7 +127,7 @@ class TokenHandlerTest {
                         tokenUtilityService,
                         tokenRequestValidator,
                         auditService,
-                        dynamoService);
+                        DYNAMO_AUTHENTICATION_SERVICE);
     }
 
     @Test

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -15,7 +15,7 @@ import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 
 import java.nio.ByteBuffer;
 import java.util.Base64;
@@ -75,7 +75,7 @@ public class UserInfoServiceTest {
 
     @BeforeEach
     public void setUp() {
-        authenticationService = mock(DynamoService.class);
+        authenticationService = mock(DynamoAuthenticationService.class);
         configurationService = mock(ConfigurationService.class);
         userInfoService = new UserInfoService(authenticationService, configurationService);
 

--- a/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
+++ b/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
@@ -20,7 +20,7 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -60,7 +60,8 @@ class NotifyCallbackHandlerTest {
 
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private final DynamoService dynamoService = mock(DynamoService.class);
+    private final DynamoAuthenticationService dynamoAuthenticationService =
+            mock(DynamoAuthenticationService.class);
 
     private final BulkEmailUsersService bulkEmailUsersService = mock(BulkEmailUsersService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
@@ -82,7 +83,7 @@ class NotifyCallbackHandlerTest {
                 new NotifyCallbackHandler(
                         cloudwatchMetricsService,
                         configurationService,
-                        dynamoService,
+                        dynamoAuthenticationService,
                         bulkEmailUsersService);
     }
 
@@ -229,17 +230,18 @@ class NotifyCallbackHandlerTest {
                 new NotifyCallbackHandler(
                         cloudwatchMetricsService,
                         configurationService,
-                        dynamoService,
+                        dynamoAuthenticationService,
                         bulkEmailUsersService);
         var reference = UUID.randomUUID().toString();
         var deliveryReceipt =
                 createDeliveryReceipt(EMAIL, "delivered", "email", TEMPLATE_ID, reference);
         String subjectId = "subject-id-1";
         UserProfile userProfile = new UserProfile().withEmail(EMAIL).withSubjectID(subjectId);
-        when(dynamoService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(Optional.of(userProfile));
+        when(dynamoAuthenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
         handlerBulkEmailOn.handleRequest(eventWithBody(deliveryReceipt), context);
 
-        verify(dynamoService).getUserProfileByEmailMaybe(EMAIL);
+        verify(dynamoAuthenticationService).getUserProfileByEmailMaybe(EMAIL);
 
         verify(bulkEmailUsersService).updateDeliveryReceiptStatus(subjectId, "delivered");
         assertThat(logging.events(), haveJourneyId(reference));
@@ -254,14 +256,14 @@ class NotifyCallbackHandlerTest {
                 new NotifyCallbackHandler(
                         cloudwatchMetricsService,
                         configurationService,
-                        dynamoService,
+                        dynamoAuthenticationService,
                         bulkEmailUsersService);
         var reference = UUID.randomUUID().toString();
         var deliveryReceipt =
                 createDeliveryReceipt(EMAIL, "delivered", "email", TEMPLATE_ID, reference);
         handlerBulkEmailOn.handleRequest(eventWithBody(deliveryReceipt), context);
 
-        verify(dynamoService, never()).getUserProfileByEmailMaybe(anyString());
+        verify(dynamoAuthenticationService, never()).getUserProfileByEmailMaybe(anyString());
         verify(bulkEmailUsersService, never())
                 .updateDeliveryReceiptStatus(anyString(), anyString());
         assertThat(logging.events(), haveJourneyId(reference));
@@ -276,7 +278,7 @@ class NotifyCallbackHandlerTest {
                 createDeliveryReceipt(EMAIL, "delivered", "email", TEMPLATE_ID, reference);
         handler.handleRequest(eventWithBody(deliveryReceipt), context);
 
-        verify(dynamoService, never()).getUserProfileByEmailMaybe(anyString());
+        verify(dynamoAuthenticationService, never()).getUserProfileByEmailMaybe(anyString());
         verify(bulkEmailUsersService, never())
                 .updateDeliveryReceiptStatus(anyString(), anyString());
         assertThat(logging.events(), haveJourneyId(reference));
@@ -291,14 +293,14 @@ class NotifyCallbackHandlerTest {
                 new NotifyCallbackHandler(
                         cloudwatchMetricsService,
                         configurationService,
-                        dynamoService,
+                        dynamoAuthenticationService,
                         bulkEmailUsersService);
         var reference = UUID.randomUUID().toString();
         var deliveryReceipt =
                 createDeliveryReceipt(EMAIL, "delivered", "email", TEMPLATE_ID, reference);
         handlerBulkEmailOn.handleRequest(eventWithBody(deliveryReceipt), context);
 
-        verify(dynamoService, never()).getUserProfileByEmailMaybe(anyString());
+        verify(dynamoAuthenticationService, never()).getUserProfileByEmailMaybe(anyString());
         verify(bulkEmailUsersService, never())
                 .updateDeliveryReceiptStatus(anyString(), anyString());
         assertThat(logging.events(), haveJourneyId(reference));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -40,7 +40,7 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
@@ -120,7 +120,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.codeStorageService = new CodeStorageService(configurationService);
         this.userMigrationService =
                 new UserMigrationService(
-                        new DynamoService(configurationService), configurationService);
+                        new DynamoAuthenticationService(configurationService),
+                        configurationService);
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
         this.commonPasswordsService = new CommonPasswordsService(configurationService);
@@ -133,7 +134,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.codeStorageService = new CodeStorageService(configurationService, redis);
         this.userMigrationService =
                 new UserMigrationService(
-                        new DynamoService(configurationService), configurationService);
+                        new DynamoAuthenticationService(configurationService),
+                        configurationService);
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
         this.commonPasswordsService = new CommonPasswordsService(configurationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -36,7 +36,7 @@ import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
@@ -101,7 +101,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
 
     public ResetPasswordHandler(ConfigurationService configurationService) {
         super(ResetPasswordCompletionRequest.class, configurationService);
-        this.authenticationService = new DynamoService(configurationService);
+        this.authenticationService = new DynamoAuthenticationService(configurationService);
         this.sqsClient =
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),
@@ -118,7 +118,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
     public ResetPasswordHandler(
             ConfigurationService configurationService, RedisConnectionService redis) {
         super(ResetPasswordCompletionRequest.class, configurationService, redis);
-        this.authenticationService = new DynamoService(configurationService);
+        this.authenticationService = new DynamoAuthenticationService(configurationService);
         this.sqsClient =
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -32,8 +32,8 @@ import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
@@ -104,7 +104,7 @@ public class StartHandler
         this.startService =
                 new StartService(
                         new DynamoClientService(configurationService),
-                        new DynamoService(configurationService),
+                        new DynamoAuthenticationService(configurationService),
                         sessionService);
         this.authSessionService = new AuthSessionService(configurationService);
         this.configurationService = configurationService;
@@ -120,7 +120,7 @@ public class StartHandler
         this.startService =
                 new StartService(
                         new DynamoClientService(configurationService),
-                        new DynamoService(configurationService),
+                        new DynamoAuthenticationService(configurationService),
                         sessionService);
         this.authSessionService = new AuthSessionService(configurationService);
         this.configurationService = configurationService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -41,7 +41,7 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
@@ -119,7 +119,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 new MfaCodeProcessorFactory(
                         configurationService,
                         codeStorageService,
-                        new DynamoService(configurationService),
+                        new DynamoAuthenticationService(configurationService),
                         auditService,
                         new DynamoAccountModifiersService(configurationService));
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
@@ -136,7 +136,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 new MfaCodeProcessorFactory(
                         configurationService,
                         codeStorageService,
-                        new DynamoService(configurationService),
+                        new DynamoAuthenticationService(configurationService),
                         auditService,
                         new DynamoAccountModifiersService(configurationService));
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -21,7 +21,7 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.services.ClientService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -40,7 +40,7 @@ import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.GA;
 public class StartService {
 
     private final ClientService clientService;
-    private final DynamoService dynamoService;
+    private final DynamoAuthenticationService dynamoAuthenticationService;
     private final SessionService sessionService;
     private static final String CLIENT_ID_PARAM = "client_id";
     public static final String COOKIE_CONSENT_ACCEPT = "accept";
@@ -50,10 +50,10 @@ public class StartService {
 
     public StartService(
             ClientService clientService,
-            DynamoService dynamoService,
+            DynamoAuthenticationService dynamoAuthenticationService,
             SessionService sessionService) {
         this.clientService = clientService;
-        this.dynamoService = dynamoService;
+        this.dynamoAuthenticationService = dynamoAuthenticationService;
         this.sessionService = sessionService;
     }
 
@@ -77,13 +77,13 @@ public class StartService {
             var clientRegistry = getClient(clientSession);
             Optional.of(session)
                     .map(Session::getEmailAddress)
-                    .flatMap(dynamoService::getUserProfileByEmailMaybe)
+                    .flatMap(dynamoAuthenticationService::getUserProfileByEmailMaybe)
                     .ifPresent(
                             t ->
                                     builder.withUserProfile(t)
                                             .withUserCredentials(
                                                     Optional.of(
-                                                            dynamoService
+                                                            dynamoAuthenticationService
                                                                     .getUserCredentialsFromEmail(
                                                                             session
                                                                                     .getEmailAddress()))));
@@ -222,7 +222,7 @@ public class StartService {
 
     public boolean isUserProfileEmpty(Session session) {
         return Optional.ofNullable(session.getEmailAddress())
-                .flatMap(dynamoService::getUserProfileByEmailMaybe)
+                .flatMap(dynamoAuthenticationService::getUserProfileByEmailMaybe)
                 .isEmpty();
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -157,7 +157,8 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                 case REGISTRATION -> dynamoService.updatePhoneNumberAndAccountVerifiedStatus(
                         emailAddress, phoneNumber, true, true);
                 case ACCOUNT_RECOVERY -> dynamoService
-                        .setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(emailAddress, phoneNumber);
+                        .setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(
+                                emailAddress, phoneNumber, true);
             }
 
             submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -37,8 +37,8 @@ import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -91,14 +91,16 @@ class StartServiceTest {
                     false);
 
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
-    private final DynamoService dynamoService = mock(DynamoService.class);
+    private final DynamoAuthenticationService dynamoAuthenticationService =
+            mock(DynamoAuthenticationService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private StartService startService;
 
     @BeforeEach
     void setup() {
-        startService = new StartService(dynamoClientService, dynamoService, sessionService);
+        startService =
+                new StartService(dynamoClientService, dynamoAuthenticationService, sessionService);
     }
 
     @Test
@@ -129,9 +131,9 @@ class StartServiceTest {
                         Optional.of(
                                 generateClientRegistry(
                                         REDIRECT_URI.toString(), CLIENT_ID.getValue(), false)));
-        when(dynamoService.getUserProfileByEmailMaybe(EMAIL))
+        when(dynamoAuthenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(mock(UserProfile.class)));
-        when(dynamoService.getUserCredentialsFromEmail(EMAIL))
+        when(dynamoAuthenticationService.getUserCredentialsFromEmail(EMAIL))
                 .thenReturn((mock(UserCredentials.class)));
         var authRequest =
                 new AuthenticationRequest.Builder(
@@ -698,7 +700,7 @@ class StartServiceTest {
     }
 
     private void withUserProfile() {
-        when(dynamoService.getUserProfileByEmailMaybe(EMAIL))
+        when(dynamoAuthenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(
                         Optional.of(
                                 new UserProfile()
@@ -707,6 +709,7 @@ class StartServiceTest {
     }
 
     private void withNoUserProfile() {
-        when(dynamoService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(Optional.empty());
+        when(dynamoAuthenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.empty());
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -271,7 +271,8 @@ class PhoneNumberCodeProcessorTest {
                         true,
                         true);
         verify(authenticationService, never())
-                .setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(anyString(), anyString());
+                .setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(
+                        anyString(), anyString(), anyBoolean());
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_UPDATE_PROFILE_PHONE_NUMBER,
@@ -294,7 +295,7 @@ class PhoneNumberCodeProcessorTest {
 
         verify(authenticationService)
                 .setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(
-                        CommonTestVariables.EMAIL, CommonTestVariables.UK_MOBILE_NUMBER);
+                        CommonTestVariables.EMAIL, CommonTestVariables.UK_MOBILE_NUMBER, true);
         verify(authenticationService, never())
                 .updatePhoneNumberAndAccountVerifiedStatus(
                         anyString(), anyString(), anyBoolean(), anyBoolean());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthenticationServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthenticationServiceIntegrationTest.java
@@ -366,7 +366,7 @@ class DynamoAuthenticationServiceIntegrationTest {
                 TEST_EMAIL, MFAMethodType.AUTH_APP, true, true, TEST_MFA_APP_CREDENTIAL);
 
         dynamoAuthenticationService.setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(
-                TEST_EMAIL, "+447316763843");
+                TEST_EMAIL, "+447316763843", true);
 
         var updatedUserCredentials =
                 dynamoAuthenticationService.getUserCredentialsFromEmail(TEST_EMAIL);
@@ -400,7 +400,7 @@ class DynamoAuthenticationServiceIntegrationTest {
                 TEST_EMAIL, ALTERNATIVE_PHONE_NUMBER, true, true);
 
         dynamoAuthenticationService.setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(
-                TEST_EMAIL, PHONE_NUMBER);
+                TEST_EMAIL, PHONE_NUMBER, true);
 
         var updatedUserCredentials =
                 dynamoAuthenticationService.getUserCredentialsFromEmail(TEST_EMAIL);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
@@ -9,7 +9,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -36,7 +36,7 @@ class AuthAppStubTest {
                         userContext,
                         mock(CodeStorageService.class),
                         configurationService,
-                        mock(DynamoService.class),
+                        mock(DynamoAuthenticationService.class),
                         99999,
                         mock(CodeRequest.class),
                         mock(AuditService.class),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -21,8 +21,8 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
@@ -105,7 +105,7 @@ public abstract class BaseFrontendHandler<T>
         this.sessionService = new SessionService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.clientService = new DynamoClientService(configurationService);
-        this.authenticationService = new DynamoService(configurationService);
+        this.authenticationService = new DynamoAuthenticationService(configurationService);
         this.authSessionService = new AuthSessionService(configurationService);
     }
 
@@ -118,7 +118,7 @@ public abstract class BaseFrontendHandler<T>
         this.sessionService = new SessionService(configurationService, redis);
         this.clientSessionService = new ClientSessionService(configurationService, redis);
         this.clientService = new DynamoClientService(configurationService);
-        this.authenticationService = new DynamoService(configurationService);
+        this.authenticationService = new DynamoAuthenticationService(configurationService);
         this.authSessionService = new AuthSessionService(configurationService);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -36,7 +36,8 @@ public interface AuthenticationService {
     void updatePhoneNumberAndAccountVerifiedStatus(
             String email, String phoneNumber, boolean phoneNumberVerified, boolean accountVerified);
 
-    void setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(String email, String phoneNumber);
+    void setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(
+            String email, String phoneNumber, boolean accountVerified);
 
     void setAccountVerified(String email);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationService.java
@@ -46,16 +46,16 @@ import static java.util.Objects.nonNull;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.numberValue;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.stringValue;
 
-public class DynamoService implements AuthenticationService {
+public class DynamoAuthenticationService implements AuthenticationService {
     private final DynamoDbTable<UserProfile> dynamoUserProfileTable;
     private final DynamoDbTable<UserCredentials> dynamoUserCredentialsTable;
     private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
     private static final String USER_PROFILE_TABLE = "user-profile";
     private static final String USER_CREDENTIAL_TABLE = "user-credentials";
     private static final String TEST_USER_INDEX_NAME = "TestUserIndex";
-    private static final Logger LOG = LogManager.getLogger(DynamoService.class);
+    private static final Logger LOG = LogManager.getLogger(DynamoAuthenticationService.class);
 
-    public DynamoService(ConfigurationService configurationService) {
+    public DynamoAuthenticationService(ConfigurationService configurationService) {
         String userProfileTableName =
                 configurationService.getEnvironment() + "-" + USER_PROFILE_TABLE;
         String userCredentialsTableName =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthenticationService.java
@@ -369,7 +369,8 @@ public class DynamoAuthenticationService implements AuthenticationService {
     }
 
     @Override
-    public void setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(String email, String phoneNumber) {
+    public void setVerifiedPhoneNumberAndRemoveAuthAppIfPresent(
+            String email, String phoneNumber, boolean accountVerified) {
         var dateTime = NowHelper.toTimestampString(NowHelper.now());
         var formattedPhoneNumber = PhoneNumberHelper.formatPhoneNumber(phoneNumber);
         var userProfile =
@@ -380,7 +381,8 @@ public class DynamoAuthenticationService implements AuthenticationService {
                                         .build())
                         .withPhoneNumber(formattedPhoneNumber)
                         .withPhoneNumberVerified(true)
-                        .withUpdated(dateTime);
+                        .withUpdated(dateTime)
+                        .withAccountVerified(accountVerified ? 1 : 0);
 
         var userCredentials =
                 dynamoUserCredentialsTable.getItem(

--- a/test-services-api/src/main/java/uk/gov/di/authentication/testservices/lambda/DeleteSyntheticsUserHandler.java
+++ b/test-services-api/src/main/java/uk/gov/di/authentication/testservices/lambda/DeleteSyntheticsUserHandler.java
@@ -12,7 +12,7 @@ import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -42,7 +42,7 @@ public class DeleteSyntheticsUserHandler
     }
 
     public DeleteSyntheticsUserHandler(ConfigurationService configurationService) {
-        this.authenticationService = new DynamoService(configurationService);
+        this.authenticationService = new DynamoAuthenticationService(configurationService);
         this.configurationService = configurationService;
         this.auditService = new AuditService(configurationService);
     }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandler.java
@@ -19,7 +19,7 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -38,18 +38,19 @@ public class BulkTestUserCreateHandler implements RequestHandler<S3Event, Void> 
     private static final Logger LOG = LogManager.getLogger(BulkTestUserCreateHandler.class);
     private static final String CSV_HEADER_ROW_TEXT =
             "Email,Password,Phone2FA,PhoneNumber,AuthApp2FA,AuthAppSecret";
-    private final DynamoService dynamoService;
+    private final DynamoAuthenticationService dynamoAuthenticationService;
     private final S3Client client;
     private final String latestTermsAndConditions;
 
-    public BulkTestUserCreateHandler(DynamoService dynamoService, S3Client client) {
-        this.dynamoService = dynamoService;
+    public BulkTestUserCreateHandler(
+            DynamoAuthenticationService dynamoAuthenticationService, S3Client client) {
+        this.dynamoAuthenticationService = dynamoAuthenticationService;
         this.client = client;
         this.latestTermsAndConditions = "test-terms-and-conditions-version";
     }
 
     public BulkTestUserCreateHandler(ConfigurationService configurationService, S3Client client) {
-        this.dynamoService = new DynamoService(configurationService);
+        this.dynamoAuthenticationService = new DynamoAuthenticationService(configurationService);
         this.client = client;
         this.latestTermsAndConditions = configurationService.getTermsAndConditionsVersion();
     }
@@ -130,7 +131,7 @@ public class BulkTestUserCreateHandler implements RequestHandler<S3Event, Void> 
         try {
             segmentedFunctionCall(
                     "dynamoCreateBatchTestUsers",
-                    () -> dynamoService.createBatchTestUsers(testUsers));
+                    () -> dynamoAuthenticationService.createBatchTestUsers(testUsers));
         } catch (Exception e) {
             LOG.error("User Profile or Credentials Dynamo Table exception thrown", e);
         }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserDeleteHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserDeleteHandler.java
@@ -6,17 +6,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class BulkTestUserDeleteHandler implements RequestHandler<String, Void> {
     private static final Logger LOG = LogManager.getLogger(BulkTestUserDeleteHandler.class);
-    private final DynamoService dynamoService;
+    private final DynamoAuthenticationService dynamoAuthenticationService;
 
     public BulkTestUserDeleteHandler(ConfigurationService configurationService) {
-        this.dynamoService = new DynamoService(configurationService);
+        this.dynamoAuthenticationService = new DynamoAuthenticationService(configurationService);
     }
 
     public BulkTestUserDeleteHandler() {
@@ -28,7 +28,7 @@ public class BulkTestUserDeleteHandler implements RequestHandler<String, Void> {
         LOG.info("Commencing deletion of all test users");
 
         long startTime = System.nanoTime();
-        List<UserProfile> allTestUsers = dynamoService.getAllBulkTestUsers();
+        List<UserProfile> allTestUsers = dynamoAuthenticationService.getAllBulkTestUsers();
         long endTime = System.nanoTime();
         long durationInMilliseconds = (endTime - startTime) / 1000000;
         LOG.info("{} records found in {} ms", allTestUsers.size(), durationInMilliseconds);
@@ -52,7 +52,7 @@ public class BulkTestUserDeleteHandler implements RequestHandler<String, Void> {
 
     private void deleteTestUserBatch(List<String> batch) {
         try {
-            dynamoService.deleteBatchTestUsers(batch);
+            dynamoAuthenticationService.deleteBatchTestUsers(batch);
         } catch (Exception e) {
             LOG.error("User Profile or Credentials Dynamo Table exception thrown", e);
         }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandler.java
@@ -11,7 +11,7 @@ import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
 import uk.gov.di.authentication.shared.exceptions.LambdaInvokerServiceException;
 import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.LambdaInvokerService;
 import uk.gov.di.authentication.shared.services.SystemService;
 import uk.gov.di.authentication.utils.exceptions.IncludedTermsAndConditionsConfigMissingException;
@@ -32,7 +32,7 @@ public class BulkUserEmailAudienceLoaderScheduledEventHandler
 
     private final BulkEmailUsersService bulkEmailUsersService;
 
-    private final DynamoService dynamoService;
+    private final DynamoAuthenticationService dynamoAuthenticationService;
 
     private final ConfigurationService configurationService;
 
@@ -45,11 +45,11 @@ public class BulkUserEmailAudienceLoaderScheduledEventHandler
 
     public BulkUserEmailAudienceLoaderScheduledEventHandler(
             BulkEmailUsersService bulkEmailUsersService,
-            DynamoService dynamoService,
+            DynamoAuthenticationService dynamoAuthenticationService,
             ConfigurationService configurationService,
             LambdaInvokerService lambdaInvokerService) {
         this.bulkEmailUsersService = bulkEmailUsersService;
-        this.dynamoService = dynamoService;
+        this.dynamoAuthenticationService = dynamoAuthenticationService;
         this.configurationService = configurationService;
         this.lambdaInvokerService = lambdaInvokerService;
     }
@@ -58,7 +58,7 @@ public class BulkUserEmailAudienceLoaderScheduledEventHandler
             ConfigurationService configurationService) {
         this.configurationService = configurationService;
         this.bulkEmailUsersService = new BulkEmailUsersService(configurationService);
-        this.dynamoService = new DynamoService(configurationService);
+        this.dynamoAuthenticationService = new DynamoAuthenticationService(configurationService);
         this.lambdaInvokerService = new LambdaInvokerService(configurationService);
     }
 
@@ -108,7 +108,7 @@ public class BulkUserEmailAudienceLoaderScheduledEventHandler
         AtomicReference<String> lastEmail = new AtomicReference<>();
         itemCounter.set(0);
 
-        dynamoService
+        dynamoAuthenticationService
                 .getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
                         exclusiveStartKey, includedTermsAndConditions)
                 .takeWhile(userProfile -> (currentBatchSize > itemCounter.get()))

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
@@ -13,7 +13,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.di.authentication.shared.services.SystemService;
 import uk.gov.di.authentication.utils.domain.BulkEmailType;
@@ -40,7 +40,7 @@ public class BulkUserEmailSenderScheduledEventHandler
 
     private final BulkEmailUsersService bulkEmailUsersService;
 
-    private final DynamoService dynamoService;
+    private final DynamoAuthenticationService dynamoAuthenticationService;
 
     private final NotificationService notificationService;
 
@@ -57,13 +57,13 @@ public class BulkUserEmailSenderScheduledEventHandler
 
     public BulkUserEmailSenderScheduledEventHandler(
             BulkEmailUsersService bulkEmailUsersService,
-            DynamoService dynamoService,
+            DynamoAuthenticationService dynamoAuthenticationService,
             ConfigurationService configurationService,
             NotificationService notificationService,
             CloudwatchMetricsService cloudwatchMetricsService,
             AuditService auditService) {
         this.bulkEmailUsersService = bulkEmailUsersService;
-        this.dynamoService = dynamoService;
+        this.dynamoAuthenticationService = dynamoAuthenticationService;
         this.configurationService = configurationService;
         this.notificationService = notificationService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
@@ -73,7 +73,7 @@ public class BulkUserEmailSenderScheduledEventHandler
     public BulkUserEmailSenderScheduledEventHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
         this.bulkEmailUsersService = new BulkEmailUsersService(configurationService);
-        this.dynamoService = new DynamoService(configurationService);
+        this.dynamoAuthenticationService = new DynamoAuthenticationService(configurationService);
         NotificationClient client =
                 configurationService
                         .getNotifyApiUrl()
@@ -137,7 +137,7 @@ public class BulkUserEmailSenderScheduledEventHandler
 
             userSubjectIdBatch.forEach(
                     subjectId -> {
-                        dynamoService
+                        dynamoAuthenticationService
                                 .getOptionalUserProfileFromSubject(subjectId)
                                 .ifPresentOrElse(
                                         userProfile ->
@@ -256,7 +256,7 @@ public class BulkUserEmailSenderScheduledEventHandler
                         ? ClientSubjectHelper.getSubjectWithSectorIdentifier(
                                         userProfile,
                                         configurationService.getInternalSectorUri(),
-                                        dynamoService)
+                                        dynamoAuthenticationService)
                                 .getValue()
                         : AuditService.UNKNOWN;
         auditService.submitAuditEvent(

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandlerTest.java
@@ -10,7 +10,7 @@ import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -33,7 +33,8 @@ import static org.mockito.Mockito.when;
 class BulkTestUserCreateHandlerTest {
 
     private BulkTestUserCreateHandler handler;
-    private final DynamoService mockDynamoService = mock(DynamoService.class);
+    private final DynamoAuthenticationService mockDynamoAuthenticationService =
+            mock(DynamoAuthenticationService.class);
     private final S3Event mockS3Event = mock(S3Event.class);
     private final Context mockContext = mock(Context.class);
     private final S3Client mockS3Client = mock(S3Client.class);
@@ -62,7 +63,7 @@ class BulkTestUserCreateHandlerTest {
         when(mockS3Client.getObject(any(GetObjectRequest.class)))
                 .thenReturn(mockS3ObjectInputStream);
 
-        this.handler = new BulkTestUserCreateHandler(mockDynamoService, mockS3Client);
+        this.handler = new BulkTestUserCreateHandler(mockDynamoAuthenticationService, mockS3Client);
 
         when(mockS3Event.getRecords())
                 .thenReturn(List.of(mock(S3EventNotification.S3EventNotificationRecord.class)));
@@ -91,7 +92,7 @@ class BulkTestUserCreateHandlerTest {
 
         int numberOfBatchWritesExpected =
                 (int) (Math.ceil((double) mockInputAsArrayList.size() / LINES_PER_BATCH_WRITE));
-        verify(mockDynamoService, times(numberOfBatchWritesExpected))
+        verify(mockDynamoAuthenticationService, times(numberOfBatchWritesExpected))
                 .createBatchTestUsers(anyMap());
     }
 }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandlerTest.java
@@ -10,7 +10,7 @@ import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.LambdaInvokerService;
 import uk.gov.di.authentication.utils.exceptions.IncludedTermsAndConditionsConfigMissingException;
 
@@ -38,7 +38,8 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
 
     private final BulkEmailUsersService bulkEmailUsersService = mock(BulkEmailUsersService.class);
 
-    private final DynamoService dynamoService = mock(DynamoService.class);
+    private final DynamoAuthenticationService dynamoAuthenticationService =
+            mock(DynamoAuthenticationService.class);
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
 
@@ -59,7 +60,7 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
         bulkUserEmailAudienceLoaderScheduledEventHandler =
                 new BulkUserEmailAudienceLoaderScheduledEventHandler(
                         bulkEmailUsersService,
-                        dynamoService,
+                        dynamoAuthenticationService,
                         configurationService,
                         lambdaInvokerService);
         when(configurationService.getBulkEmailLoaderLambdaName()).thenReturn(functionName);
@@ -71,7 +72,7 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
         when(configurationService.getBulkUserEmailAudienceLoadUserBatchSize()).thenReturn(10L);
         when(configurationService.getBulkUserEmailIncludedTermsAndConditions())
                 .thenReturn(List.of("1.5", "1.6"));
-        when(dynamoService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
+        when(dynamoAuthenticationService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
                         null, List.of("1.5", "1.6")))
                 .thenReturn(testUserProfilesFromSubjectIds(List.of(SUBJECT_ID)));
 
@@ -86,7 +87,7 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
         when(configurationService.getBulkUserEmailAudienceLoadUserBatchSize()).thenReturn(10L);
         when(configurationService.getBulkUserEmailIncludedTermsAndConditions())
                 .thenReturn(List.of("1.5", "1.6"));
-        when(dynamoService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
+        when(dynamoAuthenticationService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
                         null, List.of("1.5", "1.6")))
                 .thenReturn(testUserProfilesFromSubjectIds(List.of(SUBJECT_ID)));
 
@@ -101,7 +102,7 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
         when(configurationService.getBulkUserEmailAudienceLoadUserBatchSize()).thenReturn(10L);
         when(configurationService.getBulkUserEmailIncludedTermsAndConditions())
                 .thenReturn(List.of("1.5", "1.6"));
-        when(dynamoService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
+        when(dynamoAuthenticationService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
                         null, List.of("1.5", "1.6")))
                 .thenReturn(testUserProfilesFromSubjectIds(List.of(TEST_SUBJECT_IDS)));
 
@@ -120,7 +121,7 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
         when(configurationService.getBulkUserEmailAudienceLoadUserBatchSize()).thenReturn(3L);
         when(configurationService.getBulkUserEmailIncludedTermsAndConditions())
                 .thenReturn(List.of("1.5", "1.6"));
-        when(dynamoService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
+        when(dynamoAuthenticationService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
                         null, List.of("1.5", "1.6")))
                 .thenReturn(testUserProfilesFromSubjectIds(List.of(TEST_SUBJECT_IDS)));
 
@@ -138,7 +139,7 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
 
         var subjectIds = List.of(TEST_SUBJECT_IDS[0], TEST_SUBJECT_IDS[1], TEST_SUBJECT_IDS[2]);
         var userProfiles = testUserProfilesFromSubjectIds(subjectIds);
-        when(dynamoService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
+        when(dynamoAuthenticationService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
                         null, List.of("1.5", "1.6")))
                 .thenReturn(userProfiles);
 
@@ -197,7 +198,7 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
 
         var subjectIds = List.of(TEST_SUBJECT_IDS[3], TEST_SUBJECT_IDS[4]);
 
-        when(dynamoService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
+        when(dynamoAuthenticationService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
                         lastEvaluatedKey, List.of("1.5", "1.6")))
                 .thenReturn(testUserProfilesFromSubjectIds(subjectIds));
 
@@ -241,7 +242,7 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
         var lastEvaluatedKey =
                 Map.of("SubjectID", AttributeValue.builder().s(lastEvaluatedSubjectId).build());
 
-        when(dynamoService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
+        when(dynamoAuthenticationService.getBulkUserEmailAudienceStreamOnTermsAndConditionsVersion(
                         null, List.of("1.5", "1.6")))
                 .thenReturn(Stream.empty());
 

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
@@ -18,7 +18,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.DynamoAuthenticationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.di.authentication.utils.domain.UtilsAuditableEvent;
 import uk.gov.di.authentication.utils.exceptions.IncludedTermsAndConditionsConfigMissingException;
@@ -54,7 +54,8 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
 
     private final BulkEmailUsersService bulkEmailUsersService = mock(BulkEmailUsersService.class);
 
-    private final DynamoService dynamoService = mock(DynamoService.class);
+    private final DynamoAuthenticationService dynamoAuthenticationService =
+            mock(DynamoAuthenticationService.class);
 
     private final NotificationService notificationService = mock(NotificationService.class);
 
@@ -106,7 +107,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         bulkUserEmailSenderScheduledEventHandler =
                 new BulkUserEmailSenderScheduledEventHandler(
                         bulkEmailUsersService,
-                        dynamoService,
+                        dynamoAuthenticationService,
                         configurationService,
                         notificationService,
                         cloudwatchMetricsService,
@@ -126,8 +127,9 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         setupBulkUsersConfiguration(1, 1, 1L, true, List.of("1.0", "1.1"));
         when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.PENDING))
                 .thenReturn(List.of(SUBJECT_ID));
-        when(dynamoService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
-        when(dynamoService.getOptionalUserProfileFromSubject(SUBJECT_ID))
+        when(dynamoAuthenticationService.getOrGenerateSalt(any(UserProfile.class)))
+                .thenReturn(SALT);
+        when(dynamoAuthenticationService.getOptionalUserProfileFromSubject(SUBJECT_ID))
                 .thenReturn(
                         Optional.of(
                                 new UserProfile()
@@ -165,8 +167,9 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         setupBulkUsersConfiguration(1, 1, 1L, sendingEnabled, ALL_TERMS_AND_CONDITIONS);
         when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.PENDING))
                 .thenReturn(List.of(SUBJECT_ID));
-        when(dynamoService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
-        when(dynamoService.getOptionalUserProfileFromSubject(SUBJECT_ID))
+        when(dynamoAuthenticationService.getOrGenerateSalt(any(UserProfile.class)))
+                .thenReturn(SALT);
+        when(dynamoAuthenticationService.getOptionalUserProfileFromSubject(SUBJECT_ID))
                 .thenReturn(
                         Optional.of(
                                 new UserProfile()
@@ -201,8 +204,9 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         setupBulkUsersConfiguration(1, 1, 1L, true, List.of(includedTermsAndConditions));
         when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.PENDING))
                 .thenReturn(List.of(SUBJECT_ID));
-        when(dynamoService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
-        when(dynamoService.getOptionalUserProfileFromSubject(SUBJECT_ID))
+        when(dynamoAuthenticationService.getOrGenerateSalt(any(UserProfile.class)))
+                .thenReturn(SALT);
+        when(dynamoAuthenticationService.getOptionalUserProfileFromSubject(SUBJECT_ID))
                 .thenReturn(
                         Optional.of(
                                 new UserProfile()
@@ -240,11 +244,12 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
             throws NotificationClientException {
         var batchLimit = 5;
         setupBulkUsersConfiguration(batchLimit, 1, 1L, true, ALL_TERMS_AND_CONDITIONS);
-        when(dynamoService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
+        when(dynamoAuthenticationService.getOrGenerateSalt(any(UserProfile.class)))
+                .thenReturn(SALT);
         when(bulkEmailUsersService.getNSubjectIdsByStatus(batchLimit, BulkEmailStatus.PENDING))
                 .thenReturn(Arrays.asList(TEST_SUBJECT_IDS));
         for (int i = 0; i < TEST_SUBJECT_IDS.length; i++) {
-            when(dynamoService.getOptionalUserProfileFromSubject(TEST_SUBJECT_IDS[i]))
+            when(dynamoAuthenticationService.getOptionalUserProfileFromSubject(TEST_SUBJECT_IDS[i]))
                     .thenReturn(
                             Optional.of(
                                     new UserProfile()
@@ -287,7 +292,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         setupBulkUsersConfiguration(1, 1, 1L, true, ALL_TERMS_AND_CONDITIONS);
         when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.PENDING))
                 .thenReturn(List.of(SUBJECT_ID));
-        when(dynamoService.getOptionalUserProfileFromSubject(SUBJECT_ID))
+        when(dynamoAuthenticationService.getOptionalUserProfileFromSubject(SUBJECT_ID))
                 .thenReturn(Optional.empty());
         when(bulkEmailUsersService.updateUserStatus(SUBJECT_ID, BulkEmailStatus.ACCOUNT_NOT_FOUND))
                 .thenReturn(
@@ -311,7 +316,7 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         setupBulkUsersConfiguration(1, 1, 1L, true, ALL_TERMS_AND_CONDITIONS);
         when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.PENDING))
                 .thenReturn(List.of(SUBJECT_ID));
-        when(dynamoService.getOptionalUserProfileFromSubject(SUBJECT_ID))
+        when(dynamoAuthenticationService.getOptionalUserProfileFromSubject(SUBJECT_ID))
                 .thenReturn(Optional.of(new UserProfile().withEmail(EMAIL)));
         doThrow(NotificationClientException.class)
                 .when(notificationService)
@@ -341,8 +346,9 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
 
         when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.ERROR_SENDING_EMAIL))
                 .thenReturn(List.of(SUBJECT_ID));
-        when(dynamoService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
-        when(dynamoService.getOptionalUserProfileFromSubject(SUBJECT_ID))
+        when(dynamoAuthenticationService.getOrGenerateSalt(any(UserProfile.class)))
+                .thenReturn(SALT);
+        when(dynamoAuthenticationService.getOptionalUserProfileFromSubject(SUBJECT_ID))
                 .thenReturn(
                         Optional.of(
                                 new UserProfile()
@@ -380,8 +386,9 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         when(bulkEmailUsersService.getNSubjectIdsByDeliveryReceiptStatus(
                         1, DELIVERY_RECEIPT_STATUS_TEMPORARY_FAILURE))
                 .thenReturn(List.of(SUBJECT_ID));
-        when(dynamoService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
-        when(dynamoService.getOptionalUserProfileFromSubject(SUBJECT_ID))
+        when(dynamoAuthenticationService.getOrGenerateSalt(any(UserProfile.class)))
+                .thenReturn(SALT);
+        when(dynamoAuthenticationService.getOptionalUserProfileFromSubject(SUBJECT_ID))
                 .thenReturn(
                         Optional.of(
                                 new UserProfile()


### PR DESCRIPTION
Done for the auth version only (orch also have a copy of this service).

Better reflects that this contains domain specific logic, as opposed to dynamo only logic

# authentication-api PR template picker

> [!TIP]
> Please go to the `Preview` tab and select the appropriate sub-template

## Templates

- [Auth Team](?expand=1&template=auth_template.md)
- [Orchestration Team](?expand=1&template=orch_template.md)
