### PR TITLE
AUT-2912: Send `2fa_method` property to TICF CRI 

### DIFF
--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -51,7 +51,7 @@ public class UserInfoServiceTest {
     private static final boolean TEST_EMAIL_VERIFIED = true;
     private static final String TEST_PHONE = "test-phone";
     private static final boolean TEST_PHONE_VERIFIED = true;
-    private static final String TEST_VERIFIED_MFA_METHOD_TYPE = MFAMethodType.EMAIL.getValue();
+    private static final MFAMethodType TEST_VERIFIED_MFA_METHOD_TYPE = MFAMethodType.EMAIL;
     private static final CredentialTrustLevel TEST_CURRENT_CREDENTIAL_STRENGTH =
             CredentialTrustLevel.MEDIUM_LEVEL;
     private static final boolean TEST_UPLIFT_REQUIRED = true;
@@ -97,7 +97,7 @@ public class UserInfoServiceTest {
             String expectedPhoneNumber,
             Boolean expectedPhoneNumberVerified,
             String expectedSalt,
-            String expectedVerifiedMfaMethod,
+            MFAMethodType expectedVerifiedMfaMethod,
             CredentialTrustLevel expectedCurrentCredentialStrength,
             Boolean expectedUpliftRequired) {
         UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore, authSession);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.frontendapi.services.AccountInterventionsService
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
@@ -199,7 +200,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                         request.authenticated(),
                         authSession.getIsNewAccount(),
                         authSession.getResetPasswordState(),
-                        authSession.getResetMfaState());
+                        authSession.getResetMfaState(),
+                        authSession.getVerifiedMfaMethodType());
             }
 
             LOG.info("Generating Account Interventions outbound response for frontend");
@@ -219,7 +221,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             boolean authenticated,
             AuthSessionItem.AccountState accountState,
             AuthSessionItem.ResetPasswordState resetPasswordState,
-            AuthSessionItem.ResetMfaState resetMfaState) {
+            AuthSessionItem.ResetMfaState resetMfaState,
+            MFAMethodType verifiedMfaMethodType) {
         var vtr = new ArrayList<String>();
 
         try {
@@ -246,7 +249,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                         authenticated,
                         accountState,
                         resetPasswordState,
-                        resetMfaState);
+                        resetMfaState,
+                        verifiedMfaMethodType);
 
         String payload;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -401,7 +401,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             sessionService.storeOrUpdateSession(
                     session.setVerifiedMfaMethodType(MFAMethodType.SMS), sessionId);
             authSessionService.updateSession(
-                    authSession.withVerifiedMfaMethodType(MFAMethodType.SMS.getValue()));
+                    authSession.withVerifiedMfaMethodType(MFAMethodType.SMS));
             clearAccountRecoveryBlockIfPresent(authSession, auditContext);
             cloudwatchMetricsService.incrementAuthenticationSuccess(
                     authSession.getIsNewAccount(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -413,7 +413,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
         authSessionService.updateSession(
                 authSession
-                        .withVerifiedMfaMethodType(codeRequest.getMfaMethodType().getValue())
+                        .withVerifiedMfaMethodType(codeRequest.getMfaMethodType())
                         .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL));
 
         var clientId = userContext.getClientId();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -34,6 +34,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -287,12 +288,14 @@ class AccountInterventionsHandlerTest {
                         AuthSessionItem.AccountState.EXISTING,
                         AuthSessionItem.ResetPasswordState.NONE,
                         AuthSessionItem.ResetMfaState.NONE,
+                        MFAMethodType.NONE,
                         "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\"}"),
                 Arguments.of(
                         false,
                         AuthSessionItem.AccountState.EXISTING,
                         AuthSessionItem.ResetPasswordState.NONE,
                         AuthSessionItem.ResetMfaState.NONE,
+                        MFAMethodType.NONE,
                         "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"N\"}"),
 
                 // Testing initial registration combinations
@@ -301,12 +304,14 @@ class AccountInterventionsHandlerTest {
                         AuthSessionItem.AccountState.NEW,
                         AuthSessionItem.ResetPasswordState.NONE,
                         AuthSessionItem.ResetMfaState.NONE,
+                        MFAMethodType.NONE,
                         "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\",\"initialRegistration\":\"Y\"}"),
                 Arguments.of(
                         false,
                         AuthSessionItem.AccountState.NEW,
                         AuthSessionItem.ResetPasswordState.NONE,
                         AuthSessionItem.ResetMfaState.NONE,
+                        MFAMethodType.NONE,
                         "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"N\",\"initialRegistration\":\"Y\"}"),
 
                 // Testing password reset combinations
@@ -315,12 +320,14 @@ class AccountInterventionsHandlerTest {
                         AuthSessionItem.AccountState.EXISTING,
                         AuthSessionItem.ResetPasswordState.SUCCEEDED,
                         AuthSessionItem.ResetMfaState.NONE,
+                        MFAMethodType.NONE,
                         "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\",\"passwordReset\":\"Y\"}"),
                 Arguments.of(
                         false,
                         AuthSessionItem.AccountState.EXISTING,
                         AuthSessionItem.ResetPasswordState.ATTEMPTED,
                         AuthSessionItem.ResetMfaState.NONE,
+                        MFAMethodType.NONE,
                         "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"N\",\"passwordReset\":\"Y\"}"),
 
                 // Testing mfa reset combinations
@@ -329,19 +336,52 @@ class AccountInterventionsHandlerTest {
                         AuthSessionItem.AccountState.EXISTING,
                         AuthSessionItem.ResetPasswordState.NONE,
                         AuthSessionItem.ResetMfaState.SUCCEEDED,
+                        MFAMethodType.NONE,
                         "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\",\"2fa_reset\":\"Y\"}"),
                 Arguments.of(
                         true,
                         AuthSessionItem.AccountState.EXISTING,
                         AuthSessionItem.ResetPasswordState.NONE,
                         AuthSessionItem.ResetMfaState.ATTEMPTED,
+                        MFAMethodType.NONE,
                         "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\"}"),
                 Arguments.of(
                         false,
                         AuthSessionItem.AccountState.EXISTING,
                         AuthSessionItem.ResetPasswordState.NONE,
                         AuthSessionItem.ResetMfaState.ATTEMPTED,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"N\",\"2fa_reset\":\"Y\"}"));
