### PR TITLE
Ato 1462 basefrontendhandler authsession email address

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -291,6 +291,7 @@ class LoginHandlerReauthenticationRedisTest {
                         Optional.of(
                                 new AuthSessionItem()
                                         .withSessionId(SESSION_ID)
+                                        .withEmailAddress(EMAIL)
                                         .withAccountState(AuthSessionItem.AccountState.UNKNOWN)));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -599,6 +599,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                         Optional.of(
                                 new AuthSessionItem()
                                         .withSessionId(SESSION_ID)
+                                        .withEmailAddress(EMAIL)
                                         .withAccountState(AuthSessionItem.AccountState.UNKNOWN)));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -835,6 +835,7 @@ class LoginHandlerTest {
                         Optional.of(
                                 new AuthSessionItem()
                                         .withSessionId(SESSION_ID)
+                                        .withEmailAddress(EMAIL)
                                         .withAccountState(AuthSessionItem.AccountState.UNKNOWN)));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -142,6 +142,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         var sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         authSessionExtension.addSession(sessionId);
+        authSessionExtension.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         return sessionId;
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -109,6 +109,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionId = IdGenerator.generate();
         redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
         authSessionExtension.addSession(sessionId);
+        authSessionExtension.addEmailToSession(sessionId, email);
 
         userStore.signUp(email, password);
         userStore.updateTermsAndConditions(email, termsAndConditionsVersion);
@@ -191,6 +192,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionId = IdGenerator.generate();
         redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
         authSessionExtension.addSession(sessionId);
+        authSessionExtension.addEmailToSession(sessionId, email);
 
         userStore.signUp(email, password);
         userStore.updateTermsAndConditions(email, CURRENT_TERMS_AND_CONDITIONS);
@@ -220,6 +222,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionId = IdGenerator.generate();
         redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
         authSessionExtension.addSession(sessionId);
+        authSessionExtension.addEmailToSession(sessionId, email);
         redis.createClientSession(
                 CLIENT_SESSION_ID, CLIENT_NAME, basicAuthRequestBuilder.build().toParameters());
         var headers = validHeadersWithSessionId(sessionId);
@@ -241,6 +244,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionId = IdGenerator.generate();
         redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
         authSessionExtension.addSession(sessionId);
+        authSessionExtension.addEmailToSession(sessionId, email);
         var headers = validHeadersWithSessionId(sessionId);
 
         redis.createClientSession(
@@ -277,6 +281,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var sessionId = IdGenerator.generate();
         redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
         authSessionExtension.addSession(sessionId);
+        authSessionExtension.addEmailToSession(sessionId, email);
         var headers = validHeadersWithSessionId(sessionId);
 
         redis.createClientSession(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -231,7 +231,8 @@ public abstract class BaseFrontendHandler<T>
                 Objects.equals(
                         session.get().getEmailAddress(), authSession.get().getEmailAddress()));
 
-        session.map(Session::getEmailAddress)
+        authSession
+                .map(AuthSessionItem::getEmailAddress)
                 .map(authenticationService::getUserProfileFromEmail)
                 .ifPresentOrElse(
                         userProfile ->
@@ -250,7 +251,8 @@ public abstract class BaseFrontendHandler<T>
                         });
 
         if (loadUserCredentials) {
-            session.map(Session::getEmailAddress)
+            authSession
+                    .map(AuthSessionItem::getEmailAddress)
                     .map(authenticationService::getUserCredentialsFromEmail)
                     .ifPresent(
                             userCredentials ->


### PR DESCRIPTION
### Wider context of change

This is part of the session migration work, specifically the email migration.

### What’s changed

Change all instances of session.getEmailAddress to authSession.getEmailAddress in BaseFrontendHandler

### Manual testing

Added a log and checked on the log status.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required.**
- [x] Changes have been made to the simulator or not required. **Not required.**
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required.**

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/5982
https://github.com/govuk-one-login/authentication-api/pull/6076
https://github.com/govuk-one-login/authentication-api/pull/6077
https://github.com/govuk-one-login/authentication-api/pull/6078
https://github.com/govuk-one-login/authentication-api/pull/6080