### PR TITLE
ATO-1471: remove Old Dynamo Identity Credentials table

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -10,10 +10,6 @@ data "aws_dynamodb_table" "client_registry_table" {
   name = "${var.environment}-client-registry"
 }
 
-data "aws_dynamodb_table" "identity_credentials_table" {
-  name = "${var.environment}-identity-credentials"
-}
-
 data "aws_dynamodb_table" "doc_app_cri_credential_table" {
   name = "${var.environment}-doc-app-credential"
 }
@@ -180,95 +176,6 @@ data "aws_iam_policy_document" "dynamo_client_registration_read_policy_document"
       "kms:DescribeKey",
     ]
     resources = [local.client_registry_encryption_key_arn]
-  }
-}
-
-data "aws_iam_policy_document" "dynamo_identity_write_access_policy_document" {
-  statement {
-    sid    = "AllowAccessToDynamoTables"
-    effect = "Allow"
-
-    actions = [
-      "dynamodb:UpdateItem",
-      "dynamodb:PutItem",
-    ]
-    resources = [
-      data.aws_dynamodb_table.identity_credentials_table.arn,
-    ]
-  }
-
-  statement {
-    sid    = "AllowAccessToKms"
-    effect = "Allow"
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:CreateGrant",
-      "kms:DescribeKey",
-    ]
-    resources = [local.identity_credentials_encryption_key_arn]
-  }
-}
-
-data "aws_iam_policy_document" "dynamo_identity_delete_access_policy_document" {
-  statement {
-    sid    = "AllowAccessToDynamoTables"
-    effect = "Allow"
-
-    actions = [
-      "dynamodb:DeleteItem",
-    ]
-    resources = [
-      data.aws_dynamodb_table.identity_credentials_table.arn,
-    ]
-  }
-
-  statement {
-    sid    = "AllowAccessToKms"
-    effect = "Allow"
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:CreateGrant",
-      "kms:DescribeKey",
-    ]
-    resources = [local.identity_credentials_encryption_key_arn]
-  }
-}
-
-data "aws_iam_policy_document" "dynamo_identity_read_access_policy_document" {
-  statement {
-    sid    = "AllowAccessToDynamoTables"
-    effect = "Allow"
-
-    actions = [
-      "dynamodb:BatchGetItem",
-      "dynamodb:DescribeTable",
-      "dynamodb:Get*",
-      "dynamodb:Query",
-      "dynamodb:Scan",
-    ]
-    resources = [
-      data.aws_dynamodb_table.identity_credentials_table.arn,
-    ]
-  }
-
-  statement {
-    sid    = "AllowAccessToKms"
-    effect = "Allow"
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:CreateGrant",
-      "kms:DescribeKey",
-    ]
-    resources = [local.identity_credentials_encryption_key_arn]
   }
 }
 
@@ -906,30 +813,6 @@ resource "aws_iam_policy" "dynamo_user_write_access_policy" {
   description = "IAM policy for managing write permissions to the Dynamo User tables"
 
   policy = data.aws_iam_policy_document.dynamo_user_write_policy_document.json
-}
-
-resource "aws_iam_policy" "dynamo_identity_credentials_write_access_policy" {
-  name_prefix = "dynamo-access-policy"
-  path        = "/${var.environment}/oidc-default/"
-  description = "IAM policy for managing write permissions to the Dynamo Identity credentials table"
-
-  policy = data.aws_iam_policy_document.dynamo_identity_write_access_policy_document.json
-}
-
-resource "aws_iam_policy" "dynamo_identity_credentials_read_access_policy" {
-  name_prefix = "dynamo-access-policy"
-  path        = "/${var.environment}/oidc-default/"
-  description = "IAM policy for managing read permissions to the Dynamo Identity credentials table"
-
-  policy = data.aws_iam_policy_document.dynamo_identity_read_access_policy_document.json
-}
-
-resource "aws_iam_policy" "dynamo_identity_credentials_delete_access_policy" {
-  name_prefix = "dynamo-access-policy"
-  path        = "/${var.environment}/oidc-default/"
-  description = "IAM policy for managing delete permissions to the Dynamo Identity credentials table"
-
-  policy = data.aws_iam_policy_document.dynamo_identity_delete_access_policy_document.json
 }
 
 resource "aws_iam_policy" "dynamo_doc_app_write_access_policy" {

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -1,3 +1,23 @@
+// ATO-1471: We're duplicating the role without the old identity credentials table
+// access policies to enable us to safely remove them
+module "identity_progress_role_2" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "identity-progress-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = concat([
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    ], var.is_orch_stubbed ? [] : [
+    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn
+  ])
+  extra_tags = {
+    Service = "identity-progress"
+  }
+}
+
 module "identity_progress_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -18,26 +18,6 @@ module "identity_progress_role_2" {
   }
 }
 
