### PR TITLE
ATO-1020: validate response mode if present

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -57,6 +57,7 @@ import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.exceptions.InvalidResponseModeException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
@@ -358,7 +359,7 @@ public class AuthorisationHandler
                 LOG.info("Validating request object");
                 authRequestError = requestObjectAuthorizeValidator.validate(authRequest);
             }
-        } catch (ClientRedirectUriValidationException e) {
+        } catch (ClientRedirectUriValidationException | InvalidResponseModeException e) {
             return generateBadRequestResponse(user, e.getMessage(), client.getClientID());
         } catch (ClientSignatureValidationException e) {
             return generateApiGatewayProxyResponse(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.oidc.validators;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ResponseMode;
 import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
@@ -13,6 +14,7 @@ import uk.gov.di.authentication.oidc.services.IPVCapacityService;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
+import uk.gov.di.orchestration.shared.exceptions.InvalidResponseModeException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
@@ -135,5 +137,16 @@ public abstract class BaseAuthorizeValidator {
         }
 
         return Optional.empty();
+    }
+
+    protected void validateResponseMode(String responseMode) throws InvalidResponseModeException {
+        if (!responseMode.equals(ResponseMode.QUERY.getValue())
+                && !responseMode.equals(ResponseMode.FRAGMENT.getValue())) {
+            var errorMessage =
+                    String.format("Invalid response mode included in request: %s", responseMode);
+
+            logErrorInProdElseWarn(errorMessage);
+            throw new InvalidResponseModeException(errorMessage);
+        }
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -11,6 +11,7 @@ import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
+import uk.gov.di.orchestration.shared.exceptions.InvalidResponseModeException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
@@ -39,7 +40,8 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
     }
 
     @Override
-    public Optional<AuthRequestError> validate(AuthenticationRequest authRequest) {
+    public Optional<AuthRequestError> validate(AuthenticationRequest authRequest)
+            throws InvalidResponseModeException {
 
         var clientId = authRequest.getClientID().toString();
         attachLogFieldToLogs(CLIENT_ID, clientId);
@@ -172,8 +174,9 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
                             state));
         }
 
-        Optional.ofNullable(authRequest.getResponseMode())
-                .ifPresent(mode -> LOG.info("Attached response mode in query params: {}", mode));
+        var responseMode = Optional.ofNullable(authRequest.getResponseMode());
+
+        responseMode.ifPresent(mode -> validateResponseMode(mode.getValue()));
 
         return Optional.empty();
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -226,10 +226,10 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                 return errorResponse(redirectURI, maxAgeError.get(), state);
             }
 
-            var responseMode = jwtClaimsSet.getClaim("response_mode");
+            var responseMode = jwtClaimsSet.getStringClaim("response_mode");
 
             if (Objects.nonNull(responseMode)) {
-                LOG.info("Attached response mode in request object: {}", responseMode);
+                validateResponseMode(responseMode);
             }
 
             LOG.info("RequestObject has passed initial validation");

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/InvalidResponseModeException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/InvalidResponseModeException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.orchestration.shared.exceptions;
+
+public class InvalidResponseModeException extends RuntimeException {
+    public InvalidResponseModeException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
### Wider context of change: 

There is an optional response_mode parameter that can be attached in the `/authorize` request which dictates how we format the response with the RP's redirect_uri.  This value is often confused with response_type and we see RPs accidentally set this field to invalid values in the integration environment. This causes an error at the point at which we try to redirect to the RP and does not provide any useful information as the error is unhandled. 

This PR adds validation in the authorize request that this value is either query or fragment. 

### What’s changed:
- Updates the query params validation and request object validation to explicitly validate this field is query or fragment


### Manual testing:
- Left some logging in over the weekend to validate if this field is being attached, it is not

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required: https://github.com/govuk-one-login/simulator/pull/274

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
