### PR TITLE
Aut 3848/return mfa methods from new get endpoint

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MfaMethodsRetrieveHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MfaMethodsRetrieveHandlerIntegrationTest.java
@@ -1,0 +1,62 @@
+package uk.gov.di.accountmanagement.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.accountmanagement.lambda.MFAMethodsRetrieveHandler;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
+
+class MfaMethodsRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    private static final String EMAIL = "joe.bloggs+3@digital.cabinet-office.gov.uk";
+    private static final String PASSWORD = "password-1";
+
+    @RegisterExtension
+    private static UserStoreExtension userStoreExtension = new UserStoreExtension();
+
+    @BeforeEach
+    void setUp() {
+        handler = new MFAMethodsRetrieveHandler(TEST_CONFIGURATION_SERVICE);
+    }
+
+    @Test
+    void shouldReturn200WhenUserExists() {
+        var publicSubjectId = userStoreExtension.signUp(EMAIL, PASSWORD);
+
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("publicSubjectId", publicSubjectId),
+                        Collections.emptyMap());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals("{\"hello\": \"world\"}", response.getBody());
+    }
+
+    @Test
+    void shouldReturn404WhenUserDoesNotExist() {
+        var publicSubjectId = "userDoesNotExist";
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("publicSubjectId", publicSubjectId),
+                        Collections.emptyMap());
+
+        assertEquals(404, response.getStatusCode());
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1056));
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoMfaMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoMfaMethodsServiceIntegrationTest.java
@@ -4,9 +4,11 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.di.authentication.shared.entity.AuthAppMfaData;
+import uk.gov.di.authentication.shared.entity.AuthAppMfaDetail;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.MfaMethodData;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
-import uk.gov.di.authentication.shared.entity.SmsMfaData;
+import uk.gov.di.authentication.shared.entity.SmsMfaDetail;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoMfaMethodsService;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
@@ -38,7 +40,8 @@ class DynamoMfaMethodsServiceIntegrationTest {
 
         var result = dynamoService.getMfaMethods(TEST_EMAIL);
 
-        var expectedData = new SmsMfaData(PHONE_NUMBER, true, true, PriorityIdentifier.DEFAULT, 1);
+        var authAppDetail = new SmsMfaDetail(MFAMethodType.SMS, PHONE_NUMBER);
+        var expectedData = new MfaMethodData(1, PriorityIdentifier.DEFAULT, true, authAppDetail);
         assertEquals(result, List.of(expectedData));
     }
 
@@ -48,8 +51,8 @@ class DynamoMfaMethodsServiceIntegrationTest {
 
         var result = dynamoService.getMfaMethods(TEST_EMAIL);
 
-        var expectedData =
-                new AuthAppMfaData(AUTH_APP_CREDENTIAL, true, true, PriorityIdentifier.DEFAULT, 1);
+        var authAppDetail = new AuthAppMfaDetail(MFAMethodType.AUTH_APP, AUTH_APP_CREDENTIAL);
+        var expectedData = new MfaMethodData(1, PriorityIdentifier.DEFAULT, true, authAppDetail);
         assertEquals(result, List.of(expectedData));
     }
 
@@ -60,8 +63,8 @@ class DynamoMfaMethodsServiceIntegrationTest {
 
         var result = dynamoService.getMfaMethods(TEST_EMAIL);
 
-        var expectedData =
-                new AuthAppMfaData(AUTH_APP_CREDENTIAL, true, true, PriorityIdentifier.DEFAULT, 1);
+        var authAppDetail = new AuthAppMfaDetail(MFAMethodType.AUTH_APP, AUTH_APP_CREDENTIAL);
+        var expectedData = new MfaMethodData(1, PriorityIdentifier.DEFAULT, true, authAppDetail);
         assertEquals(List.of(expectedData), result);
     }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -69,8 +69,8 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
         return dynamoService.getPhoneNumber(email);
     }
 
