### PR TITLE
ATO-1513 set PreservedReauthCountsForAudit on AuthSessionItem

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -33,6 +33,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_REAUTH_SUCCESS;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
@@ -149,6 +150,15 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                                         configurationService.getInternalSectorUri())
                                 .getValue();
                 var metadataBuilder = ReauthMetadataBuilder.builder(rpPairwiseId);
+
+                LOG.info(
+                        "Preserved reauth counts for audit migration check {}",
+                        Objects.equals(
+                                userContext.getSession().getPreservedReauthCountsForAudit(),
+                                userContext
+                                        .getAuthSession()
+                                        .getPreservedReauthCountsForAuditMap()));
+
                 if (userContext.getSession().getPreservedReauthCountsForAudit() != null) {
                     metadataBuilder.withAllIncorrectAttemptCounts(
                             userContext.getSession().getPreservedReauthCountsForAudit());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -164,6 +164,8 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                 sessionService.storeOrUpdateSession(
                         userContext.getSession().setPreservedReauthCountsForAudit(null),
                         userContext.getAuthSession().getSessionId());
+                authSessionService.updateSession(
+                        userContext.getAuthSession().withPreservedReauthCountsForAuditMap(null));
             }
 
             return generateApiGatewayProxyResponse(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -413,7 +413,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
         if (configurationService.isAuthenticationAttemptsServiceEnabled() && subjectId != null) {
             preserveReauthCountsForAuditIfJourneyIsReauth(
-                    journeyType, subjectId, session, sessionId, maybeRpPairwiseId);
+                    journeyType, subjectId, session, authSession, sessionId, maybeRpPairwiseId);
             clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
             maybeRpPairwiseId.ifPresentOrElse(
                     this::clearReauthErrorCountsForSuccessfullyAuthenticatedUser,
@@ -432,6 +432,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             JourneyType journeyType,
             String subjectId,
             Session session,
+            AuthSessionItem authSession,
             String sessionId,
             Optional<String> maybeRpPairwiseId) {
         if (journeyType == JourneyType.REAUTHENTICATION
@@ -448,6 +449,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                                     subjectId, JourneyType.REAUTHENTICATION);
             var updatedSession = session.setPreservedReauthCountsForAudit(counts);
             sessionService.storeOrUpdateSession(updatedSession, sessionId);
+            var updatedAuthSession = authSession.withPreservedReauthCountsForAuditMap(counts);
+            authSessionService.updateSession(updatedAuthSession);
         }
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -436,7 +436,12 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 && codeRequest.getMfaMethodType() == MFAMethodType.AUTH_APP
                 && subjectId != null) {
             preserveReauthCountsForAuditIfJourneyIsReauth(
-                    codeRequest.getJourneyType(), subjectId, session, sessionId, maybeRpPairwiseId);
+                    codeRequest.getJourneyType(),
+                    subjectId,
+                    session,
+                    authSession,
+                    sessionId,
+                    maybeRpPairwiseId);
             clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
             maybeRpPairwiseId.ifPresentOrElse(
                     this::clearReauthErrorCountsForSuccessfullyAuthenticatedUser,
@@ -477,6 +482,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             JourneyType journeyType,
             String subjectId,
             Session session,
+            AuthSessionItem authSession,
             String sessionId,
             Optional<String> maybeRpPairwiseId) {
         if (journeyType == JourneyType.REAUTHENTICATION
@@ -493,6 +499,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                                     subjectId, JourneyType.REAUTHENTICATION);
             var updatedSession = session.setPreservedReauthCountsForAudit(counts);
             sessionService.storeOrUpdateSession(updatedSession, sessionId);
+            var updatedAuthSession = authSession.withPreservedReauthCountsForAuditMap(counts);
+            authSessionService.updateSession(updatedAuthSession);
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -310,6 +310,9 @@ class AuthenticationAuthCodeHandlerTest {
                     .storeOrUpdateSession(
                             argThat(s -> Objects.isNull(s.getPreservedReauthCountsForAudit())),
                             eq(SESSION_ID));
+            verify(authSessionService, atLeastOnce())
+                    .updateSession(
+                            argThat(s -> Objects.isNull(s.getPreservedReauthCountsForAuditMap())));
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -793,6 +793,12 @@ class VerifyCodeHandlerTest {
                                             s.getPreservedReauthCountsForAudit()
                                                     .equals(existingCounts)),
                             eq(SESSION_ID));
+            verify(authSessionService, atLeastOnce())
+                    .updateSession(
+                            argThat(
+                                    s ->
+                                            s.getPreservedReauthCountsForAuditMap()
+                                                    .equals(existingCounts)));
         } else {
             verify(sessionService, never())
                     .storeOrUpdateSession(
@@ -802,6 +808,13 @@ class VerifyCodeHandlerTest {
                                                     s.getPreservedReauthCountsForAudit(),
                                                     existingCounts)),
                             eq(SESSION_ID));
