### PR TITLE
ATO-1435: Consume new fields from auth frontend and log if they are in sync

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -4,6 +4,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 
+import java.util.List;
+
 public record StartRequest(
         @Expose @SerializedName("previous-session-id") String previousSessionId,
         @Expose @SerializedName("rp-pairwise-id-for-reauth") String rpPairwiseIdForReauth,
@@ -11,4 +13,11 @@ public record StartRequest(
                 String previousGovUkSigninJourneyId,
         @Expose @SerializedName("authenticated") boolean authenticated,
         @Expose @SerializedName("current-credential-strength")
-                CredentialTrustLevel currentCredentialStrength) {}
+                CredentialTrustLevel currentCredentialStrength,
+        @Expose @SerializedName("cookie_consent") String cookieConsent,
+        @Expose @SerializedName("_ga") String ga,
+        @Expose @SerializedName("vtr_list") List<String> vtrList,
+        @Expose @SerializedName("state") String state,
+        @Expose @SerializedName("client_id") String clientId,
+        @Expose @SerializedName("redirect_uri") String redirectUri,
+        @Expose @SerializedName("scope") String scope) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -151,12 +151,13 @@ public class StartHandler
         attachLogFieldToLogs(
                 PERSISTENT_SESSION_ID, extractPersistentIdFromHeaders(input.getHeaders()));
 
-        var clientSession =
+        var clientSessionOpt =
                 clientSessionService.getClientSessionFromRequestHeaders(input.getHeaders());
 
-        if (clientSession.isEmpty()) {
+        if (clientSessionOpt.isEmpty()) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1018);
         }
+        var clientSession = clientSessionOpt.get();
 
         StartRequest startRequest;
         try {
@@ -189,12 +190,11 @@ public class StartHandler
             }
             var upliftRequired =
                     startService.isUpliftRequired(
-                            clientSession.get(), startRequest.currentCredentialStrength());
+                            clientSession, startRequest.currentCredentialStrength());
 
             authSessionService.addSession(authSession.withUpliftRequired(upliftRequired));
 
-            var userContext =
-                    startService.buildUserContext(session, clientSession.get(), authSession);
+            var userContext = startService.buildUserContext(session, clientSession, authSession);
 
             attachLogFieldToLogs(
                     CLIENT_ID,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -94,6 +94,8 @@ class StartHandlerTest {
     public static final State STATE = new State();
     public static final URI REDIRECT_URL = URI.create("https://localhost/redirect");
     private static final Json objectMapper = SerializationService.getInstance();
+    private static final String COOKIE_CONSENT = "accept";
+    private static final Scope SCOPE = new Scope(OIDCScopeValue.OPENID.getValue());
 
     private StartHandler handler;
     private final Context context = mock(Context.class);
@@ -566,21 +568,18 @@ class StartHandlerTest {
         scope.add(OIDCScopeValue.OPENID);
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(
-                                responseType,
-                                scope,
-                                new ClientID(TEST_CLIENT_ID),
-                                URI.create("http://localhost/redirect"))
+                                responseType, scope, new ClientID(TEST_CLIENT_ID), REDIRECT_URL)
+                        .customParameter("cookie_consent", COOKIE_CONSENT)
+                        .customParameter("state", STATE.toString())
                         .build();
         return new ClientSession(
                 authRequest.toParameters(), null, mock(VectorOfTrust.class), TEST_CLIENT_NAME);
     }
 
     private ClientStartInfo getClientStartInfo() {
-        Scope scope = new Scope(OIDCScopeValue.OPENID.getValue());
-
         return new ClientStartInfo(
                 TEST_CLIENT_NAME,
-                scope.toStringList(),
+                SCOPE.toStringList(),
                 "MANDATORY",
                 false,
                 REDIRECT_URL,
@@ -642,12 +641,12 @@ class StartHandlerTest {
                         previousGovUkSignInJourneyId,
                         authenticated,
                         currentCredentialStrength,
+                        COOKIE_CONSENT,
                         null,
                         null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null));
+                        STATE.toString(),
+                        TEST_CLIENT_ID,
+                        REDIRECT_URL.toString(),
+                        SCOPE.toString()));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -641,6 +641,13 @@ class StartHandlerTest {
                         rpPairwiseIdForReauth,
                         previousGovUkSignInJourneyId,
                         authenticated,
-                        currentCredentialStrength));
+                        currentCredentialStrength,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -63,7 +63,14 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
     public static final String PREVIOUS_SESSION_ID = "4waJ14KA9IyxKzY7bIGIA3hUDos";
     public static final String REQUEST_BODY =
