### PR TITLE
BAU: remove authenticated shared session

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -112,7 +112,6 @@ class StartServiceTest {
                 startService.createNewSessionWithExistingIdAndClientSession(
                         SESSION_ID, currentClientSessionId);
 
-        assertFalse(session.isAuthenticated());
         assertThat(session.getCurrentCredentialStrength(), equalTo(null));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         assertTrue(session.getClientSessions().contains("some-client-session-id"));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -85,7 +85,6 @@ class StartServiceTest {
                     ClientType.WEB,
                     null,
                     true,
-                    false,
                     Optional.empty(),
                     Optional.empty(),
                     false);
@@ -185,7 +184,6 @@ class StartServiceTest {
                         ClientType.WEB,
                         null,
                         rpSupportsIdentity,
-                        isAuthenticated,
                         Optional.of(
                                 new UserProfile()
                                         .withSubjectID(new Subject().getValue())
@@ -235,7 +233,6 @@ class StartServiceTest {
                         ClientType.WEB,
                         null,
                         rpSupportsIdentity,
-                        false,
                         Optional.empty(),
                         Optional.empty(),
                         false);
@@ -425,7 +422,6 @@ class StartServiceTest {
                         ClientType.WEB,
                         null,
                         true,
-                        false,
                         Optional.of(userProfile),
                         Optional.of(userCredentials),
                         false);
@@ -461,7 +457,6 @@ class StartServiceTest {
                         cookieConsentShared,
                         clientType,
                         signedJWT,
-                        false,
                         false,
                         Optional.empty(),
                         Optional.empty(),
@@ -583,7 +578,6 @@ class StartServiceTest {
             ClientType clientType,
             SignedJWT requestObject,
             boolean identityVerificationSupport,
-            boolean isAuthenticated,
             Optional<UserProfile> userProfile,
             Optional<UserCredentials> userCredentials,
             boolean oneLoginService) {
@@ -629,7 +623,7 @@ class StartServiceTest {
                         .withClientType(clientType.getValue())
                         .withIdentityVerificationSupported(identityVerificationSupport)
                         .withOneLoginService(oneLoginService);
-        return UserContext.builder(SESSION.setAuthenticated(isAuthenticated))
+        return UserContext.builder(SESSION)
                 .withClientSession(clientSession)
                 .withClient(clientRegistry)
                 .withUserCredentials(userCredentials)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -285,7 +285,6 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(200));
-        assertThat(redis.getSession(sessionId).isAuthenticated(), equalTo(false));
         var startResponse = objectMapper.readValue(response.getBody(), StartResponse.class);
 
         assertThat(startResponse.user().isAuthenticated(), equalTo(false));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -303,7 +303,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         void setup() throws Json.JsonException {
             handler = new StartHandler(new TestConfigurationService(), redisConnectionService);
             txmaAuditQueue.clear();
-            sessionId = redis.createSession(false);
+            sessionId = redis.createSession();
             userStore.signUp(EMAIL, "password");
             authSessionExtension.addSession(sessionId);
             var state = new State();

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -50,12 +50,12 @@ public class RedisExtension
     }
 
     public String createSession(String sessionId) throws Json.JsonException {
-        return createSession(sessionId, false, Optional.empty());
+        return createSession(sessionId, Optional.empty());
     }
 
-    private String createSession(String sessionId, boolean isAuthenticated, Optional<String> email)
+    private String createSession(String sessionId, Optional<String> email)
             throws Json.JsonException {
-        Session session = new Session().setAuthenticated(isAuthenticated);
+        Session session = new Session();
         email.ifPresent(session::setEmailAddress);
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
         return sessionId;
@@ -72,21 +72,17 @@ public class RedisExtension
         return createSession(IdGenerator.generate());
     }
 
-    public String createSession(boolean isAuthenticated) throws Json.JsonException {
-        return createSession(IdGenerator.generate(), isAuthenticated, Optional.empty());
-    }
-
     public String createUnauthenticatedSessionWithEmail(String email) throws Json.JsonException {
-        return createSession(IdGenerator.generate(), false, Optional.of(email));
+        return createSession(IdGenerator.generate(), Optional.of(email));
     }
 
     public void createUnauthenticatedSessionWithIdAndEmail(String sessionId, String email)
             throws Json.JsonException {
-        createSession(sessionId, false, Optional.of(email));
+        createSession(sessionId, Optional.of(email));
     }
 
     public String createAuthenticatedSessionWithEmail(String email) throws Json.JsonException {
-        return createSession(IdGenerator.generate(), true, Optional.of(email));
+        return createSession(IdGenerator.generate(), Optional.of(email));
     }
 
     public void addStateToRedis(State state, String sessionId) throws Json.JsonException {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -140,11 +140,6 @@ public class Session {
         return this;
     }
 
-    public Session setAuthenticated(boolean authenticated) {
-        this.authenticated = authenticated;
-        return this;
-    }
-
     public MFAMethodType getVerifiedMfaMethodType() {
         return verifiedMfaMethodType;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -140,10 +140,6 @@ public class Session {
         return this;
     }
 
-    public boolean isAuthenticated() {
-        return authenticated;
-    }
-
     public Session setAuthenticated(boolean authenticated) {
         this.authenticated = authenticated;
         return this;


### PR DESCRIPTION
### Wider context of change
We migrated this field off of being used on the shared session and therefore can remove the methods from the session class for the `authenticated` field

### What’s changed:
- Removes getter and setter for authenticated which was only used in test code

### Manual testing:
- N/A just test code

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
