### PR TITLE
AUT-3484: Deployment of MFA Methods Retrieve

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
@@ -20,7 +20,7 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 
-public class GetMfaMethodsHandler
+public class MFAMethodsRetrieveHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     private final ConfigurationService configurationService;
 
@@ -28,13 +28,13 @@ public class GetMfaMethodsHandler
     private static final String INTEGRATION = "integration";
     private static final String DUMMY_UNKNOWN_SUBJECT_ID = "unknown-public-subject-id";
 
-    private static final Logger LOG = LogManager.getLogger(GetMfaMethodsHandler.class);
+    private static final Logger LOG = LogManager.getLogger(MFAMethodsRetrieveHandler.class);
 
-    public GetMfaMethodsHandler() {
+    public MFAMethodsRetrieveHandler() {
         this(ConfigurationService.getInstance());
     }
 
-    public GetMfaMethodsHandler(ConfigurationService configurationService) {
+    public MFAMethodsRetrieveHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
     }
 
@@ -44,10 +44,10 @@ public class GetMfaMethodsHandler
         ThreadContext.clearMap();
         return segmentedFunctionCall(
                 "account-management-api::" + getClass().getSimpleName(),
-                () -> getMfaMethodsHandler(input, context));
+                () -> getMFAMethodsHandler(input, context));
     }
 
-    public APIGatewayProxyResponseEvent getMfaMethodsHandler(
+    public APIGatewayProxyResponseEvent getMFAMethodsHandler(
             APIGatewayProxyRequestEvent input, Context context) {
 
         addSessionIdToLogs(input);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
@@ -17,17 +17,17 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
-class GetMfaMethodsHandlerTest {
+class MFAMethodsRetrieveHandlerTest {
     private final Context context = mock(Context.class);
     private static final String SUBJECT_ID = "some-subject-id";
     private static final ConfigurationService configurationService =
             mock(ConfigurationService.class);
 
-    private GetMfaMethodsHandler handler;
+    private MFAMethodsRetrieveHandler handler;
 
     @BeforeEach
     void setUp() {
-        handler = new GetMfaMethodsHandler(configurationService);
+        handler = new MFAMethodsRetrieveHandler(configurationService);
     }
 
     @Test

--- a/ci/terraform/account-management/api-gateway-method-management.tf
+++ b/ci/terraform/account-management/api-gateway-method-management.tf
@@ -9,6 +9,7 @@ locals {
     send-otp-notification = module.send_otp_notification
     update-phone-number   = module.update_phone_number
     mfa-mm-create-backup  = module.mfa-mm-create-backup
+    mfa-methods-retrieve  = module.mfa-methods-retrieve
   }
   openapi_spec = templatefile(
     "${path.module}/${var.openapi_spec_filename}",

--- a/ci/terraform/account-management/mfa-methods-retrieve.tf
+++ b/ci/terraform/account-management/mfa-methods-retrieve.tf
@@ -1,0 +1,54 @@
+module "account_management_api_mfa_methods_retrieve_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "account_management_api_mfa_methods_retrieve_role"
+  vpc_arn     = local.vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.dynamo_am_user_read_access_policy.arn,
+  ]
+  extra_tags = {
+    Service = "mfa-methods-retrieve"
+  }
+}
+
+module "mfa-methods-retrieve" {
+  source = "../modules/endpoint-lambda"
+
+  endpoint_name = "mfa-methods-retrieve"
+  handler_environment_variables = {
+    ENVIRONMENT          = var.environment
+    REDIS_KEY            = local.redis_key
+    TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+  }
+  handler_function_name = "uk.gov.di.accountmanagement.lambda.MFAMethodsRetrieveHandler::handleRequest"
+
+  memory_size                 = lookup(var.performance_tuning, "mfa-methods-retrieve", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "mfa-methods-retrieve", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "mfa-methods-retrieve", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "mfa-methods-retrieve", local.default_performance_parameters).scaling_trigger
+
+  source_bucket           = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file         = aws_s3_object.account_management_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  security_group_ids = [
+    local.allow_aws_service_access_security_group_id,
+    aws_security_group.allow_access_to_am_redis.id,
+  ]
+  subnet_id                              = local.private_subnet_ids
+  environment                            = var.environment
+  lambda_role_arn                        = module.account_management_api_mfa_methods_retrieve_role.arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
+
+  account_alias         = local.aws_account_alias
+  slack_event_topic_arn = local.slack_event_sns_topic_arn
+  dynatrace_secret      = local.dynatrace_secret
+
+  depends_on = [module.account_management_api_mfa_methods_retrieve_role]
+}

--- a/ci/terraform/account-management/openapi_v2.yaml
+++ b/ci/terraform/account-management/openapi_v2.yaml
@@ -77,7 +77,7 @@ paths:
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
-        uri: "${endpoint_modules.mfa-mm-create-backup.integration_uri}"
+        uri: "${endpoint_modules.mfa-methods-retrieve.integration_uri}"
         passthroughBehavior: "when_no_match"
         timeoutInMillis: 29000
       description: "Retrieve mfaMethods that for the given public subject id"


### PR DESCRIPTION
## What

The openapi spec describes the endpoints with an operation id that takes the format mfa-methods-<action>.  `mfa-methods` is the endpoint name and `action` is the business name for what the User wants to do.

The operation id for retrieving an MFA Method is mfa-methods-retrieve.

The HTTP method currently being used to retrieve an MFA Method is GET as per convention.  However, this could change to a POST and search pattern in the future.  As GET is an implementation detail we have decided to avoid using it and keep our names abstract.

To ensure that the terraform modules and the Java code are grouped together in the project we will follow this style of naming.

For terraform this means all the resources created will either start with or contain `mfa-methods-retrieve`.  The terraform file that defines the lambda is therefore called `mfa-methods-retrieve.tf`.

The handler class is renamed to `MFAMethodsRetrieveHandler` to follow this approach.


<!-- Describe what you have changed and why -->

## How to review
1. Code Review

This has been deployed and tested in authdev1 so deploying to another environment would be useful.

<!-- Describe the steps required to review this PR.
For example:

1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
