### PR TITLE
ATO-1533: Get client session from clientSessionStore in TokenHandler

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -308,7 +308,7 @@ public class DocAppCallbackHandler
 
                 var authCode =
                         authorisationCodeService.generateAndSaveAuthorisationCode(
-                                clientId, clientSessionId, clientSession);
+                                clientId, clientSessionId, null, null);
 
                 var authenticationResponse =
                         new AuthenticationSuccessResponse(

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -141,7 +141,7 @@ class DocAppCallbackHandlerTest {
     @BeforeEach
     void setUp() {
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        CLIENT_ID.getValue(), CLIENT_SESSION_ID, clientSession))
+                        CLIENT_ID.getValue(), CLIENT_SESSION_ID, null, null))
                 .thenReturn(AUTH_CODE);
         handler =
                 new DocAppCallbackHandler(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -735,7 +735,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         creationDate,
                         vtrList,
                         "client-name"));
-        redis.addAuthCode(code, CLIENT_ID, CLIENT_SESSION_ID, clientSession, TEST_EMAIL, AUTH_TIME);
+        redis.addAuthCode(code, CLIENT_ID, CLIENT_SESSION_ID, TEST_EMAIL, AUTH_TIME);
         Map<String, List<String>> customParams = new HashMap<>();
         customParams.put(
                 "grant_type", Collections.singletonList(GrantType.AUTHORIZATION_CODE.getValue()));

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -214,7 +214,6 @@ public class IPVCallbackHelper {
                         clientId,
                         clientSessionId,
                         userProfile.getEmail(),
-                        clientSession,
                         orchSession.getAuthTime());
         var authenticationResponse =
                 new AuthenticationSuccessResponse(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -29,7 +29,6 @@ import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -171,11 +170,7 @@ class IPVCallbackHelperTest {
                         new AccountIntervention(
                                 new AccountInterventionState(false, true, false, false)));
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        anyString(),
-                        anyString(),
-                        anyString(),
-                        any(ClientSession.class),
-                        any(Long.class)))
+                        anyString(), anyString(), anyString(), any(Long.class)))
                 .thenReturn(AUTH_CODE);
 
         when(oidcAPI.trustmarkURI()).thenReturn(OIDC_TRUSTMARK_URI);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -471,7 +471,6 @@ public class AuthCodeHandler
                 clientID.getValue(),
                 clientSessionId,
                 emailOptional.orElse(null),
-                clientSession,
                 orchSession.getAuthTime());
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -579,7 +579,6 @@ public class AuthenticationCallbackHandler
                                 clientId,
                                 clientSessionId,
                                 userInfo.getEmailAddress(),
-                                clientSession,
                                 orchSession.getAuthTime());
 
                 var authenticationResponse =

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -283,7 +283,6 @@ class AuthCodeHandlerTest {
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(EMAIL),
-                        eq(clientSession),
                         any(Long.class)))
                 .thenReturn(authorizationCode);
         when(orchestrationAuthorizationService.generateSuccessfulAuthResponse(
@@ -344,7 +343,6 @@ class AuthCodeHandlerTest {
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(EMAIL),
-                        eq(clientSession),
                         any(Long.class));
 
         var dimensions =
@@ -399,11 +397,7 @@ class AuthCodeHandlerTest {
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        eq(CLIENT_ID.getValue()),
-                        eq(CLIENT_SESSION_ID),
-                        eq(null),
-                        eq(clientSession),
-                        any(Long.class)))
+                        eq(CLIENT_ID.getValue()), eq(CLIENT_SESSION_ID), eq(null), any(Long.class)))
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(
                         eq(orchSession),
@@ -466,11 +460,7 @@ class AuthCodeHandlerTest {
                         pair("nonce", NONCE.getValue()));
         verify(authorisationCodeService, times(1))
                 .generateAndSaveAuthorisationCode(
-                        eq(CLIENT_ID.getValue()),
-                        eq(CLIENT_SESSION_ID),
-                        eq(null),
-                        eq(clientSession),
-                        any(Long.class));
+                        eq(CLIENT_ID.getValue()), eq(CLIENT_SESSION_ID), eq(null), any(Long.class));
 
         var expectedDimensions =
                 Map.of(
@@ -726,7 +716,6 @@ class AuthCodeHandlerTest {
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(EMAIL),
-                        eq(clientSession),
                         any(Long.class)))
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -209,7 +209,6 @@ class AuthenticationCallbackHandlerTest {
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(TEST_EMAIL_ADDRESS),
-                        eq(clientSession),
                         any(Long.class)))
                 .thenReturn(AUTH_CODE_RP_TO_ORCH);
         when(UNSUCCESSFUL_TOKEN_RESPONSE.indicatesSuccess()).thenReturn(false);
