### PR TITLE
ATO-1196: add OrchAuthCode table policies

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1637,6 +1637,7 @@ Resources:
         - !Ref RpPublicKeyCacheTableWriteAccessPolicy
         - !Ref ClientSessionTableReadAccessPolicy
         - !Ref ClientSessionTableWriteAccessPolicy
+        - !Ref OrchAuthCodeTableReadAccessPolicy
         - !Ref OrchAuthCodeTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173

--- a/template.yaml
+++ b/template.yaml
@@ -1492,6 +1492,7 @@ Resources:
         - !Ref DocAppSigningKmsAccessPolicy
         - !Ref OrchSessionTableReadAccessPolicy
         - !Ref ClientSessionTableReadAccessPolicy
+        - !Ref OrchAuthCodeTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -1636,6 +1637,7 @@ Resources:
         - !Ref RpPublicKeyCacheTableWriteAccessPolicy
         - !Ref ClientSessionTableReadAccessPolicy
         - !Ref ClientSessionTableWriteAccessPolicy
+        - !Ref OrchAuthCodeTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -2175,6 +2177,7 @@ Resources:
         - !Ref AccountInterventionsServiceUriSecretAccessPolicy
         - !Ref OrchSessionTableReadWriteAndDeleteAccessPolicy
         - !Ref ClientSessionTableReadWriteAndDeleteAccessPolicy
+        - !Ref OrchAuthCodeTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -3223,6 +3226,7 @@ Resources:
         - !Ref OrchSessionTableWriteAccessPolicy
         - !Ref ClientSessionTableReadAccessPolicy
         - !Ref AuthUserInfoTableReadAccessPolicy
+        - !Ref OrchAuthCodeTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -3880,6 +3884,7 @@ Resources:
         - !Ref AuthUserInfoTableReadAccessPolicy
         - !Ref ClientSessionTableReadAccessPolicy
         - !Ref ClientSessionTableDeleteAccessPolicy
+        - !Ref OrchAuthCodeTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 

--- a/template.yaml
+++ b/template.yaml
@@ -5606,6 +5606,43 @@ Resources:
         - Key: Name
           Value: OrchAuthCodeTable
 
+  OrchAuthCodeTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowOrchAuthCodeTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt OrchAuthCodeTable.Arn
+          - Sid: AllowOrchAuthCodeTableDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: !GetAtt OrchAuthCodeTableEncryptionKey.Arn
+
+  OrchAuthCodeTableWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowOrchAuthCodeTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+            Resource: !GetAtt OrchAuthCodeTable.Arn
+          - Sid: AllowOrchAuthCodeTableDecryptionAndEncryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+            Resource: !GetAtt OrchAuthCodeTableEncryptionKey.Arn
+
   #endregion
 
 Outputs:


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Currently RP issued auth codes are stored in Redis. We are migrating away from Redis to DynamoDB. The auth code store is being migrated under the parent ticket. The lambdas writing and reading the auth code need permissions on the DynamoDB table added under #6146.

Handlers requiring write access (calls from `generateAndSaveAuthorisationCode`):
- DocAppCallbackHandler
- IPVCallbackHandler
- AuthCodeHandler
- AuthenticationCallbackHandler

Handlers requiring read access:
- TokenHandler

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Added two new policies for the OrchAuthCode table - one read, one write.
- Added policies to the lambdas above.

Note that these lambdas do not make use of these permissions yet (will be covered by a subsequent ticket under ATO-937).

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to orch dev.

Checked both policies have been added. Checked the entities attached to each are as expected.

Tested journeys to trigger each of the lambdas for completeness (although the policies are not used by these yet).

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing. **- N/A yet, perms added but not used**

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or **not required**.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or **not required**.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or **not required**.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or **not required**.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or **not required**.

### Related PRs

- #6146
