### PR TITLE
ATO-1102: Make max_age_enabled a boxed boolean

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
@@ -85,7 +85,7 @@ public class UpdateClientConfigRequest {
 
     @SerializedName("max_age_enabled")
     @Expose
-    private boolean maxAgeEnabled;
+    private Boolean maxAgeEnabled;
 
     public UpdateClientConfigRequest() {}
 
@@ -165,7 +165,7 @@ public class UpdateClientConfigRequest {
         return channel;
     }
 
-    public boolean getMaxAgeEnabled() {
+    public Boolean getMaxAgeEnabled() {
         return maxAgeEnabled;
     }
 


### PR DESCRIPTION
### Wider context of change:

As part of the max age initiative we added this parameter to the client registry API, so that the SSE tool could eventually control the update of this field for clients in integration. However the current implementation is overwriting the configured value to false on any update.

### What’s changed:

- Makes the max age field on an update request a boxed boolean to stop defaulting to false.

### Manual testing:

- Code review commit
- Have added a new integration test to assert this

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [X] Lambdas have correct permissions for the resources they're accessing. 

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [X] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [X] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [X] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [X] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [X] Successfully run Authentication acceptance tests against sandpit or not required.
