### PR TITLE
AUT-2138: Add journey ID to AUTH_TOKEN_SENT_TO_ORCHESTRATION audit context

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
@@ -190,7 +190,8 @@ public class TokenHandler
                                             .orElse(AuditService.UNKNOWN))
                             .withSubjectId(
                                     Optional.ofNullable(internalPairwiseId)
-                                            .orElse(AuditService.UNKNOWN));
+                                            .orElse(AuditService.UNKNOWN))
+                            .withClientSessionId(authCodeStore.getJourneyID());
 
             auditService.submitAuditEvent(AUTH_TOKEN_SENT_TO_ORCHESTRATION, auditContext);
 

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
@@ -54,6 +54,7 @@ class TokenHandlerTest {
     private static final String SUBJECT_ID = "any";
     private static final String CLIENT_ID = "test-client-id";
     private static final Long PASSWORD_RESET_TIME = 1710255274L;
+    private static final String CLIENT_SESSION_ID = "client-session-id";
     private static final UserProfile USER_PROFILE =
             new UserProfile().withSubjectID("any").withSalt(ByteBuffer.allocateDirect(12345));
     private static final AuthCodeStore VALID_AUTH_CODE_STORE =
@@ -65,7 +66,8 @@ class TokenHandlerTest {
                     .withSubjectID("any")
                     .withHasBeenUsed(false)
                     .withTimeToExist(UNIX_TIME_16_08_2099)
-                    .withPasswordResetTime(PASSWORD_RESET_TIME);
+                    .withPasswordResetTime(PASSWORD_RESET_TIME)
+                    .withJourneyID(CLIENT_SESSION_ID);
     private static final String USED_AUTH_CODE = "used-auth-code";
     private static final AuthCodeStore USED_AUTH_CODE_STORE =
             new AuthCodeStore()
@@ -237,7 +239,7 @@ class TokenHandlerTest {
                         AuthExternalApiAuditableEvent.AUTH_TOKEN_SENT_TO_ORCHESTRATION,
                         new AuditContext(
                                 CLIENT_ID,
-                                AuditService.UNKNOWN,
+                                CLIENT_SESSION_ID,
                                 AuditService.UNKNOWN,
                                 internalPairwiseId,
                                 AuditService.UNKNOWN,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -120,7 +120,8 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                     false,
                     authCodeRequest.sectorIdentifier(),
                     authCodeRequest.isNewAccount(),
-                    authCodeRequest.passwordResetTime());
+                    authCodeRequest.passwordResetTime(),
+                    userContext.getClientSessionId());
 
             var state = State.parse(authCodeRequest.state());
             var redirectUri = URI.create(authCodeRequest.redirectUri());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -235,7 +235,8 @@ class AuthenticationAuthCodeHandlerTest {
                         eq(false),
                         anyString(),
                         eq(false),
-                        eq(null));
+                        eq(null),
+                        eq(CLIENT_SESSION_ID));
         assertThat(result, hasStatus(200));
         var jsonBody = new JSONObject(result.getBody());
         assertTrue(jsonBody.has(LOCATION));
@@ -412,7 +413,8 @@ class AuthenticationAuthCodeHandlerTest {
                         eq(false),
                         anyString(),
                         eq(false),
-                        eq(PASSWORD_RESET_TIME));
+                        eq(PASSWORD_RESET_TIME),
+                        eq(CLIENT_SESSION_ID));
         assertThat(result, hasStatus(200));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -30,6 +30,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
     private static final String TEST_STATE = "xyz";
     private static final String TEST_AUTHORIZATION_CODE = "SplxlOBeZQQYbYS6WxSbIA";
     private static final String TEST_SECTOR_IDENTIFIER = "sectorIdentifier";
+    private static final String TEST_JOURNEY_ID = "client-session-id";
     private static final String TEST_SUBJECT_ID = "subject-id";
     public static final String ENCODED_DEVICE_INFORMATION =
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
@@ -55,7 +56,8 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                 List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                 false,
                 TEST_SECTOR_IDENTIFIER,
-                false);
+                false,
+                TEST_JOURNEY_ID);
         userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD);
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
@@ -52,6 +52,7 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
     private static final String TEST_SECTOR_IDENTIFIER = "sectorIdentifier";
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String TEST_PASSWORD = "password-1";
+    private static final String TEST_JOURNEY_ID = "client-session-id";
     public static final String ENCODED_DEVICE_DETAILS =
             "YTtKVSlub1YlOSBTeEI4J3pVLVd7Jjl8VkBfREs2N3clZmN+fnU7fXNbcTJjKyEzN2IuUXIgMGttV058fGhUZ0xhenZUdldEblB8SH18XypwXUhWPXhYXTNQeURW%";
 
@@ -78,7 +79,8 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                 TEST_CLAIMS,
                 false,
                 TEST_SECTOR_IDENTIFIER,
-                false);
+                false,
+                TEST_JOURNEY_ID);
 
         txmaAuditQueue.clear();
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
@@ -24,6 +24,7 @@ class DynamoAuthCodeServiceIntegrationTest {
     private static final boolean IS_NEW_ACCOUNT = false;
     private static final String TEST_SECTOR_IDENTIFIER = "sectorIdentifier";
     private static final Long PASSWORD_RESET_TIME = 1696869005821L;
+    private static final String TEST_JOURNEY_ID = "client-session-id";
 
     @RegisterExtension
     protected static final AuthCodeExtension authCodeExtension = new AuthCodeExtension(180);
@@ -38,7 +39,8 @@ class DynamoAuthCodeServiceIntegrationTest {
                 List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                 HAS_BEEN_USED,
                 TEST_SECTOR_IDENTIFIER,
-                IS_NEW_ACCOUNT);
+                IS_NEW_ACCOUNT,
+                TEST_JOURNEY_ID);
     }
 
     @Test
