### PR TITLE
ATO-1419: Add missing client session sync check

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
@@ -70,14 +70,14 @@ public class OrchestrationAuthorizationService {
             DynamoClientService dynamoClientService,
             IPVCapacityService ipvCapacityService,
             KmsConnectionService kmsConnectionService,
-            RedisConnectionService redisConnectionService) {
+            RedisConnectionService redisConnectionService,
+            NoSessionOrchestrationService noSessionOrchestrationService) {
         this.configurationService = configurationService;
         this.dynamoClientService = dynamoClientService;
         this.ipvCapacityService = ipvCapacityService;
         this.kmsConnectionService = kmsConnectionService;
         this.redisConnectionService = redisConnectionService;
-        this.noSessionOrchestrationService =
-                new NoSessionOrchestrationService(configurationService, redisConnectionService);
+        this.noSessionOrchestrationService = noSessionOrchestrationService;
     }
 
     public OrchestrationAuthorizationService(ConfigurationService configurationService) {
@@ -86,7 +86,8 @@ public class OrchestrationAuthorizationService {
                 new DynamoClientService(configurationService),
                 new IPVCapacityService(configurationService),
                 new KmsConnectionService(configurationService),
-                new RedisConnectionService(configurationService));
+                new RedisConnectionService(configurationService),
+                new NoSessionOrchestrationService(configurationService));
     }
 
     public OrchestrationAuthorizationService(
@@ -96,7 +97,8 @@ public class OrchestrationAuthorizationService {
                 new DynamoClientService(configurationService),
                 new IPVCapacityService(configurationService),
                 new KmsConnectionService(configurationService),
-                redis);
+                redis,
+                new NoSessionOrchestrationService(configurationService));
     }
 
     public boolean isClientRedirectUriValid(ClientID clientID, URI redirectURI)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
@@ -42,6 +42,7 @@ import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
@@ -91,6 +92,8 @@ class OrchestrationAuthorizationServiceTest {
     private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
+    private final NoSessionOrchestrationService noSessionOrchestrationService =
+            mock(NoSessionOrchestrationService.class);
     private PrivateKey privateKey;
 
     @RegisterExtension
@@ -105,7 +108,8 @@ class OrchestrationAuthorizationServiceTest {
                         dynamoClientService,
                         ipvCapacityService,
                         kmsConnectionService,
-                        redisConnectionService);
+                        redisConnectionService,
+                        noSessionOrchestrationService);
         var keyPair = generateRsaKeyPair();
         privateKey = keyPair.getPrivate();
         String publicCertificateAsPem =
@@ -295,6 +299,8 @@ class OrchestrationAuthorizationServiceTest {
 
         verify(redisConnectionService)
                 .saveWithExpiry("auth-state:" + sessionId, state.getValue(), 3600);
+        verify(noSessionOrchestrationService)
+                .storeClientSessionIdAgainstState(clientSessionId, state);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Background
We have been logging whether the redis client session has been in sync with the dynamo client session. There was one service where this logging check was missing though.

### What
We were getting the client session in NoSessionOrchestrationService, but not logging and comparing with the new dynamo client session. This PR updates the service to compare both client sessions, also updating the tests so the logs are accurate. 

This service is not used in any handlers where we aren't already checking if the client sessions are in sync, so should not be a problem in terms of lambda permissions

