### PR TITLE
AUT-2909: Add `initial_registration` to TICF CRI payload

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsRequest;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsResponse;
 import uk.gov.di.authentication.frontendapi.entity.State;
 import uk.gov.di.authentication.frontendapi.services.AccountInterventionsService;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException;
@@ -191,7 +192,11 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
 
             if (configurationService.isInvokeTicfCRILambdaEnabled()
                     && request.authenticated() != null) {
-                sendTICF(userContext, internalPairwiseId, request.authenticated());
+                sendTICF(
+                        userContext,
+                        internalPairwiseId,
+                        request.authenticated(),
+                        userContext.getAuthSession().getIsNewAccount());
             }
 
             LOG.info("Generating Account Interventions outbound response for frontend");
@@ -206,7 +211,10 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
     }
 
     private void sendTICF(
-            UserContext userContext, String internalPairwiseId, boolean authenticated) {
+            UserContext userContext,
+            String internalPairwiseId,
+            boolean authenticated,
+            AuthSessionItem.AccountState accountState) {
         var vtr = new ArrayList<String>();
 
         try {
@@ -227,7 +235,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
 
         var ticfRequest =
                 TICFCRIRequest.basicTicfCriRequest(
-                        internalPairwiseId, vtr, journeyId, authenticated);
+                        internalPairwiseId, vtr, journeyId, authenticated, accountState);
 
         String payload;
 

--- a/shared/src/main/java/uk/gov/di/authentication/entity/TICFCRIRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/TICFCRIRequest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.entity;
 
 import com.google.gson.annotations.Expose;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.validation.Required;
 
 import java.util.List;
@@ -14,8 +15,17 @@ public record TICFCRIRequest(
         @Expose String passwordReset) {
 
     public static TICFCRIRequest basicTicfCriRequest(
-            String internalPairwiseId, List<String> vtr, String journeyId, boolean authenticated) {
+            String internalPairwiseId,
+            List<String> vtr,
+            String journeyId,
+            boolean authenticated,
+            AuthSessionItem.AccountState accountState) {
         return new TICFCRIRequest(
-                internalPairwiseId, vtr, journeyId, authenticated ? "Y" : "N", null, null);
+                internalPairwiseId,
+                vtr,
+                journeyId,
+                authenticated ? "Y" : "N",
+                accountState == AuthSessionItem.AccountState.NEW ? "Y" : null,
+                null);
     }
 }


### PR DESCRIPTION
## What

Using the `AccountState` from the users session we determine if the authenticated session represents a new account and use that to populate the `initial_registration` field to the TICF CRI.

## How to review

1. Code Review
2. Run though sign in and create journey on an environment and see that when filtering logs for the `*-account-interventions-lambda` with "Invoking TICF CRI with payload" that payload contains `\"authenticated\":\"Y\"}` for the create journey but not for sign in

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