@@ -71,7 +73,8 @@ class DynamoAuthCodeServiceIntegrationTest {
                 HAS_BEEN_USED,
                 TEST_SECTOR_IDENTIFIER,
                 IS_NEW_ACCOUNT,
-                null);
+                null,
+                TEST_JOURNEY_ID);
 
         var updatedAuthCode = dynamoAuthCodeService.getAuthCodeStore(AUTH_CODE).get();
         assertEquals(AUTH_CODE, updatedAuthCode.getAuthCode());
@@ -87,7 +90,8 @@ class DynamoAuthCodeServiceIntegrationTest {
                 HAS_BEEN_USED,
                 TEST_SECTOR_IDENTIFIER,
                 IS_NEW_ACCOUNT,
-                PASSWORD_RESET_TIME);
+                PASSWORD_RESET_TIME,
+                TEST_JOURNEY_ID);
 
         var updatedAuthCode = dynamoAuthCodeService.getAuthCodeStore(AUTH_CODE).get();
         assertEquals(AUTH_CODE, updatedAuthCode.getAuthCode());

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
@@ -65,10 +65,18 @@ public class AuthCodeExtension extends DynamoExtension implements AfterEachCallb
             List<String> claims,
             boolean hasBeenUsed,
             String sectorIdentifier,
-            boolean isNewAccount) {
+            boolean isNewAccount,
+            String journeyId) {
 
         dynamoAuthCodeService.saveAuthCode(
-                subjectID, authCode, claims, hasBeenUsed, sectorIdentifier, isNewAccount, null);
+                subjectID,
+                authCode,
+                claims,
+                hasBeenUsed,
+                sectorIdentifier,
+                isNewAccount,
+                null,
+                journeyId);
     }
 
     private void createAuthCodeStoreTable() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
@@ -17,6 +17,7 @@ public class AuthCodeStore {
     private static final String ATTRIBUTE_SECTOR_IDENTIFIER = "SectorIdentifier";
     private static final String ATTRIBUTE_IS_NEW_ACCOUNT = "IsNewAccount";
     private static final String ATTRIBUTE_PASSWORD_RESET_TIME = "PasswordResetTime";
+    private static final String JOURNEY_ID = "JourneyID";
 
     private String subjectID;
     private String authCode;
@@ -26,6 +27,7 @@ public class AuthCodeStore {
     private String sectorIdentifier;
     private boolean isNewAccount;
     private Long passwordResetTime;
+    private String journeyID;
 
     public AuthCodeStore() {}
 
@@ -139,6 +141,20 @@ public class AuthCodeStore {
 
     public AuthCodeStore withPasswordResetTime(Long passwordResetTime) {
         this.passwordResetTime = passwordResetTime;
+        return this;
+    }
+
+    @DynamoDbAttribute(JOURNEY_ID)
+    public String getJourneyId() {
+        return journeyID;
+    }
+
+    public void setJourneyID(String journeyID) {
+        this.journeyID = journeyID;
+    }
+
+    public AuthCodeStore withJourneyID(String journeyID) {
+        this.journeyID = journeyID;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
@@ -17,7 +17,7 @@ public class AuthCodeStore {
     private static final String ATTRIBUTE_SECTOR_IDENTIFIER = "SectorIdentifier";
     private static final String ATTRIBUTE_IS_NEW_ACCOUNT = "IsNewAccount";
     private static final String ATTRIBUTE_PASSWORD_RESET_TIME = "PasswordResetTime";
-    private static final String JOURNEY_ID = "JourneyID";
+    private static final String ATTRIBUTE_JOURNEY_ID = "JourneyID";
 
     private String subjectID;
     private String authCode;
@@ -144,8 +144,8 @@ public class AuthCodeStore {
         return this;
     }
 
-    @DynamoDbAttribute(JOURNEY_ID)
-    public String getJourneyId() {
+    @DynamoDbAttribute(ATTRIBUTE_JOURNEY_ID)
+    public String getJourneyID() {
         return journeyID;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthCodeService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthCodeService.java
@@ -32,7 +32,8 @@ public class DynamoAuthCodeService extends BaseDynamoService<AuthCodeStore> {
             boolean hasBeenUsed,
             String sectorIdentifier,
             boolean isNewAccount,
-            Long passwordResetTime) {
+            Long passwordResetTime,
+            String journeyId) {
         var authCodeStore =
                 new AuthCodeStore()
                         .withSubjectID(subjectID)
@@ -45,7 +46,8 @@ public class DynamoAuthCodeService extends BaseDynamoService<AuthCodeStore> {
                                 NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
                                         .toInstant()
                                         .getEpochSecond())
-                        .withPasswordResetTime(passwordResetTime);
+                        .withPasswordResetTime(passwordResetTime)
+                        .withJourneyID(journeyId);
 
         put(authCodeStore);
     }


### PR DESCRIPTION
## What

- Front end sends journey ID in request headers
- This is saved to the auth code store
- Used in the TokenHandler to populate client session ID in Audit Context

## How to review

1. Code Review
2. Deploy to dev, run through a sign in journey and see the new journey ID field populated against your email in the auth code store

