### PR TITLE
AUT-2912: Introduce an internal representation for TICF CRI requests

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -8,7 +8,7 @@ import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.authentication.entity.TICFCRIRequest;
+import uk.gov.di.authentication.entity.InternalTICFCRIRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsInboundResponse;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsRequest;
@@ -242,7 +242,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         String journeyId = userContext.getClientSessionId();
 
         var ticfRequest =
-                TICFCRIRequest.basicTicfCriRequest(
+                new InternalTICFCRIRequest(
                         internalPairwiseId,
                         vtr,
                         journeyId,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import uk.gov.di.audit.AuditContext;
-import uk.gov.di.authentication.entity.TICFCRIRequest;
+import uk.gov.di.authentication.entity.InternalTICFCRIRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsInboundResponse;
 import uk.gov.di.authentication.frontendapi.entity.AccountInterventionsRequest;
@@ -28,6 +28,9 @@ import uk.gov.di.authentication.frontendapi.entity.State;
 import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.frontendapi.services.AccountInterventionsService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem.AccountState;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem.ResetMfaState;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem.ResetPasswordState;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -285,112 +288,112 @@ class AccountInterventionsHandlerTest {
                 // Testing authenticated combinations
                 Arguments.of(
                         true,
-                        AuthSessionItem.AccountState.EXISTING,
-                        AuthSessionItem.ResetPasswordState.NONE,
-                        AuthSessionItem.ResetMfaState.NONE,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         false,
-                        AuthSessionItem.AccountState.EXISTING,
-                        AuthSessionItem.ResetPasswordState.NONE,
-                        AuthSessionItem.ResetMfaState.NONE,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"N\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
 
                 // Testing initial registration combinations
                 Arguments.of(
                         true,
-                        AuthSessionItem.AccountState.NEW,
-                        AuthSessionItem.ResetPasswordState.NONE,
-                        AuthSessionItem.ResetMfaState.NONE,
+                        AccountState.NEW,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\",\"initialRegistration\":\"Y\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         false,
-                        AuthSessionItem.AccountState.NEW,
-                        AuthSessionItem.ResetPasswordState.NONE,
-                        AuthSessionItem.ResetMfaState.NONE,
+                        AccountState.NEW,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"N\",\"initialRegistration\":\"Y\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":false,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
 
                 // Testing password reset combinations
                 Arguments.of(
                         true,
-                        AuthSessionItem.AccountState.EXISTING,
-                        AuthSessionItem.ResetPasswordState.SUCCEEDED,
-                        AuthSessionItem.ResetMfaState.NONE,
+                        AccountState.EXISTING,
+                        ResetPasswordState.SUCCEEDED,
+                        ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\",\"passwordReset\":\"Y\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"SUCCEEDED\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         false,
-                        AuthSessionItem.AccountState.EXISTING,
-                        AuthSessionItem.ResetPasswordState.ATTEMPTED,
-                        AuthSessionItem.ResetMfaState.NONE,
+                        AccountState.EXISTING,
+                        ResetPasswordState.ATTEMPTED,
+                        ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"N\",\"passwordReset\":\"Y\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"ATTEMPTED\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
 
                 // Testing mfa reset combinations
                 Arguments.of(
                         true,
-                        AuthSessionItem.AccountState.EXISTING,
-                        AuthSessionItem.ResetPasswordState.NONE,
-                        AuthSessionItem.ResetMfaState.SUCCEEDED,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.SUCCEEDED,
                         MFAMethodType.NONE,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\",\"2fa_reset\":\"Y\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"SUCCEEDED\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         true,
-                        AuthSessionItem.AccountState.EXISTING,
-                        AuthSessionItem.ResetPasswordState.NONE,
-                        AuthSessionItem.ResetMfaState.ATTEMPTED,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.ATTEMPTED,
                         MFAMethodType.NONE,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"ATTEMPTED\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         false,
-                        AuthSessionItem.AccountState.EXISTING,
-                        AuthSessionItem.ResetPasswordState.NONE,
-                        AuthSessionItem.ResetMfaState.ATTEMPTED,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.ATTEMPTED,
                         MFAMethodType.NONE,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"N\",\"2fa_reset\":\"Y\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"ATTEMPTED\",\"mfaMethodType\":\"NONE\"}"),
 
                 // Testing mfa method combinations
                 Arguments.of(
                         true,
-                        AuthSessionItem.AccountState.EXISTING,
-                        AuthSessionItem.ResetPasswordState.NONE,
-                        AuthSessionItem.ResetMfaState.NONE,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         true,
-                        AuthSessionItem.AccountState.EXISTING,
-                        AuthSessionItem.ResetPasswordState.NONE,
-                        AuthSessionItem.ResetMfaState.NONE,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.NONE,
                         MFAMethodType.EMAIL,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"EMAIL\"}"),
                 Arguments.of(
                         true,
-                        AuthSessionItem.AccountState.EXISTING,
-                        AuthSessionItem.ResetPasswordState.NONE,
-                        AuthSessionItem.ResetMfaState.NONE,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.NONE,
                         MFAMethodType.SMS,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\",\"2fa_method\":[\"SMS\"]}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"SMS\"}"),
                 Arguments.of(
                         true,
-                        AuthSessionItem.AccountState.EXISTING,
-                        AuthSessionItem.ResetPasswordState.NONE,
-                        AuthSessionItem.ResetMfaState.NONE,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.NONE,
                         MFAMethodType.AUTH_APP,
-                        "{\"sub\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":\"Y\",\"2fa_method\":[\"AUTH_APP\"]}"));
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"AUTH_APP\"}"));
     }
 
     @ParameterizedTest
     @MethodSource("ticfParametersSource")
     void checkInvokesTICFLambdaWithCorrectValues(
             boolean authenticated,
-            AuthSessionItem.AccountState accountState,
-            AuthSessionItem.ResetPasswordState resetPasswordState,
-            AuthSessionItem.ResetMfaState resetMfaState,
+            AccountState accountState,
+            ResetPasswordState resetPasswordState,
+            ResetMfaState resetMfaState,
             MFAMethodType usedMfaMethodType,
             String expectedPayload)
             throws UnsuccessfulAccountInterventionsResponseException {
@@ -603,7 +606,7 @@ class AccountInterventionsHandlerTest {
                 .invokeAsyncWithPayload(payloadCaptor.capture(), lambdaNameCaptor.capture());
 
         String capturedPayload = payloadCaptor.getValue();
-        var ticfRequest = new Gson().fromJson(capturedPayload, TICFCRIRequest.class);
+        var ticfRequest = new Gson().fromJson(capturedPayload, InternalTICFCRIRequest.class);
         assertEquals(CommonTestVariables.CLIENT_SESSION_ID, ticfRequest.govukSigninJourneyId());
         var vtr = new ArrayList<String>();
         vtr.add(CredentialTrustLevel.LOW_LEVEL.getValue());

--- a/shared/src/main/java/uk/gov/di/authentication/entity/InternalTICFCRIRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/InternalTICFCRIRequest.java
@@ -1,0 +1,19 @@
+package uk.gov.di.authentication.entity;
+
+import com.google.gson.annotations.Expose;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem.AccountState;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem.ResetMfaState;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem.ResetPasswordState;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+
+import java.util.List;
+
+public record InternalTICFCRIRequest(
+        @Expose String internalCommonSubjectIdentifier,
+        @Expose List<String> vtr,
+        @Expose String govukSigninJourneyId,
+        @Expose boolean authenticated,
+        @Expose AccountState accountState,
+        @Expose ResetPasswordState resetPasswordState,
+        @Expose ResetMfaState resetMfaState,
+        MFAMethodType mfaMethodType) {}

--- a/shared/src/test/java/uk/gov/di/authentication/entity/ExternalTICFCRIRequestTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/entity/ExternalTICFCRIRequestTest.java
@@ -1,0 +1,300 @@
+package uk.gov.di.authentication.entity;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem.AccountState;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem.ResetMfaState;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem.ResetPasswordState;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExternalTICFCRIRequestTest {
+    private static Stream<Arguments> ticfParametersSource() {
+        return Stream.of(
+                // Testing authenticated combinations
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.EXISTING,
+                                ResetPasswordState.NONE,
+                                ResetMfaState.NONE,
+                                MFAMethodType.NONE),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                null,
+                                null,
+                                null,
+                                null)),
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                false,
+                                AccountState.EXISTING,
+                                ResetPasswordState.NONE,
+                                ResetMfaState.NONE,
+                                MFAMethodType.NONE),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "N",
+                                null,
+                                null,
+                                null,
+                                null)),
+
+                // Testing initial registration combinations
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.NEW,
+                                ResetPasswordState.NONE,
+                                ResetMfaState.NONE,
+                                MFAMethodType.NONE),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                "Y",
+                                null,
+                                null,
+                                null)),
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                false,
+                                AccountState.NEW,
+                                ResetPasswordState.NONE,
+                                ResetMfaState.NONE,
+                                MFAMethodType.NONE),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "N",
+                                "Y",
+                                null,
+                                null,
+                                null)),
+                // Testing password reset combinations
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.EXISTING,
+                                ResetPasswordState.SUCCEEDED,
+                                ResetMfaState.NONE,
+                                MFAMethodType.NONE),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                null,
+                                "Y",
+                                null,
+                                null)),
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                false,
+                                AccountState.EXISTING,
+                                ResetPasswordState.ATTEMPTED,
+                                ResetMfaState.NONE,
+                                MFAMethodType.NONE),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "N",
+                                null,
+                                "Y",
+                                null,
+                                null)),
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.EXISTING,
+                                ResetPasswordState.ATTEMPTED,
+                                ResetMfaState.NONE,
+                                MFAMethodType.NONE),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                null,
+                                null,
+                                null,
+                                null)),
+                // Testing mfa reset combinations
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.EXISTING,
+                                ResetPasswordState.NONE,
+                                ResetMfaState.SUCCEEDED,
+                                MFAMethodType.NONE),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                null,
+                                null,
+                                "Y",
+                                null)),
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.EXISTING,
+                                ResetPasswordState.NONE,
+                                ResetMfaState.ATTEMPTED,
+                                MFAMethodType.NONE),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                null,
+                                null,
+                                null,
+                                null)),
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                false,
+                                AccountState.EXISTING,
+                                ResetPasswordState.NONE,
+                                ResetMfaState.ATTEMPTED,
+                                MFAMethodType.NONE),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "N",
+                                null,
+                                null,
+                                "Y",
+                                null)),
+
+                // Testing mfa method combinations
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.EXISTING,
+                                ResetPasswordState.NONE,
+                                ResetMfaState.NONE,
+                                MFAMethodType.NONE),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                null,
+                                null,
+                                null,
+                                null)),
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.EXISTING,
+                                ResetPasswordState.ATTEMPTED,
+                                ResetMfaState.NONE,
+                                MFAMethodType.EMAIL),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                null,
+                                null,
+                                null,
+                                null)),
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.EXISTING,
+                                ResetPasswordState.ATTEMPTED,
+                                ResetMfaState.NONE,
+                                MFAMethodType.SMS),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                null,
+                                null,
+                                null,
+                                List.of("SMS"))),
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.EXISTING,
+                                ResetPasswordState.ATTEMPTED,
+                                ResetMfaState.NONE,
+                                MFAMethodType.AUTH_APP),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                null,
+                                null,
+                                null,
+                                List.of("AUTH_APP"))));
+    }
+
+    @ParameterizedTest
+    @MethodSource("ticfParametersSource")
+    void shouldCorrectlyBeConstructedFromInternalRequest(
+            InternalTICFCRIRequest provided, ExternalTICFCRIRequest expected) {
+        assertEquals(expected, ExternalTICFCRIRequest.fromInternalRequest(provided));
+    }
+}

--- a/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandler.java
+++ b/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandler.java
@@ -4,7 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import uk.gov.di.authentication.entity.TICFCRIRequest;
+import uk.gov.di.authentication.entity.InternalTICFCRIRequest;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.ticf.cri.stub.lambda.entity.TICFCRIStubResponse;
@@ -22,7 +22,7 @@ public class TICFCRIStubHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         try {
-            var request = objectMapper.readValue(input.getBody(), TICFCRIRequest.class);
+            var request = objectMapper.readValue(input.getBody(), InternalTICFCRIRequest.class);
         } catch (Json.JsonException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION

## What
The TICF CRI API specification is fairly non-standard, and we need to do unusual things like represent booleans as strings. We should capture all of this weirdness right as the edge, and represent requests in a way that matches our domain model everywhere else.

There are some additional challenges around lambda deserialising request objects: if the keys are not camel case then lambda will not deserialise by default and you need to provide a custom mapper. We can avoid all of that complexity by simply using a sensible object internally.


## How to review
1. Code review
2. Deploy to dev and give a basic test
3. Pay particular attention to ticf stub
## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
