### PR TITLE
AUT-3689: update the IPV call backup URl for Build

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -13,7 +13,7 @@ ipv_backend_uri = "https://ipvstub.signin.build.account.gov.uk"
 # Shared with orch
 ipv_authorisation_uri = "https://ipvstub.signin.build.account.gov.uk/authorize/"
 # auth only
-ipv_auth_authorize_callback_uri = "https://signin-sp.build.account.gov.uk/ipv/callback/authorize"
+ipv_auth_authorize_callback_uri = "https://signin.build.account.gov.uk/ipv/callback/authorize"
 ipv_auth_authorize_client_id    = "authTestClient"
 ipv_audience                    = "https://ipvstub.signin.build.account.gov.uk"
 


### PR DESCRIPTION
## What

AUT-3689: Update the IPV call backup URl for Build env post migration to new frontend 

## How to review

1. Code Review

