### PR TITLE
ATO-1512: Remove getter from shared session

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -484,8 +484,7 @@ class ResetPasswordRequestHandlerTest {
             assertThat(result, hasJsonBody(ErrorResponse.ERROR_1022));
             verifyNoInteractions(awsSqsClient);
             verify(sessionService, atLeastOnce())
-                    .storeOrUpdateSession(
-                            argThat(s -> s.getPasswordResetCount() == 0), eq(SESSION_ID));
+                    .storeOrUpdateSession(any(Session.class), eq(SESSION_ID));
             verify(authSessionService, atLeastOnce())
                     .updateSession(argThat(as -> as.getPasswordResetCount() == 0));
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -101,21 +101,6 @@ class AuthOrchSerializationServicesIntegrationTest {
     }
 
     @Test
-    void authCanReadUnsharedFieldAfterOrchUpdatesSession() {
-        var sessionId = "some-existing-session-id";
-        var authSession = new Session();
-        authSession.incrementPasswordResetCount();
-        authSession.incrementPasswordResetCount();
-        authSession.incrementPasswordResetCount();
-        authSessionService.storeOrUpdateSession(authSession, sessionId);
-        var orchSession = orchSessionService.getSession(sessionId).get();
-        orchSession.addClientSession(CLIENT_SESSION_ID);
-        orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
-        authSession = authSessionService.getSession(sessionId).get();
-        assertThat(authSession.getPasswordResetCount(), is(equalTo(3)));
-    }
-
-    @Test
     void authCanReadSessionAfterSessionIdIsUpdated() {
         var oldSessionId = SESSION_ID;
         var newSessionId = "new-session-id";

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -73,10 +73,6 @@ public class Session {
         return this;
     }
 
-    public int getPasswordResetCount() {
-        return passwordResetCount;
-    }
-
     public Session incrementPasswordResetCount() {
         this.passwordResetCount = passwordResetCount + 1;
         return this;


### PR DESCRIPTION
### Wider context of change:

 We're migrating the Reset password count to the auth session from the shared session. 

### What’s changed: 
- Removes session getter method 
- Removes any test usages

### Manual testing: 
- N/A just test code changes

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