+            verify(authSessionService, never())
+                    .updateSession(
+                            argThat(
+                                    s ->
+                                            Objects.equals(
+                                                    s.getPreservedReauthCountsForAuditMap(),
+                                                    existingCounts)));
         }
 
         assertThat(result, hasStatus(204));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -924,6 +924,12 @@ class VerifyMfaCodeHandlerTest {
                 .storeOrUpdateSession(
                         argThat(s -> s.getPreservedReauthCountsForAudit().equals(existingCounts)),
                         eq(SESSION_ID));
+        verify(authSessionService, atLeastOnce())
+                .updateSession(
+                        argThat(
+                                s ->
+                                        s.getPreservedReauthCountsForAuditMap()
+                                                .equals(existingCounts)));
     }
 
     @Test
@@ -958,6 +964,13 @@ class VerifyMfaCodeHandlerTest {
                                                 s.getPreservedReauthCountsForAudit(),
                                                 existingCounts)),
                         eq(SESSION_ID));
+        verify(authSessionService, never())
+                .updateSession(
+                        argThat(
+                                s ->
+                                        Objects.equals(
+                                                s.getPreservedReauthCountsForAuditMap(),
+                                                existingCounts)));
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/converters/PreservedReauthCountsForAuditMapConverter.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/converters/PreservedReauthCountsForAuditMapConverter.java
@@ -1,0 +1,47 @@
+package uk.gov.di.authentication.shared.converters;
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import uk.gov.di.authentication.shared.entity.CountType;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class PreservedReauthCountsForAuditMapConverter
+        implements AttributeConverter<Map<CountType, Integer>> {
+
+    @Override
+    public AttributeValue transformFrom(Map<CountType, Integer> input) {
+        return AttributeValue.fromM(
+                input.entrySet().stream()
+                        .map(
+                                entry ->
+                                        Map.entry(
+                                                entry.getKey().name(),
+                                                AttributeValue.fromN(entry.getValue().toString())))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    @Override
+    public Map<CountType, Integer> transformTo(AttributeValue input) {
+        return input.m().entrySet().stream()
+                .map(
+                        entry ->
+                                Map.entry(
+                                        CountType.valueOf(entry.getKey()),
+                                        Integer.parseInt(entry.getValue().n())))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public EnhancedType<Map<CountType, Integer>> type() {
+        return EnhancedType.mapOf(CountType.class, Integer.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.M;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import uk.gov.di.authentication.shared.converters.CodeRequestCountMapConverter;
+import uk.gov.di.authentication.shared.converters.PreservedReauthCountsForAuditMapConverter;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 
 import java.util.HashMap;
@@ -29,6 +30,8 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_PASSWORD_RESET_COUNT = "PasswordResetCount";
     public static final String ATTRIBUTE_TTL = "ttl";
     public static final String ATTRIBUTE_CODE_REQUEST_COUNT_MAP = "CodeRequestCountMap";
+    public static final String ATTRIBUTE_PRESERVED_REAUTH_COUNTS_FOR_AUDIT_MAP =
+            "PreservedReauthCountsForAuditMap";
 
     public enum AccountState {
         NEW,
@@ -61,6 +64,7 @@ public class AuthSessionItem {
     private String emailAddress;
     private Map<CodeRequestType, Integer> codeRequestCountMap;
     private int passwordResetCount;
+    private Map<CountType, Integer> preservedReauthCountsForAuditMap;
 
     public AuthSessionItem() {
         this.codeRequestCountMap = new HashMap<>();
@@ -280,6 +284,23 @@ public class AuthSessionItem {
         for (CodeRequestType requestType : CodeRequestType.values()) {
             codeRequestCountMap.put(requestType, 0);
         }
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_PRESERVED_REAUTH_COUNTS_FOR_AUDIT_MAP)
+    @DynamoDbConvertedBy(PreservedReauthCountsForAuditMapConverter.class)
+    public Map<CountType, Integer> getPreservedReauthCountsForAuditMap() {
+        return this.preservedReauthCountsForAuditMap;
+    }
+
+    public void setPreservedReauthCountsForAuditMap(
+            Map<CountType, Integer> preservedReauthCountsForAuditMap) {
+        this.preservedReauthCountsForAuditMap = preservedReauthCountsForAuditMap;
+    }
+
+    public AuthSessionItem withPreservedReauthCountsForAuditMap(
+            Map<CountType, Integer> preservedReauthCountsForAuditMap) {
+        this.preservedReauthCountsForAuditMap = preservedReauthCountsForAuditMap;
+        return this;
     }
 
     /**


### PR DESCRIPTION
### Wider context of change

Moving PreservedReauthCountsForAudit from shared session to AuthSessionItem. Part of the session split.

### What’s changed

Created PreservedReauthCountsForAuditMap on AuthSessionItem and set it in the same places as PreservedReauthCountsForAudit on Session.

### Manual testing

Tested reauth journey on authdev

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
