### PR TITLE
ATO-1121: delete the unused isTestClientWithAllowedEmail method

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/TestClientHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/TestClientHelper.java
@@ -2,9 +2,6 @@ package uk.gov.di.orchestration.shared.helpers;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
-import uk.gov.di.orchestration.shared.services.ConfigurationService;
-import uk.gov.di.orchestration.shared.state.UserContext;
 
 import java.util.List;
 import java.util.Objects;
@@ -15,33 +12,6 @@ public class TestClientHelper {
     private static final Logger LOG = LogManager.getLogger(TestClientHelper.class);
 
     private TestClientHelper() {}
-
-    public static boolean isTestClientWithAllowedEmail(
-            UserContext userContext, ConfigurationService configurationService)
-            throws ClientNotFoundException {
-        if (configurationService.isTestClientsEnabled()) {
-            LOG.warn("TestClients are ENABLED");
-        } else {
-            LOG.info("TestClients are Disabled");
-            return false;
-        }
-        var clientRegistry =
-                userContext
-                        .getClient()
-                        .orElseThrow(() -> new ClientNotFoundException(userContext.getClientId()));
-
-        var isTestClientWithAllowedEmail =
-                (clientRegistry.isTestClient()
-                        && emailMatchesAllowlist(
-                                userContext.getSession().getEmailAddress(),
-                                clientRegistry.getTestClientEmailAllowlist()));
-
-        LOG.info(
-                "Is request from a test client with a test client email address: {}",
-                isTestClientWithAllowedEmail);
-
-        return isTestClientWithAllowedEmail;
-    }
 
     public static boolean emailMatchesAllowlist(String emailAddress, List<String> regexAllowList) {
         if (Objects.isNull(emailAddress)) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/TestClientHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/TestClientHelperTest.java
@@ -1,32 +1,21 @@
 package uk.gov.di.orchestration.shared.helpers;
 
-import com.nimbusds.oauth2.sdk.id.ClientID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import uk.gov.di.orchestration.shared.entity.ClientRegistry;
-import uk.gov.di.orchestration.shared.entity.Session;
-import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
-import uk.gov.di.orchestration.shared.services.ConfigurationService;
-import uk.gov.di.orchestration.shared.state.UserContext;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
-import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.everyItem;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class TestClientHelperTest {
 
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final List<String> ALLOWLIST =
             List.of(
                     "testclient.user1@digital.cabinet-office.gov.uk",
@@ -38,47 +27,6 @@ class TestClientHelperTest {
     @RegisterExtension
     public final CaptureLoggingExtension logging =
             new CaptureLoggingExtension(TestClientHelper.class);
-
-    @Test
-    void shouldReturnTrueIfTestClientWithAllowedEmailAddress() throws ClientNotFoundException {
-        when(configurationService.isTestClientsEnabled()).thenReturn(true);
-
-        var userContext = buildUserContext(true, Collections.singletonList(TEST_EMAIL_ADDRESS));
-
-        assertTrue(
-                TestClientHelper.isTestClientWithAllowedEmail(userContext, configurationService));
-    }
-
-    @Test
-    void shouldReturnFalseIfTestClientsAreDisabled() throws ClientNotFoundException {
-        when(configurationService.isTestClientsEnabled()).thenReturn(false);
-
-        var userContext = buildUserContext(true, Collections.singletonList(TEST_EMAIL_ADDRESS));
-
-        assertFalse(
-                TestClientHelper.isTestClientWithAllowedEmail(userContext, configurationService));
-    }
-
-    @Test
-    void shouldReturnFalseIfClientIsNotATestClient() throws ClientNotFoundException {
-        when(configurationService.isTestClientsEnabled()).thenReturn(true);
-
-        var userContext = buildUserContext(false, Collections.singletonList(TEST_EMAIL_ADDRESS));
-
-        assertFalse(
-                TestClientHelper.isTestClientWithAllowedEmail(userContext, configurationService));
-    }
-
-    @Test
-    void shouldReturnFalseIfClientDoesNotContainEmailAddressInAllowList()
-            throws ClientNotFoundException {
-        when(configurationService.isTestClientsEnabled()).thenReturn(true);
-
-        var userContext = buildUserContext(true, Collections.singletonList("test@wrong-email.com"));
-
-        assertFalse(
-                TestClientHelper.isTestClientWithAllowedEmail(userContext, configurationService));
-    }
 
     @ParameterizedTest
     @ValueSource(
@@ -126,19 +74,5 @@ class TestClientHelperTest {
     void emailShouldNotMatchRegexAllowlistWhenEmailIsNull() {
         assertFalse(TestClientHelper.emailMatchesAllowlist(null, List.of("^$", "[", "*")));
         assertThat(logging.events(), everyItem(withMessageContaining("PatternSyntaxException")));
-    }
-
-    private UserContext buildUserContext(boolean isTestClient, List<String> allowedEmails) {
-        var clientRegistry =
-                new ClientRegistry()
-                        .withClientID(new ClientID().getValue())
-                        .withClientName("some-client")
-                        .withTestClient(isTestClient)
-                        .withTestClientEmailAllowlist(allowedEmails);
-        var sessionId = IdGenerator.generate();
-        return UserContext.builder(new Session().setEmailAddress(TEST_EMAIL_ADDRESS))
-                .withSessionId(sessionId)
-                .withClient(clientRegistry)
-                .build();
     }
 }


### PR DESCRIPTION
### Wider context of change
Part of the email migration work

### What’s changed
Deletes an unused method that was only used in tests. Those tests only verified that method worked as expected.

This was copied directly over from Auth when we initially split. It hasn't been unused or updated since.

### Manual testing
n/a

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.