@@ -617,7 +616,6 @@ class AuthenticationCallbackHandlerTest {
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(TEST_EMAIL_ADDRESS),
-                        eq(mediumRequestSession),
                         any(Long.class)))
                 .thenReturn(AUTH_CODE_RP_TO_ORCH);
         usingValidClient();
@@ -1462,7 +1460,6 @@ class AuthenticationCallbackHandlerTest {
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(TEST_EMAIL_ADDRESS),
-                        eq(clientSessionWithCredentialTrustLevel),
                         any(Long.class)))
                 .thenReturn(AUTH_CODE_RP_TO_ORCH);
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -940,7 +940,6 @@ public class TokenHandlerTest {
                                 new AuthCodeExchangeData()
                                         .setEmail(TEST_EMAIL)
                                         .setClientSessionId(CLIENT_SESSION_ID)
-                                        .setClientSession(clientSession)
                                         .setAuthTime(AUTH_TIME)
                                         .setClientId(clientId)));
         var orchClientSession =

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -234,30 +234,7 @@ public class TokenHandlerTest {
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         authenticationRequest.getCustomParameter("vtr"));
         VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
-
-        when(authorisationCodeService.getExchangeDataForCode(authCode))
-                .thenReturn(
-                        Optional.of(
-                                new AuthCodeExchangeData()
-                                        .setEmail(TEST_EMAIL)
-                                        .setClientSessionId(CLIENT_SESSION_ID)
-                                        .setClientSession(
-                                                new ClientSession(
-                                                        authenticationRequest.toParameters(),
-                                                        clientSessionCreationTime,
-                                                        vtr,
-                                                        CLIENT_NAME))
-                                        .setAuthTime(AUTH_TIME)
-                                        .setClientId(CLIENT_ID)));
-        when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(
-                        Optional.of(
-                                new OrchClientSessionItem(
-                                        CLIENT_SESSION_ID,
-                                        authenticationRequest.toParameters(),
-                                        clientSessionCreationTime,
-                                        vtr,
-                                        CLIENT_NAME)));
+        setupClientSessions(authCode, authenticationRequest.toParameters(), vtr);
         when(dynamoService.getUserProfileByEmail(eq(TEST_EMAIL))).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
@@ -318,29 +295,8 @@ public class TokenHandlerTest {
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         authenticationRequest.getCustomParameter("vtr"));
         VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
-        when(authorisationCodeService.getExchangeDataForCode(authCode))
-                .thenReturn(
-                        Optional.of(
-                                new AuthCodeExchangeData()
-                                        .setEmail(TEST_EMAIL)
-                                        .setClientSessionId(CLIENT_SESSION_ID)
-                                        .setClientSession(
-                                                new ClientSession(
-                                                        authenticationRequest.toParameters(),
-                                                        clientSessionCreationTime,
-                                                        vtr,
-                                                        CLIENT_NAME))
-                                        .setAuthTime(AUTH_TIME)
-                                        .setClientId("a-different-client-id")));
-        when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(
-                        Optional.of(
-                                new OrchClientSessionItem(
-                                        CLIENT_SESSION_ID,
-                                        authenticationRequest.toParameters(),
-                                        clientSessionCreationTime,
-                                        vtr,
-                                        CLIENT_NAME)));
+        setupClientSessions(
+                authCode, authenticationRequest.toParameters(), vtr, "a-different-client-id", null);
         when(dynamoService.getUserProfileByEmail(eq(TEST_EMAIL))).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
@@ -400,29 +356,7 @@ public class TokenHandlerTest {
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         authenticationRequest.getCustomParameter("vtr"));
         VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
