### PR TITLE
AUT-3485: Add scenarios for MfaMethodsCreateHandler

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -94,6 +94,9 @@ public class MFAMethodsCreateHandler
                     case INVALID_PRIORITY_IDENTIFIER -> {
                         return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
                     }
+                    case BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST -> {
+                        return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1068);
+                    }
                 }
             }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -10,7 +10,7 @@ import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.mfa.MfaMethodCreateRequest;
 import uk.gov.di.authentication.shared.entity.mfa.MfaMethodData;
-import uk.gov.di.authentication.shared.exceptions.InvalidPriorityIdentifierException;
+import uk.gov.di.authentication.shared.exceptions.InvalidMfaDetailException;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -90,7 +90,7 @@ public class MFAMethodsCreateHandler
 
             return generateApiGatewayProxyResponse(200, mfaMethodData, true);
 
-        } catch (Json.JsonException | InvalidPriorityIdentifierException e) {
+        } catch (Json.JsonException | InvalidMfaDetailException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
     }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -97,6 +97,9 @@ public class MFAMethodsCreateHandler
                     case BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST -> {
                         return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1068);
                     }
+                    case PHONE_NUMBER_ALREADY_EXISTS -> {
+                        return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1069);
+                    }
                 }
             }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -100,6 +100,9 @@ public class MFAMethodsCreateHandler
                     case PHONE_NUMBER_ALREADY_EXISTS -> {
                         return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1069);
                     }
+                    case AUTH_APP_EXISTS -> {
+                        return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1070);
+                    }
                 }
             }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -285,6 +285,24 @@ class MFAMethodsCreateHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1069));
     }
 
