### PR TITLE
ATO-1473 SendNotificationHandler read email from AuthSession

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -299,18 +299,18 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             APIGatewayProxyRequestEvent input,
             AuditContext auditContext)
             throws JsonException, ClientNotFoundException {
-        var session = userContext.getSession();
-        var sessionId = userContext.getAuthSession().getSessionId();
+        var authSession = userContext.getAuthSession();
+        var sessionId = authSession.getSessionId();
 
         String code =
                 requestNewCode != null && requestNewCode
-                        ? generateAndSaveNewCode(session.getEmailAddress(), notificationType)
+                        ? generateAndSaveNewCode(authSession.getEmailAddress(), notificationType)
                         : codeStorageService
-                                .getOtpCode(session.getEmailAddress(), notificationType)
+                                .getOtpCode(authSession.getEmailAddress(), notificationType)
                                 .orElseGet(
                                         () ->
                                                 generateAndSaveNewCode(
-                                                        session.getEmailAddress(),
+                                                        authSession.getEmailAddress(),
                                                         notificationType));
 
         incrementUserSubmittedCredentialIfNotificationSetupJourney(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -139,7 +139,8 @@ class SendNotificationHandlerTest {
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
-                    .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID);
+                    .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID)
+                    .withEmailAddress(EMAIL);
 
     private final AuditContext auditContext =
             new AuditContext(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.api;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.SendNotificationRequest;
 import uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler;
@@ -9,6 +10,7 @@ import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.EmailCheckResultExtension;
 
 import java.util.List;
 import java.util.Map;
@@ -22,6 +24,10 @@ class SendNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String USER_EMAIL = "test@email.com";
     private String SESSION_ID;
 
+    @RegisterExtension
+    protected static final EmailCheckResultExtension emailCheckResultExtension =
+            new EmailCheckResultExtension();
+
     @BeforeEach
     void setup() throws Json.JsonException {
         txmaAuditQueue.clear();
@@ -30,6 +36,7 @@ class SendNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
         SESSION_ID = redis.createUnauthenticatedSessionWithEmail(USER_EMAIL);
         authSessionStore.addSession(SESSION_ID);
+        authSessionStore.addEmailToSession(SESSION_ID, USER_EMAIL);
     }
 
     @Test


### PR DESCRIPTION
### Wider context of change

This is part of the session migration work, specifically the email migration.

### What’s changed

Change all instances of session.getEmailAddress to authSession.getEmailAddress in SendNotificationHandler.

### Manual testing

Added a log and checked on the log status.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required.**
- [x] Changes have been made to the simulator or not required. **Not required.**
- [x] Changes have been made to stubs or not required. **Not required.**
- [x] Successfully deployed to authdev or not required. **Not required.**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required.**

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/6069
https://github.com/govuk-one-login/authentication-api/pull/6070
https://github.com/govuk-one-login/authentication-api/pull/5982
https://github.com/govuk-one-login/authentication-api/pull/6077
https://github.com/govuk-one-login/authentication-api/pull/6078
https://github.com/govuk-one-login/authentication-api/pull/6080
