### PR TITLE
ATO-1530: migrate doc app callback handler email on session

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -42,7 +42,6 @@ import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
-import uk.gov.di.orchestration.shared.services.SessionService;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -70,7 +69,6 @@ public class DocAppCallbackHandler
     private final ConfigurationService configurationService;
     private final DocAppAuthorisationService authorisationService;
     private final DocAppCriService tokenService;
-    private final SessionService sessionService;
     private final ClientSessionService clientSessionService;
     private final OrchClientSessionService orchClientSessionService;
     private final AuditService auditService;
@@ -91,7 +89,6 @@ public class DocAppCallbackHandler
             ConfigurationService configurationService,
             DocAppAuthorisationService responseService,
             DocAppCriService tokenService,
-            SessionService sessionService,
             ClientSessionService clientSessionService,
             OrchClientSessionService orchClientSessionService,
             AuditService auditService,
@@ -105,7 +102,6 @@ public class DocAppCallbackHandler
         this.configurationService = configurationService;
         this.authorisationService = responseService;
         this.tokenService = tokenService;
-        this.sessionService = sessionService;
         this.clientSessionService = clientSessionService;
         this.orchClientSessionService = orchClientSessionService;
         this.auditService = auditService;
@@ -130,7 +126,6 @@ public class DocAppCallbackHandler
                         new JwksService(configurationService, kmsConnectionService));
         this.tokenService =
                 new DocAppCriService(configurationService, kmsConnectionService, this.docAppCriApi);
-        this.sessionService = new SessionService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
         this.auditService = new AuditService(configurationService);
@@ -156,7 +151,6 @@ public class DocAppCallbackHandler
                         new JwksService(configurationService, kmsConnectionService));
         this.tokenService =
                 new DocAppCriService(configurationService, kmsConnectionService, this.docAppCriApi);
-        this.sessionService = new SessionService(configurationService, redis);
         this.clientSessionService = new ClientSessionService(configurationService, redis);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
         this.auditService = new AuditService(configurationService);
@@ -210,10 +204,6 @@ public class DocAppCallbackHandler
             }
             var sessionId = sessionCookiesIds.getSessionId();
             var clientSessionId = sessionCookiesIds.getClientSessionId();
-            var session =
-                    sessionService
-                            .getSession(sessionId)
-                            .orElseThrow(() -> new DocAppCallbackException("Session not found"));
 
             var orchSession =
                     orchSessionService

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -318,10 +318,7 @@ public class DocAppCallbackHandler
 
                 var authCode =
                         authorisationCodeService.generateAndSaveAuthorisationCode(
-                                clientId,
-                                clientSessionId,
-                                session.getEmailAddress(),
-                                clientSession);
+                                clientId, clientSessionId, clientSession);
 
                 var authenticationResponse =
                         new AuthenticationSuccessResponse(

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -316,11 +316,6 @@ public class DocAppCallbackHandler
                                         "Successful", Boolean.toString(true)));
                 cloudwatchMetricsService.incrementCounter("DocAppCallback", dimensions);
 
