### PR TITLE
ATO-1467 StartService use email address from AuthSessionItem

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -169,7 +169,13 @@ public class StartHandler
 
         boolean isUserAuthenticatedWithValidProfile;
         try {
-            var isUserProfileEmpty = startService.isUserProfileEmpty(session);
+            var authSession =
+                    authSessionService.getUpdatedPreviousSessionOrCreateNew(
+                            Optional.ofNullable(startRequest.previousSessionId()),
+                            sessionId,
+                            startRequest.currentCredentialStrength());
+
+            var isUserProfileEmpty = startService.isUserProfileEmpty(authSession);
 
             isUserAuthenticatedWithValidProfile =
                     startRequest.authenticated() && !isUserProfileEmpty;
@@ -187,12 +193,6 @@ public class StartHandler
             var upliftRequired =
                     startService.isUpliftRequired(
                             clientSession.get(), client, startRequest.currentCredentialStrength());
-
-            var authSession =
-                    authSessionService.getUpdatedPreviousSessionOrCreateNew(
-                            Optional.ofNullable(startRequest.previousSessionId()),
-                            sessionId,
-                            startRequest.currentCredentialStrength());
 
             authSessionService.addSession(authSession.withUpliftRequired(upliftRequired));
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -75,8 +75,8 @@ public class StartService {
         UserContext userContext;
         try {
             var clientRegistry = getClient(clientSession);
-            Optional.of(session)
-                    .map(Session::getEmailAddress)
+            Optional.of(authSession)
+                    .map(AuthSessionItem::getEmailAddress)
                     .flatMap(dynamoService::getUserProfileByEmailMaybe)
                     .ifPresent(
                             t ->
@@ -85,7 +85,7 @@ public class StartService {
                                                     Optional.of(
                                                             dynamoService
                                                                     .getUserCredentialsFromEmail(
-                                                                            session
+                                                                            authSession
                                                                                     .getEmailAddress()))));
             userContext = builder.withClient(clientRegistry).build();
         } catch (ClientNotFoundException e) {
@@ -220,8 +220,8 @@ public class StartService {
         }
     }
 
-    public boolean isUserProfileEmpty(Session session) {
-        return Optional.ofNullable(session.getEmailAddress())
+    public boolean isUserProfileEmpty(AuthSessionItem authSession) {
+        return Optional.ofNullable(authSession.getEmailAddress())
                 .flatMap(dynamoService::getUserProfileByEmailMaybe)
                 .isEmpty();
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -712,11 +712,11 @@ class StartHandlerTest {
     }
 
     private void withNoUserProfilePresent() {
-        when(startService.isUserProfileEmpty(any(Session.class))).thenReturn(true);
+        when(startService.isUserProfileEmpty(any(AuthSessionItem.class))).thenReturn(true);
     }
 
     private void withUserProfilePresent() {
-        when(startService.isUserProfileEmpty(any(Session.class))).thenReturn(false);
+        when(startService.isUserProfileEmpty(any(AuthSessionItem.class))).thenReturn(false);
     }
 
     private Map<String, String> headersWithReauthenticate(String reauthenticate) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -158,13 +158,13 @@ class StartServiceTest {
     @Test
     void returnsFalseIfUserProfilePresent() {
         withUserProfile();
-        assertFalse(startService.isUserProfileEmpty(SESSION));
+        assertFalse(startService.isUserProfileEmpty(AUTH_SESSION));
     }
 
     @Test
     void returnsTrueWhenUserProfileEmpty() {
         withNoUserProfile();
-        assertTrue(startService.isUserProfileEmpty(SESSION));
+        assertTrue(startService.isUserProfileEmpty(AUTH_SESSION));
     }
 
     private static Stream<Arguments> userStartInfo() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -106,6 +106,9 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String sessionId = redis.createSession();
         userStore.signUp(EMAIL, "password");
         redis.addEmailToSession(sessionId, EMAIL);
+        authSessionExtension.addSession(PREVIOUS_SESSION_ID);
+        authSessionExtension.addEmailToSession(PREVIOUS_SESSION_ID, EMAIL);
+        authSessionExtension.addSession(sessionId);
         var state = new State();
         Scope scope = new Scope();
         scope.add(OIDCScopeValue.OPENID);
@@ -172,6 +175,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String sessionId = redis.createSession();
         userStore.signUp(EMAIL, "password");
         redis.addEmailToSession(sessionId, EMAIL);
+        authSessionExtension.addSession(sessionId);
         var state = new State();
         Scope scope = new Scope();
         scope.add(OIDCScopeValue.OPENID);
@@ -213,6 +217,9 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var isAuthenticated = true;
         var sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, userEmail);
+        authSessionExtension.addSession(PREVIOUS_SESSION_ID);
+        authSessionExtension.addEmailToSession(PREVIOUS_SESSION_ID, userEmail);
+        authSessionExtension.addSession(sessionId);
 
         userStore.signUp(userEmail, "rubbbishPassword");
 
@@ -273,6 +280,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
         var state = new State();
         var sessionId = redis.createSession(isAuthenticated);
+        authSessionExtension.addSession(sessionId);
         var scope = new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);
         var authRequest =
                 new AuthenticationRequest.Builder(
@@ -327,6 +335,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var userEmail = "joe.bloggs+3@digital.cabinet-office.gov.uk";
         var sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, userEmail);
+        authSessionExtension.addSession(sessionId);
         redis.addClientSessionIdToSession(CLIENT_SESSION_ID, sessionId);
         registerClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR(), ClientType.WEB);
 
@@ -357,8 +366,10 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             handler = new StartHandler(new TestConfigurationService(), redisConnectionService);
             txmaAuditQueue.clear();
             sessionId = redis.createSession(false);
+            authSessionExtension.addSession(sessionId);
             userStore.signUp(EMAIL, "password");
             redis.addEmailToSession(sessionId, EMAIL);
+            authSessionExtension.addEmailToSession(sessionId, EMAIL);
             var state = new State();
             Scope scope = new Scope();
             scope.add(OIDCScopeValue.OPENID);


### PR DESCRIPTION
### Wider context of change

This is part of the session migration work, specifically the email migration.

### What’s changed

Change all instances of session.getEmailAddress to authSession.getEmailAddress in StartService.

### Manual testing

Added a log and checked on the log status.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required.**
- [x] Changes have been made to the simulator or not required. **Not required.**
- [x] Changes have been made to stubs or not required. **Not required.**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required.**

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/6069
https://github.com/govuk-one-login/authentication-api/pull/5982
https://github.com/govuk-one-login/authentication-api/pull/6076
https://github.com/govuk-one-login/authentication-api/pull/6077
https://github.com/govuk-one-login/authentication-api/pull/6078
https://github.com/govuk-one-login/authentication-api/pull/6080