### PR TITLE
ATO-1512: Adds password reset count to auth session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -39,6 +39,7 @@ class AuthSessionServiceIntegrationTest {
         for (CodeRequestType requestType : CodeRequestType.values()) {
             assertEquals(retrievedSession.get().getCodeRequestCount(requestType), 0);
         }
+        assertEquals(0, retrievedSession.get().getPasswordResetCount());
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -24,6 +24,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
     public static final String ATTRIBUTE_UPLIFT_REQUIRED = "UpliftRequired";
     public static final String ATTRIBUTE_EMAIL = "Email";
+    public static final String ATTRIBUTE_PASSWORD_RESET_COUNT = "PasswordResetCount";
     public static final String ATTRIBUTE_TTL = "ttl";
     public static final String ATTRIBUTE_CODE_REQUEST_COUNT_MAP = "CodeRequestCountMap";
 
@@ -50,6 +51,7 @@ public class AuthSessionItem {
     private boolean upliftRequired;
     private String emailAddress;
     private Map<CodeRequestType, Integer> codeRequestCountMap;
+    private int passwordResetCount;
 
     public AuthSessionItem() {
         this.codeRequestCountMap = new HashMap<>();
@@ -181,6 +183,25 @@ public class AuthSessionItem {
 
     public AuthSessionItem withEmailAddress(String emailAddress) {
         this.emailAddress = emailAddress;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_PASSWORD_RESET_COUNT)
+    public int getPasswordResetCount() {
+        return passwordResetCount;
+    }
+
+    public void setPasswordResetCount(int passwordResetCount) {
+        this.passwordResetCount = passwordResetCount;
+    }
+
+    public AuthSessionItem incrementPasswordResetCount() {
+        this.passwordResetCount = passwordResetCount + 1;
+        return this;
+    }
+
+    public AuthSessionItem resetPasswordResetCount() {
+        this.passwordResetCount = 0;
         return this;
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -55,6 +55,7 @@ class AuthSessionServiceTest {
         for (CodeRequestType requestType : CodeRequestType.values()) {
             assertEquals(session.getCodeRequestCount(requestType), 0);
         }
+        assertEquals(0, session.getPasswordResetCount());
     }
 
     @Test


### PR DESCRIPTION
## What: 

- Adds password reset count to auth session item 

## How to review:
-Deployed to auth dev1
    - Come off the stub, and look up your session. It has the new attribute set to 0

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