-    public void signUp(String email, String password) {
-        signUp(email, password, new Subject());
+    public String signUp(String email, String password) {
+        return signUp(email, password, new Subject());
     }
 
     public String signUp(String email, String password, Subject subject) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthAppMfaDetail.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthAppMfaDetail.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.google.gson.annotations.Expose;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public record AuthAppMfaDetail(
+        @Expose @Required MFAMethodType mfaMethodType, @Expose @Required String credential)
+        implements MfaDetail {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MfaDetail.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MfaDetail.java
@@ -1,0 +1,3 @@
+package uk.gov.di.authentication.shared.entity;
+
+public interface MfaDetail {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MfaMethodData.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MfaMethodData.java
@@ -1,0 +1,34 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.google.gson.annotations.Expose;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public record MfaMethodData(
+        @Expose int mfaIdentifier,
+        @Expose @Required PriorityIdentifier priorityIdentifier,
+        @Expose @Required boolean methodVerified,
+        @Expose @Required MfaDetail method) {
+    public static MfaMethodData smsMethodData(
+            int mfaIdentifier,
+            PriorityIdentifier priorityIdentifier,
+            boolean methodVerified,
+            String phoneNumber) {
+        return new MfaMethodData(
+                mfaIdentifier,
+                priorityIdentifier,
+                methodVerified,
+                new SmsMfaDetail(MFAMethodType.SMS, phoneNumber));
+    }
+
+    public static MfaMethodData authAppMfaData(
+            int mfaIdentifier,
+            PriorityIdentifier priorityIdentifier,
+            boolean methodVerified,
+            String credential) {
+        return new MfaMethodData(
+                mfaIdentifier,
+                priorityIdentifier,
+                methodVerified,
+                new AuthAppMfaDetail(MFAMethodType.AUTH_APP, credential));
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/SmsMfaDetail.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/SmsMfaDetail.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.google.gson.annotations.Expose;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public record SmsMfaDetail(
+        @Expose @Required MFAMethodType mfaMethodType, @Expose @Required String phoneNumber)
+        implements MfaDetail {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -44,7 +44,7 @@ public interface AuthenticationService {
 
     UserProfile getUserProfileFromSubject(String subject);
 
-    UserProfile getUserProfileFromPublicSubject(String subject);
+    Optional<UserProfile> getOptionalUserProfileFromPublicSubject(String subject);
 
     void updateTermsAndConditions(String email, String version);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -540,21 +540,16 @@ public class DynamoService implements AuthenticationService {
     }
 
     @Override
-    public UserProfile getUserProfileFromPublicSubject(String subject) {
+    public Optional<UserProfile> getOptionalUserProfileFromPublicSubject(String subject) {
         QueryConditional q =
                 QueryConditional.keyEqualTo(Key.builder().partitionValue(subject).build());
         DynamoDbIndex<UserProfile> subjectIDIndex =
                 dynamoUserProfileTable.index("PublicSubjectIDIndex");
         QueryEnhancedRequest queryEnhancedRequest =
                 QueryEnhancedRequest.builder().consistentRead(false).queryConditional(q).build();
-        Optional<UserProfile> userProfile =
-                subjectIDIndex.query(queryEnhancedRequest).stream()
-                        .findFirst()
-                        .flatMap(page -> page.items().stream().findFirst());
-        if (userProfile.isEmpty()) {
-            throw new RuntimeException("No userCredentials found with query search");
-        }
-        return userProfile.get();
+        return subjectIDIndex.query(queryEnhancedRequest).stream()
+                .findFirst()
+                .flatMap(page -> page.items().stream().findFirst());
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/MfaMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/MfaMethodsService.java
@@ -5,5 +5,5 @@ import uk.gov.di.authentication.shared.entity.MfaData;
 import java.util.List;
 
 public interface MfaMethodsService {
-    List<MfaData> getMfaMethods(String internalCommonSubjectId);
+    List<MfaData> getMfaMethods(String email);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/MfaMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/MfaMethodsService.java
@@ -1,9 +1,9 @@
 package uk.gov.di.authentication.shared.services;
 
-import uk.gov.di.authentication.shared.entity.MfaData;
+import uk.gov.di.authentication.shared.entity.MfaMethodData;
 
 import java.util.List;
 
 public interface MfaMethodsService {
-    List<MfaData> getMfaMethods(String email);
+    List<MfaMethodData> getMfaMethods(String email);
 }


### PR DESCRIPTION
## What

Implements the substantive logic for the mfa methods get endpoint. Currently, we only support non-migrated users (i.e. users with a single mfa method at most, with sms mfa details stored in the user profile table, and auth app details stored in the user credentials table.)

## Why

As part of the initiative to enable back up mfa methods, we need to implement a new api for home to use in their account management flow. This new GET endpoint supports returning multiple MFA methods for a user.

## How to review

1. Code review
1. Deploy to a test environment (currently in authdev1)