+                        MFAMethodType.NONE,
+                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"N\",\"2fa_reset\":\"Y\"}"),
+
+                // Testing mfa method combinations
+                Arguments.of(
+                        true,
+                        AuthSessionItem.AccountState.EXISTING,
+                        AuthSessionItem.ResetPasswordState.NONE,
+                        AuthSessionItem.ResetMfaState.NONE,
+                        MFAMethodType.NONE,
+                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\"}"),
+                Arguments.of(
+                        true,
+                        AuthSessionItem.AccountState.EXISTING,
+                        AuthSessionItem.ResetPasswordState.NONE,
+                        AuthSessionItem.ResetMfaState.NONE,
+                        MFAMethodType.EMAIL,
+                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\"}"),
+                Arguments.of(
+                        true,
+                        AuthSessionItem.AccountState.EXISTING,
+                        AuthSessionItem.ResetPasswordState.NONE,
+                        AuthSessionItem.ResetMfaState.NONE,
+                        MFAMethodType.SMS,
+                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\",\"2fa_method\":[\"SMS\"]}"),
+                Arguments.of(
+                        true,
+                        AuthSessionItem.AccountState.EXISTING,
+                        AuthSessionItem.ResetPasswordState.NONE,
+                        AuthSessionItem.ResetMfaState.NONE,
+                        MFAMethodType.AUTH_APP,
+                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\",\"2fa_method\":[\"AUTH_APP\"]}"));
     }
 
     @ParameterizedTest
@@ -351,6 +391,7 @@ class AccountInterventionsHandlerTest {
             AuthSessionItem.AccountState accountState,
             AuthSessionItem.ResetPasswordState resetPasswordState,
             AuthSessionItem.ResetMfaState resetMfaState,
+            MFAMethodType usedMfaMethodType,
             String expectedPayload)
             throws UnsuccessfulAccountInterventionsResponseException {
         when(configurationService.accountInterventionsServiceActionEnabled()).thenReturn(false);
@@ -365,7 +406,8 @@ class AccountInterventionsHandlerTest {
                 authSession
                         .withAccountState(accountState)
                         .withResetPasswordState(resetPasswordState)
-                        .withResetMfaState(resetMfaState);
+                        .withResetMfaState(resetMfaState)
+                        .withVerifiedMfaMethodType(usedMfaMethodType);
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSessionWithChanges));
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -645,9 +645,9 @@ class VerifyCodeHandlerTest {
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
 
         assertThat(result, hasStatus(204));
-        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS.getValue()));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         verify(authSessionService)
-                .updateSession(authSession.withVerifiedMfaMethodType(MFAMethodType.SMS.getValue()));
+                .updateSession(authSession.withVerifiedMfaMethodType(MFAMethodType.SMS));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -335,7 +335,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                         .getSession(TEST_SESSION_ID)
                         .get()
                         .withAccountState(AuthSessionItem.AccountState.NEW)
-                        .withVerifiedMfaMethodType(MFAMethodType.AUTH_APP.getValue())
+                        .withVerifiedMfaMethodType(MFAMethodType.AUTH_APP)
                         .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL)
                         .withUpliftRequired(true));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -372,7 +373,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
