### PR TITLE
ATO-1512: get password reset count auth session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -202,7 +202,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
             ResetPasswordRequest request,
             UserContext userContext,
             boolean isTestClient) {
-        int passwordResetCounter = userContext.getSession().getPasswordResetCount();
+        int passwordResetCounter = userContext.getAuthSession().getPasswordResetCount();
         var passwordResetCounterPair = pair("passwordResetCounter", passwordResetCounter);
         var passwordResetTypePair =
                 request.isWithinForcedPasswordResetJourney()
@@ -301,7 +301,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         var codeRequestType =
                 CodeRequestType.getCodeRequestType(
                         RESET_PASSWORD_WITH_CODE, JourneyType.PASSWORD_RESET);
-        var codeRequestCount = userContext.getSession().getPasswordResetCount();
+        var codeRequestCount = userContext.getAuthSession().getPasswordResetCount();
         var codeRequestBlockedKeyPrefix = CODE_REQUEST_BLOCKED_KEY_PREFIX + codeRequestType;
         var codeAttemptsBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
         if (codeRequestCount >= configurationService.getCodeMaxRetries()) {


### PR DESCRIPTION
### Wider context of change:

- We've started incrementing and resetting the password rest count on the auth session. Now we can swap the getter for this value to no longer use the auth sessio

### What’s changed: 
- Swaps shared session `getPasswordResetCount` for Auth session equivalent

### Manual testing

-Deployed to a sandpit:  
    - Went on a reset password journey and repeatedly request a reset password code
    - Saw count incremented and reset when hit the too many codes screen

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs: 
- https://github.com/govuk-one-login/authentication-api/pull/6160
