### PR TITLE
AUT-3485: Create request and response for Create MFA

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/MfaMethodCreateRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/MfaMethodCreateRequest.java
@@ -1,8 +1,15 @@
 package uk.gov.di.accountmanagement.entity;
 
 import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
-import uk.gov.di.authentication.shared.validation.Required;
+import uk.gov.di.authentication.shared.entity.MfaDetail;
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.serialization.MfaDetailDeserializer;
 
-public record MfaMethodCreateRequest(
-        @Expose @SerializedName("mfaMethod") @Required String mfaMethod) {}
+public record MfaMethodCreateRequest(@Expose @SerializedName("mfaMethod") MfaMethod mfaMethod) {
+    public record MfaMethod(
+            @Expose @SerializedName("priorityIdentifier") PriorityIdentifier priorityIdentifier,
+            @Expose @SerializedName("method") @JsonAdapter(MfaDetailDeserializer.class)
+                    MfaDetail method) {}
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -21,6 +21,7 @@ import java.util.List;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+import static uk.gov.di.authentication.shared.services.DynamoMfaMethodsService.HARDCODED_APP_MFA_ID;
 
 public class MFAMethodsCreateHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -72,7 +73,9 @@ public class MFAMethodsCreateHandler
 
             LOG.info("Update MFA POST called with: {}", mfaMethodCreateRequest.mfaMethod());
             return generateApiGatewayProxyResponse(
-                    200, new MfaMethodData(2, priorityIdentifier, true, mfaMethod), true);
+                    200,
+                    new MfaMethodData(HARDCODED_APP_MFA_ID, priorityIdentifier, true, mfaMethod),
+                    true);
 
         } catch (Json.JsonException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -1,17 +1,21 @@
 package uk.gov.di.accountmanagement.api;
 
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.lambda.MFAMethodsCreateHandler;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.shared.services.DynamoMfaMethodsService.HARDCODED_APP_MFA_ID;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 
 class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -33,32 +37,41 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
         var response =
                 makeRequest(
                         Optional.of(
-                                "{\n"
-                                        + "\"mfaMethod\": {\n"
-                                        + "\"priorityIdentifier\": \"BACKUP\",\n"
-                                        + "\"method\": {\n"
-                                        + "\"mfaMethodType\": \"AUTH_APP\",\n"
-                                        + "\"credential\": \"AAAABBBBCCCCCDDDDD55551111EEEE2222FFFF3333GGGG4444\"\n"
-                                        + "}\n"
-                                        + "}\n"
-                                        + "}"),
+                                format(
+                                        """
+                                        { "mfaMethod": {
+                                            "priorityIdentifier": "BACKUP",
+                                            "method": {
+                                                "mfaMethodType": "%s",
+                                                "credential": "%s" }
+                                            }
+                                        }
+                                       """,
+                                        MFAMethodType.AUTH_APP.getValue(), TEST_CREDENTIAL)),
                         Collections.emptyMap(),
                         Collections.emptyMap(),
                         Map.of("publicSubjectId", TEST_PUBLIC_SUBJECT),
                         Collections.emptyMap());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(
-                "{"
-                        + "\"mfaIdentifier\":2,"
-                        + "\"priorityIdentifier\":\"BACKUP\","
-                        + "\"methodVerified\":true,"
-                        + "\"method\":{"
-                        + "\"mfaMethodType\":\"AUTH_APP\","
-                        + "\"credential\":\"AAAABBBBCCCCCDDDDD55551111EEEE2222FFFF3333GGGG4444\""
-                        + "}"
-                        + "}",
-                response.getBody());
+        var expectedResponse =
+                format(
+                        """
+                {
+                  "mfaIdentifier": "%s",
+                  "priorityIdentifier": "BACKUP",
+                  "methodVerified": true,
+                  "method": {
+                    "mfaMethodType": "AUTH_APP",
+                    "credential": "%s"
+                  }
+                }
+                """,
+                        HARDCODED_APP_MFA_ID, TEST_CREDENTIAL);
+        var expectedResponseParsedToString =
+                JsonParser.parseString(expectedResponse).getAsJsonObject().toString();
+
+        assertEquals(expectedResponseParsedToString, response.getBody());
     }
 
     @Test
