### PR TITLE
BAU: Increase backchannel logout error rate to 25

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1315,7 +1315,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-backchannel-logout-request-error-rate-alarm
-      AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} backchannel logout request lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/OoDyFAE"
+      AlarmDescription: !Sub "Lambda error rate of 25 has been reached in the ${Environment} backchannel logout request lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/OoDyFAE"
       ActionsEnabled: !If
         - IsIntegration
         - false
@@ -1324,7 +1324,7 @@ Resources:
         - !Ref SlackEvents
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      Threshold: 10
+      Threshold: 25
       Metrics:
         - Id: e1
           ReturnData: true


### PR DESCRIPTION
Due to the way we handle failed requests, this lambda errors at quite a high rate. We're going to improve the error handling, but for a temporary fix for the alarms, increase error rate

# authentication-api PR template picker

> [!TIP]
> Please go to the `Preview` tab and select the appropriate sub-template

## Templates

- [Auth Team](?expand=1&template=auth_template.md)
- [Orchestration Team](?expand=1&template=orch_template.md)
