### PR TITLE
Bau/update mfa identifier type

### DIFF
--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -35,6 +36,7 @@ class MFAMethodsRetrieveHandlerTest {
     private static final DynamoService dynamoService = mock(DynamoService.class);
     private static final UserProfile userProfile = mock(UserProfile.class);
     private static final MfaMethodsService mfaMethodsService = mock(MfaMethodsService.class);
+    private static final String MFA_IDENTIFIER = "03a89933-cddd-471d-8fdb-562f14a2404f";
 
     private MFAMethodsRetrieveHandler handler;
 
@@ -54,7 +56,7 @@ class MFAMethodsRetrieveHandlerTest {
 
         var method =
                 new MfaMethodData(
-                        1,
+                        MFA_IDENTIFIER,
                         PriorityIdentifier.DEFAULT,
                         true,
                         new SmsMfaDetail(MFAMethodType.SMS, "+44123456789"));
@@ -68,9 +70,11 @@ class MFAMethodsRetrieveHandlerTest {
         var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
-        assertEquals(
-                "[{\"mfaIdentifier\":1,\"priorityIdentifier\":\"DEFAULT\",\"methodVerified\":true,\"method\":{\"mfaMethodType\":\"SMS\",\"phoneNumber\":\"+44123456789\"}}]",
-                result.getBody());
+        var expectedBody =
+                format(
+                        "[{\"mfaIdentifier\":\"%s\",\"priorityIdentifier\":\"DEFAULT\",\"methodVerified\":true,\"method\":{\"mfaMethodType\":\"SMS\",\"phoneNumber\":\"+44123456789\"}}]",
+                        MFA_IDENTIFIER);
+        assertEquals(expectedBody, result.getBody());
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MfaMethodsRetrieveHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MfaMethodsRetrieveHandlerIntegrationTest.java
@@ -14,8 +14,11 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.shared.services.DynamoMfaMethodsService.HARDCODED_APP_MFA_ID;
+import static uk.gov.di.authentication.shared.services.DynamoMfaMethodsService.HARDCODED_SMS_MFA_ID;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 
 class MfaMethodsRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -47,9 +50,10 @@ class MfaMethodsRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegrat
 
         assertEquals(200, response.getStatusCode());
         var expectedResponse =
-                """
+                format(
+                        """
                 [{
-                     "mfaIdentifier": 1,
+                     "mfaIdentifier": "%s",
                      "priorityIdentifier": "DEFAULT",
                      "methodVerified": true,
                      "method": {
@@ -57,7 +61,8 @@ class MfaMethodsRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegrat
                        "phoneNumber": "+441234567890"
                      }
                    }]
-                """;
+                """,
+                        HARDCODED_SMS_MFA_ID);
         var expectedResponseAsJson = JsonParser.parseString(expectedResponse).getAsJsonArray();
         assertThat(response, hasJsonBody(expectedResponseAsJson));
     }
@@ -78,9 +83,10 @@ class MfaMethodsRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegrat
 
         assertEquals(200, response.getStatusCode());
         var expectedResponse =
-                """
+                format(
+                        """
                 [{
-                     "mfaIdentifier": 1,
+                     "mfaIdentifier": "%s",
                      "priorityIdentifier": "DEFAULT",
                      "methodVerified": true,
                      "method": {
@@ -88,7 +94,8 @@ class MfaMethodsRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegrat
                        "credential": "some-credential"
                      }
                    }]
-                """;
+                """,
+                        HARDCODED_APP_MFA_ID);
         var expectedResponseAsJson = JsonParser.parseString(expectedResponse).getAsJsonArray();
         assertThat(response, hasJsonBody(expectedResponseAsJson));
     }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -90,7 +90,9 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldCopyMfaDetailsAndReturn204WhenUpdatingEmailIsSuccessful() {
         var internalCommonSubId = setupUserAndRetrieveInternalCommonSubId();
         userStore.addMfaMethod(EXISTING_EMAIL_ADDRESS, AUTH_APP, true, true, "cred");
-        var newStyleSmsData = new SmsMfaData("1234", true, true, PriorityIdentifier.BACKUP, 1);
+        var mfaIdentifier = "03a89933-cddd-471d-8fdb-562f14a2404f";
+        var newStyleSmsData =
+                new SmsMfaData("1234", true, true, PriorityIdentifier.BACKUP, mfaIdentifier);
         userStore.addMfaMethodSupportingMultiple(EXISTING_EMAIL_ADDRESS, newStyleSmsData);
         var otp = redis.generateAndSaveEmailCode(NEW_EMAIL_ADDRESS, 300);
 

--- a/ci/terraform/account-management/openapi_v2.yaml
+++ b/ci/terraform/account-management/openapi_v2.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.1"
 info:
   title: "auth-account-management-method-management-api"
-  version: 0.1.0
+  version: 1.0.1
   description: Auth Account Management API
 paths:
   /authenticate:
@@ -98,7 +98,7 @@ paths:
                 user-with-single-mfa-type-app:
                   summary: a user with a single MFA
                   value:
-                    - mfaIdentifier: 1
+                    - mfaIdentifier: "bb5ccc7d-2591-4ccd-ae04-2b2c95b4e256"
                       priorityIdentifier: BACKUP
                       method:
                         mfaMethodType: AUTH_APP
@@ -107,13 +107,13 @@ paths:
                 user-with-multiple-mfa-types-primary-sms:
                   summary: a user with a default mfa method of SMS, and a backup auth app method
                   value:
-                    - mfaIdentifier: 1
+                    - mfaIdentifier: "78b8b624-d59d-49e8-b321-1a5e0876a244"
                       priorityIdentifier: DEFAULT
                       method:
                         mfaMethodType: SMS
                         phoneNumber: "070"
                       methodVerified: true
-                    - mfaIdentifier: 2
+                    - mfaIdentifier: "4372e333-266c-4245-8c4d-385aafdd3fb3"
                       priorityIdentifier: BACKUP
                       method:
                         mfaMethodType: AUTH_APP
@@ -201,6 +201,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: publicSubjectId
         in: path
         required: true
@@ -269,6 +270,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
         - name: publicSubjectId
           in: path
           required: true
@@ -309,7 +311,8 @@ components:
       type: object
       properties:
         mfaIdentifier:
-          type: integer
+          type: string
+          format: uuid
         priorityIdentifier:
           $ref: "#/components/schemas/PriorityEnum"
         method:

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoMfaMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoMfaMethodsServiceIntegrationTest.java
@@ -16,6 +16,8 @@ import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.shared.services.DynamoMfaMethodsService.HARDCODED_APP_MFA_ID;
+import static uk.gov.di.authentication.shared.services.DynamoMfaMethodsService.HARDCODED_SMS_MFA_ID;
 
 class DynamoMfaMethodsServiceIntegrationTest {
 
@@ -41,7 +43,9 @@ class DynamoMfaMethodsServiceIntegrationTest {
         var result = dynamoService.getMfaMethods(TEST_EMAIL);
 
         var authAppDetail = new SmsMfaDetail(MFAMethodType.SMS, PHONE_NUMBER);
-        var expectedData = new MfaMethodData(1, PriorityIdentifier.DEFAULT, true, authAppDetail);
+        var expectedData =
+                new MfaMethodData(
+                        HARDCODED_SMS_MFA_ID, PriorityIdentifier.DEFAULT, true, authAppDetail);
         assertEquals(result, List.of(expectedData));
     }
 
@@ -52,7 +56,9 @@ class DynamoMfaMethodsServiceIntegrationTest {
         var result = dynamoService.getMfaMethods(TEST_EMAIL);
 
         var authAppDetail = new AuthAppMfaDetail(MFAMethodType.AUTH_APP, AUTH_APP_CREDENTIAL);
-        var expectedData = new MfaMethodData(1, PriorityIdentifier.DEFAULT, true, authAppDetail);
+        var expectedData =
+                new MfaMethodData(
+                        HARDCODED_APP_MFA_ID, PriorityIdentifier.DEFAULT, true, authAppDetail);
         assertEquals(result, List.of(expectedData));
     }
 
@@ -64,7 +70,9 @@ class DynamoMfaMethodsServiceIntegrationTest {
         var result = dynamoService.getMfaMethods(TEST_EMAIL);
 
         var authAppDetail = new AuthAppMfaDetail(MFAMethodType.AUTH_APP, AUTH_APP_CREDENTIAL);
-        var expectedData = new MfaMethodData(1, PriorityIdentifier.DEFAULT, true, authAppDetail);
+        var expectedData =
+                new MfaMethodData(
+                        HARDCODED_APP_MFA_ID, PriorityIdentifier.DEFAULT, true, authAppDetail);
         assertEquals(List.of(expectedData), result);
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -159,15 +159,33 @@ class DynamoServiceIntegrationTest {
         }
 
         private SmsMfaData defaultPrioritySmsData =
-                new SmsMfaData(PHONE_NUMBER, true, true, PriorityIdentifier.DEFAULT, 1);
+                new SmsMfaData(
+                        PHONE_NUMBER,
+                        true,
+                        true,
+                        PriorityIdentifier.DEFAULT,
+                        "04615937-eb48-4a1f-9de2-2ff0a3dc3bc4");
         private SmsMfaData backupPrioritySmsData =
-                new SmsMfaData(PHONE_NUMBER, true, true, PriorityIdentifier.BACKUP, 2);
+                new SmsMfaData(
+                        PHONE_NUMBER,
+                        true,
+                        true,
+                        PriorityIdentifier.BACKUP,
+                        "daa4b59d-4efa-4e97-8b48-e6732c953060");
         private AuthAppMfaData defaultPriorityAuthAppData =
                 new AuthAppMfaData(
-                        TEST_MFA_APP_CREDENTIAL, true, true, PriorityIdentifier.DEFAULT, 3);
+                        TEST_MFA_APP_CREDENTIAL,
+                        true,
+                        true,
+                        PriorityIdentifier.DEFAULT,
+                        "7968d195-7db3-45f6-b7d3-a627aad118b7");
         private AuthAppMfaData backupAuthAppData =
                 new AuthAppMfaData(
-                        TEST_MFA_APP_CREDENTIAL, true, true, PriorityIdentifier.BACKUP, 4);
+                        TEST_MFA_APP_CREDENTIAL,
+                        true,
+                        true,
+                        PriorityIdentifier.BACKUP,
+                        "03a89933-cddd-471d-8fdb-562f14a2404f");
 
         @Test
         void shouldAddDefaultPriorityAuthAppMFAMethodWhenNoOtherMethodExists() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthAppMfaData.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthAppMfaData.java
@@ -5,7 +5,7 @@ public record AuthAppMfaData(
         boolean verified,
         boolean enabled,
         PriorityIdentifier priority,
-        int mfaIdentifier)
+        String mfaIdentifier)
         implements MfaData {
     @Override
     public MFAMethod toDatabaseRecord(String updated) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
@@ -26,7 +26,7 @@ public class MFAMethod {
     private String updated;
     private String destination;
     private String priority;
-    private Integer mfaIdentifier;
+    private String mfaIdentifier;
 
     public MFAMethod() {}
 
@@ -50,7 +50,7 @@ public class MFAMethod {
             boolean enabled,
             String updated,
             PriorityIdentifier priority,
-            int mfaIdentifier) {
+            String mfaIdentifier) {
         this.mfaMethodType = mfaMethodType;
         this.credentialValue = credentialValue;
         this.methodVerified = methodVerified;
@@ -67,7 +67,7 @@ public class MFAMethod {
             String destination,
             String updated,
             PriorityIdentifier priority,
-            int mfaIdentifier) {
+            String mfaIdentifier) {
         this.mfaMethodType = mfaMethodType;
         this.methodVerified = methodVerified;
         this.enabled = enabled;
@@ -178,15 +178,15 @@ public class MFAMethod {
     }
 
     @DynamoDbAttribute(ATTRIBUTE_MFA_IDENTIFIER)
-    public Integer getMfaIdentifier() {
+    public String getMfaIdentifier() {
         return mfaIdentifier;
     }
 
-    public void setMfaIdentifier(Integer mfaIdentifier) {
+    public void setMfaIdentifier(String mfaIdentifier) {
         this.mfaIdentifier = mfaIdentifier;
     }
 
-    public MFAMethod withMfaIdentifier(Integer mfaIdentifier) {
+    public MFAMethod withMfaIdentifier(String mfaIdentifier) {
         this.mfaIdentifier = mfaIdentifier;
         return this;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MfaMethodData.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MfaMethodData.java
@@ -4,12 +4,12 @@ import com.google.gson.annotations.Expose;
 import uk.gov.di.authentication.shared.validation.Required;
 
 public record MfaMethodData(
-        @Expose int mfaIdentifier,
+        @Expose String mfaIdentifier,
         @Expose @Required PriorityIdentifier priorityIdentifier,
         @Expose @Required boolean methodVerified,
         @Expose @Required MfaDetail method) {
     public static MfaMethodData smsMethodData(
-            int mfaIdentifier,
+            String mfaIdentifier,
             PriorityIdentifier priorityIdentifier,
             boolean methodVerified,
             String phoneNumber) {
@@ -21,7 +21,7 @@ public record MfaMethodData(
     }
 
     public static MfaMethodData authAppMfaData(
-            int mfaIdentifier,
+            String mfaIdentifier,
             PriorityIdentifier priorityIdentifier,
             boolean methodVerified,
             String credential) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/SmsMfaData.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/SmsMfaData.java
@@ -5,7 +5,7 @@ public record SmsMfaData(
         boolean verified,
         boolean enabled,
         PriorityIdentifier priority,
-        int mfaIdentifier)
+        String mfaIdentifier)
         implements MfaData {
     @Override
     public MFAMethod toDatabaseRecord(String updated) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoMfaMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoMfaMethodsService.java
@@ -10,6 +10,10 @@ public class DynamoMfaMethodsService implements MfaMethodsService {
 
     private final DynamoService dynamoService;
 
+    // TODO generate and store UUID (AUT-4122)
+    public static final String HARDCODED_APP_MFA_ID = "f2ec40f3-9e63-496c-a0a5-a3bdafee868b";
+    public static final String HARDCODED_SMS_MFA_ID = "35c7940d-be5f-4b31-95b7-0eedc42929b9";
+
     public DynamoMfaMethodsService(ConfigurationService configurationService) {
         this.dynamoService = new DynamoService(configurationService);
     }
@@ -19,19 +23,21 @@ public class DynamoMfaMethodsService implements MfaMethodsService {
         var userProfile = dynamoService.getUserProfileByEmail(email);
         var userCredentials = dynamoService.getUserCredentialsFromEmail(email);
         var enabledAuthAppMethod = getPrimaryMFAMethod(userCredentials);
-        // TODO how to get identifier?
         if (enabledAuthAppMethod.isPresent()) {
             var method = enabledAuthAppMethod.get();
             return List.of(
                     MfaMethodData.authAppMfaData(
-                            1,
+                            HARDCODED_APP_MFA_ID,
                             PriorityIdentifier.DEFAULT,
                             method.isMethodVerified(),
                             method.getCredentialValue()));
         } else if (userProfile.isPhoneNumberVerified()) {
             return List.of(
                     MfaMethodData.smsMethodData(
-                            1, PriorityIdentifier.DEFAULT, true, userProfile.getPhoneNumber()));
+                            HARDCODED_SMS_MFA_ID,
+                            PriorityIdentifier.DEFAULT,
+                            true,
+                            userProfile.getPhoneNumber()));
         } else {
             return List.of();
         }


### PR DESCRIPTION
Update mfa identifier to be a string (UUID).

Currently, on read we return hard-coded UUIDs. As this feature is unused for now, this is a temporary solution while we continue work on method management. This will be updated in a subsequent PR (covered in [AUT-4122](https://govukverify.atlassian.net/browse/AUT-4122))

[AUT-4122]: https://govukverify.atlassian.net/browse/AUT-4122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