### PR TITLE
ATO-1116: get rpPairwiseId from client session in logout helper

### DIFF
--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -1163,7 +1163,7 @@ class IPVCallbackHandlerTest {
 
         verify(logoutService)
                 .handleAccountInterventionLogout(
-                        new DestroySessionsRequest(SESSION_ID, List.of(), TEST_EMAIL_ADDRESS),
+                        new DestroySessionsRequest(SESSION_ID, List.of()),
                         TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER,
                         event,
                         CLIENT_ID.getValue(),
@@ -1208,7 +1208,7 @@ class IPVCallbackHandlerTest {
 
         verify(logoutService)
                 .handleAccountInterventionLogout(
-                        new DestroySessionsRequest(SESSION_ID, List.of(), TEST_EMAIL_ADDRESS),
+                        new DestroySessionsRequest(SESSION_ID, List.of()),
                         TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER,
                         request,
                         CLIENT_ID.getValue(),

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -258,7 +258,7 @@ class ProcessingIdentityHandlerTest {
 
         verify(logoutService)
                 .handleAccountInterventionLogout(
-                        new DestroySessionsRequest(SESSION_ID, List.of(), null),
+                        new DestroySessionsRequest(SESSION_ID, List.of()),
                         null,
                         event,
                         CLIENT_ID,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -489,11 +489,7 @@ class AuthenticationCallbackHandlerTest {
 
         verify(logoutService, times(1))
                 .handleReauthenticationFailureLogout(
-                        eq(
-                                new DestroySessionsRequest(
-                                        SESSION_ID,
-                                        List.of(CLIENT_SESSION_ID),
-                                        TEST_EMAIL_ADDRESS)),
+                        eq(new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID))),
                         eq(null),
                         eq(event),
                         eq(CLIENT_ID.toString()),
@@ -891,8 +887,7 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                new DestroySessionsRequest(
-                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID)),
                                 TEST_INTERNAL_COMMON_SUBJECT_ID,
                                 event,
                                 CLIENT_ID.toString(),
@@ -912,8 +907,7 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                new DestroySessionsRequest(
-                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID)),
                                 TEST_INTERNAL_COMMON_SUBJECT_ID,
                                 event,
                                 CLIENT_ID.toString(),
@@ -933,8 +927,7 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                new DestroySessionsRequest(
-                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID)),
                                 TEST_INTERNAL_COMMON_SUBJECT_ID,
                                 event,
                                 CLIENT_ID.toString(),
@@ -977,8 +970,7 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                new DestroySessionsRequest(
-                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID)),
                                 TEST_INTERNAL_COMMON_SUBJECT_ID,
                                 event,
                                 CLIENT_ID.getValue(),
@@ -1039,8 +1031,7 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                new DestroySessionsRequest(
-                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID)),
                                 TEST_INTERNAL_COMMON_SUBJECT_ID,
                                 event,
                                 CLIENT_ID.getValue(),
@@ -1096,8 +1087,7 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                new DestroySessionsRequest(
-                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID)),
                                 TEST_INTERNAL_COMMON_SUBJECT_ID,
                                 event,
                                 CLIENT_ID.toString(),
@@ -1151,8 +1141,7 @@ class AuthenticationCallbackHandlerTest {
 
                 verify(logoutService)
                         .handleAccountInterventionLogout(
-                                new DestroySessionsRequest(
-                                        SESSION_ID, List.of(CLIENT_SESSION_ID), TEST_EMAIL_ADDRESS),
+                                new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID)),
                                 TEST_INTERNAL_COMMON_SUBJECT_ID,
                                 event,
                                 CLIENT_ID.toString(),
@@ -1326,9 +1315,7 @@ class AuthenticationCallbackHandlerTest {
                     .handleMaxAgeLogout(
                             eq(
                                     new DestroySessionsRequest(
-                                            PREVIOUS_SESSION_ID,
-                                            PREVIOUS_CLIENT_SESSIONS,
-                                            TEST_EMAIL_ADDRESS)),
+                                            PREVIOUS_SESSION_ID, PREVIOUS_CLIENT_SESSIONS)),
                             eq(previousOrchSession),
                             any(TxmaAuditUser.class));
         }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -142,8 +142,7 @@ class LogoutHandlerTest {
         var expectedDestroySessionsRequest =
                 new DestroySessionsRequest(
                         SESSION_ID,
-                        List.of(CLIENT_SESSION_ID, "client-session-id-2", "client-session-id-3"),
-                        EMAIL);
+                        List.of(CLIENT_SESSION_ID, "client-session-id-2", "client-session-id-3"));
         TxmaAuditUser expectedAuditUser =
                 TxmaAuditUser.user()
                         .withIpAddress(SOURCE_IP)
