### PR TITLE
ATO-1521: Make jar Validation a boxed boolean

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
@@ -49,7 +49,7 @@ public class UpdateClientConfigRequest {
 
     @SerializedName("jar_validation_required")
     @Expose
-    private boolean jarValidationRequired;
+    private Boolean jarValidationRequired;
 
     @SerializedName("claims")
     @Expose
@@ -129,7 +129,7 @@ public class UpdateClientConfigRequest {
         return serviceType;
     }
 
-    public boolean getJarValidationRequired() {
+    public Boolean getJarValidationRequired() {
         return jarValidationRequired;
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/UpdateClientConfigRequest.java
@@ -157,7 +157,7 @@ public class UpdateClientConfigRequest {
         return idTokenSigningAlgorithm;
     }
 
-    public Boolean getidentityVerificationSupported() {
+    public Boolean getIdentityVerificationSupported() {
         return identityVerificationSupported;
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
@@ -136,7 +136,7 @@ public class DynamoClientService implements ClientService {
                 .ifPresent(clientRegistry::withClientType);
         Optional.ofNullable(updateRequest.getSectorIdentifierUri())
                 .ifPresent(clientRegistry::withSectorIdentifierUri);
-        Optional.of(updateRequest.getJarValidationRequired())
+        Optional.ofNullable(updateRequest.getJarValidationRequired())
                 .ifPresent(clientRegistry::withJarValidationRequired);
         Optional.ofNullable(updateRequest.getClaims()).ifPresent(clientRegistry::withClaims);
         Optional.ofNullable(updateRequest.getClientLoCs())

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
@@ -145,7 +145,7 @@ public class DynamoClientService implements ClientService {
                 .ifPresent(clientRegistry::withBackChannelLogoutUri);
         Optional.ofNullable(updateRequest.getIdTokenSigningAlgorithm())
                 .ifPresent(clientRegistry::withIdTokenSigningAlgorithm);
-        Optional.ofNullable(updateRequest.getidentityVerificationSupported())
+        Optional.ofNullable(updateRequest.getIdentityVerificationSupported())
                 .ifPresent(clientRegistry::withIdentityVerificationSupported);
         Optional.ofNullable(updateRequest.getChannel()).ifPresent(clientRegistry::withChannel);
         Optional.ofNullable(updateRequest.getMaxAgeEnabled())


### PR DESCRIPTION
### Wider context of change:

- When updating the client registry this field would always default to false, so it would  always disable it


### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
