### PR TITLE
Bau: move method management feature flag to terraform

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
@@ -16,7 +16,6 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.MfaMethodsService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
-import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
@@ -30,9 +29,6 @@ public class MFAMethodsRetrieveHandler
     private final ConfigurationService configurationService;
     private final DynamoService dynamoService;
     private final MfaMethodsService mfaMethodsService;
-
-    private static final String PRODUCTION = "production";
-    private static final String INTEGRATION = "integration";
 
     private static final Logger LOG = LogManager.getLogger(MFAMethodsRetrieveHandler.class);
 
@@ -69,8 +65,7 @@ public class MFAMethodsRetrieveHandler
 
         addSessionIdToLogs(input);
 
-        var disabledEnvironments = List.of(PRODUCTION, INTEGRATION);
-        if (disabledEnvironments.contains(configurationService.getEnvironment())) {
+        if (!configurationService.isMfaMethodManagementApiEnabled()) {
             LOG.error(
                     "Request to create MFA method in {} environment but feature is switched off.",
                     configurationService.getEnvironment());

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -6,8 +6,6 @@ import com.google.gson.JsonParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
@@ -48,7 +46,7 @@ class MFAMethodsCreateHandlerTest {
 
     @BeforeEach
     void setUp() {
-        when(configurationService.getEnvironment()).thenReturn("test");
+        when(configurationService.isMfaMethodManagementApiEnabled()).thenReturn(true);
         handler = new MFAMethodsCreateHandler(configurationService);
         when(configurationService.getAwsRegion()).thenReturn("eu-west-2");
     }
@@ -81,10 +79,9 @@ class MFAMethodsCreateHandlerTest {
         assertEquals(expectedResponseParsedToString, result.getBody());
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"production", "integration"})
-    void shouldReturn400IfRequestIsMadeInProductionOrIntegration(String environment) {
-        when(configurationService.getEnvironment()).thenReturn(environment);
+    @Test
+    void shouldReturn400IfRequestIsMadeInEnvWhereApiNotEnabled() {
+        when(configurationService.isMfaMethodManagementApiEnabled()).thenReturn(false);
         handler = new MFAMethodsCreateHandler(configurationService);
 
         var event =

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.lambda.MFAMethodsCreateHandler;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.util.Collections;
@@ -26,7 +27,15 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     @BeforeEach
     void setUp() {
-        handler = new MFAMethodsCreateHandler(TEST_CONFIGURATION_SERVICE);
+        ConfigurationService mfaMethodEnabledConfigurationService =
+                new ConfigurationService() {
+                    @Override
+                    public boolean isMfaMethodManagementApiEnabled() {
+                        return true;
+                    }
+                };
+
+        handler = new MFAMethodsCreateHandler(mfaMethodEnabledConfigurationService);
         userStore.signUp(TEST_EMAIL, TEST_PASSWORD);
         TEST_PUBLIC_SUBJECT =
                 userStore.getUserProfileFromEmail(TEST_EMAIL).get().getPublicSubjectID();

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MfaMethodsRetrieveHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MfaMethodsRetrieveHandlerIntegrationTest.java
@@ -10,6 +10,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.SmsMfaData;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 
@@ -35,7 +36,14 @@ class MfaMethodsRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegrat
 
     @BeforeEach
     void setUp() {
-        handler = new MFAMethodsRetrieveHandler(TEST_CONFIGURATION_SERVICE);
+        ConfigurationService mfaMethodEnabledConfigurationService =
+                new ConfigurationService() {
+                    @Override
+                    public boolean isMfaMethodManagementApiEnabled() {
+                        return true;
+                    }
+                };
+        handler = new MFAMethodsRetrieveHandler(mfaMethodEnabledConfigurationService);
     }
 
     @Test

--- a/ci/terraform/account-management/authdev1.tfvars
+++ b/ci/terraform/account-management/authdev1.tfvars
@@ -1,5 +1,6 @@
-common_state_bucket = "di-auth-development-tfstate"
-vpc_environment     = "dev"
+common_state_bucket               = "di-auth-development-tfstate"
+vpc_environment                   = "dev"
+mfa_method_management_api_enabled = true
 
 # App-specific
 openapi_spec_filename = "openapi_v2.yaml"

--- a/ci/terraform/account-management/authdev2.tfvars
+++ b/ci/terraform/account-management/authdev2.tfvars
@@ -1,5 +1,8 @@
 common_state_bucket = "di-auth-development-tfstate"
 vpc_environment     = "dev"
 
+# Feature flags
+mfa_method_management_api_enabled = true
+
 # App-specific
 openapi_spec_filename = "openapi_v2.yaml"

--- a/ci/terraform/account-management/build.tfvars
+++ b/ci/terraform/account-management/build.tfvars
@@ -10,3 +10,6 @@ logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_c
 # Sizing
 redis_node_size        = "cache.t2.small"
 lambda_min_concurrency = 1
+
+# Feature flags
+mfa_method_management_api_enabled = true

--- a/ci/terraform/account-management/dev.tfvars
+++ b/ci/terraform/account-management/dev.tfvars
@@ -15,3 +15,6 @@ openapi_spec_filename = "openapi_v2.yaml"
 # Sizing
 redis_node_size        = "cache.t2.small"
 lambda_min_concurrency = 1
+
+# Feature flags
+mfa_method_management_api_enabled = true

--- a/ci/terraform/account-management/integration.tfvars
+++ b/ci/terraform/account-management/integration.tfvars
@@ -13,3 +13,6 @@ lambda_min_concurrency = 1
 
 # App-specific
 openapi_spec_filename = "openapi_v2.yaml"
+
+# Feature flags
+mfa_method_management_api_enabled = false

--- a/ci/terraform/account-management/mfa-methods-create.tf
+++ b/ci/terraform/account-management/mfa-methods-create.tf
@@ -18,10 +18,11 @@ module "mfa-methods-create" {
 
   endpoint_name = "mfa-methods-create"
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    REDIS_KEY            = local.redis_key
-    TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    ENVIRONMENT                       = var.environment
+    REDIS_KEY                         = local.redis_key
+    TXMA_AUDIT_QUEUE_URL              = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI               = var.internal_sector_uri
+    MFA_METHOD_MANAGEMENT_API_ENABLED = var.mfa_method_management_api_enabled
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.MFAMethodsCreateHandler::handleRequest"
 

--- a/ci/terraform/account-management/mfa-methods-retrieve.tf
+++ b/ci/terraform/account-management/mfa-methods-retrieve.tf
@@ -17,10 +17,11 @@ module "mfa-methods-retrieve" {
 
   endpoint_name = "mfa-methods-retrieve"
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    REDIS_KEY            = local.redis_key
-    TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    ENVIRONMENT                       = var.environment
+    REDIS_KEY                         = local.redis_key
+    TXMA_AUDIT_QUEUE_URL              = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI               = var.internal_sector_uri
+    MFA_METHOD_MANAGEMENT_API_ENABLED = var.mfa_method_management_api_enabled
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.MFAMethodsRetrieveHandler::handleRequest"
 

--- a/ci/terraform/account-management/production.tfvars
+++ b/ci/terraform/account-management/production.tfvars
@@ -32,3 +32,6 @@ performance_tuning = {
 
 lambda_max_concurrency = 10
 lambda_min_concurrency = 3
+
+# Feature flags
+mfa_method_management_api_enabled = false

--- a/ci/terraform/account-management/sandpit.tfvars
+++ b/ci/terraform/account-management/sandpit.tfvars
@@ -6,6 +6,7 @@ otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
 
 # Feature Flags
-support_email_check_enabled = true
+support_email_check_enabled       = true
+mfa_method_management_api_enabled = true
 
 openapi_spec_filename = "openapi_v2.yaml"

--- a/ci/terraform/account-management/staging.tfvars
+++ b/ci/terraform/account-management/staging.tfvars
@@ -27,3 +27,6 @@ performance_tuning = {
 
 lambda_min_concurrency = 1
 lambda_max_concurrency = 3
+
+# Feature flags
+mfa_method_management_api_enabled = true

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -202,3 +202,9 @@ variable "vpc_environment" {
   type        = string
   default     = null
 }
+
+variable "mfa_method_management_api_enabled" {
+  description = "Feature flag for the method management api, enabling us to manage multiple mfa methods for a user"
+  type        = bool
+  default     = false
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -686,4 +686,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     public String getIPVAuthorisationClientId() {
         return System.getenv().getOrDefault("IPV_AUTHORISATION_CLIENT_ID", "");
     }
+
+    public boolean isMfaMethodManagementApiEnabled() {
+        return System.getenv()
+                .getOrDefault("MFA_METHOD_MANAGEMENT_API_ENABLED", String.valueOf(false))
+                .equals(FEATURE_SWITCH_ON);
+    }
 }


### PR DESCRIPTION
## What

Introduce terraform feature flags for the new mfa method management api endpoints. This replaces logic to look up the environment and disable based on that, and brings us more in line with how we do feature flags elsewhere.

The switch is off in integration and production.

## How to review

1. Code review
1. If you like, you can also deploy to an env toggling the relevant tf var for that environment on / off, and test that api via api gateway. You should immediately get a 400 for either the get or post endpoint (no need to construct a body) when the flag is off, and a relevant response when the flag is on. I've already done this bit of testing so up to you if you'd also like to see.