-            "{\"previous-session-id\":\"4waJ14KA9IyxKzY7bIGIA3hUDos\", \"authenticated\": %s}";
+            "{\"previous-session-id\":\"4waJ14KA9IyxKzY7bIGIA3hUDos\", "
+                    + "\"authenticated\": %s, "
+                    + "\"state\": \"%s\","
+                    + "\"client_id\": \"%s\","
+                    + "\"redirect_uri\": \"%s\","
+                    + "\"vtr_list\": %s, "
+                    + "\"scope\": \"%s\""
+                    + "}";
 
     @RegisterExtension
     protected static final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
@@ -82,7 +89,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         return Stream.of(
                 Arguments.of(Map.of(), false, false),
                 Arguments.of(Map.of(), false, true),
-                Arguments.of(Map.of("vtr", "[\"P0.Cl.Cm\"]"), false, false),
+                Arguments.of(Map.of("vtr", "[\"Cl.Cm\", \"P0.Cl.Cm\"]"), false, false),
                 Arguments.of(Map.of("vtr", "[\"P2.Cl.Cm\"]"), true, false));
     }
 
@@ -105,6 +112,9 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new AuthenticationRequest.Builder(
                                 ResponseType.CODE, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
                         .nonce(new Nonce())
+                        .customParameter("client_id", CLIENT_ID)
+                        .customParameter("redirect_uri", REDIRECT_URI.toString())
+                        .customParameter("state", state.getValue())
                         .state(state);
         customAuthParameters.forEach(builder::customParameter);
         var authRequest = builder.build();
@@ -114,7 +124,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         registerWebClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR());
         var response =
                 makeRequest(
-                        Optional.of(makeRequestBody(isAuthenticated)),
+                        Optional.of(makeRequestBody(isAuthenticated, authRequest)),
                         standardHeadersWithSessionId(sessionId),
                         Map.of());
         assertThat(response, hasStatus(200));