@@ -66,15 +79,17 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
         var response =
                 makeRequest(
                         Optional.of(
-                                "{\n"
-                                        + "\"mfaMethod\": {\n"
-                                        + "\"priorityIdentifier\": \"BACKUP\",\n"
-                                        + "\"method\": {\n"
-                                        + "\"mfaMethodType\": \"AUTH_APP\",\n"
-                                        + "\"credential\": \"AAAABBBBCCCCCDDDDD55551111EEEE2222FFFF3333GGGG4444\"\n"
-                                        + "}\n"
-                                        + "}\n"
-                                        + "}"),
+                                format(
+                                        """
+                                        { "mfaMethod": {
+                                            "priorityIdentifier": "BACKUP",
+                                            "method": {
+                                                "mfaMethodType": "%s",
+                                                "credential": "%s" }
+                                            }
+                                        }
+                                       """,
+                                        MFAMethodType.AUTH_APP.getValue(), TEST_CREDENTIAL)),
                         Collections.emptyMap(),
                         Collections.emptyMap(),
                         Collections.emptyMap(),

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -15,34 +15,69 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 
 class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+    private static final String TEST_EMAIL = "test@email.com";
+    private static final String TEST_PASSWORD = "test-password";
+    private static final String TEST_CREDENTIAL = "ZZ11BB22CC33DD44EE55FF66GG77HH88II99JJ00";
+    private static String TEST_PUBLIC_SUBJECT;
 
     @BeforeEach
     void setUp() {
         handler = new MFAMethodsCreateHandler(TEST_CONFIGURATION_SERVICE);
+        userStore.signUp(TEST_EMAIL, TEST_PASSWORD);
+        TEST_PUBLIC_SUBJECT =
+                userStore.getUserProfileFromEmail(TEST_EMAIL).get().getPublicSubjectID();
     }
 
     @Test
