### PR TITLE
AUT-2910: Send `password_reset` to TICF CRI API

### DIFF
--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -13,7 +13,8 @@ module "frontend_api_reset_password_request_role" {
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
-    aws_iam_policy.dynamo_auth_session_read_policy.arn
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
+    aws_iam_policy.dynamo_auth_session_write_policy.arn
   ]
   extra_tags = {
     Service = "reset-password-request"

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -19,7 +19,8 @@ module "frontend_api_reset_password_role" {
     local.client_registry_encryption_policy_arn,
     local.common_passwords_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
-    aws_iam_policy.dynamo_auth_session_read_policy.arn
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
+    aws_iam_policy.dynamo_auth_session_write_policy.arn
   ]
   extra_tags = {
     Service = "reset-password"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -192,11 +192,13 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
 
             if (configurationService.isInvokeTicfCRILambdaEnabled()
                     && request.authenticated() != null) {
+                AuthSessionItem authSession = userContext.getAuthSession();
                 sendTICF(
                         userContext,
                         internalPairwiseId,
                         request.authenticated(),
-                        userContext.getAuthSession().getIsNewAccount());
+                        authSession.getIsNewAccount(),
+                        authSession.getResetPasswordState());
             }
 
             LOG.info("Generating Account Interventions outbound response for frontend");
@@ -214,7 +216,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             UserContext userContext,
             String internalPairwiseId,
             boolean authenticated,
-            AuthSessionItem.AccountState accountState) {
+            AuthSessionItem.AccountState accountState,
+            AuthSessionItem.ResetPasswordState resetPasswordState) {
         var vtr = new ArrayList<String>();
 
         try {
@@ -235,7 +238,12 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
 
         var ticfRequest =
                 TICFCRIRequest.basicTicfCriRequest(
-                        internalPairwiseId, vtr, journeyId, authenticated, accountState);
+                        internalPairwiseId,
+                        vtr,
+                        journeyId,
+                        authenticated,
+                        accountState,
+                        resetPasswordState);
 
         String payload;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -11,6 +11,7 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ResetPasswordCompletionRequest;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
@@ -168,6 +169,11 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             var userProfile =
                     authenticationService.getUserProfileByEmail(
                             userContext.getSession().getEmailAddress());
+
+            authSessionService.updateSession(
+                    userContext
+                            .getAuthSession()
+                            .withResetPasswordState(AuthSessionItem.ResetPasswordState.SUCCEEDED));
 
             LOG.info("Calculating internal common subject identifier");
             var internalCommonSubjectId =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.frontendapi.entity.PasswordResetType;
 import uk.gov.di.authentication.frontendapi.entity.ResetPasswordRequest;
 import uk.gov.di.authentication.frontendapi.entity.ResetPasswordRequestHandlerResponse;
 import uk.gov.di.authentication.frontendapi.exceptions.SerializationException;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
@@ -161,6 +162,11 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                 return generateApiGatewayProxyErrorResponse(
                         400, userIsNewlyLockedOutOfPasswordReset.get());
             }
+
+            authSessionService.updateSession(
+                    userContext
+                            .getAuthSession()
+                            .withResetPasswordState(AuthSessionItem.ResetPasswordState.ATTEMPTED));
 
             return processPasswordResetRequest(request, userContext, isTestClient);
         } catch (SdkClientException ex) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -74,6 +74,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -375,6 +376,23 @@ class ResetPasswordRequestHandlerTest {
                             auditContext.withTxmaAuditEncoded(Optional.empty()),
                             PASSWORD_RESET_COUNTER,
                             PASSWORD_RESET_TYPE_FORGOTTEN_PASSWORD);
+        }
+
+        @Test
+        void shouldRecordPasswordResetAttemptInSession() {
+            usingValidSession();
+            usingValidClientSession();
+
+            handler.handleRequest(validEvent, context);
+
+            verify(authSessionService, times(1))
+                    .updateSession(
+                            argThat(
+                                    state ->
+                                            state.getResetPasswordState()
+                                                    .equals(
+                                                            AuthSessionItem.ResetPasswordState
+                                                                    .ATTEMPTED)));
         }
 
         @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
