### PR TITLE
ATO-1479 resetpasswordhandler read email from authsessionitem

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -156,7 +156,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             }
             var userCredentials =
                     authenticationService.getUserCredentialsFromEmail(
-                            userContext.getSession().getEmailAddress());
+                            userContext.getAuthSession().getEmailAddress());
 
             if (Objects.nonNull(userCredentials.getPassword())) {
                 if (verifyPassword(userCredentials.getPassword(), request.password())) {
@@ -168,7 +168,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             authenticationService.updatePassword(userCredentials.getEmail(), request.password());
             var userProfile =
                     authenticationService.getUserProfileByEmail(
-                            userContext.getSession().getEmailAddress());
+                            userContext.getAuthSession().getEmailAddress());
 
             authSessionService.updateSession(
                     userContext

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -131,7 +131,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
 
         LOG.info("Processing request");
         try {
-            if (Objects.isNull(userContext.getSession().getEmailAddress())
+            if (Objects.isNull(userContext.getAuthSession().getEmailAddress())
                     || !userContext.getSession().validateSession(request.getEmail())) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
             }
@@ -185,7 +185,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         var codeRequestBlockedKeyPrefix = CODE_REQUEST_BLOCKED_KEY_PREFIX + codeRequestType;
         LOG.info("Setting block for email as user has requested too many OTPs");
         codeStorageService.saveBlockedForEmail(
-                userContext.getSession().getEmailAddress(),
+                userContext.getAuthSession().getEmailAddress(),
                 codeRequestBlockedKeyPrefix,
                 configurationService.getLockoutDuration());
         sessionService.storeOrUpdateSession(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -136,7 +136,8 @@ class ResetPasswordHandlerTest {
 
     private ResetPasswordHandler handler;
     private final Session session = new Session().setEmailAddress(EMAIL);
-    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem().withSessionId(SESSION_ID).withEmailAddress(EMAIL);
 
     private final ClientRegistry testClientRegistry =
             new ClientRegistry()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -137,6 +137,7 @@ class ResetPasswordRequestHandlerTest {
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
+                    .withEmailAddress(CommonTestVariables.EMAIL)
                     .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID);
     private final ResetPasswordRequestHandler handler =
             new ResetPasswordRequestHandler(
@@ -198,7 +199,7 @@ class ResetPasswordRequestHandlerTest {
         public static APIGatewayProxyRequestEvent validEvent;
 
         private boolean isSessionWithEmailSent(Session session) {
-            return session.getEmailAddress().equals(CommonTestVariables.EMAIL);
+            return authSession.getEmailAddress().equals(CommonTestVariables.EMAIL);
         }
 
         @BeforeEach

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -79,7 +79,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         var sessionId = redis.createSession();
         authSessionStore.addSession(sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
         var response =
                 makeRequest(
@@ -107,7 +107,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, phoneNumber);
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
         var response =
                 makeRequest(
@@ -145,7 +145,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, phoneNumber);
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
         var response =
                 makeRequest(
@@ -172,7 +172,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         var sessionId = redis.createSession();
         authSessionStore.addSession(sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
         var body =
                 format(
@@ -197,7 +197,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         var sessionId = redis.createSession();
         authSessionStore.addSession(sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
         var response =
                 makeRequest(
@@ -232,7 +232,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         userStore.setPhoneNumberAndVerificationStatus(
                 EMAIL_ADDRESS, phoneNumber, phoneNumberVerified, phoneNumberVerified);
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
         byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
 
         var response =
@@ -283,7 +283,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
         userStore.addMfaMethod(
                 EMAIL_ADDRESS, MFAMethodType.AUTH_APP, authAppVerified, true, "credential");
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
         var response =
                 makeRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -49,6 +49,7 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         userStore.addVerifiedPhoneNumber(email, phoneNumber);
         String sessionId = redis.createSession();
         authSessionStore.addSession(sessionId);
+        authSessionStore.addEmailToSession(sessionId, email);
         String persistentSessionId = "test-persistent-id";
         redis.addEmailToSession(sessionId, email);
         var clientSessionId = IdGenerator.generate();


### PR DESCRIPTION
### Wider context of change

This is part of the session migration work, specifically the email migration.

### What’s changed

Change all instances of session.getEmailAddress to authSession.getEmailAddress in ResetPasswordHandler

### Manual testing

Added a log and checked on the log status.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required.**
- [x] Changes have been made to the simulator or not required. **Not required.**
- [x] Changes have been made to stubs or not required. **Not required.**
- [x] Successfully deployed to authdev or not required. **Not required.**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required.**

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/6069
https://github.com/govuk-one-login/authentication-api/pull/6070
https://github.com/govuk-one-login/authentication-api/pull/5982
https://github.com/govuk-one-login/authentication-api/pull/6076
https://github.com/govuk-one-login/authentication-api/pull/6078
https://github.com/govuk-one-login/authentication-api/pull/6080