-        when(authorisationCodeService.getExchangeDataForCode(authCode))
-                .thenReturn(
-                        Optional.of(
-                                new AuthCodeExchangeData()
-                                        .setEmail(TEST_EMAIL)
-                                        .setClientSessionId(CLIENT_SESSION_ID)
-                                        .setClientSession(
-                                                new ClientSession(
-                                                        authenticationRequest.toParameters(),
-                                                        clientSessionCreationTime,
-                                                        vtr,
-                                                        CLIENT_NAME))
-                                        .setAuthTime(AUTH_TIME)
-                                        .setClientId(CLIENT_ID)));
-        when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(
-                        Optional.of(
-                                new OrchClientSessionItem(
-                                        CLIENT_SESSION_ID,
-                                        authenticationRequest.toParameters(),
-                                        clientSessionCreationTime,
-                                        vtr,
-                                        CLIENT_NAME)));
+        setupClientSessions(authCode, authenticationRequest.toParameters(), vtr);
         when(dynamoService.getUserProfileByEmail(eq(TEST_EMAIL))).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
@@ -709,29 +643,7 @@ public class TokenHandlerTest {
         String authCode = new AuthorizationCode().toString();
         List<VectorOfTrust> vtr = List.of(mock(VectorOfTrust.class));
         var authRequestParams = generateAuthRequest().toParameters();
-        when(authorisationCodeService.getExchangeDataForCode(authCode))
-                .thenReturn(
-                        Optional.of(
-                                new AuthCodeExchangeData()
-                                        .setEmail(TEST_EMAIL)
-                                        .setClientSessionId(CLIENT_SESSION_ID)
-                                        .setClientSession(
-                                                new ClientSession(
-                                                        authRequestParams,
-                                                        clientSessionCreationTime,
-                                                        vtr,
-                                                        CLIENT_NAME))
-                                        .setAuthTime(AUTH_TIME)
-                                        .setClientId(CLIENT_ID)));
-        when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(
-                        Optional.of(
-                                new OrchClientSessionItem(
-                                        CLIENT_SESSION_ID,
-                                        authRequestParams,
-                                        clientSessionCreationTime,
-                                        vtr,
-                                        CLIENT_NAME)));
+        setupClientSessions(authCode, authRequestParams, vtr);
         APIGatewayProxyResponseEvent result =
                 generateApiGatewayRequest(
                         privateKeyJWT, authCode, "http://invalid-redirect-uri", CLIENT_ID, true);
@@ -776,31 +688,12 @@ public class TokenHandlerTest {
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         authenticationRequest.getCustomParameter("vtr"));
         VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
-        ClientSession clientSession =
-                new ClientSession(
-                        authenticationRequest.toParameters(),
-                        clientSessionCreationTime,
-                        vtr,
-                        CLIENT_NAME);
-        clientSession.setDocAppSubjectId(DOC_APP_USER_PUBLIC_SUBJECT);
-        when(authorisationCodeService.getExchangeDataForCode(authCode))
-                .thenReturn(
-                        Optional.of(
-                                new AuthCodeExchangeData()
-                                        .setEmail(TEST_EMAIL)
-                                        .setClientSessionId(CLIENT_SESSION_ID)
-                                        .setClientSession(clientSession)
-                                        .setClientId(DOC_APP_CLIENT_ID.getValue())));
-        var orchClientSessionItem =
-                new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authenticationRequest.toParameters(),
-                        clientSessionCreationTime,
-                        vtr,
-                        CLIENT_NAME);
-        orchClientSessionItem.setDocAppSubjectId(DOC_APP_USER_PUBLIC_SUBJECT.getValue());
-        when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(Optional.of(orchClientSessionItem));
+        setupClientSessions(
+                authCode,
+                authenticationRequest.toParameters(),
+                vtr,
+                DOC_APP_CLIENT_ID.getValue(),
+                DOC_APP_USER_PUBLIC_SUBJECT);
         when(dynamoService.getUserProfileByEmail(TEST_EMAIL)).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         DOC_APP_CLIENT_ID.getValue(),
@@ -875,20 +768,7 @@ public class TokenHandlerTest {
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         authenticationRequest.getCustomParameter("vtr"));
         VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