@@ -170,7 +180,9 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new AuthenticationRequest.Builder(
                                 ResponseType.CODE, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
                         .nonce(new Nonce())
-                        .state(state);
+                        .state(state)
+                        .customParameter("client_id", CLIENT_ID)
+                        .customParameter("redirect_uri", REDIRECT_URI.toString());
         var authRequest = builder.build();
 
         redis.createClientSession(CLIENT_SESSION_ID, TEST_CLIENT_NAME, authRequest.toParameters());
@@ -180,7 +192,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var headers = standardHeadersWithSessionId(sessionId);
         headers.put("Reauthenticate", "true");
 
-        var response = makeRequest(Optional.of(makeRequestBody(true)), headers, Map.of());
+        var response =
+                makeRequest(Optional.of(makeRequestBody(true, authRequest)), headers, Map.of());
         assertThat(response, hasStatus(200));
 
         StartResponse startResponse =
@@ -223,6 +236,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 ResponseType.CODE, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
                         .nonce(new Nonce())
                         .state(state)
+                        .customParameter("client_id", CLIENT_ID)
+                        .customParameter("redirect_uri", REDIRECT_URI.toString())
                         .customParameter("vtr", "[\"Cl.Cm\"]");
         var authRequest = builder.build();
 
@@ -232,7 +247,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         var response =
                 makeRequest(
-                        Optional.of(makeRequestBody(isAuthenticated)),
+                        Optional.of(makeRequestBody(isAuthenticated, authRequest)),
                         standardHeadersWithSessionId(sessionId),
                         Map.of());
         assertThat(response, hasStatus(200));
@@ -269,6 +284,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 ResponseType.CODE, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
                         .nonce(new Nonce())
                         .state(STATE)
+                        .customParameter("client_id", CLIENT_ID)
+                        .customParameter("redirect_uri", REDIRECT_URI.toString())
                         .customParameter("vtr", "[\"Cl.Cm\"]")
                         .build();
         redis.createClientSession(CLIENT_SESSION_ID, TEST_CLIENT_NAME, authRequest.toParameters());
@@ -280,7 +297,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         var response =
                 makeRequest(
-                        Optional.of(makeRequestBody(isAuthenticated)),
+                        Optional.of(makeRequestBody(isAuthenticated, authRequest)),
                         standardHeadersWithSessionId(sessionId),
                         Map.of());
 
@@ -299,6 +316,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Nested
     class AuthSession {
         String sessionId;
+        State state;
+        Scope scope;
 
         @BeforeEach
         void setup() throws Json.JsonException {
@@ -307,8 +326,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             sessionId = redis.createSession(false);
             userStore.signUp(EMAIL, "password");
             authSessionExtension.addSession(sessionId);
-            var state = new State();
-            Scope scope = new Scope();
+            state = new State();
+            scope = new Scope();
             scope.add(OIDCScopeValue.OPENID);
             var builder =
                     new AuthenticationRequest.Builder(
@@ -323,7 +342,18 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         @Test
         void shouldAddSessionToDynamoWhenNoPreviousSessionIdIsProvidedInRequestBody() {
-            makeRequest(Optional.of("{}"), standardHeadersWithSessionId(sessionId), Map.of());
+            makeRequest(
+                    Optional.of(
+                            format(
+                                    "{"
+                                            + "\"state\": \"%s\","
+                                            + "\"redirect_uri\": \"%s\","
+                                            + "\"scope\": \"%s\","
+                                            + "\"client_id\": \"%s\""
+                                            + "}",
+                                    state.getValue(), REDIRECT_URI, scope.toString(), CLIENT_ID)),
+                    standardHeadersWithSessionId(sessionId),
+                    Map.of());
 
             assertThat(authSessionExtension.getSession(sessionId).isPresent(), equalTo(true));
         }
@@ -336,7 +366,14 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     equalTo(true));
 
             makeRequest(
-                    Optional.of(makeRequestBody(false)),
+                    Optional.of(
+                            makeRequestBody(
+                                    false,
+                                    Map.of(
+                                            "state", state.getValue(),
+                                            "redirect_uri", REDIRECT_URI.toString(),
+                                            "scope", scope.toString(),
+                                            "client_id", CLIENT_ID))),
                     standardHeadersWithSessionId(sessionId),
                     Map.of());
 
@@ -349,7 +386,14 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         @Test
         void shouldAddSessionToDynamoWhenPreviousSessionIsProvidedInRequestBodyButIsNotInDynamo() {
             makeRequest(
-                    Optional.of(makeRequestBody(false)),
+                    Optional.of(
+                            makeRequestBody(
+                                    false,
+                                    Map.of(
+                                            "state", state.getValue(),
+                                            "redirect_uri", REDIRECT_URI.toString(),
+                                            "scope", scope.toString(),
+                                            "client_id", CLIENT_ID))),
                     standardHeadersWithSessionId(sessionId),
                     Map.of());
 
@@ -360,8 +404,32 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         }
     }
 
-    private String makeRequestBody(boolean isAuthenticated) {
-        return String.format(REQUEST_BODY, isAuthenticated);
+    private String makeRequestBody(boolean isAuthenticated, AuthenticationRequest authRequest) {
+        return String.format(
+                REQUEST_BODY,
+                isAuthenticated,
+                authRequest.getState().getValue(),
+                Optional.ofNullable(authRequest.getCustomParameter("client_id"))
+                        .map(l -> l.get(0))
+                        .orElse(null),
+                Optional.ofNullable(authRequest.getCustomParameter("redirect_uri"))
+                        .map(l -> l.get(0))
+                        .orElse(null),
+                Optional.ofNullable(authRequest.getCustomParameter("vtr"))
+                        .map(l -> l.get(0))
+                        .orElse(null),
+                authRequest.getScope().toString());
+    }
+
+    private String makeRequestBody(boolean isAuthenticated, Map<String, String> customAuthParams) {
+        return String.format(
+                REQUEST_BODY,
+                isAuthenticated,
+                customAuthParams.get("state"),
+                customAuthParams.get("client_id"),
+                customAuthParams.get("redirect_uri"),
+                customAuthParams.get("vtr"),
+                customAuthParams.get("scope"));
     }
 
     private void registerWebClient(KeyPair keyPair) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -91,9 +91,18 @@ public class VectorOfTrust {
     }
 
     private static VectorOfTrust parseVtrSet(JSONArray vtrJsonArray) {
+        return parseVtrStringList(vtrJsonArray.stream().map(Object::toString).toList());
+    }
+
+    public static VectorOfTrust parseVtrStringList(List<String> vtrStringArray) {
+        if (isNull(vtrStringArray) || vtrStringArray.isEmpty()) {
+            LOG.info(
+                    "VTR attribute is not present so defaulting to {}",
+                    CredentialTrustLevel.getDefault().getValue());
+            return new VectorOfTrust(CredentialTrustLevel.getDefault());
+        }
         List<VectorOfTrust> vectorOfTrusts = new ArrayList<>();
-        for (Object obj : vtrJsonArray) {
-            String vtr = (String) obj;
+        for (String vtr : vtrStringArray) {
             var splitVtr = vtr.split("\\.");
 
             var levelOfConfidence =


### PR DESCRIPTION
### Wider context of change

We have started passing new fields to the auth frontend, with the intent of replacing the calls to ClientSession.getAuthRequestParams. They will be passed into the auth backend in this PR: https://github.com/govuk-one-login/authentication-frontend/pull/2666

### What’s changed

We would like to consume these new fields from the frontend, and log whether they match the fields in the client session authRequestParams. They will be added to the AuthSessionItem in a later ticket.

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. n/a
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a

### Related PRs

Should merge https://github.com/govuk-one-login/authentication-frontend/pull/2666 before merging this one
