### PR TITLE
ATO-1512: set password reset count auth session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -194,6 +194,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         sessionService.storeOrUpdateSession(
                 userContext.getSession().resetPasswordResetCount(),
                 userContext.getAuthSession().getSessionId());
+        authSessionService.updateSession(userContext.getAuthSession().resetPasswordResetCount());
     }
 
     private void emitPasswordResetRequestedAuditEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -154,6 +154,9 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                     userContext.getSession().incrementPasswordResetCount(),
                     userContext.getAuthSession().getSessionId());
 
+            authSessionService.updateSession(
+                    userContext.getAuthSession().incrementPasswordResetCount());
+
             var userIsNewlyLockedOutOfPasswordReset =
                     hasUserExceededMaxAllowedRequests(request.getEmail(), userContext);
 


### PR DESCRIPTION
### Wider context of change:

- We're migrating the Reset password count to the auth session from the shared session. This involves incrementing and reseting in the same places as the shared session

### What’s changed: 

- Increments the password reset count in same place as shared session
- Resets the password reset count in same place as shared session

### Manual testing

- Deployed to authdev2  
    - Went on a reset password journey and repeatedly request a reset password code
    - Saw count incremented and reset when hit the too many codes screen

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs: 
- https://github.com/govuk-one-login/authentication-api/pull/6158
