### PR TITLE
Aut 3714: Mfa method management retrieve for migrated users

### DIFF
--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -145,6 +145,10 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
         dynamoService.setAccountVerified(email);
     }
 
+    public void setMfaMethodsMigrated(String email, boolean mfaMethodsMigrated) {
+        dynamoService.setMfaMethodsMigrated(email, mfaMethodsMigrated);
+    }
+
     public List<MFAMethod> getMfaMethod(String email) {
         return dynamoService.getUserCredentialsFromEmail(email).getMfaMethods();
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -74,7 +74,8 @@ public enum ErrorResponse {
     ERROR_1060(1060, "Failed to generate MFA Reset Authorize JAR for IPV"),
     ERROR_1061(1061, "State returned from IPV does not match expected state"),
     ERROR_1062(1062, "Invalid MFAMethod"),
-    ERROR_1063(1063, "New method management api not available in environment");
+    ERROR_1063(1063, "New method management api not available in environment"),
+    ERROR_1064(1064, "Unknown mfa method type");
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -25,6 +25,7 @@ public class UserProfile {
     public static final String ATTRIBUTE_SALT = "salt";
     public static final String ATTRIBUTE_ACCOUNT_VERIFIED = "accountVerified";
     public static final String ATTRIBUTE_TEST_USER = "testUser";
+    public static final String ATTRIBUTE_MFA_METHODS_MIGRATED = "mfaMethodsMigrated";
 
     private String email;
     private String subjectID;
@@ -39,6 +40,7 @@ public class UserProfile {
     private ByteBuffer salt;
     private int accountVerified;
     private int testUser;
+    private boolean mfaMethodsMigrated;
 
     public UserProfile() {}
 
@@ -227,5 +229,19 @@ public class UserProfile {
 
     public void setTestUser(int isTestUser) {
         this.testUser = isTestUser;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_MFA_METHODS_MIGRATED)
+    public boolean getMfaMethodsMigrated() {
+        return mfaMethodsMigrated;
+    }
+
+    public void setMfaMethodsMigrated(boolean mfaMethodsMigrated) {
+        this.mfaMethodsMigrated = mfaMethodsMigrated;
+    }
+
+    public UserProfile withMfaMethodsMigrated(boolean mfaMethodsMigrated) {
+        this.mfaMethodsMigrated = mfaMethodsMigrated;
+        return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnknownMfaTypeException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnknownMfaTypeException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class UnknownMfaTypeException extends RuntimeException {
+    public UnknownMfaTypeException(String message) {
+        super(message);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -78,4 +78,6 @@ public interface AuthenticationService {
     void setAuthAppAndAccountVerified(String email, String credentialValue);
 
     void setVerifiedAuthAppAndRemoveExistingMfaMethod(String email, String credentialValue);
+
+    void setMfaMethodsMigrated(String email, boolean mfaMethodsMigrated);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -563,6 +563,17 @@ public class DynamoService implements AuthenticationService {
                         .withAccountVerified(1));
     }
 
+    @Override
+    public void setMfaMethodsMigrated(String email, boolean mfaMethodsMigrated) {
+        dynamoUserProfileTable.updateItem(
+                dynamoUserProfileTable
+                        .getItem(
+                                Key.builder()
+                                        .partitionValue(email.toLowerCase(Locale.ROOT))
+                                        .build())
+                        .withMfaMethodsMigrated(mfaMethodsMigrated));
+    }
+
     public List<UserProfile> getAllBulkTestUsers() {
         Expression filterExpression =
                 Expression.builder()


### PR DESCRIPTION
## What

Updates the mfa methods dynamo service to handle returning methods for migrated users (those with all their mfa details stored in the user credentials table and the possibility for a backup method).

This necessitated adding a flag to the user profile table to indicate whether or not a user has been migrated yet.

No users will currently be in this migrated state.

## How to review

Code review will be fine, when we've implemented the post endpoint we can round-trip test this.
