### PR TITLE
ATO-1419: Fetch orch client session with strong consistent reads if not in sync

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -60,6 +60,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
+import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.getOrchClientSessionWithRetryIfNotEqual;
 import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.logIfClientSessionsAreNotEqual;
 
 public class DocAppCallbackHandler
@@ -220,8 +221,9 @@ public class DocAppCallbackHandler
                             .orElseThrow(
                                     () -> new DocAppCallbackException("ClientSession not found"));
             var orchClientSession =
-                    orchClientSessionService.getClientSession(clientSessionId).orElse(null);
-
+                    getOrchClientSessionWithRetryIfNotEqual(
+                                    clientSession, clientSessionId, orchClientSessionService)
+                            .orElse(null);
             logIfClientSessionsAreNotEqual(clientSession, orchClientSession);
 
             if (Objects.isNull(clientSession.getDocAppSubjectId()))

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -80,6 +80,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.getOrchClientSessionWithRetryIfNotEqual;
 import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.logIfClientSessionsAreNotEqual;
 
 public class IPVCallbackHandler
@@ -263,8 +264,9 @@ public class IPVCallbackHandler
                                             new IPVCallbackNoSessionException(
                                                     "ClientSession not found"));
             var orchClientSession =
-                    orchClientSessionService.getClientSession(clientSessionId).orElse(null);
-
+                    getOrchClientSessionWithRetryIfNotEqual(
+                                    clientSession, clientSessionId, orchClientSessionService)
+                            .orElse(null);
             logIfClientSessionsAreNotEqual(clientSession, orchClientSession);
 
             var authRequest = AuthenticationRequest.parse(clientSession.getAuthRequestParams());

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -98,6 +98,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFiel
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.orchestration.shared.services.AuditService.UNKNOWN;
+import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.getOrchClientSessionWithRetryIfNotEqual;
 import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.logIfClientSessionsAreNotEqual;
 
 public class AuthenticationCallbackHandler
@@ -294,15 +295,13 @@ public class AuthenticationCallbackHandler
                                             new AuthenticationCallbackException(
                                                     "ClientSession not found"));
             var orchClientSession =
-                    orchClientSessionService
-                            .getClientSession(clientSessionId)
+                    getOrchClientSessionWithRetryIfNotEqual(
+                                    clientSession, clientSessionId, orchClientSessionService)
                             .orElseThrow(
                                     () ->
                                             new AuthenticationCallbackException(
                                                     "OrchClientSession not found"));
-
             logIfClientSessionsAreNotEqual(clientSession, orchClientSession);
-
             String persistentSessionId =
                     PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders());
             attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentSessionId);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -68,6 +68,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.updateAttachedLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.RequestBodyHelper.parseRequestBody;
+import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.getOrchClientSessionWithRetryIfNotEqual;
 import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.logIfClientSessionsAreNotEqual;
 
 public class TokenHandler
@@ -244,7 +245,9 @@ public class TokenHandler
                     400, OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString());
         }
         var clientSession = clientSessionOpt.get();
-        var orchClientSessionOpt = orchClientSessionService.getClientSession(clientSessionId);
+        var orchClientSessionOpt =
+                getOrchClientSessionWithRetryIfNotEqual(
+                        clientSession, clientSessionId, orchClientSessionService);
         if (orchClientSessionOpt.isEmpty()) {
             LOG.warn("No orch client session found for auth code client session id");
         }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
@@ -65,6 +66,15 @@ public class BaseDynamoService<T> {
         return Optional.ofNullable(
                 dynamoTable.getItem(
                         Key.builder().partitionValue(partition).sortValue(sort).build()));
+    }
+
+    public Optional<T> getWithConsistentRead(String partition, boolean consistentRead) {
+        return Optional.ofNullable(
+                dynamoTable.getItem(
+                        GetItemEnhancedRequest.builder()
+                                .consistentRead(consistentRead)
+                                .key(Key.builder().partitionValue(partition).build())
+                                .build()));
     }
 
     public void delete(String partition) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchClientSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchClientSessionService.java
@@ -75,10 +75,19 @@ public class OrchClientSessionService extends BaseDynamoService<OrchClientSessio
         }
     }
 