-        when(authorisationCodeService.getExchangeDataForCode(authCode))
-                .thenReturn(
-                        Optional.of(
-                                new AuthCodeExchangeData()
-                                        .setEmail(TEST_EMAIL)
-                                        .setClientSessionId(CLIENT_SESSION_ID)
-                                        .setClientSession(
-                                                new ClientSession(
-                                                        authenticationRequest.toParameters(),
-                                                        LocalDateTime.now(),
-                                                        vtr,
-                                                        CLIENT_NAME))
-                                        .setAuthTime(AUTH_TIME)
-                                        .setClientId(CLIENT_ID)));
+        setupClientSessions(authCode, authenticationRequest.toParameters(), vtr);
         when(dynamoService.getUserProfileByEmail(eq(TEST_EMAIL))).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         eq(CLIENT_ID),
@@ -948,20 +828,7 @@ public class TokenHandlerTest {
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         authenticationRequest.getCustomParameter("vtr"));
         VectorOfTrust lowestLevelVtr = VectorOfTrust.orderVtrList(vtr).get(0);
-        when(authorisationCodeService.getExchangeDataForCode(authCode))
-                .thenReturn(
-                        Optional.of(
-                                new AuthCodeExchangeData()
-                                        .setEmail(TEST_EMAIL)
-                                        .setClientSessionId(CLIENT_SESSION_ID)
-                                        .setClientSession(
-                                                new ClientSession(
-                                                        authenticationRequest.toParameters(),
-                                                        LocalDateTime.now(),
-                                                        vtr,
-                                                        CLIENT_NAME))
-                                        .setAuthTime(AUTH_TIME)
-                                        .setClientId(CLIENT_ID)));
+        setupClientSessions(authCode, authenticationRequest.toParameters(), vtr);
         when(dynamoService.getUserProfileByEmail(eq(TEST_EMAIL))).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         eq(CLIENT_ID),
