### PR TITLE
AUT-2469: Log TICF CRI request payload

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -241,6 +241,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             return;
         }
 
+        LOG.info("Invoking TICF CRI with payload: {}", payload);
         lambdaInvoker.invokeAsyncWithPayload(
                 payload, configurationService.getTicfCRILambdaIdentifier());
     }


### PR DESCRIPTION
## What

We make requests to TICF CRI, but currently do not log any helpful data for debugging and assessing requests unless they error.

Here a log is added before a request is made, dumping the payload to logs.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.

