### PR TITLE
ATO-1511 read code request count  from auth session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -266,7 +266,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
     private Optional<ErrorResponse> validateCodeRequestAttempts(
             String email, JourneyType journeyType, UserContext userContext) {
         Session session = userContext.getSession();
-        var codeRequestCount = session.getCodeRequestCount(MFA_SMS, journeyType);
+        AuthSessionItem authSession = userContext.getAuthSession();
+        var codeRequestCount = authSession.getCodeRequestCount(MFA_SMS, journeyType);
         LOG.info("CodeRequestCount is: {}", codeRequestCount);
         var codeRequestType = CodeRequestType.getCodeRequestType(MFA_SMS, journeyType);
         var newCodeRequestBlockPrefix = CODE_REQUEST_BLOCKED_KEY_PREFIX + codeRequestType;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -412,7 +412,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             NotificationType notificationType,
             JourneyType journeyType) {
 
-        var codeRequestCount = session.getCodeRequestCount(notificationType, journeyType);
+        var codeRequestCount = authSession.getCodeRequestCount(notificationType, journeyType);
         LOG.info("CodeRequestCount is: {}", codeRequestCount);
 
         var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -61,7 +61,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -244,15 +243,6 @@ class MfaHandlerTest {
                         any(String.class),
                         anyLong(),
                         any(NotificationType.class));
-        verify(sessionService)
-                .storeOrUpdateSession(
-                        argThat(
-                                session ->
-                                        session.getCodeRequestCount(
-                                                        NotificationType.MFA_SMS,
-                                                        JourneyType.SIGN_IN)
-                                                == 1),
-                        eq(SESSION_ID));
         verify(authSessionService)
                 .updateSession(
                         argThat(
@@ -350,7 +340,7 @@ class MfaHandlerTest {
         usingValidSession();
         when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         for (int i = 0; i < MAX_CODE_RETRIES; i++) {
-            session.incrementCodeRequestCount(
+            authSession.incrementCodeRequestCount(
                     NotificationType.VERIFY_EMAIL, JourneyType.REGISTRATION);
         }
 
@@ -393,7 +383,7 @@ class MfaHandlerTest {
 
         when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         for (int i = 0; i < MAX_CODE_RETRIES; i++) {
-            session.incrementCodeRequestCount(MFA_SMS, journeyType);
+            authSession.incrementCodeRequestCount(MFA_SMS, journeyType);
         }
 
         var body = format("{ \"email\": \"%s\", \"journeyType\": \"%s\"}", EMAIL, journeyType);
@@ -412,15 +402,6 @@ class MfaHandlerTest {
                 journeyType, reauthEnabled, codeRequestType);
 
         checkUserIsBlockedWhenNotReAuthenticating(journeyType, codeRequestType);
-
-        verify(sessionService)
-                .storeOrUpdateSession(
-                        argThat(
-                                sessionForTestUser ->
-                                        sessionForTestUser.getCodeRequestCount(
-                                                        NotificationType.MFA_SMS, journeyType)
-                                                == 0),
-                        eq(SESSION_ID));
 
         verify(authSessionService)
                 .updateSession(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -281,11 +281,7 @@ class SendNotificationHandlerTest {
                 verify(codeStorageService).getOtpCode(EMAIL, notificationType);
                 verify(sessionService)
                         .storeOrUpdateSession(
-                                argThat(
-                                        session ->
-                                                isSessionWithEmailSent(
-                                                        session, notificationType, journeyType)),
-                                eq(SESSION_ID));
+                                argThat(this::isSessionWithEmailSent), eq(SESSION_ID));
 
                 verify(authSessionService)
                         .updateSession(
@@ -479,12 +475,7 @@ class SendNotificationHandlerTest {
         verify(codeStorageService)
                 .saveOtpCode(EMAIL, TEST_SIX_DIGIT_CODE, CODE_EXPIRY_TIME, notificationType);
         verify(sessionService)
-                .storeOrUpdateSession(
-                        argThat(
-                                session ->
-                                        isSessionWithEmailSent(
-                                                session, notificationType, journeyType)),
-                        eq(SESSION_ID));
+                .storeOrUpdateSession(argThat(this::isSessionWithEmailSent), eq(SESSION_ID));
 
         var testClientAuditContext = auditContext.withClientId(TEST_CLIENT_ID);
 
@@ -512,12 +503,7 @@ class SendNotificationHandlerTest {
         verifyNoInteractions(emailSqsClient);
         verifyNoInteractions(codeStorageService);
         verify(sessionService, never())
-                .storeOrUpdateSession(
-                        argThat(
-                                session ->
-                                        isSessionWithEmailSent(
-                                                session, notificationType, journeyType)),
-                        eq(SESSION_ID));
+                .storeOrUpdateSession(argThat(this::isSessionWithEmailSent), eq(SESSION_ID));
         verifyNoInteractions(auditService);
     }
 
@@ -1075,12 +1061,12 @@ class SendNotificationHandlerTest {
 
     private void maxOutCodeRequestCount(
             NotificationType notificationType, JourneyType journeyType) {
-        session.resetCodeRequestCount(notificationType, journeyType);
-        session.incrementCodeRequestCount(notificationType, journeyType);
-        session.incrementCodeRequestCount(notificationType, journeyType);
-        session.incrementCodeRequestCount(notificationType, journeyType);
-        session.incrementCodeRequestCount(notificationType, journeyType);
-        session.incrementCodeRequestCount(notificationType, journeyType);
+        authSession.resetCodeRequestCount(notificationType, journeyType);
+        authSession.incrementCodeRequestCount(notificationType, journeyType);
+        authSession.incrementCodeRequestCount(notificationType, journeyType);
+        authSession.incrementCodeRequestCount(notificationType, journeyType);
+        authSession.incrementCodeRequestCount(notificationType, journeyType);
+        authSession.incrementCodeRequestCount(notificationType, journeyType);
     }
 
     private void usingValidSession() {
@@ -1105,9 +1091,7 @@ class SendNotificationHandlerTest {
         when(clientSession.getAuthRequestParams()).thenReturn(authRequest.toParameters());
     }
 
-    private boolean isSessionWithEmailSent(
-            Session session, NotificationType notificationType, JourneyType journeyType) {
-        return session.getEmailAddress().equals(EMAIL)
-                && session.getCodeRequestCount(notificationType, journeyType) == 1;
+    private boolean isSessionWithEmailSent(Session session) {
+        return session.getEmailAddress().equals(EMAIL);
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
@@ -147,9 +147,9 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     private static void aUserHasEnteredAnOTPIncorrectlyTheMaximumAllowedTimes(
-            String authenticatedSessionId) throws Json.JsonException {
+            String authenticatedSessionId) {
         for (int i = 0; i < ConfigurationService.getInstance().getCodeMaxRetries(); i++) {
-            redis.incrementSessionCodeRequestCount(
+            authSessionStore.incrementSessionCodeRequestCount(
                     authenticatedSessionId, MFA_SMS, JourneyType.REAUTHENTICATION);
         }
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
@@ -57,14 +57,7 @@ class SendNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        var session = redis.getSession(SESSION_ID);
         var authSession = authSessionExtension.getSession(SESSION_ID).orElseThrow();
-        assertThat(
-                session.getCodeRequestCount(
-                        NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
-                        JourneyType.ACCOUNT_RECOVERY),
-                equalTo(1));
-
         assertThat(
                 authSession.getCodeRequestCount(
                         NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -109,11 +109,11 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
     @MethodSource("emailNotificationTypes")
     void shouldResetCodeRequestCountWhenSuccessfulEmailCodeAndReturn204(
             NotificationType emailNotificationType) throws Json.JsonException {
-        redis.incrementSessionCodeRequestCount(
+        authSessionExtension.incrementSessionCodeRequestCount(
                 sessionId, emailNotificationType, JourneyType.ACCOUNT_RECOVERY);
-        redis.incrementSessionCodeRequestCount(
+        authSessionExtension.incrementSessionCodeRequestCount(
                 sessionId, emailNotificationType, JourneyType.ACCOUNT_RECOVERY);
-        redis.incrementSessionCodeRequestCount(
+        authSessionExtension.incrementSessionCodeRequestCount(
                 sessionId, emailNotificationType, JourneyType.ACCOUNT_RECOVERY);
         setUpTestWithoutSignUp(sessionId, withScope());
         String code = redis.generateAndSaveEmailCode(EMAIL_ADDRESS, 900, emailNotificationType);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -10,6 +10,8 @@ import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
@@ -103,5 +105,13 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
     public Optional<AuthSessionItem> getSessionFromRequestHeaders(
             Map<String, String> requestHeaders) {
         return authSessionService.getSessionFromRequestHeaders(requestHeaders);
+    }
+
+    public void incrementSessionCodeRequestCount(
+            String sessionId, NotificationType notificationType, JourneyType journeyType) {
+        updateSession(
+                getSession(sessionId)
+                        .orElseThrow()
+                        .incrementCodeRequestCount(notificationType, journeyType));
     }
 }


### PR DESCRIPTION
### Wider context of change:

- We're migrating the CodeRequestCount map to the new auth session store, as opposed to storing in the redis session store. In a previous PR we started writing to the new Code Request map, so now we can read from it when fetching a code request count
 
### What’s changed: 

- Replacing any calls to shared session method `getCodeRequestCount` with the auth session equivalent.

### Manual testing

 - Deployed to sandpit:  
    - Run through a signup journey 
    - Saw email code incremented
    - Ran through a sign in journey with auth app after this

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs: 

- Branches off of: https://github.com/govuk-one-login/authentication-api/pull/6174 so must be merged first
- 