@@ -201,6 +201,8 @@ class TicfCriHandlerTest {
         return List.of(
                 Arguments.of(false, AuthSessionItem.ResetPasswordState.NONE, false),
                 Arguments.of(true, AuthSessionItem.ResetPasswordState.NONE, false),
+                Arguments.of(false, AuthSessionItem.ResetPasswordState.ATTEMPTED, true),
+                Arguments.of(true, AuthSessionItem.ResetPasswordState.ATTEMPTED, false),
                 Arguments.of(true, AuthSessionItem.ResetPasswordState.SUCCEEDED, true));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
@@ -56,6 +56,8 @@ class TicfCriHandlerTest {
 
     private static final AuthSessionItem.AccountState EXISTING_ACCOUNT_STATE =
             AuthSessionItem.AccountState.EXISTING;
+    private static final AuthSessionItem.ResetPasswordState NA_RESET_PASSWORD_STATE =
+            AuthSessionItem.ResetPasswordState.NONE;
     private static final String SERVICE_URI = "http://www.example.com";
     private static final String COMMON_SUBJECTID = "a-subject-id";
     private static final String JOURNEY_ID = "journey-id";
@@ -92,7 +94,8 @@ class TicfCriHandlerTest {
                         VECTORS_OF_TRUST,
                         JOURNEY_ID,
                         userIsAuthenticated,
-                        EXISTING_ACCOUNT_STATE);
+                        EXISTING_ACCOUNT_STATE,
+                        NA_RESET_PASSWORD_STATE);
         var expectedRequestBody =
                 format(
                         "{\"sub\":\"%s\",\"vtr\":%s,\"govuk_signin_journey_id\":\"%s\",\"authenticated\":\"%s\"}",
@@ -118,7 +121,8 @@ class TicfCriHandlerTest {
 
     @ParameterizedTest
     @EnumSource(AuthSessionItem.AccountState.class)
-    void shouldMakeTheCorrectCallToTheTicfCri(AuthSessionItem.AccountState accountState)
+    void shouldMakeTheCorrectCallToTheTicfCriForInitialRegistration(
+            AuthSessionItem.AccountState accountState)
             throws IOException, InterruptedException, ExecutionException {
         var ticfRequest =
                 basicTicfCriRequest(
@@ -126,7 +130,8 @@ class TicfCriHandlerTest {
                         VECTORS_OF_TRUST,
                         JOURNEY_ID,
                         USER_IS_AUTHENTICATED,
-                        accountState);
+                        accountState,
+                        NA_RESET_PASSWORD_STATE);
         var expectedRequestBody =
                 format(
                         "{\"sub\":\"%s\",\"vtr\":%s,\"govuk_signin_journey_id\":\"%s\",\"authenticated\":\"%s\"%s}",
@@ -154,6 +159,52 @@ class TicfCriHandlerTest {
     }
 
     @ParameterizedTest
+    @MethodSource("resetPassword")
+    void shouldMakeTheCorrectCallToTheTicfCriForResetPassword(
+            boolean authenticated,
+            AuthSessionItem.ResetPasswordState resetPasswordState,
+            boolean expectPasswordReset)
+            throws IOException, InterruptedException, ExecutionException {
+        var ticfRequest =
+                basicTicfCriRequest(
+                        COMMON_SUBJECTID,
+                        VECTORS_OF_TRUST,
+                        JOURNEY_ID,
+                        authenticated,
+                        EXISTING_ACCOUNT_STATE,
+                        resetPasswordState);
+        var expectedRequestBody =
+                format(
+                        "{\"sub\":\"%s\",\"vtr\":%s,\"govuk_signin_journey_id\":\"%s\",\"authenticated\":\"%s\"%s}",
+                        COMMON_SUBJECTID,
+                        jsonArrayFrom(VECTORS_OF_TRUST),
+                        JOURNEY_ID,
+                        authenticated ? "Y" : "N",
+                        expectPasswordReset ? ",\"password_reset\":\"Y\"" : "");
+
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        handler.handleRequest(ticfRequest, context);
+
+        var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(httpRequestCaptor.capture(), ArgumentMatchers.any());
+
+        var actualRequestBody =
+                bodyPublisherToString(httpRequestCaptor.getValue().bodyPublisher().get());
+
+        var expectedUri = URI.create(SERVICE_URI + "/auth");
+        assertEquals(expectedUri, httpRequestCaptor.getValue().uri());
+        assertEquals(expectedRequestBody, actualRequestBody);
+    }
+
+    private static List<Arguments> resetPassword() {
+        return List.of(
+                Arguments.of(false, AuthSessionItem.ResetPasswordState.NONE, false),
+                Arguments.of(true, AuthSessionItem.ResetPasswordState.NONE, false),
+                Arguments.of(true, AuthSessionItem.ResetPasswordState.SUCCEEDED, true));
+    }
+
+    @ParameterizedTest
     @MethodSource("statusCodes")
     void sendsMetricsAndLogsBasedOnTheHttpStatusCode(Integer statusCode, Level expectedLogLevel)
             throws IOException, InterruptedException {
@@ -163,7 +214,8 @@ class TicfCriHandlerTest {
                         VECTORS_OF_TRUST,
                         JOURNEY_ID,
                         USER_IS_AUTHENTICATED,
-                        EXISTING_ACCOUNT_STATE);
+                        EXISTING_ACCOUNT_STATE,
+                        NA_RESET_PASSWORD_STATE);
         when(httpResponse.statusCode()).thenReturn(statusCode);
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
 
@@ -204,7 +256,8 @@ class TicfCriHandlerTest {
                         VECTORS_OF_TRUST,
                         JOURNEY_ID,
                         USER_IS_AUTHENTICATED,
-                        EXISTING_ACCOUNT_STATE),
+                        EXISTING_ACCOUNT_STATE,
+                        NA_RESET_PASSWORD_STATE),
                 context);
 
         verify(cloudwatchMetricsService).incrementCounter(metricName, METRICS_CONTEXT);

--- a/shared/src/main/java/uk/gov/di/authentication/entity/TICFCRIRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/TICFCRIRequest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.entity;
 
 import com.google.gson.annotations.Expose;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem.ResetPasswordState;
 import uk.gov.di.authentication.shared.validation.Required;
 
 import java.util.List;
@@ -19,13 +20,14 @@ public record TICFCRIRequest(
             List<String> vtr,
             String journeyId,
             boolean authenticated,
-            AuthSessionItem.AccountState accountState) {
+            AuthSessionItem.AccountState accountState,
+            ResetPasswordState resetPasswordState) {
         return new TICFCRIRequest(
                 internalPairwiseId,
                 vtr,
                 journeyId,
                 authenticated ? "Y" : "N",
                 accountState == AuthSessionItem.AccountState.NEW ? "Y" : null,
-                null);
+                resetPasswordState.equals(ResetPasswordState.SUCCEEDED) ? "Y" : null);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/entity/TICFCRIRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/TICFCRIRequest.java
@@ -22,12 +22,17 @@ public record TICFCRIRequest(
             boolean authenticated,
             AuthSessionItem.AccountState accountState,
             ResetPasswordState resetPasswordState) {
+        boolean passwordResetSuccess = resetPasswordState.equals(ResetPasswordState.SUCCEEDED);
+        boolean reportablePasswordAttempted =
+                (!authenticated && resetPasswordState.equals(ResetPasswordState.ATTEMPTED));
+        boolean passwordReset = passwordResetSuccess || reportablePasswordAttempted;
+
         return new TICFCRIRequest(
                 internalPairwiseId,
                 vtr,
                 journeyId,
                 authenticated ? "Y" : "N",
                 accountState == AuthSessionItem.AccountState.NEW ? "Y" : null,
-                resetPasswordState.equals(ResetPasswordState.SUCCEEDED) ? "Y" : null);
+                passwordReset ? "Y" : null);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -26,6 +26,7 @@ public class AuthSessionItem {
 
     public enum ResetPasswordState {
         NONE,
+        ATTEMPTED,
         SUCCEEDED,
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -169,4 +169,26 @@ public class AuthSessionItem {
         this.emailAddress = emailAddress;
         return this;
     }
+
+    /**
+     * Return a string representation of the instance that is safe to record in logs (e.g. does not
+     * contain PII)
+     */
+    public String toLogSafeString() {
+        return "AuthSessionItem{sessionId = '"
+                + sessionId
+                + "', verifiedMfaMethodType = '"
+                + verifiedMfaMethodType
+                + "', timeToLive = '"
+                + timeToLive
+                + "', isNewAccount = '"
+                + isNewAccount
+                + "', resetPasswordState = '"
+                + resetPasswordState
+                + "', internalCommonSubjectId = '"
+                + internalCommonSubjectId
+                + "', upliftRequired = '"
+                + upliftRequired
+                + "'}}";
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -9,6 +9,7 @@ public class AuthSessionItem {
 
     public static final String ATTRIBUTE_SESSION_ID = "SessionId";
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "isNewAccount";
+    public static final String ATTRIBUTE_RESET_PASSWORD_STATE = "resetPasswordState";
     public static final String ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH = "currentCredentialStrength";
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
@@ -23,10 +24,16 @@ public class AuthSessionItem {
         UNKNOWN
     }
 
+    public enum ResetPasswordState {
+        NONE,
+        SUCCEEDED,
+    }
+
     private String sessionId;
     private String verifiedMfaMethodType;
     private long timeToLive;
     private AccountState isNewAccount;
+    private ResetPasswordState resetPasswordState = ResetPasswordState.NONE;
     private CredentialTrustLevel currentCredentialStrength;
     private String internalCommonSubjectId;
     private boolean upliftRequired;
@@ -102,6 +109,20 @@ public class AuthSessionItem {
 
     public AuthSessionItem withAccountState(AccountState accountState) {
         this.isNewAccount = accountState;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_RESET_PASSWORD_STATE)
+    public ResetPasswordState getResetPasswordState() {
+        return this.resetPasswordState;
+    }
+
+    public void setResetPasswordState(ResetPasswordState resetPasswordState) {
+        this.resetPasswordState = resetPasswordState;
+    }
+
+    public AuthSessionItem withResetPasswordState(ResetPasswordState resetPasswordState) {
+        this.resetPasswordState = resetPasswordState;
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -76,6 +76,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                                 .get()
                                 .withSessionId(newSessionId)
                                 .withCurrentCredentialStrength(currentCredentialStrength)
+                                .withResetPasswordState(AuthSessionItem.ResetPasswordState.NONE)
                                 .withTimeToLive(
                                         NowHelper.nowPlus(timeToLive, ChronoUnit.SECONDS)
                                                 .toInstant()

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -152,6 +152,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
 
     public void updateSession(AuthSessionItem sessionItem) {
         try {
+            LOG.info("Updating auth session item {}", sessionItem.toLogSafeString());
             update(sessionItem);
         } catch (Exception e) {
             logAndThrowAuthSessionException(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -131,6 +131,8 @@ class AuthSessionServiceTest {
         assertThat(authSession.getSessionId(), is(NEW_SESSION_ID));
         assertThat(
                 authSession.getCurrentCredentialStrength(), is(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                authSession.getResetPasswordState(), is(AuthSessionItem.ResetPasswordState.NONE));
     }
 
     @Test


### PR DESCRIPTION
## What

When a user has attempted to reset their password and when they successfully reset their password it is now recorded in their session. This is then used, in combination with their authenticated state, to determine if the `password_reset=Y` attribute should be added to the payload to the TICF CRI API at the end of the users sign in journey.

This happens if either:
- the user is authenticated and has successfully reset their password
- the user is failed to sign in but attempted to reset their password

At this point the TICF CRI API is not called outside of a successful sign in, so while the code is configured for the attempted password reset, it won't be sent to TICF until we support the CRI API for non-successful sign in journeys.

## How to review

1. Code Review
1. Deploy to a dev environment
1. Sign in as usual
1. Start again and sign in with a password reset
1. Filtering CloudWatch logs in the `*-account-interventions-lambda` with "Invoking TICF CRI with payload" and check the payload for your password reset journey contains `"password_reset":"Y"`, but does not contain it for the sign in journey without the reset

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