-module "identity_progress_role_1" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "identity-progress-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = concat([
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    ], var.is_orch_stubbed ? [] : [
-    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn,
-    aws_iam_policy.dynamo_orch_client_session_cross_account_read_access_policy[0].arn
-  ])
-  extra_tags = {
-    Service = "identity-progress"
-  }
-}
-
 module "identity_progress" {
   source = "../modules/endpoint-module-v2"
 
@@ -75,7 +55,7 @@ module "identity_progress" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.identity_progress_role_1.arn
+  lambda_role_arn                        = module.identity_progress_role_2.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -1,3 +1,31 @@
+// ATO-1471: We're duplicating the role without the old identity credentials table
+// access policies to enable us to safely remove them
+module "ipv_callback_role_1" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-callback-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.ipv_token_auth_kms_policy.arn,
+    aws_iam_policy.spot_queue_encryption_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    local.user_credentials_encryption_policy_arn,
+    local.user_profile_encryption_policy_arn,
+    aws_iam_policy.spot_queue_write_access_policy.arn
+  ]
+  extra_tags = {
+    Service = "ipv-callback"
+  }
+}
+
 module "ipv_callback_role" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -1,5 +1,3 @@
-// ATO-1471: We're duplicating the role without the old identity credentials table
-// access policies to enable us to safely remove them
 module "ipv_callback_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -17,35 +15,6 @@ module "ipv_callback_role_1" {
     aws_iam_policy.spot_queue_encryption_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn,
-    local.user_profile_encryption_policy_arn,
-    aws_iam_policy.spot_queue_write_access_policy.arn
-  ]
-  extra_tags = {
-    Service = "ipv-callback"
-  }
-}
-
-module "ipv_callback_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "ipv-callback-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.dynamo_user_read_access_policy.arn,
-    aws_iam_policy.dynamo_user_write_access_policy.arn,
-    aws_iam_policy.dynamo_identity_credentials_write_access_policy.arn,
-    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.ipv_token_auth_kms_policy.arn,
-    aws_iam_policy.spot_queue_encryption_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn,
-    local.identity_credentials_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     local.user_profile_encryption_policy_arn,
     aws_iam_policy.spot_queue_write_access_policy.arn
@@ -103,7 +72,7 @@ module "ipv-callback" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.ipv_callback_role.arn
+  lambda_role_arn                        = module.ipv_callback_role_1.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention

--- a/ci/terraform/oidc/ipv-handback-alerts.tf
+++ b/ci/terraform/oidc/ipv-handback-alerts.tf
@@ -13,7 +13,7 @@ moved {
 data "aws_cloudwatch_log_group" "spot_response_lambda_log_group" {
   name = replace("/aws/lambda/${var.environment}-spot-response-lambda", ".", "")
   depends_on = [
-    module.ipv_spot_response_role
+    module.ipv_spot_response_role_1
   ]
 }
 moved {

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -56,6 +56,36 @@ moved {
   to   = module.ipv_processing_identity_role_with_orch_session_table_access[0]
 }
 
+// ATO-1471: We're duplicating the role without the old identity credentials table
+// access policies to enable us to safely remove them
+module "ipv_processing_identity_role_with_orch_session_table_access_1" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-processing-identity-role-with-orch-session-access"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.pepper_parameter_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    local.identity_credentials_encryption_policy_arn,
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_decrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_read_and_delete_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn
+  ]
+}
+
 module "processing-identity" {
   source = "../modules/endpoint-module-v2"
 

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -1,3 +1,27 @@
+// ATO-1471: We're duplicating the role without the old identity credentials table
+// access policies to enable us to safely remove them
+module "ipv_spot_response_role_1" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-spot-response-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.spot_response_sqs_read_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.identity_credentials_encryption_policy_arn
+  ]
+
+  depends_on = [
+    aws_iam_policy.spot_response_sqs_read_policy
+  ]
+  extra_tags = {
+    Service = "spot-response"
+  }
+}
+
 module "ipv_spot_response_role" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -1,5 +1,3 @@
