### PR TITLE
ATO-1432: Add new claims for auth frontend

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
@@ -98,6 +98,15 @@ public class RequestObjectToAuthRequestHelper {
                 builder.codeChallenge(parsedCodeChallenge, parsedCodeChallengeMethod);
             }
 
+            if (Objects.nonNull(jwtClaimsSet.getStringClaim("_ga"))) {
+                builder.customParameter("_ga", jwtClaimsSet.getStringClaim("_ga"));
+            }
+
+            if (Objects.nonNull(jwtClaimsSet.getStringClaim("cookie_consent"))) {
+                builder.customParameter(
+                        "cookie_consent", jwtClaimsSet.getStringClaim("cookie_consent"));
+            }
+
             return builder.build();
         } catch (ParseException | com.nimbusds.oauth2.sdk.ParseException | Json.JsonException e) {
             LOG.error("Parse exception thrown whilst converting RequestObject to Auth Request", e);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -90,6 +90,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.nimbusds.oauth2.sdk.OAuth2Error.ACCESS_DENIED_CODE;
 import static com.nimbusds.oauth2.sdk.OAuth2Error.INVALID_REQUEST;
@@ -511,11 +512,18 @@ public class AuthorisationHandler
 
     private VectorOfTrust extractVoTFromIdTokenHint(SignedJWT idTokenHint)
             throws java.text.ParseException {
+        return VectorOfTrust.parseFromAuthRequestAttribute(
+                        extractVoTStringListFromIdTokenHint(idTokenHint))
+                .get(0);
+    }
+
+    private List<String> extractVoTStringListFromIdTokenHint(SignedJWT idTokenHint)
+            throws java.text.ParseException {
         var votClaim = idTokenHint.getJWTClaimsSet().getClaim("vot");
         if (votClaim == null) {
-            return new VectorOfTrust(CredentialTrustLevel.getDefault());
+            return List.of(CredentialTrustLevel.getDefault().getValue());
         } else if (votClaim instanceof String vot) {
-            return VectorOfTrust.parseFromAuthRequestAttribute(List.of(vot)).get(0);
+            return List.of(vot);
         }
         throw new java.text.ParseException("vtr is in an invalid format. Could not be parsed.", 0);
     }
@@ -889,6 +897,9 @@ public class AuthorisationHandler
         var state = new State();
         orchestrationAuthorizationService.storeState(sessionId, clientSessionId, state);
 
+        List<String> vtrStringList =
+                Optional.ofNullable(authenticationRequest.getCustomParameter(VTR_PARAM))
+                        .orElse(List.of(CredentialTrustLevel.getDefault().getValue()));
         String reauthSub = null;
         String reauthSid = null;
         if (reauthRequested) {
@@ -896,6 +907,9 @@ public class AuthorisationHandler
                 SignedJWT reauthIdToken = getReauthIdToken(authenticationRequest);
                 reauthSub = reauthIdToken.getJWTClaimsSet().getSubject();
                 reauthSid = reauthIdToken.getJWTClaimsSet().getStringClaim("sid");
+                if (isNull(authenticationRequest.getCustomParameter(VTR_PARAM))) {
+                    vtrStringList = extractVoTStringListFromIdTokenHint(reauthIdToken);
+                }
             } catch (RuntimeException e) {
                 return generateErrorResponse(
                         authenticationRequest.getRedirectionURI(),
@@ -910,6 +924,14 @@ public class AuthorisationHandler
             }
         }
 
+        var cookieConsentOpt =
+                Optional.ofNullable(authenticationRequest.getCustomParameter("cookie_consent"))
+                        .map(List::stream)
+                        .flatMap(Stream::findFirst);
+        var gaOpt =
+                Optional.ofNullable(authenticationRequest.getCustomParameter("_ga"))
+                        .map(List::stream)
+                        .flatMap(Stream::findFirst);
         var claimsBuilder =
                 new JWTClaimsSet.Builder()
                         .issuer(configurationService.getOrchestrationClientId())
@@ -937,9 +959,14 @@ public class AuthorisationHandler
                         .claim("authenticated", orchSession.getAuthenticated())
                         .claim(
                                 "current_credential_strength",
-                                orchSession.getCurrentCredentialStrength());
+                                orchSession.getCurrentCredentialStrength())
+                        .claim("vtr_list", String.join(" ", vtrStringList))
+                        .claim("scope", authenticationRequest.getScope().toString());
 
         previousSessionId.ifPresent(id -> claimsBuilder.claim("previous_session_id", id));
+        gaOpt.ifPresent(ga -> claimsBuilder.claim("_ga", ga));
+        cookieConsentOpt.ifPresent(
+                cookieConsent -> claimsBuilder.claim("cookie_consent", cookieConsent));
 
         var claimsSetRequest =
                 constructAdditionalAuthenticationClaims(client, authenticationRequest);
@@ -954,7 +981,6 @@ public class AuthorisationHandler
                         .endpointURI(URI.create(redirectURI))
                         .requestObject(encryptedJWT)
                         .build();
-
         redirectURI = authorizationRequest.toURI().toString();
 
         return generateApiGatewayProxyResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -3069,6 +3069,7 @@ class AuthorisationHandlerTest {
                 .claim("claims", CLAIMS)
                 .issuer(CLIENT_ID.getValue())
                 .claim("max_age", "1000")
+                .claim("vtr", "[Cl.Cm]")
                 .build();
     }
 


### PR DESCRIPTION
### Wider context of change

We would like to migrate away from the current auth client session and use the new orch client session stored in dynamo. To start, we need to remove usages of the `authRequestParams` on the auth clientSession.

### What’s changed

This PR passes fields that are accessed on the authRequestParams as claims in the request to the auth frontend. This means that we do not need to access the authRequestParams field on the client session, and will eventually be able to get rid of it, and store these fields elsewhere.

This wont do anything at the moment, as the new claims that have been added are not being used, they will be available to the auth frontend to pass on to the auth backend though.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a?
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required - Change for orch stub will be made in separate PR.
- [x] Successfully deployed to authdev or not required. n/a
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a