-    void shouldReturn200AndHelloWorld() {
+    void shouldReturn200AndMfaMethodData() {
         var response =
                 makeRequest(
-                        Optional.of("{\"mfaMethod\": \"Hello World\"}"),
+                        Optional.of(
+                                "{\n"
+                                        + "\"mfaMethod\": {\n"
+                                        + "\"priorityIdentifier\": \"BACKUP\",\n"
+                                        + "\"method\": {\n"
+                                        + "\"mfaMethodType\": \"AUTH_APP\",\n"
+                                        + "\"credential\": \"AAAABBBBCCCCCDDDDD55551111EEEE2222FFFF3333GGGG4444\"\n"
+                                        + "}\n"
+                                        + "}\n"
+                                        + "}"),
                         Collections.emptyMap(),
                         Collections.emptyMap(),
-                        Map.of("publicSubjectId", "helloPath"),
+                        Map.of("publicSubjectId", TEST_PUBLIC_SUBJECT),
                         Collections.emptyMap());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals("{\"mfaMethod\": \"Hello World\"}", response.getBody());
+        assertEquals(
+                "{"
+                        + "\"mfaIdentifier\":2,"
+                        + "\"priorityIdentifier\":\"BACKUP\","
+                        + "\"methodVerified\":true,"
+                        + "\"method\":{"
+                        + "\"mfaMethodType\":\"AUTH_APP\","
+                        + "\"credential\":\"AAAABBBBCCCCCDDDDD55551111EEEE2222FFFF3333GGGG4444\""
+                        + "}"
+                        + "}",
+                response.getBody());
     }
 
     @Test
-    void shouldReturn400AndBadRequestWhenPathParameterIsWrong() {
+    void shouldReturn400AndBadRequestWhenPathParameterIsNotPresent() {
         var response =
                 makeRequest(
-                        Optional.of("{\"mfaMethod\": \"Hello World\"}"),
+                        Optional.of(
+                                "{\n"
+                                        + "\"mfaMethod\": {\n"
+                                        + "\"priorityIdentifier\": \"BACKUP\",\n"
+                                        + "\"method\": {\n"
+                                        + "\"mfaMethodType\": \"AUTH_APP\",\n"
+                                        + "\"credential\": \"AAAABBBBCCCCCDDDDD55551111EEEE2222FFFF3333GGGG4444\"\n"
+                                        + "}\n"
+                                        + "}\n"
+                                        + "}"),
                         Collections.emptyMap(),
                         Collections.emptyMap(),
-                        Map.of("publicSubjectId", "wrongPath"),
+                        Collections.emptyMap(),
                         Collections.emptyMap());
 
         assertEquals(400, response.getStatusCode());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/serialization/MfaDetailDeserializer.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/serialization/MfaDetailDeserializer.java
@@ -1,0 +1,33 @@
+package uk.gov.di.authentication.shared.serialization;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import uk.gov.di.authentication.shared.entity.AuthAppMfaDetail;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.MfaDetail;
+import uk.gov.di.authentication.shared.entity.SmsMfaDetail;
+
+import java.lang.reflect.Type;
+
+public class MfaDetailDeserializer implements JsonDeserializer<MfaDetail> {
+    @Override
+    public MfaDetail deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        JsonObject jsonObject = json.getAsJsonObject();
+        String type = jsonObject.get("mfaMethodType").getAsString();
+
+        if (MFAMethodType.SMS.getValue().equalsIgnoreCase(type)) {
+            SmsMfaDetail smsDetail = context.deserialize(jsonObject, SmsMfaDetail.class);
+            return new SmsMfaDetail(MFAMethodType.SMS, smsDetail.phoneNumber());
+        } else if (MFAMethodType.AUTH_APP.getValue().equalsIgnoreCase(type)) {
+            AuthAppMfaDetail authAppDetail =
+                    context.deserialize(jsonObject, AuthAppMfaDetail.class);
+            return new AuthAppMfaDetail(MFAMethodType.AUTH_APP, authAppDetail.credential());
+        } else {
+            throw new JsonParseException("Unknown mfa detail type: " + type);
+        }
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/serialization/MfaDetailDeserializerTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/serialization/MfaDetailDeserializerTest.java
@@ -1,0 +1,41 @@
+package uk.gov.di.authentication.shared.serialization;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.AuthAppMfaDetail;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.MfaDetail;
+import uk.gov.di.authentication.shared.entity.SmsMfaDetail;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class MfaDetailDeserializerTest {
+
+    @Test
+    void shouldDeserializeSmsMfaDetail() {
+        String json = "{\"mfaMethodType\": \"SMS\", \"phoneNumber\": \"+447700900123\"}";
+        Gson gson =
+                new GsonBuilder()
+                        .registerTypeAdapter(MfaDetail.class, new MfaDetailDeserializer())
+                        .create();
+        MfaDetail mfaDetail = gson.fromJson(json, MfaDetail.class);
+        assertInstanceOf(SmsMfaDetail.class, mfaDetail);
+        assertEquals(MFAMethodType.SMS, ((SmsMfaDetail) mfaDetail).mfaMethodType());
+        assertEquals("+447700900123", ((SmsMfaDetail) mfaDetail).phoneNumber());
+    }
+
+    @Test
+    void shouldDeserializeAuthAppMfaDetail() {
+        String json = "{\"mfaMethodType\": \"AUTH_APP\", \"credential\": \"123456\"}";
+        Gson gson =
+                new GsonBuilder()
+                        .registerTypeAdapter(MfaDetail.class, new MfaDetailDeserializer())
+                        .create();
+        MfaDetail mfaDetail = gson.fromJson(json, MfaDetail.class);
+        assertInstanceOf(AuthAppMfaDetail.class, mfaDetail);
+        assertEquals(MFAMethodType.AUTH_APP, ((AuthAppMfaDetail) mfaDetail).mfaMethodType());
+        assertEquals("123456", ((AuthAppMfaDetail) mfaDetail).credential());
+    }
+}


### PR DESCRIPTION
## What

- Created MfaMethodCreateRequest object
-- Added deserializer to know which MFADetail implementation to use when reading json
- Return already existing MfaMethodData response object

## How to review

1. Code Review


## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
