### PR TITLE
Ato 1482 misc email address authsessionitem

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -349,7 +349,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                 auditContextFromUserContext(
                         userContext,
                         userContext.getAuthSession().getInternalCommonSubjectId(),
-                        userContext.getSession().getEmailAddress(),
+                        userContext.getAuthSession().getEmailAddress(),
                         IpAddressHelper.extractIpAddress(input),
                         userContext
                                 .getUserProfile()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -117,7 +117,7 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
             CheckReauthUserRequest request,
             UserContext userContext) {
 
-        var emailUserIsSignedInWith = userContext.getSession().getEmailAddress();
+        var emailUserIsSignedInWith = userContext.getAuthSession().getEmailAddress();
 
         var auditContext =
                 auditContextFromUserContext(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -136,7 +136,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 auditContextFromUserContext(
                         userContext,
                         authSession.getInternalCommonSubjectId(),
-                        session.getEmailAddress(),
+                        authSession.getEmailAddress(),
                         ipAddress,
                         auditablePhoneNumber,
                         persistentSessionId);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -127,6 +127,7 @@ class AccountInterventionsHandlerTest {
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
+                    .withEmailAddress(EMAIL)
                     .withInternalCommonSubjectId(INTERNAL_SUBJECT_ID);
 
     private static final AuditContext AUDIT_CONTEXT =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -90,7 +90,8 @@ class CheckReAuthUserHandlerTest {
             apiRequestEventWithHeadersAndBody(VALID_HEADERS, null);
 
     private final Session session = new Session().setEmailAddress(EMAIL_USED_TO_SIGN_IN);
-    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem().withSessionId(SESSION_ID).withEmailAddress(EMAIL_USED_TO_SIGN_IN);
 
     private final AuditContext testAuditContextWithoutAuditEncoded =
             new AuditContext(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -125,6 +125,7 @@ class MfaHandlerTest {
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
+                    .withEmailAddress(EMAIL)
                     .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID);
     private final ClientRegistry testClientRegistry =
             new ClientRegistry()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -95,6 +95,7 @@ class UpdateProfileHandlerTest {
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
+                    .withEmailAddress(EMAIL)
                     .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID);
 
     private final AuditContext auditContextWithAllUserInfo =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
@@ -45,7 +45,6 @@ class MfaCodeProcessorFactoryTest {
 
     @Test
     void whenMfaMethodGeneratesAuthAppCodeProcessor() {
-
         var mfaCodeProcessor =
                 mfaCodeProcessorFactory.getMfaCodeProcessor(
                         MFAMethodType.AUTH_APP,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
@@ -100,6 +100,7 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
 
         var sessionId = redis.createAuthenticatedSessionWithEmail(TEST_EMAIL);
         authSessionExtension.addSession(sessionId);
+        authSessionExtension.addEmailToSession(sessionId, TEST_EMAIL);
         requestHeaders = createHeaders(sessionId);
         redis.createClientSession(CLIENT_SESSION_ID, createClientSession());
         handler = new CheckReAuthUserHandler(CONFIGURATION_SERVICE, redisConnectionService);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -73,6 +73,7 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
         scope.add(OIDCScopeValue.EMAIL);
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         authSessionStore.addSession(sessionId);
+        authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(
                                 ResponseType.CODE,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TestClientHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TestClientHelper.java
@@ -33,7 +33,7 @@ public class TestClientHelper {
         var isTestClientWithAllowedEmail =
                 (clientRegistry.isTestClient()
                         && emailMatchesAllowlist(
-                                userContext.getSession().getEmailAddress(),
+                                userContext.getAuthSession().getEmailAddress(),
                                 clientRegistry.getTestClientEmailAllowlist()));
 
         LOG.info(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
@@ -135,8 +136,11 @@ class TestClientHelperTest {
                         .withClientName("some-client")
                         .withTestClient(isTestClient)
                         .withTestClientEmailAllowlist(allowedEmails);
-        return UserContext.builder(new Session().setEmailAddress(TEST_EMAIL_ADDRESS))
+        var session = new Session().setEmailAddress(TEST_EMAIL_ADDRESS);
+        var authSession = new AuthSessionItem().withEmailAddress(TEST_EMAIL_ADDRESS);
+        return UserContext.builder(session)
                 .withClient(clientRegistry)
+                .withAuthSession(authSession)
                 .build();
     }
 }


### PR DESCRIPTION
### Wider context of change

This is part of the session migration work, specifically the email migration.

### What’s changed

Change all instances of session.getEmailAddress to authSession.getEmailAddress in some of the smaller files left with email address getters.

### Manual testing

Added a log and checked on the log status.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required.**
- [x] Changes have been made to the simulator or not required. **Not required.**
- [x] Changes have been made to stubs or not required. **Not required.**
- [x] Successfully deployed to authdev or not required. **Not required.**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required.**

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/6069
https://github.com/govuk-one-login/authentication-api/pull/6070
https://github.com/govuk-one-login/authentication-api/pull/5982
https://github.com/govuk-one-login/authentication-api/pull/6076
https://github.com/govuk-one-login/authentication-api/pull/6077
https://github.com/govuk-one-login/authentication-api/pull/6078
