### PR TITLE
ATO-1511: add code request count map to auth session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.services;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 
@@ -34,6 +35,10 @@ class AuthSessionServiceIntegrationTest {
         assertThat(
                 retrievedSession.get().getIsNewAccount(),
                 equalTo(AuthSessionItem.AccountState.UNKNOWN));
+
+        for (CodeRequestType requestType : CodeRequestType.values()) {
+            assertEquals(retrievedSession.get().getCodeRequestCount(requestType), 0);
+        }
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/converters/CodeRequestCountMapConverter.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/converters/CodeRequestCountMapConverter.java
@@ -1,0 +1,47 @@
+package uk.gov.di.authentication.shared.converters;
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CodeRequestCountMapConverter
+        implements AttributeConverter<Map<CodeRequestType, Integer>> {
+
+    @Override
+    public AttributeValue transformFrom(Map<CodeRequestType, Integer> input) {
+        return AttributeValue.fromM(
+                input.entrySet().stream()
+                        .map(
+                                entry ->
+                                        Map.entry(
+                                                entry.getKey().name(),
+                                                AttributeValue.fromN(entry.getValue().toString())))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    @Override
+    public Map<CodeRequestType, Integer> transformTo(AttributeValue input) {
+        return input.m().entrySet().stream()
+                .map(
+                        entry ->
+                                Map.entry(
+                                        CodeRequestType.valueOf(entry.getKey()),
+                                        Integer.parseInt(entry.getValue().n())))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public EnhancedType<Map<CodeRequestType, Integer>> type() {
+        return EnhancedType.mapOf(CodeRequestType.class, Integer.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.M;
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.exceptions.AuthSessionException;
 
@@ -50,6 +51,10 @@ class AuthSessionServiceTest {
         assertEquals(SESSION_ID, session.getSessionId());
         assertEquals(AuthSessionItem.AccountState.UNKNOWN, session.getIsNewAccount());
         assertTrue(session.getTimeToLive() > Instant.now().getEpochSecond());
+
+        for (CodeRequestType requestType : CodeRequestType.values()) {
+            assertEquals(session.getCodeRequestCount(requestType), 0);
+        }
     }
 
     @Test


### PR DESCRIPTION
### Wider context of change: 

We're migrating fields from the redis session to dynamoDB, this migrates another field CodeRequestCountMap

### What’s changed:
- Adds a convertor which converts the CodeRequestCount type of `Map<CodeRequestType, Integer>` to something dynamo can store easily
- Adds the field to the session class along with the minimum required getter/setter methods. I have chose to omit the builder `withXX` method as the Auth session is instantiated with a default code request count map upon creation.
- Lifts and shifts the increment and get methods from the Session class itself, so interfaces and logic are all the same.

### Manual testing:
- Deployed to Authdev1 
- Came off the stub and saw my auth session contained a CodeRequestCount map with all keys initialised to 0


### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing. N/A

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked. N/A

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required. N/A

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required. N/A

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required. N/A

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required. N/A

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required. N/A

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