+    @Test
+    void shouldReturn400WhenMfaMethodServiceReturnsAuthAppAlreadyExistsError() {
+        var event =
+                generateApiGatewayEvent(
+                        PriorityIdentifier.BACKUP,
+                        new AuthAppMfaDetail(MFAMethodType.AUTH_APP, TEST_CREDENTIAL),
+                        TEST_PUBLIC_SUBJECT);
+        when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
+                .thenReturn(Optional.of(userProfile));
+        when(mfaMethodsService.addBackupMfa(any(), any()))
+                .thenReturn(Either.left(MfaCreateFailureReason.AUTH_APP_EXISTS));
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1070));
+    }
+
     private APIGatewayProxyRequestEvent generateApiGatewayEvent(
             PriorityIdentifier priorityIdentifier, MfaDetail mfaDetail, String publicSubject) {
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.google.gson.JsonParser;
+import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -17,7 +18,6 @@ import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
 import uk.gov.di.authentication.shared.entity.mfa.MfaMethodCreateRequest;
 import uk.gov.di.authentication.shared.entity.mfa.MfaMethodData;
 import uk.gov.di.authentication.shared.entity.mfa.SmsMfaDetail;
-import uk.gov.di.authentication.shared.exceptions.InvalidMfaDetailException;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -76,17 +76,18 @@ class MFAMethodsCreateHandlerTest {
     }
 
     @Test
-    void shouldReturn200AndCreateMfaSmsMfaMethod() throws InvalidMfaDetailException {
+    void shouldReturn200AndCreateMfaSmsMfaMethod() {
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
         when(userProfile.getEmail()).thenReturn(TEST_EMAIL);
         when(mfaMethodsService.addBackupMfa(any(), any()))
                 .thenReturn(
-                        new MfaMethodData(
-                                TEST_SMS_MFA_ID,
-                                PriorityIdentifier.BACKUP,
-                                true,
-                                new SmsMfaDetail(MFAMethodType.SMS, TEST_PHONE_NUMBER)));
+                        Either.right(
+                                new MfaMethodData(
+                                        TEST_SMS_MFA_ID,
+                                        PriorityIdentifier.BACKUP,
+                                        true,
+                                        new SmsMfaDetail(MFAMethodType.SMS, TEST_PHONE_NUMBER))));
 
         var event =
                 generateApiGatewayEvent(
@@ -127,17 +128,19 @@ class MFAMethodsCreateHandlerTest {
     }
 
     @Test
-    void shouldReturn200AndCreateAuthAppMfa() throws InvalidMfaDetailException {
+    void shouldReturn200AndCreateAuthAppMfa() {
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
         when(userProfile.getEmail()).thenReturn(TEST_EMAIL);
         when(mfaMethodsService.addBackupMfa(any(), any()))
                 .thenReturn(
-                        new MfaMethodData(
-                                TEST_AUTH_APP_ID,
-                                PriorityIdentifier.BACKUP,
-                                true,
-                                new AuthAppMfaDetail(MFAMethodType.AUTH_APP, TEST_CREDENTIAL)));
+                        Either.right(
+                                new MfaMethodData(
+                                        TEST_AUTH_APP_ID,
+                                        PriorityIdentifier.BACKUP,
+                                        true,
+                                        new AuthAppMfaDetail(
+                                                MFAMethodType.AUTH_APP, TEST_CREDENTIAL))));
 
         var event =
                 generateApiGatewayEvent(

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -191,7 +191,7 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
     }
 
     @Test
-    void shouldReturn409ErrorResponseWhenAddingMfaAfterMfaCountLimitReached() {
+    void shouldReturn400ErrorResponseWhenAddingMfaAfterMfaCountLimitReached() {
         userStore.addMfaMethodSupportingMultiple(
                 TEST_EMAIL,
                 MFAMethod.smsMfaMethod(
@@ -220,8 +220,34 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                         Map.of("publicSubjectId", TEST_PUBLIC_SUBJECT),
                         Collections.emptyMap());
 
-        assertEquals(409, response.getStatusCode());
+        assertEquals(400, response.getStatusCode());
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1068));
+    }
+
+    @Test
+    void shouldReturn400ErrorResponseWhenSmsUserAddsSmsMfaWithSamePhoneNumber() {
+        userStore.addMfaMethodSupportingMultiple(
+                TEST_EMAIL,
+                MFAMethod.smsMfaMethod(
+                        true,
+                        true,
+                        TEST_PHONE_NUMBER,
+                        PriorityIdentifier.DEFAULT,
+                        UUID.randomUUID().toString()));
+
+        var response =
+                makeRequest(
+                        Optional.of(
+                                constructRequestBody(
+                                        PriorityIdentifier.BACKUP,
+                                        new SmsMfaDetail(MFAMethodType.SMS, TEST_PHONE_NUMBER))),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("publicSubjectId", TEST_PUBLIC_SUBJECT),
+                        Collections.emptyMap());
+
+        assertEquals(400, response.getStatusCode());
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1069));
     }
 
     private static String constructRequestBody(

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -34,8 +34,30 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
     private static final String TEST_EMAIL = "test@email.com";
     private static final String TEST_PASSWORD = "test-password";
     private static final String TEST_PHONE_NUMBER = "07123123123";
+    private static final String TEST_PHONE_NUMBER_TWO = "07987987987";
     private static final String TEST_CREDENTIAL = "ZZ11BB22CC33DD44EE55FF66GG77HH88II99JJ00";
     private static String TEST_PUBLIC_SUBJECT;
+    private static final MFAMethod defaultPrioritySms =
+            MFAMethod.smsMfaMethod(
+                    true,
+                    true,
+                    TEST_PHONE_NUMBER,
+                    PriorityIdentifier.DEFAULT,
+                    UUID.randomUUID().toString());
+    private static final MFAMethod backupPrioritySms =
+            MFAMethod.smsMfaMethod(
+                    true,
+                    true,
+                    TEST_PHONE_NUMBER_TWO,
+                    PriorityIdentifier.BACKUP,
+                    UUID.randomUUID().toString());
+    private static final MFAMethod defaultPriorityAuthApp =
+            MFAMethod.authAppMfaMethod(
+                    TEST_CREDENTIAL,
+                    true,
+                    true,
+                    PriorityIdentifier.DEFAULT,
+                    UUID.randomUUID().toString());
 
     @BeforeEach
     void setUp() {
@@ -55,14 +77,7 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     @Test
     void shouldReturn200AndMfaMethodDataWhenAuthAppUserAddsSmsMfa() {
-        userStore.addMfaMethodSupportingMultiple(
-                TEST_EMAIL,
-                MFAMethod.authAppMfaMethod(
-                        TEST_CREDENTIAL,
-                        true,
-                        true,
-                        PriorityIdentifier.DEFAULT,
-                        UUID.randomUUID().toString()));
+        userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, defaultPriorityAuthApp);
         var response =
                 makeRequest(
                         Optional.of(
@@ -101,14 +116,7 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     @Test
     void shouldReturn200AndMfaMethodDataWhenSmsUserAddsAuthAppMfa() {
-        userStore.addMfaMethodSupportingMultiple(
-                TEST_EMAIL,
-                MFAMethod.smsMfaMethod(
-                        true,
-                        true,
-                        TEST_PHONE_NUMBER,
-                        PriorityIdentifier.DEFAULT,
-                        UUID.randomUUID().toString()));
+        userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, defaultPrioritySms);
         var response =
                 makeRequest(
                         Optional.of(
@@ -199,22 +207,8 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     @Test
     void shouldReturn400ErrorResponseWhenAddingMfaAfterMfaCountLimitReached() {
-        userStore.addMfaMethodSupportingMultiple(
-                TEST_EMAIL,
-                MFAMethod.smsMfaMethod(
-                        true,
-                        true,
-                        TEST_PHONE_NUMBER,
-                        PriorityIdentifier.DEFAULT,
-                        UUID.randomUUID().toString()));
-        userStore.addMfaMethodSupportingMultiple(
-                TEST_EMAIL,
-                MFAMethod.smsMfaMethod(
-                        true,
-                        true,
-                        TEST_PHONE_NUMBER,
-                        PriorityIdentifier.BACKUP,
-                        UUID.randomUUID().toString()));
+        userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, defaultPrioritySms);
+        userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, backupPrioritySms);
 
         var response =
                 makeRequest(
@@ -233,14 +227,7 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     @Test
     void shouldReturn400ErrorResponseWhenSmsUserAddsSmsMfaWithSamePhoneNumber() {
-        userStore.addMfaMethodSupportingMultiple(
-                TEST_EMAIL,
-                MFAMethod.smsMfaMethod(
-                        true,
-                        true,
-                        TEST_PHONE_NUMBER,
-                        PriorityIdentifier.DEFAULT,
-                        UUID.randomUUID().toString()));
+        userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, defaultPrioritySms);
 
         var response =
                 makeRequest(
@@ -259,14 +246,7 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     @Test
     void shouldReturn400ErrorResponseWhenAuthAppAddsSecondAuthApp() {
-        userStore.addMfaMethodSupportingMultiple(
-                TEST_EMAIL,
-                MFAMethod.authAppMfaMethod(
-                        TEST_CREDENTIAL,
-                        true,
-                        true,
-                        PriorityIdentifier.BACKUP,
-                        UUID.randomUUID().toString()));
+        userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, defaultPriorityAuthApp);
 
         var response =
                 makeRequest(

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -55,7 +55,14 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     @Test
     void shouldReturn200AndMfaMethodDataWhenAuthAppUserAddsSmsMfa() {
-        userStore.addAuthAppMethod(TEST_EMAIL, true, true, TEST_CREDENTIAL);
+        userStore.addMfaMethodSupportingMultiple(
+                TEST_EMAIL,
+                MFAMethod.authAppMfaMethod(
+                        TEST_CREDENTIAL,
+                        true,
+                        true,
+                        PriorityIdentifier.DEFAULT,
+                        UUID.randomUUID().toString()));
         var response =
                 makeRequest(
                         Optional.of(

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -257,6 +257,34 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1069));
     }
 
+    @Test
+    void shouldReturn400ErrorResponseWhenAuthAppAddsSecondAuthApp() {
+        userStore.addMfaMethodSupportingMultiple(
+                TEST_EMAIL,
+                MFAMethod.authAppMfaMethod(
+                        TEST_CREDENTIAL,
+                        true,
+                        true,
+                        PriorityIdentifier.BACKUP,
+                        UUID.randomUUID().toString()));
+
+        var response =
+                makeRequest(
+                        Optional.of(
+                                constructRequestBody(
+                                        PriorityIdentifier.BACKUP,
+                                        new AuthAppMfaDetail(
+                                                MFAMethodType.AUTH_APP,
+                                                "AA99BB88CC77DD66EE55FF44GG33HH22II11JJ00"))),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("publicSubjectId", TEST_PUBLIC_SUBJECT),
+                        Collections.emptyMap());
+
+        assertEquals(400, response.getStatusCode());
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1070));
+    }
+
     private static String constructRequestBody(
             PriorityIdentifier priorityIdentifier, MfaDetail mfaDetail) {
         return format(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MfaMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MfaMethodsServiceIntegrationTest.java
@@ -309,6 +309,21 @@ class MfaMethodsServiceIntegrationTest {
                         MfaCreateFailureReason.BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST,
                         result.getLeft());
             }
+
+            @Test
+            void shouldReturnPhoneNumberAlreadyExistsErrorWhenSmsMfaUserAddsBackupWithSameNumber() {
+                userStoreExtension.addMfaMethodSupportingMultiple(EMAIL, defaultPrioritySms);
+
+                MfaMethodCreateRequest request =
+                        new MfaMethodCreateRequest(
+                                new MfaMethodCreateRequest.MfaMethod(
+                                        PriorityIdentifier.BACKUP,
+                                        new SmsMfaDetail(MFAMethodType.SMS, PHONE_NUMBER)));
+
+                var result = mfaMethodsService.addBackupMfa(TEST_EMAIL, request.mfaMethod());
+
+                assertEquals(MfaCreateFailureReason.PHONE_NUMBER_ALREADY_EXISTS, result.getLeft());
+            }
         }
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MfaMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MfaMethodsServiceIntegrationTest.java
@@ -291,6 +291,24 @@ class MfaMethodsServiceIntegrationTest {
 
                 assertEquals(MfaCreateFailureReason.INVALID_PRIORITY_IDENTIFIER, result.getLeft());
             }
+
+            @Test
+            void shouldReturnAtMaximumMfaErrorWhenAddingBackupWithTwoExistingMfaMethods() {
+                userStoreExtension.addMfaMethodSupportingMultiple(EMAIL, defaultPriorityAuthApp);
+                userStoreExtension.addMfaMethodSupportingMultiple(EMAIL, backupPrioritySms);
+
+                MfaMethodCreateRequest request =
+                        new MfaMethodCreateRequest(
+                                new MfaMethodCreateRequest.MfaMethod(
+                                        PriorityIdentifier.BACKUP,
+                                        new SmsMfaDetail(MFAMethodType.SMS, PHONE_NUMBER)));
+
+                var result = mfaMethodsService.addBackupMfa(TEST_EMAIL, request.mfaMethod());
+
+                assertEquals(
+                        MfaCreateFailureReason.BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST,
+                        result.getLeft());
+            }
         }
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MfaMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MfaMethodsServiceIntegrationTest.java
@@ -318,6 +318,22 @@ class MfaMethodsServiceIntegrationTest {
 
                 assertEquals(MfaCreateFailureReason.PHONE_NUMBER_ALREADY_EXISTS, result.getLeft());
             }
+
+            @Test
+            void shouldReturnAuthAppAlreadyExistsErrorWhenAuthAppMfaUserAddsSecondAuthAppMfa() {
+                userStoreExtension.addMfaMethodSupportingMultiple(EMAIL, defaultPriorityAuthApp);
+
+                MfaMethodCreateRequest request =
+                        new MfaMethodCreateRequest(
+                                new MfaMethodCreateRequest.MfaMethod(
+                                        PriorityIdentifier.BACKUP,
+                                        new AuthAppMfaDetail(
+                                                MFAMethodType.AUTH_APP, AUTH_APP_CREDENTIAL)));
+
+                var result = mfaMethodsService.addBackupMfa(TEST_EMAIL, request.mfaMethod());
+
+                assertEquals(MfaCreateFailureReason.AUTH_APP_EXISTS, result.getLeft());
+            }
         }
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -80,7 +80,8 @@ public enum ErrorResponse {
     ERROR_1066(1066, "Cannot delete default priority mfa method"),
     ERROR_1067(1067, "Cannot delete mfa method for non-migrated user"),
     ERROR_1068(1068, "MFA method count limit reached"),
-    ERROR_1069(1069, "SMS MFA with same number already exists");
+    ERROR_1069(1069, "SMS MFA with same number already exists"),
+    ERROR_1070(1070, "AUTH APP MFA already exists");
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -79,7 +79,8 @@ public enum ErrorResponse {
     ERROR_1065(1065, "Mfa method not found"),
     ERROR_1066(1066, "Cannot delete default priority mfa method"),
     ERROR_1067(1067, "Cannot delete mfa method for non-migrated user"),
-    ERROR_1068(1068, "MFA method count limit reached");
+    ERROR_1068(1068, "MFA method count limit reached"),
+    ERROR_1069(1069, "SMS MFA with same number already exists");
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -78,7 +78,8 @@ public enum ErrorResponse {
     ERROR_1064(1064, "Unknown mfa method type"),
     ERROR_1065(1065, "Mfa method not found"),
     ERROR_1066(1066, "Cannot delete default priority mfa method"),
-    ERROR_1067(1067, "Cannot delete mfa method for non-migrated user");
+    ERROR_1067(1067, "Cannot delete mfa method for non-migrated user"),
+    ERROR_1068(1068, "MFA method count limit reached");
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/InvalidMfaDetailException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/InvalidMfaDetailException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.authentication.shared.exceptions;
-
-public class InvalidMfaDetailException extends Exception {
-    public InvalidMfaDetailException(String message) {
-        super(message);
-    }
-}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/InvalidMfaDetailException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/InvalidMfaDetailException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class InvalidMfaDetailException extends Exception {
+    public InvalidMfaDetailException(String message) {
+        super(message);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaCreateFailureReason.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaCreateFailureReason.java
@@ -3,5 +3,6 @@ package uk.gov.di.authentication.shared.services.mfa;
 public enum MfaCreateFailureReason {
     INVALID_PRIORITY_IDENTIFIER,
     BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST,
-    PHONE_NUMBER_ALREADY_EXISTS
+    PHONE_NUMBER_ALREADY_EXISTS,
+    AUTH_APP_EXISTS
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaCreateFailureReason.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaCreateFailureReason.java
@@ -1,0 +1,5 @@
+package uk.gov.di.authentication.shared.services.mfa;
+
+public enum MfaCreateFailureReason {
+    INVALID_PRIORITY_IDENTIFIER
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaCreateFailureReason.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaCreateFailureReason.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.services.mfa;
 
 public enum MfaCreateFailureReason {
-    INVALID_PRIORITY_IDENTIFIER
+    INVALID_PRIORITY_IDENTIFIER,
+    BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaCreateFailureReason.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaCreateFailureReason.java
@@ -2,5 +2,6 @@ package uk.gov.di.authentication.shared.services.mfa;
 
 public enum MfaCreateFailureReason {
     INVALID_PRIORITY_IDENTIFIER,
-    BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST
+    BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST,
+    PHONE_NUMBER_ALREADY_EXISTS
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaMethodsService.java
@@ -176,6 +176,16 @@ public class MfaMethodsService {
                             true,
                             smsMfaDetail.phoneNumber()));
         } else {
+            boolean authAppExists =
+                    mfaMethods.stream()
+                            .map(MfaMethodData::method)
+                            .filter(AuthAppMfaDetail.class::isInstance)
+                            .anyMatch(mfa -> true);
+
+            if (authAppExists) {
+                return Either.left(MfaCreateFailureReason.AUTH_APP_EXISTS);
+            }
+
             String uuid = UUID.randomUUID().toString();
             persistentService.addMFAMethodSupportingMultiple(
                     email,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaMethodsService.java
@@ -140,6 +140,13 @@ public class MfaMethodsService {
             return Either.left(MfaCreateFailureReason.INVALID_PRIORITY_IDENTIFIER);
         }
 
+        UserCredentials userCredentials = persistentService.getUserCredentialsFromEmail(email);
+        List<MfaMethodData> mfaMethods = getMfaMethodsForMigratedUser(userCredentials);
+
+        if (mfaMethods.size() >= 2) {
+            return Either.left(MfaCreateFailureReason.BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST);
+        }
+
         if (mfaMethod.method() instanceof SmsMfaDetail smsMfaDetail) {
             String uuid = UUID.randomUUID().toString();
             persistentService.addMFAMethodSupportingMultiple(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaMethodsService.java
@@ -148,6 +148,18 @@ public class MfaMethodsService {
         }
 
         if (mfaMethod.method() instanceof SmsMfaDetail smsMfaDetail) {
+
+            boolean phoneNumberExists =
+                    mfaMethods.stream()
+                            .map(MfaMethodData::method)
+                            .filter(SmsMfaDetail.class::isInstance)
+                            .map(SmsMfaDetail.class::cast)
+                            .anyMatch(mfa -> mfa.phoneNumber().equals(smsMfaDetail.phoneNumber()));
+
+            if (phoneNumberExists) {
+                return Either.left(MfaCreateFailureReason.PHONE_NUMBER_ALREADY_EXISTS);
+            }
+
             String uuid = UUID.randomUUID().toString();
             persistentService.addMFAMethodSupportingMultiple(
                     email,


### PR DESCRIPTION
## What
Implements the success scenario P2 and error scenarios E2, E5, and E6

- P2: Migrated user with sms mfa only adds an auth app mfa (no OTP presented)
- E2: Migrated user with auth app mfa only attempts to add a second auth app mfa
- E5: Already have 2 MFAs
- E6: Client attempts to add an SMS MFA with the same number as an existing SMS MFA

Error scenario E1 and success scenarios P1 and P3 were implemented in a [previous pull request](https://github.com/govuk-one-login/authentication-api/pull/6121) (albeit for P1 and P3 without OTP handling).

This leaves error scenarios E3 and E4 unimplemented at the time of writing as they are based around the user having provided an invalid OTP when OTP handling has not yet been implemented.

See scenarios [here](https://govukverify.atlassian.net/browse/AUT-3485)

## How to review

1.  Code review
2. Deploy to dev environment with account in required state and make test requests to the mfa-methods-create seeing expected responses.

