### PR TITLE
Ato 1471 swap to duplicated roles

### DIFF
--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -18,25 +18,6 @@ module "identity_progress_role_2" {
   }
 }
 
-module "identity_progress_role_1" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "identity-progress-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = concat([
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    ], var.is_orch_stubbed ? [] : [
-    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn
-  ])
-  extra_tags = {
-    Service = "identity-progress"
-  }
-}
-
 module "identity_progress" {
   source = "../modules/endpoint-module-v2"
 
@@ -74,7 +55,7 @@ module "identity_progress" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.identity_progress_role_1.arn
+  lambda_role_arn                        = module.identity_progress_role_2.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -1,3 +1,23 @@
+// ATO-1471: We're duplicating the role without the old identity credentials table
+// access policies to enable us to safely remove them
+module "identity_progress_role_2" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "identity-progress-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = concat([
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    ], var.is_orch_stubbed ? [] : [
+    aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn
+  ])
+  extra_tags = {
+    Service = "identity-progress"
+  }
+}
+
 module "identity_progress_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -1,3 +1,31 @@
+// ATO-1471: We're duplicating the role without the old identity credentials table
+// access policies to enable us to safely remove them
+module "ipv_callback_role_1" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-callback-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.ipv_token_auth_kms_policy.arn,
+    aws_iam_policy.spot_queue_encryption_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    local.user_credentials_encryption_policy_arn,
+    local.user_profile_encryption_policy_arn,
+    aws_iam_policy.spot_queue_write_access_policy.arn
+  ]
+  extra_tags = {
+    Service = "ipv-callback"
+  }
+}
+
 module "ipv_callback_role" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -1,5 +1,3 @@
-// ATO-1471: We're duplicating the role without the old identity credentials table
-// access policies to enable us to safely remove them
 module "ipv_callback_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -17,35 +15,6 @@ module "ipv_callback_role_1" {
     aws_iam_policy.spot_queue_encryption_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn,
-    local.user_profile_encryption_policy_arn,
-    aws_iam_policy.spot_queue_write_access_policy.arn
-  ]
-  extra_tags = {
-    Service = "ipv-callback"
-  }
-}
-
-module "ipv_callback_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "ipv-callback-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.dynamo_user_read_access_policy.arn,
-    aws_iam_policy.dynamo_user_write_access_policy.arn,
-    aws_iam_policy.dynamo_identity_credentials_write_access_policy.arn,
-    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.ipv_token_auth_kms_policy.arn,
-    aws_iam_policy.spot_queue_encryption_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn,
-    local.identity_credentials_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     local.user_profile_encryption_policy_arn,
     aws_iam_policy.spot_queue_write_access_policy.arn
@@ -103,7 +72,7 @@ module "ipv-callback" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.ipv_callback_role.arn
+  lambda_role_arn                        = module.ipv_callback_role_1.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention

--- a/ci/terraform/oidc/ipv-handback-alerts.tf
+++ b/ci/terraform/oidc/ipv-handback-alerts.tf
@@ -13,7 +13,7 @@ moved {
 data "aws_cloudwatch_log_group" "spot_response_lambda_log_group" {
   name = replace("/aws/lambda/${var.environment}-spot-response-lambda", ".", "")
   depends_on = [
-    module.ipv_spot_response_role
+    module.ipv_spot_response_role_1
   ]
 }
 moved {

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -56,6 +56,36 @@ moved {
   to   = module.ipv_processing_identity_role_with_orch_session_table_access[0]
 }
 
+// ATO-1471: We're duplicating the role without the old identity credentials table
+// access policies to enable us to safely remove them
+module "ipv_processing_identity_role_with_orch_session_table_access_1" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-processing-identity-role-with-orch-session-access"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.pepper_parameter_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    local.identity_credentials_encryption_policy_arn,
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_decrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_read_and_delete_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn
+  ]
+}
+
 module "processing-identity" {
   source = "../modules/endpoint-module-v2"
 

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -1,3 +1,27 @@
+// ATO-1471: We're duplicating the role without the old identity credentials table
+// access policies to enable us to safely remove them
+module "ipv_spot_response_role_1" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-spot-response-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.spot_response_sqs_read_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.identity_credentials_encryption_policy_arn
+  ]
+
+  depends_on = [
+    aws_iam_policy.spot_response_sqs_read_policy
+  ]
+  extra_tags = {
+    Service = "spot-response"
+  }
+}
+
 module "ipv_spot_response_role" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -1,5 +1,3 @@
-// ATO-1471: We're duplicating the role without the old identity credentials table
-// access policies to enable us to safely remove them
 module "ipv_spot_response_role_1" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -7,31 +5,6 @@ module "ipv_spot_response_role_1" {
   vpc_arn     = local.authentication_vpc_arn
 
   policies_to_attach = [
-    aws_iam_policy.spot_response_sqs_read_policy.arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    local.identity_credentials_encryption_policy_arn
-  ]
-
-  depends_on = [
-    aws_iam_policy.spot_response_sqs_read_policy
-  ]
-  extra_tags = {
-    Service = "spot-response"
-  }
-}
-
-module "ipv_spot_response_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "ipv-spot-response-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.dynamo_identity_credentials_write_access_policy.arn,
-    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
-    aws_iam_policy.dynamo_identity_credentials_delete_access_policy.arn,
     aws_iam_policy.spot_response_sqs_read_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
@@ -108,7 +81,7 @@ resource "aws_lambda_event_source_mapping" "spot_response_lambda_sqs_mapping" {
 
 resource "aws_lambda_function" "spot_response_lambda" {
   function_name = "${var.environment}-spot-response-lambda"
-  role          = module.ipv_spot_response_role.arn
+  role          = module.ipv_spot_response_role_1.arn
   handler       = "uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler::handleRequest"
   timeout       = 30
   memory_size   = 512

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -1,29 +1,3 @@
-module "oidc_userinfo_role_1" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "oidc-userinfo-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
-    aws_iam_policy.oidc_token_kms_signing_policy.arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.dynamo_user_read_access_policy.arn,
-    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    local.client_registry_encryption_policy_arn,
-    local.identity_credentials_encryption_policy_arn,
-    local.doc_app_credential_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
-  ]
-  extra_tags = {
-    Service = "userinfo"
-  }
-}
-// ATO-1471: We're duplicating the role without the old identity credentials table
-// access policies to enable us to safely remove them
 module "oidc_userinfo_role_2" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -83,7 +57,7 @@ module "userinfo" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = module.oidc_userinfo_role_1.arn
+  lambda_role_arn                        = module.oidc_userinfo_role_2.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -22,6 +22,31 @@ module "oidc_userinfo_role_1" {
     Service = "userinfo"
   }
 }
+// ATO-1471: We're duplicating the role without the old identity credentials table
+// access policies to enable us to safely remove them
+module "oidc_userinfo_role_2" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "oidc-userinfo-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.oidc_token_kms_signing_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    local.identity_credentials_encryption_policy_arn,
+    local.doc_app_credential_encryption_policy_arn,
+    local.user_credentials_encryption_policy_arn
+  ]
+  extra_tags = {
+    Service = "userinfo"
+  }
+}
 
 module "userinfo" {
   source = "../modules/endpoint-module-v2"


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