@@ -988,6 +855,42 @@ public class TokenHandlerTest {
         assertTrue(result.getBody().contains(refreshToken.getValue()));
         assertTrue(result.getBody().contains(accessToken.getValue()));
         assertClaimsRequestIfPresent(oidcClaimsRequest, true);
+    }
+
+    private void setupClientSessions(
+            String authCode, Map<String, List<String>> authRequestParams, List<VectorOfTrust> vtr) {
+        setupClientSessions(authCode, authRequestParams, vtr, CLIENT_ID, null);
+    }
+
+    private void setupClientSessions(
+            String authCode,
+            Map<String, List<String>> authRequestParams,
+            List<VectorOfTrust> vtr,
+            String clientId,
+            Subject docAppSubjectId) {
+        var clientSession =
+                new ClientSession(authRequestParams, clientSessionCreationTime, vtr, CLIENT_NAME)
+                        .setDocAppSubjectId(docAppSubjectId);
+        when(authorisationCodeService.getExchangeDataForCode(authCode))
+                .thenReturn(
+                        Optional.of(
+                                new AuthCodeExchangeData()
+                                        .setEmail(TEST_EMAIL)
+                                        .setClientSessionId(CLIENT_SESSION_ID)
+                                        .setClientSession(clientSession)
+                                        .setAuthTime(AUTH_TIME)
+                                        .setClientId(clientId)));
+        var orchClientSession =
+                new OrchClientSessionItem(
+                        CLIENT_SESSION_ID,
+                        authRequestParams,
+                        clientSessionCreationTime,
+                        vtr,
+                        CLIENT_NAME);
+        Optional.ofNullable(docAppSubjectId)
+                .ifPresent(subject -> orchClientSession.setDocAppSubjectId(subject.getValue()));
+        when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(orchClientSession));
     }
 
     private UserProfile generateUserProfile() {

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -204,7 +204,6 @@ public class RedisExtension
                         new AuthCodeExchangeData()
                                 .setClientSessionId(clientSessionId)
                                 .setEmail(email)
-                                .setClientSession(clientSession)
                                 .setAuthTime(authTime)
                                 .setClientId(clientId)),
                 300);

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -191,12 +191,7 @@ public class RedisExtension
     }
 
     public void addAuthCode(
-            String authCode,
-            String clientId,
-            String clientSessionId,
-            ClientSession clientSession,
-            String email,
-            Long authTime)
+            String authCode, String clientId, String clientSessionId, String email, Long authTime)
             throws Json.JsonException {
         redis.saveWithExpiry(
                 AUTH_CODE_PREFIX.concat(authCode),

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthCodeExchangeData.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthCodeExchangeData.java
@@ -40,10 +40,6 @@ public class AuthCodeExchangeData {
         return this;
     }
 
-    public ClientSession getClientSession() {
-        return clientSession;
-    }
-
     public AuthCodeExchangeData setClientSession(ClientSession clientSession) {
         this.clientSession = clientSession;
         return this;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthCodeExchangeData.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthCodeExchangeData.java
@@ -15,10 +15,6 @@ public class AuthCodeExchangeData {
     @Expose private String email;
 
     @Expose
-    @SerializedName("clientSession")
-    private ClientSession clientSession;
-
-    @Expose
     @SerializedName("authTime")
     private Long authTime;
 
@@ -37,11 +33,6 @@ public class AuthCodeExchangeData {
 
     public AuthCodeExchangeData setEmail(String email) {
         this.email = email;
-        return this;
-    }
-
-    public AuthCodeExchangeData setClientSession(ClientSession clientSession) {
-        this.clientSession = clientSession;
         return this;
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
@@ -61,7 +61,6 @@ public class AuthorisationCodeService {
                                     .setEmail(email)
                                     .setClientId(clientId)
                                     .setClientSessionId(clientSessionId)
-                                    .setClientSession(clientSession)
                                     .setAuthTime(authTime)),
                     authorisationCodeExpiry);
             return authorizationCode;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
@@ -4,7 +4,6 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 
@@ -40,17 +39,7 @@ public class AuthorisationCodeService {
     }
 
     public AuthorizationCode generateAndSaveAuthorisationCode(
-            String clientId, String clientSessionId, ClientSession clientSession) {
-        return generateAndSaveAuthorisationCode(
-                clientId, clientSessionId, null, clientSession, null);
-    }
-
-    public AuthorizationCode generateAndSaveAuthorisationCode(
-            String clientId,
-            String clientSessionId,
-            String email,
-            ClientSession clientSession,
-            Long authTime) {
+            String clientId, String clientSessionId, String email, Long authTime) {
         LOG.info("Generating and saving AuthorisationCode");
         AuthorizationCode authorizationCode = new AuthorizationCode();
         try {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
@@ -44,7 +44,6 @@ class AuthorisationCodeServiceTest {
                         .setClientId("test-client-id")
                         .setClientSessionId("test-client-session")
                         .setEmail("test@email.com")
-                        .setClientSession(clientSession)
                         .setAuthTime(12345L);
         String expectedJson = objectMapper.writeValueAsString(expectedExchangeData);
         verify(redisConnectionService)

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
@@ -3,12 +3,7 @@ package uk.gov.di.orchestration.shared.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.serialization.Json;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
@@ -33,11 +28,8 @@ class AuthorisationCodeServiceTest {
 
     @Test
     void shouldSaveToRedisWhenGeneratingAuthCode() throws Json.JsonException {
-        ClientSession clientSession =
-                new ClientSession(Map.of(), LocalDateTime.now(), List.of(), "test-client");
-
         authCodeService.generateAndSaveAuthorisationCode(
-                "test-client-id", "test-client-session", "test@email.com", clientSession, 12345L);
+                "test-client-id", "test-client-session", "test@email.com", 12345L);
 
         AuthCodeExchangeData expectedExchangeData =
                 new AuthCodeExchangeData()


### PR DESCRIPTION
### Wider context of change

We recently added a new client session store to save client sessions to a dynamo table, in addition to redis, and started writing to the new store wherever we were writing to the old one. We also added logging to check whether the 2 sessions were in sync.

We found that if a user hit the `TokenHandler` endpoint multiple times, it would use an outdated view of the `clientSession`. In `AuthenticationCallbackHandler`, the `AuthCodeExchangeData` is saved with the current `clientSession`. The `TokenHandler` uses this `AuthCodeExchangeData` to get the `clientSession`, then updates the `clientSession` with an `idTokenHint` later on. 

### What’s changed

This PR updates the TokenHandler to use the `clientSessionService.getClientSession()`, using the `clientSessionId` already in the `AuthCodeExchangeData`.

Since that was the only usage of the client session in the `AuthCodeExchangeData`, this PR also removes the `clientSession` field from the class.

### Manual testing

Tested auth and identity journey in dev. 
- Tested logging in and signing out
- Tested trying to log in when there was already a session cookie. 

All scenarios worked fine.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. n/a
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a
