### PR TITLE
ATO-1117: add test for base64EncodedSalt in spot queue

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -41,6 +41,7 @@ import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.IPVStubExtension;
@@ -63,9 +64,12 @@ import java.util.Optional;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.AUTH_CODE_ISSUED;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED;
@@ -280,6 +284,70 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 .get(ValidClaims.RETURN_CODE.getValue()),
                         JSONArray.class);
         assertThat(returnCode.size(), equalTo(2));
+    }
+
+    @Test
+    void shouldSendCorrectRawStringToSpot() throws Json.JsonException {
+        var scope = new Scope(OIDCScopeValue.OPENID);
+        var authRequestBuilder =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                scope,
+                                new ClientID(CLIENT_ID),
+                                URI.create(REDIRECT_URI))
+                        .nonce(new Nonce())
+                        .state(RP_STATE);
+        redis.createSession(SESSION_ID);
+        var clientCreationTime = LocalDateTime.now();
+        redis.createClientSession(
+                CLIENT_SESSION_ID,
+                CLIENT_NAME,
+                authRequestBuilder.build().toParameters(),
+                clientCreationTime);
+        orchClientSessionExtension.storeClientSession(
+                new OrchClientSessionItem(
+                        CLIENT_SESSION_ID,
+                        authRequestBuilder.build().toParameters(),
+                        clientCreationTime,
+                        List.of(VectorOfTrust.getDefaults()),
+                        CLIENT_NAME));
+        redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
+        redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
+
+        makeRequest(
+                Optional.empty(),
+                Map.of(
+                        "Cookie",
+                        format(
+                                "gs=%s.%s;di-persistent-session-id=%s",
+                                SESSION_ID, CLIENT_SESSION_ID, PERSISTENT_SESSION_ID)),
+                new HashMap<>(
+                        Map.of(
+                                "state",
+                                ORCHESTRATION_STATE.getValue(),
+                                "code",
+                                new AuthorizationCode().getValue())));
+
+        await().atMost(1, SECONDS)
+                .untilAsserted(
+                        () -> assertThat(spotQueue.getApproximateMessageCount(), equalTo(1)));
+
+        var rawSpotRequest = spotQueue.getRawMessages();
+
+        assertEquals(
+                rawSpotRequest.get(0),
+                "{\"in_claims\":{\"https://vocab.account.gov.uk/v1/coreIdentity\":{\"name\":[{\"nameParts\":[{\"type\":\"GivenName\",\"value\":\"kenneth\"},{\"type\":\"FamilyName\",\"value\":\"decerqueira\"}]}],\"birthDate\":[{\"value\":\"1964-11-07\"}]},\"https://vocab.account.gov.uk/v1/credentialJWT\":[\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvaW50ZWdyYXRpb24tZGktaXB2LWNyaS1hZGRyZXNzLWZyb250LmxvbmRvbi5jbG91ZGFwcHMuZGlnaXRhbCIsInN1YiI6InVybjpmZGM6Z292LnVrOjIwMjI6XzM5VVBHaU1KakVWUG9faEZVcGRqNmRuUVdaM2RLRHZZeVM4TVl6XzIzQSIsIm5iZiI6MTY1NDg2NzE2MSwiZXhwIjoxNjU0ODY5ODYxLCJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJhZGRyZXNzIjpbeyJ1cHJuIjpudWxsLCJidWlsZGluZ051bWJlciI6IjgiLCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJhZGRyZXNzQ291bnRyeSI6IkdCIiwidmFsaWRGcm9tIjoiMjAwMC0wMS0wMSJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJBZGRyZXNzQ3JlZGVudGlhbCJdLCJAY29udGV4dCI6WyJodHRwczpcL1wvd3d3LnczLm9yZ1wvMjAxOFwvY3JlZGVudGlhbHNcL3YxIiwiaHR0cHM6XC9cL3ZvY2FiLmxvbmRvbi5jbG91ZGFwcHMuZGlnaXRhbFwvY29udGV4dHNcL2lkZW50aXR5LXYxLmpzb25sZCJdfX0.MEUCIEjlQYJ_Tp5sH_twF6FNhByRqyEq_6VOUWV8DpLoYs2FAiEA-om1BW1HXy2y-elaK98N109FVDxHSVmz-WyLfU1Laq8\",\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvaW50ZWdyYXRpb24tZGktaXB2LWNyaS1mcmF1ZC1mcm9udC5sb25kb24uY2xvdWRhcHBzLmRpZ2l0YWwiLCJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOl8zOVVQR2lNSmpFVlBvX2hGVXBkajZkblFXWjNkS0R2WXlTOE1Zel8yM0EiLCJuYmYiOjE2NTQ4NjcxODQsImV4cCI6MTY1NDg2OTg4NCwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5NjQtMTEtMDcifV0sImFkZHJlc3MiOlt7ImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvQm94TnVtYmVyIjpudWxsLCJhZGRyZXNzVHlwZSI6IkNVUlJFTlQiLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImlkIjpudWxsLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwic3ViQnVpbGRpbmdOYW1lIjpudWxsfV0sIm5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoia2VubmV0aCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6ImRlY2VycXVlaXJhIn1dfV19LCJldmlkZW5jZSI6W3sidHhuIjoiUkIwMDAwOTk3MDI2MTYiLCJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsImlkZW50aXR5RnJhdWRTY29yZSI6MSwiY2kiOltdfV0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJJZGVudGl0eUNoZWNrQ3JlZGVudGlhbCJdfX0.MEYCIQD5ClbV90UKbTBle9UzWvgq1SdiwKlw1-K2W03pMgv5iwIhAK0sr2ebq8Bac0vGARafUZrhy2RraWf53MP0pmAy-_g2\",\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvaW50ZWdyYXRpb24tZGktaXB2LWNyaS1rYnYtZnJvbnQubG9uZG9uLmNsb3VkYXBwcy5kaWdpdGFsIiwic3ViIjoidXJuOmZkYzpnb3YudWs6MjAyMjpfMzlVUEdpTUpqRVZQb19oRlVwZGo2ZG5RV1ozZEtEdll5UzhNWXpfMjNBIiwibmJmIjoxNjU0ODY3MzUwLCJleHAiOjE2NTQ4NzAwNTAsInZjIjp7ImV2aWRlbmNlIjpbeyJ0eG4iOiI3SkFRSjRGQzRHIiwidmVyaWZpY2F0aW9uU2NvcmUiOjIsInR5cGUiOiJJZGVudGl0eUNoZWNrIn1dLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6Imtlbm5ldGgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJkZWNlcnF1ZWlyYSJ9XX1dLCJhZGRyZXNzIjpbeyJhZGRyZXNzQ291bnRyeSI6IkdCIiwidXBybiI6bnVsbCwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwidmFsaWRGcm9tIjoiMjAwMC0wMS0wMSJ9LHsidXBybiI6bnVsbCwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIn1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk2NC0xMS0wNyJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJJZGVudGl0eUNoZWNrQ3JlZGVudGlhbCJdfX0.MEQCICA_FEuk_sVCfqQLS2FKnxCEkaH8KOtKE1RbqwzrMKPQAiBKy2V_u0ZQ5O1fwaww6WTZhZUk2k0f5abLDB48ViwjKg\",\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOl8zOVVQR2lNSmpFVlBvX2hGVXBkajZkblFXWjNkS0R2WXlTOE1Zel8yM0EiLCJhdWQiOiJodHRwczpcL1wvaWRlbnRpdHkuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJuYmYiOjE2NTQ4NjcwODYsImlzcyI6Imh0dHBzOlwvXC9yZXZpZXctcC5pbnRlZ3JhdGlvbi5hY2NvdW50Lmdvdi51ayIsImV4cCI6MTY1NDg2OTQ4NiwidmMiOnsiZXZpZGVuY2UiOlt7InZhbGlkaXR5U2NvcmUiOjIsInN0cmVuZ3RoU2NvcmUiOjQsImNpIjpudWxsLCJ0eG4iOiIzMjY3NzY2NC1mMGRkLTQ4YWQtYjY1NC03MzYzNGMwZTJkMmIiLCJ0eXBlIjoiSWRlbnRpdHlDaGVjayJ9XSwiY3JlZGVudGlhbFN1YmplY3QiOnsicGFzc3BvcnQiOlt7ImV4cGlyeURhdGUiOiIyMDMwLTAxLTAxIiwiZG9jdW1lbnROdW1iZXIiOiIzMjE2NTQ5ODcifV0sIm5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoia2VubmV0aCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6ImRlY2VycXVlaXJhIn1dfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTY0LTExLTA3In1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl19fQ.MEUCIQD3z0rGb7YPFvOKt7p-tlkarsU16lpuOzcdlyNP3WutHgIgfbP0zxvHFAS54VGbnpumfTAxvMM1dsVhfje-2xWTQ0I\"],\"vot\":\"P2\",\"vtm\":\"http://localhost/trustmark\"},"
+                        + "\"in_local_account_id\":\""
+                        + TEST_SUBJECT.getValue()
+                        + "\",\"in_salt\":"
+                        + SerializationService.getInstance().writeValueAsString(base64EncodedSalt)
+                        + ",\"in_rp_sector_id\":\"test.com\","
+                        + "\"out_sub\":\""
+                        + internalCommonSubjectId
+                        + "\",\"log_ids\":{\"session_id\":\"some-session-id\""
+                        + ",\"persistent_session_id\":\""
+                        + PERSISTENT_SESSION_ID
+                        + "\",\"request_id\":null,\"client_id\":\"test-client-id\",\"client_session_id\":\"some-client-session-id\"},\"out_audience\":\"test-client-id\"}");
     }
 
     @Test


### PR DESCRIPTION
### Wider context of change
Part of the email migration work on IPVCallbackHandler

### What’s changed
The SpotRequest object holds salt as byte[], but in this ticket, I want to refactor it to use base64EncodedSalt instead. This is because the salt on the AuthUserInfo table is stored as a base64 string, and the way we send salt on to SPOT is also as a base64 string. I'm adding this test here to verify the raw string we send to Spot is the same thing now as it is with the new refactor. The one piece of nuance is that the `writeValueAsString` method changes the "=" to "\u003d". That happens currently, and this test proves that it will continue to happen when we pass in a string rather than a byte[].

### Manual testing
n/a

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs
Created this test after a comment on https://github.com/govuk-one-login/authentication-api/pull/5804. I checked manually that my understanding is correct, but rightly so, it's really important that it's correct, so I'm adding this test to verify the change.