### PR TITLE
ATO-1474 verifycodehandler read email from authsessionitem

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -236,7 +236,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             }
 
             processSuccessfulCodeRequest(
-                    authSession,
                     codeRequest,
                     userContext,
                     subjectId,
@@ -373,7 +372,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     }
 
     private void processSuccessfulCodeRequest(
-            AuthSessionItem authSession,
             VerifyCodeRequest codeRequest,
             UserContext userContext,
             String subjectId,
@@ -382,7 +380,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             ClientRegistry client,
             Optional<String> maybeRpPairwiseId) {
         var session = userContext.getSession();
-        var sessionId = userContext.getAuthSession().getSessionId();
+        var authSession = userContext.getAuthSession();
+        var sessionId = authSession.getSessionId();
         var notificationType = codeRequest.notificationType();
         int loginFailureCount =
                 codeStorageService.getIncorrectMfaCodeAttemptsCount(session.getEmailAddress());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -469,6 +469,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     private void setUpTestWithoutSignUp(String sessionId, Scope scope) throws Json.JsonException {
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        authSessionExtension.addEmailToSession(sessionId, EMAIL_ADDRESS);
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(
                                 ResponseType.CODE,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -875,6 +875,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setUpSmsRequest(journeyType, PHONE_NUMBER);
 
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        authSessionExtension.addEmailToSession(sessionId, EMAIL_ADDRESS);
         var codeRequestType = CodeRequestType.getCodeRequestType(MFAMethodType.SMS, journeyType);
         var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
         redis.blockMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix);
@@ -911,6 +912,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             throws Json.JsonException {
         setUpSmsRequest(journeyType, PHONE_NUMBER);
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        authSessionExtension.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
         var codeRequest =
                 new VerifyMfaCodeRequest(
@@ -976,6 +978,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private void setUpTest(String sessionId, Scope scope) throws Json.JsonException {
         userStore.addUnverifiedUser(EMAIL_ADDRESS, USER_PASSWORD);
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        authSessionExtension.addEmailToSession(sessionId, EMAIL_ADDRESS);
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(
                                 ResponseType.CODE,


### PR DESCRIPTION
### Wider context of change

This is part of the session migration work, specifically the email migration.

### What’s changed

Change all instances of session.getEmailAddress to authSession.getEmailAddress in VerifyCodeHandler.

### Manual testing

Added a log and checked on the log status.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required.**
- [x] Changes have been made to the simulator or not required. **Not required.**
- [x] Changes have been made to stubs or not required. **Not required.**
- [x] Successfully deployed to authdev or not required. **Not required.**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required.**

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/6069
https://github.com/govuk-one-login/authentication-api/pull/6070
https://github.com/govuk-one-login/authentication-api/pull/5982
https://github.com/govuk-one-login/authentication-api/pull/6076
https://github.com/govuk-one-login/authentication-api/pull/6077
https://github.com/govuk-one-login/authentication-api/pull/6080