-                equalTo("SMS"));
+                equalTo(MFAMethodType.SMS));
     }
 
     @ParameterizedTest
@@ -404,7 +405,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED));
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
-                equalTo("SMS"));
+                equalTo(MFAMethodType.SMS));
     }
 
     @Test
@@ -431,7 +432,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
-                equalTo("SMS"));
+                equalTo(MFAMethodType.SMS));
     }
 
     @ParameterizedTest

--- a/shared/src/main/java/uk/gov/di/authentication/entity/TICFCRIRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/TICFCRIRequest.java
@@ -8,7 +8,9 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem.ResetPasswordState
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.validation.Required;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public record TICFCRIRequest(
         @Expose String sub,
@@ -54,5 +56,56 @@ public record TICFCRIRequest(
                 passwordReset ? "Y" : null,
                 mfaReset ? "Y" : null,
                 sanitisedMfaMethodType != null ? new String[] {sanitisedMfaMethodType} : null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TICFCRIRequest comparison = (TICFCRIRequest) o;
+
+        return Objects.equals(sub, comparison.sub)
+                && vtr == comparison.vtr
+                && Objects.equals(govukSigninJourneyId, comparison.govukSigninJourneyId)
+                && Objects.equals(authenticated, comparison.authenticated)
+                && Objects.equals(initialRegistration, comparison.initialRegistration)
+                && Objects.equals(passwordReset, comparison.passwordReset)
+                && Objects.equals(mfaReset, comparison.mfaReset)
+                && Arrays.equals(mfaMethod, comparison.mfaMethod);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(sub);
+        result = 31 * result * Objects.hash(vtr);
+        result = 31 * result * Objects.hash(govukSigninJourneyId);
+        result = 31 * result * Objects.hash(authenticated);
+        result = 31 * result * Objects.hash(initialRegistration);
+        result = 31 * result * Objects.hash(passwordReset);
+        result = 31 * result * Objects.hash(mfaReset);
+        result = 31 * result * Arrays.hashCode(mfaMethod);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TICFCRIRequest{"
+                + "sub='"
+                + sub
+                + "', vtr='"
+                + vtr
+                + "', govukSigninJourneyId='"
+                + govukSigninJourneyId
+                + "', authenticated='"
+                + authenticated
+                + "', initialRegistration='"
+                + initialRegistration
+                + "', passwordReset='"
+                + passwordReset
+                + "', mfaReset='"
+                + mfaReset
+                + "', mfaMethod='"
+                + Arrays.toString(mfaMethod)
+                + "'}";
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import uk.gov.di.authentication.shared.converters.CodeRequestCountMapConverter;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,7 +50,7 @@ public class AuthSessionItem {
     }
 
     private String sessionId;
-    private String verifiedMfaMethodType;
+    private MFAMethodType verifiedMfaMethodType;
     private long timeToLive;
     private AccountState isNewAccount;
     private ResetPasswordState resetPasswordState = ResetPasswordState.NONE;
@@ -82,15 +83,15 @@ public class AuthSessionItem {
     }
 
     @DynamoDbAttribute(ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE)
-    public String getVerifiedMfaMethodType() {
+    public MFAMethodType getVerifiedMfaMethodType() {
         return verifiedMfaMethodType;
     }
 
-    public void setVerifiedMfaMethodType(String verifiedMfaMethodType) {
+    public void setVerifiedMfaMethodType(MFAMethodType verifiedMfaMethodType) {
         this.verifiedMfaMethodType = verifiedMfaMethodType;
     }
 
-    public AuthSessionItem withVerifiedMfaMethodType(String verifiedMfaMethodType) {
+    public AuthSessionItem withVerifiedMfaMethodType(MFAMethodType verifiedMfaMethodType) {
         this.verifiedMfaMethodType = verifiedMfaMethodType;
         return this;
     }


### PR DESCRIPTION
## What

When a user submits a MFA method code it is recorded in their session. This is then used to determine if the `2fa_method=[SMS]` or `2fa_method=[AUTH_APP]` attribute should be added to the payload to the TICF CRI API in sign in, sign up and account recovery journeys.



## How to review

1. Code Review
1. Deploy to a dev environment
2. Do the following journeys (in this order helps assuming you start with an account that has `AUTH_APP` MFA method type set up)
```
sign in AUTH_APP submitted
account recovery new SMS submitted
password reset SMS submitted
sign in SMS submitted
account recovery new AUTH_APP submitted
password reset AUTH_APP submitted
sign up SMS submitted
sign up AUTH_APP submitted
Password only sign in
```
4. Filtering CloudWatch logs in the `*-account-interventions-lambda` with "Invoking TICF CRI with payload" and check the payload for journies contains `"2fa_method":...` as expected.

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.