-// ATO-1471: We're duplicating the role without the old identity credentials table
-// access policies to enable us to safely remove them
 module "ipv_spot_response_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -7,31 +5,6 @@ module "ipv_spot_response_role_1" {
   vpc_arn     = local.authentication_vpc_arn
 
   policies_to_attach = [
-    aws_iam_policy.spot_response_sqs_read_policy.arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    local.identity_credentials_encryption_policy_arn
-  ]
-
-  depends_on = [
-    aws_iam_policy.spot_response_sqs_read_policy
-  ]
-  extra_tags = {
-    Service = "spot-response"
-  }
-}
-
-module "ipv_spot_response_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "ipv-spot-response-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.dynamo_identity_credentials_write_access_policy.arn,
-    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
-    aws_iam_policy.dynamo_identity_credentials_delete_access_policy.arn,
     aws_iam_policy.spot_response_sqs_read_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
@@ -108,7 +81,7 @@ resource "aws_lambda_event_source_mapping" "spot_response_lambda_sqs_mapping" {
 
 resource "aws_lambda_function" "spot_response_lambda" {
   function_name = "${var.environment}-spot-response-lambda"
-  role          = module.ipv_spot_response_role.arn
+  role          = module.ipv_spot_response_role_1.arn
   handler       = "uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler::handleRequest"
   timeout       = 30
   memory_size   = 512

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -1,29 +1,3 @@
-module "oidc_userinfo_role_1" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "oidc-userinfo-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
-    aws_iam_policy.oidc_token_kms_signing_policy.arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.dynamo_user_read_access_policy.arn,
-    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn,
-    local.identity_credentials_encryption_policy_arn,
-    local.doc_app_credential_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
-  ]
-  extra_tags = {
-    Service = "userinfo"
-  }
-}
-// ATO-1471: We're duplicating the role without the old identity credentials table
-// access policies to enable us to safely remove them
 module "oidc_userinfo_role_2" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -83,7 +57,7 @@ module "userinfo" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.oidc_userinfo_role_1.arn
+  lambda_role_arn                        = module.oidc_userinfo_role_2.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -22,6 +22,31 @@ module "oidc_userinfo_role_1" {
     Service = "userinfo"
   }
 }
+// ATO-1471: We're duplicating the role without the old identity credentials table
+// access policies to enable us to safely remove them
+module "oidc_userinfo_role_2" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "oidc-userinfo-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.oidc_token_kms_signing_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    local.identity_credentials_encryption_policy_arn,
+    local.doc_app_credential_encryption_policy_arn,
+    local.user_credentials_encryption_policy_arn
+  ]
+  extra_tags = {
+    Service = "userinfo"
+  }
+}
 
 module "userinfo" {
   source = "../modules/endpoint-module-v2"

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -225,47 +225,6 @@ resource "aws_dynamodb_table" "client_registry_table" {
   )
 }
 