+    public Optional<OrchClientSessionItem> forceGetClientSession(String clientSessionId) {
+        return getClientSession(clientSessionId, true);
+    }
+
     public Optional<OrchClientSessionItem> getClientSession(String clientSessionId) {
+        return getClientSession(clientSessionId, false);
+    }
+
+    private Optional<OrchClientSessionItem> getClientSession(
+            String clientSessionId, boolean consistentRead) {
         Optional<OrchClientSessionItem> clientSession = Optional.empty();
         try {
-            clientSession = get(clientSessionId);
+            clientSession = getWithConsistentRead(clientSessionId, consistentRead);
         } catch (Exception e) {
             logAndThrowOrchClientSessionException(
                     "Failed to get Orch client session item", clientSessionId, e);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/ClientSessionMigrationUtils.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/ClientSessionMigrationUtils.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
+import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -13,6 +14,19 @@ public class ClientSessionMigrationUtils {
     private static final Logger LOG = LogManager.getLogger(ClientSessionMigrationUtils.class);
 
     private ClientSessionMigrationUtils() {}
+
+    public static Optional<OrchClientSessionItem> getOrchClientSessionWithRetryIfNotEqual(
+            ClientSession clientSession,
+            String clientSessionId,
+            OrchClientSessionService orchClientSessionService) {
+        var orchClientSessionOpt = orchClientSessionService.getClientSession(clientSessionId);
+        if (!areClientSessionsEqual(clientSession, orchClientSessionOpt.orElse(null))) {
+            LOG.warn("Client sessions are not equal");
+            LOG.info("Refetching orch client session with strongly consistent reads");
+            orchClientSessionOpt = orchClientSessionService.forceGetClientSession(clientSessionId);
+        }
+        return orchClientSessionOpt;
+    }
 
     public static void logIfClientSessionsAreNotEqual(
             ClientSession clientSession, OrchClientSessionItem orchClientSession) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchClientSessionServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
@@ -124,6 +125,12 @@ class OrchClientSessionServiceTest {
                 new OrchClientSessionItem(CLIENT_SESSION_ID)
                         .withClientName(CLIENT_NAME)
                         .withTimeToLive(VALID_TTL);
+        when(table.getItem(
+                        GetItemEnhancedRequest.builder()
+                                .consistentRead(false)
+                                .key(CLIENT_SESSION_ID_PARTITION_KEY)
+                                .build()))
+                .thenReturn(existingSession);
         when(table.getItem(CLIENT_SESSION_ID_PARTITION_KEY)).thenReturn(existingSession);
         return existingSession;
     }
@@ -145,7 +152,7 @@ class OrchClientSessionServiceTest {
     private void withFailedGet() {
         doThrow(DynamoDbException.builder().message("Failed to get from table").build())
                 .when(table)
-                .getItem(any(Key.class));
+                .getItem(any(GetItemEnhancedRequest.class));
     }
 
     private void withFailedUpdate() {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/utils/ClientSessionMigrationUtilsTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/utils/ClientSessionMigrationUtilsTest.java
@@ -1,21 +1,31 @@
 package uk.gov.di.orchestration.shared.utils;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
+import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.areClientSessionsEqual;
+import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.getOrchClientSessionWithRetryIfNotEqual;
+import static uk.gov.di.orchestration.sharedtest.helper.Constants.CLIENT_SESSION_ID;
 
 class ClientSessionMigrationUtilsTest {
     private static final Map<String, List<String>> AUTH_REQUEST_PARAMS =
@@ -26,90 +36,147 @@ class ClientSessionMigrationUtilsTest {
     private static final List<VectorOfTrust> VTR_LIST =
             List.of(VectorOfTrust.of(CredentialTrustLevel.LOW_LEVEL, LevelOfConfidence.LOW_LEVEL));
     private static final String CLIENT_NAME = "test-client-name";
+    private final OrchClientSessionService orchClientSessionService =
+            mock(OrchClientSessionService.class);
 
-    @Test
-    void shouldIdentifyClientSessionsAsEqual() {
-        var clientSession =
-                new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
-        var orchClientSession =
-                new OrchClientSessionItem(
-                        "test-client-session-id",
-                        AUTH_REQUEST_PARAMS,
-                        CREATION_DATE,
-                        VTR_LIST,
-                        CLIENT_NAME);
+    @Nested
+    class AreClientSessionsEqual {
+        @Test
+        void shouldIdentifyClientSessionsAsEqual() {
+            var clientSession =
+                    new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
+            var orchClientSession =
+                    new OrchClientSessionItem(
+                            "test-client-session-id",
+                            AUTH_REQUEST_PARAMS,
+                            CREATION_DATE,
+                            VTR_LIST,
+                            CLIENT_NAME);
 
-        assertTrue(areClientSessionsEqual(clientSession, orchClientSession));
+            assertTrue(areClientSessionsEqual(clientSession, orchClientSession));
+        }
+
+        @Test
+        void shouldIdentifyClientSessionsAsEqualIfBothAreNull() {
+            assertTrue(areClientSessionsEqual(null, null));
+        }
+
+        @Test
+        void shouldIdentifyClientSessionsAsNotEqualWhenBothFieldsAreNotNull() {
+            var clientSession =
+                    new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
+            var orchClientSession =
+                    new OrchClientSessionItem(
+                            "test-client-session-id",
+                            AUTH_REQUEST_PARAMS,
+                            CREATION_DATE,
+                            VTR_LIST,
+                            "a-different-client-name");
+
+            assertFalse(areClientSessionsEqual(clientSession, orchClientSession));
+        }
+
+        @Test
+        void shouldIdentifyClientSessionsAsNotEqualWhenOneFieldIsNull() {
+            var clientSession =
+                    new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
+            var orchClientSession =
+                    new OrchClientSessionItem(
+                            "test-client-session-id",
+                            AUTH_REQUEST_PARAMS,
+                            CREATION_DATE,
+                            VTR_LIST,
+                            null);
+
+            assertFalse(areClientSessionsEqual(clientSession, orchClientSession));
+        }
+
+        @Test
+        void shouldIdentifyClientSessionsAsNotEqualWhenRedisClientSessionIsNull() {
+            var orchClientSession =
+                    new OrchClientSessionItem(
+                            "test-client-session-id",
+                            AUTH_REQUEST_PARAMS,
+                            CREATION_DATE,
+                            VTR_LIST,
+                            CLIENT_NAME);
+
+            assertFalse(areClientSessionsEqual(null, orchClientSession));
+        }
+
+        @Test
+        void shouldIdentifyClientSessionsAsNotEqualWhenOrchClientSessionIsNull() {
+            var clientSession =
+                    new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
+
+            assertFalse(areClientSessionsEqual(clientSession, null));
+        }
+
+        @Test
+        void shouldIdentifyClientSessionsAsNotEqualWhenMoreThanOneFieldIsDifferent() {
+            var clientSession =
+                    new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
+            var orchClientSession =
+                    new OrchClientSessionItem(
+                            "test-client-session-id",
+                            Map.of(),
+                            LocalDateTime.now(),
+                            List.of(),
+                            "different-client-name");
+
+            assertFalse(areClientSessionsEqual(clientSession, orchClientSession));
+        }
     }
 
-    @Test
-    void shouldIdentifyClientSessionsAsEqualIfBothAreNull() {
-        assertTrue(areClientSessionsEqual(null, null));
-    }
+    @Nested
+    class RetryGetClientSession {
+        LocalDateTime creationDate = LocalDateTime.now();
+        ClientSession clientSession =
+                new ClientSession(Map.of(), creationDate, List.of(), CLIENT_NAME);
 
-    @Test
-    void shouldIdentifyClientSessionsAsNotEqualWhenBothFieldsAreNotNull() {
-        var clientSession =
-                new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
-        var orchClientSession =
-                new OrchClientSessionItem(
-                        "test-client-session-id",
-                        AUTH_REQUEST_PARAMS,
-                        CREATION_DATE,
-                        VTR_LIST,
-                        "a-different-client-name");
+        @Test
+        void shouldRetryGetFromDynamoIfClientSessionsAreNotEqual() {
+            OrchClientSessionItem oldClientSession =
+                    new OrchClientSessionItem(
+                            CLIENT_SESSION_ID,
+                            Map.of(),
+                            creationDate,
+                            List.of(),
+                            "a-different-client-name");
+            OrchClientSessionItem latestClientSession =
+                    new OrchClientSessionItem(
+                            CLIENT_SESSION_ID, Map.of(), creationDate, List.of(), CLIENT_NAME);
+            when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
+                    .thenReturn(Optional.of(oldClientSession));
+            when(orchClientSessionService.forceGetClientSession(CLIENT_SESSION_ID))
+                    .thenReturn(Optional.of(latestClientSession));
 
-        assertFalse(areClientSessionsEqual(clientSession, orchClientSession));
-    }
+            var actualOrchClientSession =
+                    getOrchClientSessionWithRetryIfNotEqual(
+                            clientSession, CLIENT_SESSION_ID, orchClientSessionService);
 
-    @Test
-    void shouldIdentifyClientSessionsAsNotEqualWhenOneFieldIsNull() {
-        var clientSession =
-                new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
-        var orchClientSession =
-                new OrchClientSessionItem(
-                        "test-client-session-id",
-                        AUTH_REQUEST_PARAMS,
-                        CREATION_DATE,
-                        VTR_LIST,
-                        null);
+            assertTrue(actualOrchClientSession.isPresent());
+            assertEquals(latestClientSession, actualOrchClientSession.get());
+            verify(orchClientSessionService).getClientSession(CLIENT_SESSION_ID);
+            verify(orchClientSessionService).forceGetClientSession(CLIENT_SESSION_ID);
+        }
 
-        assertFalse(areClientSessionsEqual(clientSession, orchClientSession));
-    }
+        @Test
+        void shouldNotRetryGetFromDynamoIfClientSessionsAreEqual() {
+            OrchClientSessionItem orchClientSession =
+                    new OrchClientSessionItem(
+                            CLIENT_SESSION_ID, Map.of(), creationDate, List.of(), CLIENT_NAME);
+            when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
+                    .thenReturn(Optional.of(orchClientSession));
 
-    @Test
-    void shouldIdentifyClientSessionsAsNotEqualWhenRedisClientSessionIsNull() {
-        var orchClientSession =
-                new OrchClientSessionItem(
-                        "test-client-session-id",
-                        AUTH_REQUEST_PARAMS,
-                        CREATION_DATE,
-                        VTR_LIST,
-                        CLIENT_NAME);
+            var actualOrchClientSession =
+                    getOrchClientSessionWithRetryIfNotEqual(
+                            clientSession, CLIENT_SESSION_ID, orchClientSessionService);
 
-        assertFalse(areClientSessionsEqual(null, orchClientSession));
-    }
-
-    @Test
-    void shouldIdentifyClientSessionsAsNotEqualWhenOrchClientSessionIsNull() {
-        var clientSession =
-                new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
-
-        assertFalse(areClientSessionsEqual(clientSession, null));
-    }
-
-    @Test
-    void shouldIdentifyClientSessionsAsNotEqualWhenMoreThanOneFieldIsDifferent() {
-        var clientSession =
-                new ClientSession(AUTH_REQUEST_PARAMS, CREATION_DATE, VTR_LIST, CLIENT_NAME);
-        var orchClientSession =
-                new OrchClientSessionItem(
-                        "test-client-session-id",
-                        Map.of(),
-                        LocalDateTime.now(),
-                        List.of(),
-                        "different-client-name");
-
-        assertFalse(areClientSessionsEqual(clientSession, orchClientSession));
+            assertTrue(actualOrchClientSession.isPresent());
+            assertEquals(orchClientSession, actualOrchClientSession.get());
+            verify(orchClientSessionService).getClientSession(CLIENT_SESSION_ID);
+            verify(orchClientSessionService, never()).forceGetClientSession(CLIENT_SESSION_ID);
+        }
     }
 }


### PR DESCRIPTION
### Wider context of change

We recently added logging to determine if the redis client session was in sync with the dynamo client session. We saw a few instances where the orch client session was out of sync, having null fields where it should have fields set. We wondered if this was related to the requests being eventually consistent.

### What’s changed

If the client sessions are not in sync, we will try to fetch the orch client session from dynamo again with strongly consistent reads. 

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. n/a
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a
