### PR TITLE
ATO-1511: write to new code request map

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -244,6 +244,23 @@ class MfaHandlerTest {
                         any(String.class),
                         anyLong(),
                         any(NotificationType.class));
+        verify(sessionService)
+                .storeOrUpdateSession(
+                        argThat(
+                                session ->
+                                        session.getCodeRequestCount(
+                                                        NotificationType.MFA_SMS,
+                                                        JourneyType.SIGN_IN)
+                                                == 1),
+                        eq(SESSION_ID));
+        verify(authSessionService)
+                .updateSession(
+                        argThat(
+                                session ->
+                                        session.getCodeRequestCount(
+                                                        NotificationType.MFA_SMS,
+                                                        JourneyType.SIGN_IN)
+                                                == 1));
         assertThat(result, hasStatus(204));
 
         verify(auditService)
@@ -404,6 +421,14 @@ class MfaHandlerTest {
                                                         NotificationType.MFA_SMS, journeyType)
                                                 == 0),
                         eq(SESSION_ID));
+
+        verify(authSessionService)
+                .updateSession(
+                        argThat(
+                                sessionForTestUser ->
+                                        sessionForTestUser.getCodeRequestCount(
+                                                        NotificationType.MFA_SMS, journeyType)
+                                                == 0));
 
         verify(auditService)
                 .submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -286,6 +286,14 @@ class SendNotificationHandlerTest {
                                                 isSessionWithEmailSent(
                                                         session, notificationType, journeyType)),
                                 eq(SESSION_ID));
+
+                verify(authSessionService)
+                        .updateSession(
+                                argThat(
+                                        authSession ->
+                                                authSession.getCodeRequestCount(
+                                                                notificationType, journeyType)
+                                                        == 1));
                 verify(auditService)
                         .submitAuditEvent(
                                 notificationType.equals(VERIFY_EMAIL)


### PR DESCRIPTION
### Wider context of change:

- We're migrating the CodeRequestCount map to the new auth session store, as opposed to storing in the redis session store. In a previous PR we started initialising sessions with this new map, here we start writing to it by incrementing and resetting in the same places as previously.
 
### What’s changed: 

- Increments the map counts in the same place as the one on the shared session
- Resets the map counts in the same place as the one on the shared session

### Manual testing

- Deployed to dev  
    - Run through a signup journey 
    - Saw email code incremented
    - Ran through a sign in journey with auth app after this

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs: 

- Branches off of: https://github.com/govuk-one-login/authentication-api/pull/6174 so must be merged first
- 