@@ -217,8 +216,7 @@ class LogoutHandlerTest {
                                 CLIENT_SESSION_ID,
                                 "client-session-id-2",
                                 "client-session-id-3",
-                                "expired-client-session-id"),
-                        EMAIL);
+                                "expired-client-session-id"));
         TxmaAuditUser expectedAuditUser =
                 TxmaAuditUser.user()
                         .withIpAddress(SOURCE_IP)

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/DestroySessionsRequest.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/DestroySessionsRequest.java
@@ -6,17 +6,14 @@ import java.util.Objects;
 public class DestroySessionsRequest {
     private final String sessionId;
     private final List<String> clientSessions;
-    private final String emailAddress;
 
     public DestroySessionsRequest(String sessionId, Session session) {
-        this(sessionId, session.getClientSessions(), session.getEmailAddress());
+        this(sessionId, session.getClientSessions());
     }
 
-    public DestroySessionsRequest(
-            String sessionId, List<String> clientSessions, String emailAddress) {
+    public DestroySessionsRequest(String sessionId, List<String> clientSessions) {
         this.sessionId = sessionId;
         this.clientSessions = clientSessions;
-        this.emailAddress = emailAddress;
     }
 
     public String getSessionId() {
@@ -27,23 +24,18 @@ public class DestroySessionsRequest {
         return clientSessions;
     }
 
-    public String getEmailAddress() {
-        return emailAddress;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DestroySessionsRequest that = (DestroySessionsRequest) o;
         return Objects.equals(sessionId, that.sessionId)
-                && Objects.equals(clientSessions, that.clientSessions)
-                && Objects.equals(emailAddress, that.emailAddress);
+                && Objects.equals(clientSessions, that.clientSessions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sessionId, clientSessions, emailAddress);
+        return Objects.hash(sessionId, clientSessions);
     }
 
     @Override
@@ -54,8 +46,6 @@ public class DestroySessionsRequest {
                 + '\''
                 + ", clientSessions="
                 + clientSessions
-                + ", emailAddress='"
-                + emailAddress
                 + '\''
                 + '}';
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
@@ -5,8 +5,6 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.BackChannelLogoutMessage;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 
-import java.util.Objects;
-
 import static org.apache.logging.log4j.util.Strings.isBlank;
 import static uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper.getSubject;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
@@ -59,28 +57,6 @@ public class BackChannelLogoutService {
         var subjectId =
                 getSubject(user.get(), clientRegistry, authenticationService, internalSectorUri)
                         .getValue();
-
-        if (Objects.equals(subjectId, rpPairwiseId)) {
-            LOGGER.info(
-                    "calculated and given rpPairwiseId are the same, client-id = {}",
-                    clientRegistry.getClientID());
-        } else {
-            if (Objects.equals(subjectId, user.get().getPublicSubjectID())) {
-                LOGGER.info(
-                        "subjectId is publicSubjectId, client-id = {}",
-                        clientRegistry.getClientID());
-            } else if (rpPairwiseId == null) {
-                LOGGER.info(
-                        "rpPairwiseId on client session is null, client-id = {}",
-                        clientRegistry.getClientID());
-            } else if (subjectId == null) {
-                LOGGER.info("subjectId is null, client-id = {}", clientRegistry.getClientID());
-            } else {
-                LOGGER.info(
-                        "calculated and given rpPairwiseId are different, client-id = {}",
-                        clientRegistry.getClientID());
-            }
-        }
 
         var message =
                 new BackChannelLogoutMessage(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
@@ -26,11 +26,7 @@ public class BackChannelLogoutService {
         this.awsSqsClient = awsSqsClient;
     }
 
-    public void sendLogoutMessage(
-            ClientRegistry clientRegistry,
-            String emailAddress,
-            String internalSectorUri,
-            String rpPairwiseId) {
+    public void sendLogoutMessage(ClientRegistry clientRegistry, String rpPairwiseId) {
 
         if (isBlank(clientRegistry.getClientID())
                 || isBlank(clientRegistry.getBackChannelLogoutUri())) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
@@ -6,7 +6,6 @@ import uk.gov.di.orchestration.shared.entity.BackChannelLogoutMessage;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 
 import static org.apache.logging.log4j.util.Strings.isBlank;
-import static uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper.getSubject;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 
@@ -47,22 +46,11 @@ public class BackChannelLogoutService {
 
         LOGGER.info("Sending logout message");
 
-        var user = authenticationService.getUserProfileByEmailMaybe(emailAddress);
-
-        if (user.isEmpty()) {
-            LOGGER.warn("User does not exist");
-            return;
-        }
-
-        var subjectId =
-                getSubject(user.get(), clientRegistry, authenticationService, internalSectorUri)
-                        .getValue();
-
         var message =
                 new BackChannelLogoutMessage(
                         clientRegistry.getClientID(),
                         clientRegistry.getBackChannelLogoutUri(),
-                        subjectId);
+                        rpPairwiseId);
 
         awsSqsClient.sendAsync(message);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
@@ -13,21 +13,17 @@ public class BackChannelLogoutService {
 
     private static final Logger LOGGER = LogManager.getLogger(BackChannelLogoutService.class);
     private final AwsSqsClient awsSqsClient;
-    private final AuthenticationService authenticationService;
 
     public BackChannelLogoutService(ConfigurationService configurationService) {
         this(
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),
                         configurationService.getBackChannelLogoutQueueURI(),
-                        configurationService.getSqsEndpointURI()),
-                new DynamoService(configurationService));
+                        configurationService.getSqsEndpointURI()));
     }
 
-    public BackChannelLogoutService(
-            AwsSqsClient awsSqsClient, AuthenticationService authenticationService) {
+    public BackChannelLogoutService(AwsSqsClient awsSqsClient) {
         this.awsSqsClient = awsSqsClient;
-        this.authenticationService = authenticationService;
     }
 
     public void sendLogoutMessage(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -33,7 +33,6 @@ public class LogoutService {
 
     private static final Logger LOG = LogManager.getLogger(LogoutService.class);
 
-    private final ConfigurationService configurationService;
     private final SessionService sessionService;
     private final OrchSessionService orchSessionService;
     private final DynamoClientService dynamoClientService;
@@ -49,7 +48,6 @@ public class LogoutService {
 
     public LogoutService(ConfigurationService configurationService) {
         this(
-                configurationService,
                 new SessionService(configurationService),
                 new OrchSessionService(configurationService),
                 new DynamoClientService(configurationService),
@@ -64,7 +62,6 @@ public class LogoutService {
 
     public LogoutService(ConfigurationService configurationService, RedisConnectionService redis) {
         this(
-                configurationService,
                 new SessionService(configurationService, redis),
                 new OrchSessionService(configurationService),
                 new DynamoClientService(configurationService),
@@ -78,7 +75,6 @@ public class LogoutService {
     }
 
     public LogoutService(
-            ConfigurationService configurationService,
             SessionService sessionService,
             OrchSessionService orchSessionService,
             DynamoClientService dynamoClientService,
@@ -89,7 +85,6 @@ public class LogoutService {
             BackChannelLogoutService backChannelLogoutService,
             AuthFrontend authFrontend,
             NowClock nowClock) {
-        this.configurationService = configurationService;
         this.sessionService = sessionService;
         this.orchSessionService = orchSessionService;
         this.dynamoClientService = dynamoClientService;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -131,9 +131,6 @@ public class LogoutService {
                                             clientRegistry ->
                                                     backChannelLogoutService.sendLogoutMessage(
                                                             clientRegistry,
-                                                            request.getEmailAddress(),
-                                                            configurationService
-                                                                    .getInternalSectorURI(),
                                                             orchClientSessionItem
                                                                     .getCorrectPairwiseIdGivenSubjectType(
                                                                             clientRegistry

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutServiceTest.java
@@ -21,8 +21,7 @@ class BackChannelLogoutServiceTest {
     private final AwsSqsClient sqs = Mockito.mock(AwsSqsClient.class);
     private final AuthenticationService authenticationService =
             Mockito.mock(AuthenticationService.class);
-    private final BackChannelLogoutService service =
-            new BackChannelLogoutService(sqs, authenticationService);
+    private final BackChannelLogoutService service = new BackChannelLogoutService(sqs);
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final String RP_SECTOR_HOST = "example.sign-in.service.gov.uk";
     private static final String SUBJECT_ID = "subject";

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutServiceTest.java
@@ -22,7 +22,6 @@ class BackChannelLogoutServiceTest {
     private final AuthenticationService authenticationService =
             Mockito.mock(AuthenticationService.class);
     private final BackChannelLogoutService service = new BackChannelLogoutService(sqs);
-    private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final String RP_SECTOR_HOST = "example.sign-in.service.gov.uk";
     private static final String SUBJECT_ID = "subject";
     private static String rpPairwiseId;
@@ -46,8 +45,6 @@ class BackChannelLogoutServiceTest {
                         .withSubjectType("pairwise")
                         .withSectorIdentifierUri("https://example.sign-in.service.gov.uk")
                         .withBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
-                "test@test.com",
-                INTERNAL_SECTOR_URI,
                 rpPairwiseId);
 
         var captor = ArgumentCaptor.forClass(BackChannelLogoutMessage.class);
@@ -72,11 +69,7 @@ class BackChannelLogoutServiceTest {
         Stream.of(noLogoutUri, noClientId, neitherField)
                 .forEach(
                         clientRegistry ->
-                                service.sendLogoutMessage(
-                                        clientRegistry,
-                                        null,
-                                        INTERNAL_SECTOR_URI,
-                                        "dummy-rpPairwiseId"));
+                                service.sendLogoutMessage(clientRegistry, "dummy-rpPairwiseId"));
 
         Mockito.verify(sqs, Mockito.never()).send(ArgumentMatchers.anyString());
     }
@@ -90,8 +83,6 @@ class BackChannelLogoutServiceTest {
                 new ClientRegistry()
                         .withClientID("client-id")
                         .withBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
-                "test@test.com",
-                INTERNAL_SECTOR_URI,
                 "dummy-rpPairwiseId");
 
         Mockito.verify(sqs, Mockito.never()).send(ArgumentMatchers.anyString());

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -61,6 +61,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -533,6 +534,8 @@ class LogoutServiceTest {
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
                         argThat(withClientId("client-id-3")), eq("rp-pairwise-id-client-3"));
+        verify(backChannelLogoutService, never())
+                .sendLogoutMessage(argThat(withClientId("client-id-4")), anyString());
         verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
@@ -647,7 +650,11 @@ class LogoutServiceTest {
         destroySessionsRequest =
                 new DestroySessionsRequest(
                         SESSION_ID,
-                        List.of(CLIENT_SESSION_ID, "client-session-id-2", "client-session-id-3"));
+                        List.of(
+                                CLIENT_SESSION_ID,
+                                "client-session-id-2",
+                                "client-session-id-3",
+                                "client-session-id-4"));
     }
 
     private void setupClientSessionToken(JWT idToken) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -221,11 +221,7 @@ class LogoutServiceTest {
                         pair("logoutReason", "front-channel"),
                         pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id")),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq(rpPairwiseId.get()));
+                .sendLogoutMessage(argThat(withClientId("client-id")), eq(rpPairwiseId.get()));
         verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
@@ -259,11 +255,7 @@ class LogoutServiceTest {
                         pair("logoutReason", "front-channel"),
                         pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id")),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq(rpPairwiseId.get()));
+                .sendLogoutMessage(argThat(withClientId("client-id")), eq(rpPairwiseId.get()));
         verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
@@ -297,11 +289,7 @@ class LogoutServiceTest {
                         pair("logoutReason", "front-channel"),
                         pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id")),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq(rpPairwiseId.get()));
+                .sendLogoutMessage(argThat(withClientId("client-id")), eq(rpPairwiseId.get()));
         verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
@@ -336,11 +324,7 @@ class LogoutServiceTest {
                         pair("logoutReason", "front-channel"),
                         pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id")),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq(rpPairwiseId.get()));
+                .sendLogoutMessage(argThat(withClientId("client-id")), eq(rpPairwiseId.get()));
         verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
@@ -388,11 +372,7 @@ class LogoutServiceTest {
                         auditUser,
                         pair("logoutReason", "intervention"));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id")),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq(rpPairwiseId.get()));
+                .sendLogoutMessage(argThat(withClientId("client-id")), eq(rpPairwiseId.get()));
         verify(cloudwatchMetricsService)
                 .incrementLogout(Optional.of(CLIENT_ID), Optional.of(intervention));
 
@@ -427,11 +407,7 @@ class LogoutServiceTest {
                         auditUser,
                         pair("logoutReason", "intervention"));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id")),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq(rpPairwiseId.get()));
+                .sendLogoutMessage(argThat(withClientId("client-id")), eq(rpPairwiseId.get()));
         verify(cloudwatchMetricsService)
                 .incrementLogout(Optional.of(CLIENT_ID), Optional.of(intervention));
 
@@ -467,11 +443,7 @@ class LogoutServiceTest {
         verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id")),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq(rpPairwiseId.get()));
+                .sendLogoutMessage(argThat(withClientId("client-id")), eq(rpPairwiseId.get()));
         verify(cloudwatchMetricsService).incrementLogout(Optional.empty());
         verify(auditService)
                 .submitAuditEvent(
@@ -557,23 +529,13 @@ class LogoutServiceTest {
                         pair("logoutReason", "front-channel"),
                         pair("rpPairwiseId", rpPairwiseId.get()));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id")),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq(rpPairwiseId.get()));
+                .sendLogoutMessage(argThat(withClientId("client-id")), eq(rpPairwiseId.get()));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
-                        argThat(withClientId("client-id-2")),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq("rp-pairwise-id-client-2"));
+                        argThat(withClientId("client-id-2")), eq("rp-pairwise-id-client-2"));
         verify(backChannelLogoutService)
                 .sendLogoutMessage(
-                        argThat(withClientId("client-id-3")),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq("rp-pairwise-id-client-3"));
+                        argThat(withClientId("client-id-3")), eq("rp-pairwise-id-client-3"));
         verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
 
         assertThat(response, hasStatus(302));
@@ -612,11 +574,7 @@ class LogoutServiceTest {
         verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId("client-id")),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq(rpPairwiseId.get()));
+                .sendLogoutMessage(argThat(withClientId("client-id")), eq(rpPairwiseId.get()));
         verify(cloudwatchMetricsService).incrementLogout(Optional.of(CLIENT_ID));
         verify(auditService)
                 .submitAuditEvent(
@@ -658,17 +616,9 @@ class LogoutServiceTest {
         verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId(clientId1)),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq("rp-pairwise-id-client-1"));
+                .sendLogoutMessage(argThat(withClientId(clientId1)), eq("rp-pairwise-id-client-1"));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(
-                        argThat(withClientId(clientId2)),
-                        eq(EMAIL),
-                        eq(INTERNAL_SECTOR_URI),
-                        eq("rp-pairwise-id-client-2"));
+                .sendLogoutMessage(argThat(withClientId(clientId2)), eq("rp-pairwise-id-client-2"));
         var expectedExtensions = new ArrayList<AuditService.MetadataPair>();
         expectedExtensions.add(pair("logoutReason", MAX_AGE_EXPIRY.getValue()));
         expectedExtensions.add(pair("sessionAge", 3600));

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -116,7 +116,6 @@ class LogoutServiceTest {
     private static final URI CLIENT_LOGOUT_URI = URI.create("http://localhost/logout");
     private static final String CLIENT_ID = "client-id";
     private static final Subject SUBJECT = new Subject();
-    private static final String EMAIL = "joe.bloggs@test.com";
     private static Session session;
 
     private static final String FRONTEND_BASE_URL = "https://signin.test.account.gov.uk/";
@@ -184,8 +183,7 @@ class LogoutServiceTest {
         session = new Session();
         setUpClientSession(CLIENT_SESSION_ID, CLIENT_ID, rpPairwiseId.get());
         when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
-        destroySessionsRequest =
-                new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID), EMAIL);
+        destroySessionsRequest = new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID));
     }
 
     @AfterEach
@@ -353,7 +351,7 @@ class LogoutServiceTest {
                 new AccountIntervention(new AccountInterventionState(true, false, false, false));
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
-                        new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID), EMAIL),
+                        new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID)),
                         SUBJECT.getValue(),
                         event,
                         CLIENT_ID,
@@ -388,7 +386,7 @@ class LogoutServiceTest {
 
         APIGatewayProxyResponseEvent response =
                 logoutService.handleAccountInterventionLogout(
-                        new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID), EMAIL),
+                        new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID)),
                         SUBJECT.getValue(),
                         event,
                         CLIENT_ID,
@@ -459,7 +457,7 @@ class LogoutServiceTest {
                 new AccountIntervention(new AccountInterventionState(false, false, false, false));
 
         var expectedDestroySessionsRequest =
-                new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID), EMAIL);
+                new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID));
         var expectedInternalCommonSubjectId = SUBJECT.getValue();
         RuntimeException exception =
                 assertThrows(
@@ -561,7 +559,7 @@ class LogoutServiceTest {
     void successfullyLogsOutAndGeneratesRedirectResponseForeReauthenticationFailure() {
         var response =
                 logoutService.handleReauthenticationFailureLogout(
-                        new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID), EMAIL),
+                        new DestroySessionsRequest(SESSION_ID, List.of(CLIENT_SESSION_ID)),
                         SUBJECT.getValue(),
                         event,
                         CLIENT_ID,
@@ -593,8 +591,7 @@ class LogoutServiceTest {
         var clientId1 = CLIENT_ID + "1";
         var clientId2 = CLIENT_ID + "2";
         var destroySessionsRequestForClients =
-                new DestroySessionsRequest(
-                        SESSION_ID, List.of(clientSessionId1, clientSessionId2), EMAIL);
+                new DestroySessionsRequest(SESSION_ID, List.of(clientSessionId1, clientSessionId2));
 
         var authTime = Instant.parse("2025-01-23T15:00:00Z");
         var previousOrchSession =
@@ -650,8 +647,7 @@ class LogoutServiceTest {
         destroySessionsRequest =
                 new DestroySessionsRequest(
                         SESSION_ID,
-                        List.of(CLIENT_SESSION_ID, "client-session-id-2", "client-session-id-3"),
-                        EMAIL);
+                        List.of(CLIENT_SESSION_ID, "client-session-id-2", "client-session-id-3"));
     }
 
     private void setupClientSessionToken(JWT idToken) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -161,7 +161,6 @@ class LogoutServiceTest {
 
         logoutService =
                 new LogoutService(
-                        configurationService,
                         sessionService,
                         orchSessionService,
                         dynamoClientService,
@@ -632,7 +631,6 @@ class LogoutServiceTest {
 
     private LogoutService logoutServiceWithClock(Clock clock) {
         return new LogoutService(
-                configurationService,
                 sessionService,
                 orchSessionService,
                 dynamoClientService,


### PR DESCRIPTION
### Wider context of change
Part of the email migration work

### What’s changed
This PR replaces the calculation for rpPairwiseId with its value on the orchClientSessionItem. This removes the need to get UserProfile via email address, hence removing this need for session.getEmailAddress().

This got blocked for a while, as there were 3 issues with rpPairwiseId being out of sync that needed addressing:
1) [rpPairwiseId isn't always rpPairwiseId - it is sometimes publicSubjectId](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22subjectId%20is%20publicSubjectId*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1743375600&latest=1744066800&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&display.general.type=events&display.visualizations.charting.chart.stackMode=default&display.visualizations.charting.chart=column&sid=1745320258.93322). Here, we use `getCorrectPairwiseIdGivenSubjectType` to match the logic of the `ClientSubjectHelper.getSubject()` method this replaces
2) [rpPairwiseId is sometimes null](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22rpPairwiseId%20on%20client%20session%20is%20null*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1744671600&latest=1745362800&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&display.general.type=events&display.visualizations.charting.chart.stackMode=default&display.visualizations.charting.chart=column&sid=1745320310.93333). This is for journeys which didn't reach authenticationCallbackHandler. Currently, that isn't important, as `getSubject()` will still find the user, even if that clientSession doesn't know who they are. We have decided this is fine to change here. If a client session doesn't know who a user is, it's fine that a logout message isn't sent, as we still send logout messages for all successful journeys. See logs below.
3) [rpPairwiseId is sometimes a different value](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22calculated%20and%20given%20rpPairwiseId%20are%20different*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1744671600&latest=1745362800&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&display.general.type=events&display.visualizations.charting.chart.stackMode=default&display.visualizations.charting.chart=column&sid=1745320350.93363). This was a very tricky one to uncover. We believe this is an existing bug, and in fact this change fixes the bug. By using the rpPairwiseId given to us during the journey, rather than calculating it much later on at logout, we consistently use that same value as the source of truth for the user.

### More Splunk queries:
[Last lambda hit for each clientSession where rpPairwiseId was logged as null at logout](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20%5Bsearch%20index%3D%22gds_di_production%22%20message%3D%22rpPairwiseId%20on%20client%20session%20is%20null*%22%20%7C%20stats%20count%20by%20client-session-id%20%7C%20fields%20client-session-id%5D%0A%7C%20sort%200%20client-session-id%2C%20_time%0A%0A%7C%20eval%20prior_time_candidate%20%3D%20if(like(loggerName%2C%20%22%25lambda%25%22)%2C%20_time%2C%20null())%0A%7C%20eval%20prior_message_candidate%20%3D%20if(like(loggerName%2C%20%22%25lambda%25%22)%2C%20message%2C%20null())%0A%7C%20eval%20prior_loggerName_candidate%20%3D%20if(like(loggerName%2C%20%22%25lambda%25%22)%2C%20loggerName%2C%20null())%0A%0A%0A%7C%20streamstats%20last(prior_time_candidate)%20as%20prior_event_time%20last(prior_message_candidate)%20as%20prior_event_message%20last(prior_loggerName_candidate)%20as%20prior_event_loggerName%20by%20client-session-id%0A%0A%0A%7C%20where%20like(message%2C%20%22rpPairwiseId%20on%20client%20session%20is%20null%25%22)%0A%0A%0A%7C%20where%20isnotnull(prior_event_time)%0A%0A%0A%7C%20eval%20time_diff_seconds%20%3D%20_time%20-%20prior_event_time%0A%0A%0A%7C%20eval%20time_target%20%3D%20strftime(_time%2C%20%22%25Y-%25m-%25d%20%25H%3A%25M%3A%25S.%253N%22)%0A%7C%20eval%20time_prior%20%3D%20strftime(prior_event_time%2C%20%22%25Y-%25m-%25d%20%25H%3A%25M%3A%25S.%253N%22)%0A%0A%0A%7C%20table%20client-session-id%2C%20time_prior%2C%20prior_event_loggerName%2C%20prior_event_message%2C%20time_target%2C%20message%2C%20time_diff_seconds%0A%7C%20stats%20count%20by%20prior_event_loggerName%0A%0A%7C%20sort%20client-session-id%2C%20time_target&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1744671600&latest=1745362800&display.page.search.tab=visualizations&display.page.search.patterns.sensitivity=0.866&display.general.type=visualizations&display.visualizations.charting.chart.stackMode=default&display.visualizations.charting.chart=column&sid=1745320443.93443): this was consistently not UserInfo, and in fact was never a handler beyond authenticationCallbackHandler. Hence, these journeys where rpPairwiseId is null are only for client sessions where we the client session doesn't know who the user is. 
See also [last lambda hit for each clientSession where rpPairwiseId was logged as being different](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20%5Bsearch%20index%3D%22gds_di_production%22%20message%3D%22calculated%20and%20given%20rpPairwiseId%20are%20different*%22%20%7C%20stats%20count%20by%20client-session-id%20%7C%20fields%20client-session-id%5D%0A%7C%20sort%200%20client-session-id%2C%20_time%0A%0A%7C%20eval%20prior_time_candidate%20%3D%20if(like(loggerName%2C%20%22%25lambda%25%22)%2C%20_time%2C%20null())%0A%7C%20eval%20prior_message_candidate%20%3D%20if(like(loggerName%2C%20%22%25lambda%25%22)%2C%20message%2C%20null())%0A%7C%20eval%20prior_loggerName_candidate%20%3D%20if(like(loggerName%2C%20%22%25lambda%25%22)%2C%20loggerName%2C%20null())%0A%0A%0A%7C%20streamstats%20last(prior_time_candidate)%20as%20prior_event_time%20last(prior_message_candidate)%20as%20prior_event_message%20last(prior_loggerName_candidate)%20as%20prior_event_loggerName%20by%20client-session-id%0A%0A%0A%7C%20where%20like(message%2C%20%22calculated%20and%20given%20rpPairwiseId%20are%20different%25%22)%0A%0A%0A%7C%20where%20isnotnull(prior_event_time)%0A%0A%0A%7C%20eval%20time_diff_seconds%20%3D%20_time%20-%20prior_event_time%0A%0A%0A%7C%20eval%20time_target%20%3D%20strftime(_time%2C%20%22%25Y-%25m-%25d%20%25H%3A%25M%3A%25S.%253N%22)%0A%7C%20eval%20time_prior%20%3D%20strftime(prior_event_time%2C%20%22%25Y-%25m-%25d%20%25H%3A%25M%3A%25S.%253N%22)%0A%0A%0A%7C%20table%20client-session-id%2C%20time_prior%2C%20prior_event_loggerName%2C%20prior_event_message%2C%20time_target%2C%20message%2C%20time_diff_seconds%0A%7C%20stats%20count%20by%20prior_event_loggerName%0A%0A%7C%20sort%20client-session-id%2C%20time_target&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=-7d%40h&latest=now&display.page.search.tab=statistics&display.page.search.patterns.sensitivity=0.866&display.general.type=statistics&display.visualizations.charting.chart.stackMode=default&display.visualizations.charting.chart=column&sid=1744213664.123894). This shows the final lambda for these journeys as being UserInfo, which both verifies the query is working, and also tells us something about the journeys when they are different.

I wanted to check my homework on this, so I took another approach to verify the conclusion:
[Proportion of all journeys that reach AuthenticationCalbackHandler](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%0A%0A%7C%20eval%20is_auth_event%20%3D%20if(message%3D%3D%22Successfully%20processed%20request%22%20AND%20loggerName%3D%3D%22uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler%22%2C%201%2C%200)%0A%0A%7C%20stats%20max(is_auth_event)%20as%20session_has_auth%20by%20client-session-id%0A%0A%7C%20eval%20did_journey_reach_auth%20%3D%20if(session_has_auth%20%3D%3D%201%2C%20%22true%22%2C%20%22false%22)%0A%0A%7C%20stats%20count%20by%20did_journey_reach_auth&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1745317020&latest=1745320620&display.page.search.tab=statistics&display.page.search.patterns.sensitivity=0.866&display.general.type=statistics&display.visualizations.charting.chart.stackMode=default&display.visualizations.charting.chart=column&sid=1745320630.93610).
vs
[Proportion of journeys that reach AuthenticationCalbackHandler given they later have a log showing rpPairwiseId to be null](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22rpPairwiseId%20on%20client%20session%20is%20null*%22%0A%0A%7C%20eval%20is_auth_event%20%3D%20if(message%3D%3D%22Successfully%20processed%20request%22%20AND%20loggerName%3D%3D%22uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler%22%2C%201%2C%200)%0A%0A%7C%20stats%20max(is_auth_event)%20as%20session_has_auth%20by%20client-session-id%0A%0A%7C%20eval%20did_journey_reach_auth%20%3D%20if(session_has_auth%20%3D%3D%201%2C%20%22true%22%2C%20%22false%22)%0A%0A%7C%20stats%20count%20by%20did_journey_reach_auth&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1744671600&latest=1745362800&display.page.search.tab=statistics&display.page.search.patterns.sensitivity=0.866&display.general.type=statistics&display.visualizations.charting.chart.stackMode=default&display.visualizations.charting.chart=column&sid=1745320729.93645)

### Manual testing
tbd: deploy to dev to test a logout is successful

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing. **No new tables accessed**
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **not required**
- [x] Changes have been made to the simulator or not required. **not required**
- [x] Changes have been made to stubs or not required. **not required**
- [x] Successfully deployed to authdev or not required. **not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **not required**