### PR TITLE
ATO-1415: Update TTL when updating orch client session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchClientSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchClientSessionServiceIntegrationTest.java
@@ -114,6 +114,21 @@ class OrchClientSessionServiceIntegrationTest {
     }
 
     @Test
+    void shouldUpdateTimeToLiveWhenUpdatingClientSession() {
+        fixTime(Instant.parse("2025-02-18T11:00:00Z"));
+        clientSessionExtension.storeClientSession(clientSession);
+
+        // Reset TTL, so should be valid for another hour
+        fixTime(Instant.parse("2025-02-18T11:50:00Z"));
+        clientSessionExtension.updateStoredClientSession(clientSession);
+
+        fixTime(Instant.parse("2025-02-18T12:00:01Z"));
+        var clientSessionOpt = clientSessionExtension.getClientSession(CLIENT_SESSION_ID);
+
+        assertTrue(clientSessionOpt.isPresent());
+    }
+
+    @Test
     void shouldUpdateClientSession() {
         clientSessionExtension.storeClientSession(clientSession);
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchClientSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchClientSessionService.java
@@ -100,8 +100,13 @@ public class OrchClientSessionService extends BaseDynamoService<OrchClientSessio
     }
 
     public void updateStoredClientSession(OrchClientSessionItem clientSession) {
+        var item =
+                clientSession.withTimeToLive(
+                        nowClock.nowPlus(timeToLive, ChronoUnit.SECONDS)
+                                .toInstant()
+                                .getEpochSecond());
         try {
-            update(clientSession);
+            update(item);
         } catch (Exception e) {
             logAndThrowOrchClientSessionException(
                     "Error updating Orch client session item",


### PR DESCRIPTION
### Wider context of change

We have a dynamo client session store that we are currently writing to. We are also getting from it to compare the dynamo client session to the redis client session. There have been a couple of log messages indicating that the TTL had expired for the orch client session.

### What’s changed

We weren't updating the TTL whenever we were calling `updateStoredClientSession`. This PR updates the TTL based on the configured session expiration, just like we do when we store the client session.

### Manual testing

Added an integration test scenario for this situation.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. n/a
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a