-resource "aws_dynamodb_table" "identity_credentials_table" {
-  name         = "${var.environment}-identity-credentials"
-  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
-  hash_key     = "SubjectID"
-
-  read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
-  write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
-
-  deletion_protection_enabled = false
-
-  attribute {
-    name = "SubjectID"
-    type = "S"
-  }
-
-  point_in_time_recovery {
-    enabled = true
-  }
-
-  server_side_encryption {
-    enabled     = true
-    kms_key_arn = aws_kms_key.identity_credentials_table_encryption_key.arn
-  }
-
-  lifecycle {
-    prevent_destroy = false
-  }
-
-  ttl {
-    attribute_name = "TimeToExist"
-    enabled        = true
-  }
-
-  tags = (
-    var.environment == "integration" || var.environment == "production" ?
-    {
-      "BackupFrequency" = "Bihourly"
-    } : {}
-  )
-}
-
 resource "aws_dynamodb_table" "doc_app_credential_table" {
   name         = "${var.environment}-doc-app-credential"
   billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -233,7 +233,7 @@ resource "aws_dynamodb_table" "identity_credentials_table" {
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
 
-  deletion_protection_enabled = var.dynamo_deletion_protection_enabled
+  deletion_protection_enabled = false
 
   attribute {
     name = "SubjectID"

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -639,10 +639,6 @@ resource "aws_dynamodb_resource_policy" "client_registry_table_policy" {
   policy       = data.aws_iam_policy_document.cross_account_table_resource_policy_document.json
 }
 
-resource "aws_dynamodb_resource_policy" "identity_credentials_table_policy" {
-  resource_arn = aws_dynamodb_table.identity_credentials_table.arn
-  policy       = data.aws_iam_policy_document.cross_account_identity_credentials_table_resource_policy_document.json
-}
 
 resource "aws_dynamodb_resource_policy" "user_profile_table_policy" {
   resource_arn = aws_dynamodb_table.user_profile_table.arn
@@ -660,27 +656,6 @@ data "aws_iam_policy_document" "cross_account_table_resource_policy_document" {
       "dynamodb:BatchWriteItem",
       "dynamodb:UpdateItem",
       "dynamodb:PutItem",
-    ]
-    effect = "Allow"
-    principals {
-      identifiers = [var.orchestration_account_id]
-      type        = "AWS"
-    }
-    resources = ["*"]
-  }
-}
-
-data "aws_iam_policy_document" "cross_account_identity_credentials_table_resource_policy_document" {
-  statement {
-    actions = [
-      "dynamodb:BatchGetItem",
-      "dynamodb:DescribeTable",
-      "dynamodb:Get*",
-      "dynamodb:Query",
-      "dynamodb:Scan",
-      "dynamodb:UpdateItem",
-      "dynamodb:PutItem",
-      "dynamodb:DeleteItem",
     ]
     effect = "Allow"
     principals {

--- a/ci/terraform/shared/kms-policies.tf
+++ b/ci/terraform/shared/kms-policies.tf
@@ -64,28 +64,6 @@ data "aws_iam_policy_document" "doc_app_credential_encryption_key_policy_documen
   }
 }
 
-resource "aws_iam_policy" "identity_credentials_encryption_key_kms_policy" {
-  name        = "${var.environment}-identity-credentials-table-encryption-key-kms-policy"
-  path        = "/"
-  description = "IAM policy for managing KMS encryption of the identity credentials table"
-
-  policy = data.aws_iam_policy_document.identity_credentials_encryption_key_policy_document.json
-}
-
-data "aws_iam_policy_document" "identity_credentials_encryption_key_policy_document" {
-  statement {
-    sid    = "AllowAccessToIdentityCredentialsTableKmsEncryptionKey"
-    effect = "Allow"
-
-    actions = [
-      "kms:*",
-    ]
-    resources = [
-      aws_kms_key.identity_credentials_table_encryption_key.arn
-    ]
-  }
-}
-
 resource "aws_iam_policy" "client_registry_encryption_key_kms_policy" {
   name        = "${var.environment}-client-registry-table-encryption-key-kms-policy"
   path        = "/"

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -715,20 +715,6 @@ resource "aws_kms_alias" "client_registry_table_encryption_key_alias" {
   target_key_id = aws_kms_key.client_registry_table_encryption_key.key_id
 }
 
-resource "aws_kms_key" "identity_credentials_table_encryption_key" {
-  description              = "KMS encryption key for identity credentials table in DynamoDB"
-  deletion_window_in_days  = 30
-  key_usage                = "ENCRYPT_DECRYPT"
-  customer_master_key_spec = "SYMMETRIC_DEFAULT"
-  enable_key_rotation      = true
-  policy                   = data.aws_iam_policy_document.cross_account_table_encryption_key_access_policy.json
-}
-
-resource "aws_kms_alias" "identity_credentials_table_encryption_key_alias" {
-  name          = "alias/${var.environment}-identity-credentials-table-encryption-key"
-  target_key_id = aws_kms_key.identity_credentials_table_encryption_key.key_id
-}
-
 data "aws_iam_policy_document" "cross_account_table_encryption_key_access_policy" {
   statement {
     sid    = "key-policy-dynamodb"

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -209,10 +209,6 @@ output "client_registry_encryption_policy_arn" {
   value = aws_iam_policy.client_registry_encryption_key_kms_policy.arn
 }
 
-output "identity_credentials_encryption_policy_arn" {
-  value = aws_iam_policy.identity_credentials_encryption_key_kms_policy.arn
-}
-
 output "doc_app_credential_encryption_policy_arn" {
   value = aws_iam_policy.doc_app_credential_encryption_key_kms_policy.arn
 }
@@ -235,10 +231,6 @@ output "email_check_results_encryption_policy_arn" {
 
 output "client_registry_encryption_key_arn" {
   value = aws_kms_key.client_registry_table_encryption_key.arn
-}
-
-output "identity_credentials_encryption_key_arn" {
-  value = aws_kms_key.identity_credentials_table_encryption_key.arn
 }
 
 output "user_profile_kms_key_arn" {


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs:
- Branches off of https://github.com/govuk-one-login/authentication-api/pull/6081, so must be merged first
- Also branches off of https://github.com/govuk-one-login/authentication-api/pull/6118 so must be merged first