-                // TODO: ATO-922: delete once verified that session has no email address in DocApp
-                // journey
-                LOG.info("is session email address null: {}", session.getEmailAddress() == null);
-                //
-
                 var authCode =
                         authorisationCodeService.generateAndSaveAuthorisationCode(
                                 clientId,

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -37,7 +37,6 @@ import uk.gov.di.orchestration.shared.entity.NoSessionEntity;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
-import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.services.AuditService;
@@ -49,7 +48,6 @@ import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
-import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
@@ -84,7 +82,6 @@ class DocAppCallbackHandlerTest {
     private final DocAppAuthorisationService responseService =
             mock(DocAppAuthorisationService.class);
     private final DocAppCriService tokenService = mock(DocAppCriService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
@@ -123,7 +120,6 @@ class DocAppCallbackHandlerTest {
     private static final State RP_STATE = new State();
     private static final Nonce NONCE = new Nonce();
 
-    private final Session session = new Session();
     private final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID)
                     .withAccountState(OrchSessionItem.AccountState.EXISTING_DOC_APP_JOURNEY);
@@ -152,7 +148,6 @@ class DocAppCallbackHandlerTest {
                         configService,
                         responseService,
                         tokenService,
-                        sessionService,
                         clientSessionService,
                         orchClientSessionService,
                         auditService,
@@ -172,7 +167,6 @@ class DocAppCallbackHandlerTest {
 
     @Test
     void shouldRedirectToRPForSuccessfulResponse() throws UnsuccessfulCredentialResponseException {
-        usingValidRedisSession();
         usingValidClientSession();
         usingValidOrchSession();
         var successfulTokenResponse =
@@ -244,7 +238,6 @@ class DocAppCallbackHandlerTest {
 
     @Test
     void shouldRedirectToFrontendErrorPageWhenNoOrchSession() {
-        usingValidRedisSession();
         usingValidClientSession();
         withNoOrchSession();
         var event = new APIGatewayProxyRequestEvent();
@@ -267,7 +260,6 @@ class DocAppCallbackHandlerTest {
         var event = new APIGatewayProxyRequestEvent();
         event.setQueryStringParameters(Collections.emptyMap());
         event.setHeaders(Map.of(COOKIE, buildCookieString()));
-        usingValidRedisSession();
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(clientSession));
 
@@ -284,7 +276,6 @@ class DocAppCallbackHandlerTest {
 
     @Test
     void shouldRedirectToRPWhenAuthnResponseContainsError() {
-        usingValidRedisSession();
         usingValidClientSession();
         usingValidOrchSession();
 
@@ -338,7 +329,6 @@ class DocAppCallbackHandlerTest {
 
     @Test
     void shouldRedirectToFrontendErrorPageWhenTokenResponseIsNotSuccessful() {
-        usingValidRedisSession();
         usingValidClientSession();
         usingValidOrchSession();
         var unsuccessfulTokenResponse = new TokenErrorResponse(new ErrorObject("Error object"));
@@ -387,7 +377,6 @@ class DocAppCallbackHandlerTest {
     @Test
     void shouldRedirectToFrontendErrorPageWhenCRIRequestIsNotSuccessful()
             throws UnsuccessfulCredentialResponseException {
-        usingValidRedisSession();
         usingValidClientSession();
         usingValidOrchSession();
         var successfulTokenResponse =
@@ -441,7 +430,6 @@ class DocAppCallbackHandlerTest {
     void
             shouldRedirectToRPWhenNoSessionCookieAndCallToNoSessionOrchestrationServiceReturnsNoSessionEntity()
                     throws NoSessionException {
-        usingValidRedisSession();
         usingValidClientSession();
         when(configService.isCustomDocAppClaimEnabled()).thenReturn(true);
 
@@ -496,7 +484,6 @@ class DocAppCallbackHandlerTest {
     void
             shouldRedirectToFrontendErrorPageWhenNoSessionCookieButCallToNoSessionOrchestrationServiceThrowsException()
                     throws NoSessionException {
-        usingValidRedisSession();
         usingValidClientSession();
 
         Map<String, String> queryParameters = new HashMap<>();
@@ -533,7 +520,6 @@ class DocAppCallbackHandlerTest {
     @Test
     void shouldGenerateAuthenticationErrorResponseWhenCRIRequestReturns404()
             throws UnsuccessfulCredentialResponseException {
-        usingValidRedisSession();
         usingValidClientSession();
         usingValidOrchSession();
         var successfulTokenResponse =
@@ -595,10 +581,6 @@ class DocAppCallbackHandlerTest {
         return format(
                 "%s=%s.%s; Max-Age=%d; %s",
                 "gs", SESSION_ID, CLIENT_SESSION_ID, 3600, "Secure; HttpOnly;");
-    }
-
-    private void usingValidRedisSession() {
-        when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
     }
 
     private void usingValidOrchSession() {

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -110,7 +110,6 @@ class DocAppCallbackHandlerTest {
     private static final String SESSION_ID = "a-session-id";
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final String REQUEST_ID = "a-request-id";
-    private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final URI REDIRECT_URI = URI.create("test-uri");
     private static final ClientID CLIENT_ID = new ClientID();
     private static final Subject PAIRWISE_SUBJECT_ID = new Subject();
@@ -124,7 +123,7 @@ class DocAppCallbackHandlerTest {
     private static final State RP_STATE = new State();
     private static final Nonce NONCE = new Nonce();
 
-    private final Session session = new Session().setEmailAddress(TEST_EMAIL_ADDRESS);
+    private final Session session = new Session();
     private final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID)
                     .withAccountState(OrchSessionItem.AccountState.EXISTING_DOC_APP_JOURNEY);
@@ -624,7 +623,6 @@ class DocAppCallbackHandlerTest {
         Scope scope = new Scope();
         scope.add(OIDCScopeValue.OPENID);
         scope.add("phone");
-        scope.add("email");
         return new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
                 .state(RP_STATE)
                 .nonce(NONCE)

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -146,7 +146,7 @@ class DocAppCallbackHandlerTest {
     @BeforeEach
     void setUp() {
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        CLIENT_ID.getValue(), CLIENT_SESSION_ID, TEST_EMAIL_ADDRESS, clientSession))
+                        CLIENT_ID.getValue(), CLIENT_SESSION_ID, clientSession))
                 .thenReturn(AUTH_CODE);
         handler =
                 new DocAppCallbackHandler(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -355,7 +355,6 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                                 URI.create(REDIRECT_URI))
                         .state(RP_STATE)
                         .nonce(new Nonce());
-        redis.createSession(SESSION_ID);
         var clientSessionCreationDate =
                 LocalDateTime.ofInstant(
                         Instant.parse("2025-02-19T15:00:00Z"), ZoneId.systemDefault());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
@@ -40,9 +40,9 @@ public class AuthorisationCodeService {
     }
 
     public AuthorizationCode generateAndSaveAuthorisationCode(
-            String clientId, String clientSessionId, String email, ClientSession clientSession) {
+            String clientId, String clientSessionId, ClientSession clientSession) {
         return generateAndSaveAuthorisationCode(
-                clientId, clientSessionId, email, clientSession, null);
+                clientId, clientSessionId, null, clientSession, null);
     }
 
     public AuthorizationCode generateAndSaveAuthorisationCode(


### PR DESCRIPTION
### Wider context of change
Part of the email migration work.

### What’s changed
Removes email address from the DocAppCallbackHandler

### Manual testing
TBD: Deploy to dev and test a DocApp journey

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing. **No new permissions needed**

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required. **Not required**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required. **Not required**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required. **Not required**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required. **Not required**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required**