### PR TITLE
ATO-1420: Swap to using dynamo client session

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -198,10 +198,7 @@ public class DocAppCallbackHandler
                         TxmaAuditUser.user()
                                 .withGovukSigninJourneyId(noSessionEntity.getClientSessionId())
                                 .withUserId(
-                                        noSessionEntity
-                                                .getClientSession()
-                                                .getDocAppSubjectId()
-                                                .getValue()));
+                                        noSessionEntity.getClientSession().getDocAppSubjectId()));
             }
             var sessionId = sessionCookiesIds.getSessionId();
             var clientSessionId = sessionCookiesIds.getClientSessionId();

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -440,7 +440,7 @@ class DocAppCallbackHandlerTest {
         when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
                 .thenReturn(
                         new NoSessionEntity(
-                                CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, clientSession));
+                                CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, orchClientSession));
 
         var response =
                 handler.handleRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.app.lambda.DocAppCallbackHandler;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
@@ -358,14 +357,6 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         var clientSessionCreationDate =
                 LocalDateTime.ofInstant(
                         Instant.parse("2025-02-19T15:00:00Z"), ZoneId.systemDefault());
-        var clientSession =
-                new ClientSession(
-                        authRequestBuilder.build().toParameters(),
-                        clientSessionCreationDate,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME);
-        clientSession.setDocAppSubjectId(docAppSubjectId);
-        redis.createClientSession(CLIENT_SESSION_ID, clientSession);
         var orchClientSession =
                 new OrchClientSessionItem(
                         CLIENT_SESSION_ID,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -17,7 +17,6 @@ import uk.gov.di.authentication.ipv.entity.SPOTClaims;
 import uk.gov.di.authentication.ipv.entity.SPOTRequest;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.IdentityClaims;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -195,7 +194,7 @@ public class IPVCallbackHelper {
             Session session,
             String sessionId,
             OrchSessionItem orchSession,
-            ClientSession clientSession,
+            String clientName,
             Subject rpPairwiseSubject,
             String internalPairwiseSubjectId,
             UserInfo userIdentityUserInfo,
@@ -227,7 +226,7 @@ public class IPVCallbackHelper {
 
         var dimensions =
                 authCodeResponseService.getDimensions(
-                        orchSession, clientSession, clientSessionId, false, false);
+                        orchSession, clientName, clientSessionId, false, false);
 
         var subjectId = authCodeResponseService.getSubjectId(session);
 
@@ -261,10 +260,7 @@ public class IPVCallbackHelper {
         cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
 
         cloudwatchMetricsService.incrementSignInByClient(
-                orchSession.getIsNewAccount(),
-                clientId,
-                clientSession.getClientName(),
-                isTestJourney);
+                orchSession.getIsNewAccount(), clientId, clientName, isTestJourney);
 
         authCodeResponseService.saveSession(
                 false, sessionService, session, sessionId, orchSessionService, orchSession);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -17,7 +17,6 @@ import uk.gov.di.orchestration.shared.lambda.BaseOrchestrationFrontendHandler;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
-import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
@@ -63,15 +62,9 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
             CloudwatchMetricsService cloudwatchMetricsService,
             SessionService sessionService,
             AuthenticationUserInfoStorageService userInfoStorageService,
-            ClientSessionService clientSessionService,
             OrchSessionService orchSessionService,
             OrchClientSessionService orchClientSessionService) {
-        super(
-                configurationService,
-                sessionService,
-                clientSessionService,
-                orchSessionService,
-                orchClientSessionService);
+        super(configurationService, sessionService, orchSessionService, orchClientSessionService);
         this.dynamoIdentityService = dynamoIdentityService;
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
@@ -96,13 +89,13 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
 
             AuthenticationRequest authenticationRequest;
             try {
-                if (Objects.isNull(userSession.getClientSession())) {
+                if (Objects.isNull(userSession.getOrchClientSession())) {
                     LOG.info("ClientSession not found");
                     return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1018);
                 }
                 authenticationRequest =
                         AuthenticationRequest.parse(
-                                userSession.getClientSession().getAuthRequestParams());
+                                userSession.getOrchClientSession().getAuthRequestParams());
             } catch (ParseException e) {
                 LOG.warn("Authentication request could not be parsed", e);
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1038);
@@ -184,7 +177,7 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
                     200,
                     new IdentityProgressResponse(
                             processingStatus,
-                            userSession.getClientSession().getClientName(),
+                            userSession.getOrchClientSession().getClientName(),
                             authenticationRequest.getRedirectionURI(),
                             authenticationRequest.getState()));
         } catch (Json.JsonException e) {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -23,7 +23,6 @@ import uk.gov.di.orchestration.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
-import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
@@ -86,7 +85,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             DynamoIdentityService dynamoIdentityService,
             AccountInterventionService accountInterventionService,
             SessionService sessionService,
-            ClientSessionService clientSessionService,
             DynamoClientService dynamoClientService,
             DynamoService dynamoService,
             ConfigurationService configurationService,
@@ -99,7 +97,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                 ProcessingIdentityRequest.class,
                 configurationService,
                 sessionService,
-                clientSessionService,
                 dynamoClientService,
                 dynamoService,
                 orchSessionService,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -988,7 +988,7 @@ class IPVCallbackHandlerTest {
         when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
                 .thenReturn(
                         new NoSessionEntity(
-                                CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, clientSession));
+                                CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, orchClientSession));
 
         var response =
                 handler.handleRequest(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -284,7 +284,6 @@ class IPVCallbackHandlerTest {
                         orchSessionService,
                         authUserInfoStorageService,
                         dynamoService,
-                        clientSessionService,
                         orchClientSessionService,
                         dynamoClientService,
                         auditService,
@@ -393,8 +392,19 @@ class IPVCallbackHandlerTest {
         when(ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, VTR_LIST))
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
-                        any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-                        any(), any()))
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        anyString(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any()))
                 .thenReturn(
                         new AuthenticationSuccessResponse(
                                 REDIRECT_URI, null, null, null, null, null, null));
@@ -472,8 +482,19 @@ class IPVCallbackHandlerTest {
             when(ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, VTR_LIST))
                     .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
             when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
-                            any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-                            any(), any(), any()))
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            anyString(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any()))
                     .thenReturn(
                             new AuthenticationSuccessResponse(
                                     REDIRECT_URI, null, null, null, null, null, null));
@@ -570,8 +591,19 @@ class IPVCallbackHandlerTest {
         when(ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, VTR_LIST))
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
-                        any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-                        any(), any()))
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        anyString(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any()))
                 .thenReturn(
                         new AuthenticationSuccessResponse(
                                 FRONT_END_IPV_CALLBACK_URI, null, null, null, null, null, null));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -99,7 +99,6 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFiel
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.orchestration.shared.services.AuditService.UNKNOWN;
-import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.getOrchClientSessionWithRetryIfNotEqual;
 import static uk.gov.di.orchestration.shared.utils.ClientSessionMigrationUtils.logIfClientSessionsAreNotEqual;
 
 public class AuthenticationCallbackHandler
@@ -297,8 +296,8 @@ public class AuthenticationCallbackHandler
                                             new AuthenticationCallbackException(
                                                     "ClientSession not found"));
             var orchClientSession =
-                    getOrchClientSessionWithRetryIfNotEqual(
-                                    clientSession, clientSessionId, orchClientSessionService)
+                    orchClientSessionService
+                            .getClientSession(clientSessionId)
                             .orElseThrow(
                                     () ->
                                             new AuthenticationCallbackException(
@@ -315,7 +314,7 @@ public class AuthenticationCallbackHandler
                             .withPersistentSessionId(persistentSessionId);
 
             var authenticationRequest =
-                    AuthenticationRequest.parse(clientSession.getAuthRequestParams());
+                    AuthenticationRequest.parse(orchClientSession.getAuthRequestParams());
 
             String clientId = authenticationRequest.getClientID().getValue();
             attachLogFieldToLogs(CLIENT_ID, clientId);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -595,10 +595,7 @@ public class AuthorisationHandler
         var state = new State();
         var encryptedJWT =
                 docAppAuthorisationService.constructRequestJWT(
-                        state,
-                        clientSession.getDocAppSubjectId().getValue(),
-                        client,
-                        clientSessionId);
+                        state, orchClientSession.getDocAppSubjectId(), client, clientSessionId);
         var authRequestBuilder =
                 new AuthorizationRequest.Builder(
                                 new ResponseType(ResponseType.Value.CODE),
@@ -615,7 +612,7 @@ public class AuthorisationHandler
                 DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
                 client.getClientID(),
                 user.withSessionId(newSessionId)
-                        .withUserId(clientSession.getDocAppSubjectId().getValue()));
+                        .withUserId(orchClientSession.getDocAppSubjectId()));
 
         URI authorisationRequestUri = authorisationRequest.toURI();
         LOG.info(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -595,7 +595,10 @@ public class AuthorisationHandler
         var state = new State();
         var encryptedJWT =
                 docAppAuthorisationService.constructRequestJWT(
-                        state, clientSession.getDocAppSubjectId(), client, clientSessionId);
+                        state,
+                        clientSession.getDocAppSubjectId().getValue(),
+                        client,
+                        clientSessionId);
         var authRequestBuilder =
                 new AuthorizationRequest.Builder(
                                 new ResponseType(ResponseType.Value.CODE),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -32,7 +32,6 @@ import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AuthCodeResponse;
 import uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
@@ -51,7 +50,6 @@ import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthCodeResponseGenerationService;
 import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
-import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
@@ -111,8 +109,6 @@ class AuthCodeHandlerTest {
     private final AuditService auditService = mock(AuditService.class);
     private final AuthorisationCodeService authorisationCodeService =
             mock(AuthorisationCodeService.class);
-    private final ClientSession clientSession = mock(ClientSession.class);
-    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final OrchClientSessionItem orchClientSession = mock(OrchClientSessionItem.class);
     private final OrchClientSessionService orchClientSessionService =
             mock(OrchClientSessionService.class);
@@ -184,7 +180,6 @@ class AuthCodeHandlerTest {
                         authCodeResponseService,
                         authorisationCodeService,
                         orchestrationAuthorizationService,
-                        clientSessionService,
                         orchClientSessionService,
                         auditService,
                         cloudwatchMetricsService,
@@ -237,7 +232,7 @@ class AuthCodeHandlerTest {
         if (Objects.nonNull(mfaMethodType)) {
             when(authCodeResponseService.getDimensions(
                             eq(orchSession),
-                            eq(clientSession),
+                            eq(CLIENT_NAME),
                             eq(CLIENT_ID.getValue()),
                             anyBoolean(),
                             anyBoolean()))
@@ -261,7 +256,7 @@ class AuthCodeHandlerTest {
         }
         doCallRealMethod()
                 .when(authCodeResponseService)
-                .processVectorOfTrust(eq(clientSession), any());
+                .processVectorOfTrust(any(OrchClientSessionItem.class), any());
         var authorizationCode = new AuthorizationCode();
         var authRequest = generateValidSessionAndAuthRequest(requestedLevel, false);
         session.setCurrentCredentialStrength(initialLevel)
@@ -291,10 +286,9 @@ class AuthCodeHandlerTest {
                         any(URI.class),
                         any(State.class)))
                 .thenReturn(authSuccessResponse);
-        when(clientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(requestedLevel)));
-        when(clientSession.getVtrLocsAsCommaSeparatedString()).thenReturn("P0");
         when(orchClientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(requestedLevel)));
-        when(clientSession.getRpPairwiseId())
+        when(orchClientSession.getVtrLocsAsCommaSeparatedString()).thenReturn("P0");
+        when(orchClientSession.getRpPairwiseId())
                 .thenReturn(
                         ClientSubjectHelper.calculatePairwiseIdentifier(
                                 SUBJECT.getValue(), "rp-sector-uri", SALT));
@@ -390,8 +384,6 @@ class AuthCodeHandlerTest {
                         null,
                         authRequest.getResponseMode());
 
-        when(clientSession.getDocAppSubjectId()).thenReturn(new Subject(DOC_APP_SUBJECT_ID));
-        when(clientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(requestedLevel)));
         when(orchClientSession.getDocAppSubjectId()).thenReturn(DOC_APP_SUBJECT_ID);
         when(orchClientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(requestedLevel)));
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
@@ -401,7 +393,7 @@ class AuthCodeHandlerTest {
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(
                         eq(orchSession),
-                        eq(clientSession),
+                        eq(CLIENT_NAME),
                         eq(CLIENT_ID.getValue()),
                         anyBoolean(),
                         eq(true)))
@@ -492,9 +484,6 @@ class AuthCodeHandlerTest {
 
     @Test
     void shouldGenerateErrorResponseWhenOrchSessionIsNotFound() {
-        when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(clientSession));
-        when(clientSession.getClientName()).thenReturn(CLIENT_NAME);
         when(orchClientSessionService.getClientSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(orchClientSession));
         when(orchClientSession.getClientName()).thenReturn(CLIENT_NAME);
@@ -558,10 +547,10 @@ class AuthCodeHandlerTest {
             throws Json.JsonException, JOSEException, ClientNotFoundException {
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
-        when(clientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(MEDIUM_LEVEL)));
-        when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(clientSession));
-        when(clientSession.getClientName()).thenReturn(CLIENT_NAME);
+        when(orchClientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(MEDIUM_LEVEL)));
+        when(orchClientSessionService.getClientSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(orchClientSession));
+        when(orchClientSession.getClientName()).thenReturn(CLIENT_NAME);
         when(orchSessionService.getSession(anyString())).thenReturn(Optional.of(orchSession));
         AuthenticationErrorResponse authenticationErrorResponse =
                 new AuthenticationErrorResponse(
@@ -591,12 +580,12 @@ class AuthCodeHandlerTest {
     void shouldGenerateErrorResponseWhenOrchSessionHasNoInternalCommonSubjectId()
             throws Json.JsonException, JOSEException, ParseException, ClientNotFoundException {
         generateAuthUserInfo();
-        when(clientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(MEDIUM_LEVEL)));
+        when(orchClientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(MEDIUM_LEVEL)));
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
-        when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(clientSession));
-        when(clientSession.getClientName()).thenReturn(CLIENT_NAME);
+        when(orchClientSessionService.getClientSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(orchClientSession));
+        when(orchClientSession.getClientName()).thenReturn(CLIENT_NAME);
         generateValidSessionAndAuthRequest(MEDIUM_LEVEL, false);
         when(orchSessionService.getSession(anyString()))
                 .thenReturn(
@@ -706,8 +695,6 @@ class AuthCodeHandlerTest {
                         null,
                         authRequest.getResponseMode());
 
-        when(clientSession.getDocAppSubjectId()).thenReturn(new Subject(DOC_APP_SUBJECT_ID));
-        when(clientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(MEDIUM_LEVEL)));
         when(orchClientSession.getDocAppSubjectId()).thenReturn(DOC_APP_SUBJECT_ID);
         when(orchClientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(MEDIUM_LEVEL)));
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
@@ -720,7 +707,7 @@ class AuthCodeHandlerTest {
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(
                         eq(orchSession),
-                        eq(clientSession),
+                        eq(CLIENT_NAME),
                         eq(CLIENT_ID.getValue()),
                         anyBoolean(),
                         eq(true)))
@@ -782,13 +769,9 @@ class AuthCodeHandlerTest {
             Map<String, List<String>> authRequestParams, CredentialTrustLevel requestedLevel) {
         when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
         when(orchSessionService.getSession(anyString())).thenReturn(Optional.of(orchSession));
-        when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(clientSession));
         when(orchClientSessionService.getClientSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(orchClientSession));
         when(vectorOfTrust.getCredentialTrustLevel()).thenReturn(requestedLevel);
-        when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
-        when(clientSession.getClientName()).thenReturn(CLIENT_NAME);
         when(orchClientSession.getAuthRequestParams()).thenReturn(authRequestParams);
         when(orchClientSession.getClientName()).thenReturn(CLIENT_NAME);
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -397,7 +397,7 @@ class AuthenticationCallbackHandlerTest {
         when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
                 .thenReturn(
                         new NoSessionEntity(
-                                CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, clientSession));
+                                CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, orchClientSession));
 
         var response = handler.handleRequest(event, CONTEXT);
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -2272,7 +2272,7 @@ class AuthorisationHandlerTest {
             when(configService.getDocAppAuthorisationURI())
                     .thenReturn(URI.create(DOC_APP_REDIRECT_URI));
             encryptedJwt = createEncryptedJWT();
-            when(docAppAuthorisationService.constructRequestJWT(any(), any(), any(), any()))
+            when(docAppAuthorisationService.constructRequestJWT(any(), anyString(), any(), any()))
                     .thenReturn(encryptedJwt);
         }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -82,7 +82,6 @@ import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.helpers.DocAppSubjectIdHelper;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
-import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ClientService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
@@ -92,10 +91,8 @@ import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
-import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.shared.services.TokenValidationService;
-import uk.gov.di.orchestration.shared.state.UserContext;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 import uk.gov.di.orchestration.sharedtest.helper.TokenGeneratorHelper;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
@@ -172,14 +169,12 @@ class AuthorisationHandlerTest {
     private final OrchClientSessionItem orchClientSession = mock(OrchClientSessionItem.class);
     private final OrchestrationAuthorizationService orchestrationAuthorizationService =
             mock(OrchestrationAuthorizationService.class);
-    private final UserContext userContext = mock(UserContext.class);
     private final AuditService auditService = mock(AuditService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
     private final AuthFrontend authFrontend = mock(AuthFrontend.class);
     private final AuthorisationService authorisationService = mock(AuthorisationService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
-    protected final Json objectMapper = SerializationService.getInstance();
 
     private final NoSessionOrchestrationService noSessionOrchestrationService =
             mock(NoSessionOrchestrationService.class);
@@ -297,7 +292,6 @@ class AuthorisationHandlerTest {
         when(orchestrationAuthorizationService.getExistingOrCreateNewPersistentSessionId(any()))
                 .thenReturn(EXPECTED_PERSISTENT_COOKIE_VALUE_WITH_TIMESTAMP);
         when(orchestrationAuthorizationService.getVtrList(any())).thenCallRealMethod();
-        when(userContext.getClient()).thenReturn(Optional.of(generateClientRegistry()));
         when(context.getAwsRequestId()).thenReturn(AWS_REQUEST_ID);
         handler =
                 new AuthorisationHandler(
@@ -662,8 +656,6 @@ class AuthorisationHandlerTest {
         @Test
         void shouldRedirectToLoginWithPromptParamWhenSetToLoginAndExistingSessionIsPresent() {
             withExistingSession(session);
-            when(userContext.getClientSession()).thenReturn(clientSession);
-            when(userContext.getSession()).thenReturn(session);
             var authRequestParams = generateAuthRequest(Optional.empty()).toParameters();
             when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
             when(orchClientSession.getAuthRequestParams()).thenReturn(authRequestParams);
@@ -708,8 +700,6 @@ class AuthorisationHandlerTest {
         void shouldRetainGoogleAnalyticsParamThroughRedirectToLoginWhenClientIsFaceToFaceRp(
                 boolean isAuthOrchSplitEnabled) {
             withExistingSession(session);
-            when(userContext.getClientSession()).thenReturn(clientSession);
-            when(userContext.getSession()).thenReturn(session);
             var authRequestParams = generateAuthRequest(Optional.empty()).toParameters();
             when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
             when(orchClientSession.getAuthRequestParams()).thenReturn(authRequestParams);
@@ -736,8 +726,6 @@ class AuthorisationHandlerTest {
         void shouldRedirectToLoginWhenUserNeedsToBeUplifted() {
             session.setCurrentCredentialStrength(CredentialTrustLevel.LOW_LEVEL);
             withExistingSession(session);
-            when(userContext.getClientSession()).thenReturn(clientSession);
-            when(userContext.getSession()).thenReturn(session);
             var authRequestParams =
                     generateAuthRequest(Optional.of(jsonArrayOf("Cl.Cm"))).toParameters();
             when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
@@ -781,8 +769,6 @@ class AuthorisationHandlerTest {
         @Test
         void shouldRedirectToLoginWhenSingleFactorInVtr() {
             withExistingSession(session);
-            when(userContext.getClientSession()).thenReturn(clientSession);
-            when(userContext.getSession()).thenReturn(session);
             var authRequestParams =
                     generateAuthRequest(Optional.of(jsonArrayOf("Cl"))).toParameters();
             when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
@@ -829,8 +815,6 @@ class AuthorisationHandlerTest {
         @Test
         void shouldRedirectToLoginWhenIdentityIsPresentInVtr() {
             withExistingSession(session);
-            when(userContext.getClientSession()).thenReturn(clientSession);
-            when(userContext.getSession()).thenReturn(session);
             var authRequestParams =
                     generateAuthRequest(Optional.of(jsonArrayOf("P2.Cl.Cm"))).toParameters();
             when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelper.java
@@ -8,6 +8,7 @@ import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.RequestObjectException;
 import uk.gov.di.orchestration.shared.state.UserContext;
 
@@ -46,6 +47,15 @@ public class DocAppUserHelper {
         boolean isDocCheckingUser =
                 clientSession.getDocAppSubjectId() != null
                         && hasDocCheckingScope(clientSession.getAuthRequestParams());
+        LOG.info("User is Doc Checking App user: {}", isDocCheckingUser);
+        return isDocCheckingUser;
+    }
+
+    public static boolean isDocCheckingAppUserWithSubjectId(
+            OrchClientSessionItem orchClientSession) {
+        boolean isDocCheckingUser =
+                orchClientSession.getDocAppSubjectId() != null
+                        && hasDocCheckingScope(orchClientSession.getAuthRequestParams());
         LOG.info("User is Doc Checking App user: {}", isDocCheckingUser);
         return isDocCheckingUser;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelper.java
@@ -23,7 +23,7 @@ public class DocAppUserHelper {
     private DocAppUserHelper() {}
 
     public static boolean isDocCheckingAppUser(UserContext context) {
-        var authRequestParams = context.getClientSession().getAuthRequestParams();
+        var authRequestParams = context.getOrchClientSession().getAuthRequestParams();
         return isDocCheckingAppUser(authRequestParams, context.getClient());
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientSession.java
@@ -2,6 +2,7 @@ package uk.gov.di.orchestration.shared.entity;
 
 import com.google.gson.annotations.Expose;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import uk.gov.di.orchestration.shared.utils.VtrListUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -89,19 +90,6 @@ public class ClientSession {
     }
 
     public String getVtrLocsAsCommaSeparatedString() {
-        List<VectorOfTrust> orderedVtrList = VectorOfTrust.orderVtrList(this.vtrList);
-        StringBuilder strBuilder = new StringBuilder();
-        for (VectorOfTrust vtr : orderedVtrList) {
-            String loc =
-                    vtr.containsLevelOfConfidence()
-                            ? vtr.getLevelOfConfidence().getValue()
-                            : LevelOfConfidence.NONE.getValue();
-            strBuilder.append(loc).append(",");
-        }
-        if (!strBuilder.isEmpty()) {
-            strBuilder.setLength(strBuilder.length() - 1);
-            return strBuilder.toString();
-        }
-        return "";
+        return VtrListUtils.getVtrLocsAsCommaSeparatedString(vtrList);
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/NoSessionEntity.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/NoSessionEntity.java
@@ -6,13 +6,15 @@ public class NoSessionEntity {
 
     private final String clientSessionId;
     private final ErrorObject errorObject;
-    private final ClientSession clientSession;
+    private final OrchClientSessionItem orchClientSession;
 
     public NoSessionEntity(
-            String clientSessionId, ErrorObject errorObject, ClientSession clientSession) {
+            String clientSessionId,
+            ErrorObject errorObject,
+            OrchClientSessionItem orchClientSession) {
         this.clientSessionId = clientSessionId;
         this.errorObject = errorObject;
-        this.clientSession = clientSession;
+        this.orchClientSession = orchClientSession;
     }
 
     public String getClientSessionId() {
@@ -23,7 +25,7 @@ public class NoSessionEntity {
         return errorObject;
     }
 
-    public ClientSession getClientSession() {
-        return clientSession;
+    public OrchClientSessionItem getClientSession() {
+        return orchClientSession;
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
@@ -184,4 +184,21 @@ public class OrchClientSessionItem {
         this.timeToLive = timeToLive;
         return this;
     }
+
+    public String getVtrLocsAsCommaSeparatedString() {
+        List<VectorOfTrust> orderedVtrList = VectorOfTrust.orderVtrList(this.vtrList);
+        StringBuilder strBuilder = new StringBuilder();
+        for (VectorOfTrust vtr : orderedVtrList) {
+            String loc =
+                    vtr.containsLevelOfConfidence()
+                            ? vtr.getLevelOfConfidence().getValue()
+                            : LevelOfConfidence.NONE.getValue();
+            strBuilder.append(loc).append(",");
+        }
+        if (!strBuilder.isEmpty()) {
+            strBuilder.setLength(strBuilder.length() - 1);
+            return strBuilder.toString();
+        }
+        return "";
+    }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import uk.gov.di.orchestration.shared.converters.VtrListConverter;
+import uk.gov.di.orchestration.shared.utils.VtrListUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -186,19 +187,6 @@ public class OrchClientSessionItem {
     }
 
     public String getVtrLocsAsCommaSeparatedString() {
-        List<VectorOfTrust> orderedVtrList = VectorOfTrust.orderVtrList(this.vtrList);
-        StringBuilder strBuilder = new StringBuilder();
-        for (VectorOfTrust vtr : orderedVtrList) {
-            String loc =
-                    vtr.containsLevelOfConfidence()
-                            ? vtr.getLevelOfConfidence().getValue()
-                            : LevelOfConfidence.NONE.getValue();
-            strBuilder.append(loc).append(",");
-        }
-        if (!strBuilder.isEmpty()) {
-            strBuilder.setLength(strBuilder.length() - 1);
-            return strBuilder.toString();
-        }
-        return "";
+        return VtrListUtils.getVtrLocsAsCommaSeparatedString(vtrList);
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -2,7 +2,6 @@ package uk.gov.di.orchestration.shared.services;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
@@ -36,20 +35,6 @@ public class AuthCodeResponseGenerationService {
 
     public AuthCodeResponseGenerationService() {
         this(ConfigurationService.getInstance());
-    }
-
-    public Map<String, String> getDimensions(
-            OrchSessionItem orchSession,
-            ClientSession clientSession,
-            String clientSessionId,
-            boolean isTestJourney,
-            boolean docAppJourney) {
-        return getDimensions(
-                orchSession,
-                clientSession.getClientName(),
-                clientSessionId,
-                isTestJourney,
-                docAppJourney);
     }
 
     public Map<String, String> getDimensions(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
@@ -21,7 +21,6 @@ import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.oauth2.sdk.id.State;
-import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
@@ -143,7 +142,10 @@ public class DocAppAuthorisationService {
     }
 
     public EncryptedJWT constructRequestJWT(
-            State state, Subject subject, ClientRegistry clientRegistry, String clientSessionId) {
+            State state,
+            String subjectValue,
+            ClientRegistry clientRegistry,
+            String clientSessionId) {
         LOG.info("Generating request JWT");
         var docAppTokenSigningKeyAlias = configurationService.getDocAppTokenSigningKeyAlias();
         var signingKeyId =
@@ -171,7 +173,7 @@ public class DocAppAuthorisationService {
                         .issuer(configurationService.getDocAppAuthorisationClientId())
                         .audience(audience.getValue())
                         .expirationTime(expiryDate)
-                        .subject(subject.getValue())
+                        .subject(subjectValue)
                         .issueTime(NowHelper.now())
                         .notBeforeTime(NowHelper.now())
                         .jwtID(jwtID)

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/OrchestrationUserSession.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/OrchestrationUserSession.java
@@ -1,7 +1,7 @@
 package uk.gov.di.orchestration.shared.state;
 
 import org.jetbrains.annotations.Nullable;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 
@@ -9,7 +9,7 @@ public class OrchestrationUserSession {
     private final Session session;
     private final String sessionId;
     @Nullable private final String clientId;
-    @Nullable private final ClientSession clientSession;
+    @Nullable private final OrchClientSessionItem orchClientSession;
     private final String clientSessionId;
     private final OrchSessionItem orchSessionItem;
 
@@ -17,13 +17,13 @@ public class OrchestrationUserSession {
             Session session,
             String sessionId,
             @Nullable String clientId,
-            @Nullable ClientSession clientSession,
+            @Nullable OrchClientSessionItem orchClientSession,
             String clientSessionId,
             OrchSessionItem orchSession) {
         this.session = session;
         this.sessionId = sessionId;
         this.clientId = clientId;
-        this.clientSession = clientSession;
+        this.orchClientSession = orchClientSession;
         this.clientSessionId = clientSessionId;
         this.orchSessionItem = orchSession;
     }
@@ -40,8 +40,8 @@ public class OrchestrationUserSession {
         return clientId;
     }
 
-    public @Nullable ClientSession getClientSession() {
-        return clientSession;
+    public @Nullable OrchClientSessionItem getOrchClientSession() {
+        return orchClientSession;
     }
 
     public String getClientSessionId() {
@@ -57,10 +57,10 @@ public class OrchestrationUserSession {
     }
 
     public static class Builder {
-        private Session session;
+        private final Session session;
         private String sessionId;
         private String clientId;
-        private ClientSession clientSession;
+        private OrchClientSessionItem orchClientSession;
         private String clientSessionId;
         private OrchSessionItem orchSession;
 
@@ -78,8 +78,8 @@ public class OrchestrationUserSession {
             return this;
         }
 
-        public Builder withClientSession(ClientSession clientSession) {
-            this.clientSession = clientSession;
+        public Builder withOrchClientSession(OrchClientSessionItem orchClientSession) {
+            this.orchClientSession = orchClientSession;
             return this;
         }
 
@@ -95,7 +95,7 @@ public class OrchestrationUserSession {
 
         public OrchestrationUserSession build() {
             return new OrchestrationUserSession(
-                    session, sessionId, clientId, clientSession, clientSessionId, orchSession);
+                    session, sessionId, clientId, orchClientSession, clientSessionId, orchSession);
         }
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/UserContext.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/UserContext.java
@@ -2,6 +2,7 @@ package uk.gov.di.orchestration.shared.state;
 
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.UserCredentials;
@@ -18,6 +19,7 @@ public class UserContext {
     private final boolean userAuthenticated;
     private final Optional<ClientRegistry> client;
     private final ClientSession clientSession;
+    private final OrchClientSessionItem orchClientSession;
     private final SupportedLanguage userLanguage;
     private final String clientSessionId;
     private final OrchSessionItem orchSession;
@@ -30,6 +32,7 @@ public class UserContext {
             boolean userAuthenticated,
             Optional<ClientRegistry> client,
             ClientSession clientSession,
+            OrchClientSessionItem orchClientSession,
             SupportedLanguage userLanguage,
             String clientSessionId,
             OrchSessionItem orchSession) {
@@ -40,6 +43,7 @@ public class UserContext {
         this.userAuthenticated = userAuthenticated;
         this.client = client;
         this.clientSession = clientSession;
+        this.orchClientSession = orchClientSession;
         this.userLanguage = userLanguage;
         this.clientSessionId = clientSessionId;
         this.orchSession = orchSession;
@@ -81,6 +85,10 @@ public class UserContext {
         return clientSession;
     }
 
+    public OrchClientSessionItem getOrchClientSession() {
+        return orchClientSession;
+    }
+
     public SupportedLanguage getUserLanguage() {
         return userLanguage;
     }
@@ -98,13 +106,14 @@ public class UserContext {
     }
 
     public static class Builder {
-        private Session session;
+        private final Session session;
         private String sessionId;
         private Optional<UserProfile> userProfile = Optional.empty();
         private Optional<UserCredentials> userCredentials = Optional.empty();
         private boolean userAuthenticated = false;
         private Optional<ClientRegistry> client = Optional.empty();
         private ClientSession clientSession = null;
+        private OrchClientSessionItem orchClientSession;
         private SupportedLanguage userLanguage;
         private String clientSessionId;
         private OrchSessionItem orchSession;
@@ -151,6 +160,11 @@ public class UserContext {
             return this;
         }
 
+        public Builder withOrchClientSession(OrchClientSessionItem orchClientSession) {
+            this.orchClientSession = orchClientSession;
+            return this;
+        }
+
         public Builder withUserLanguage(SupportedLanguage userLanguage) {
             this.userLanguage = userLanguage;
             return this;
@@ -175,6 +189,7 @@ public class UserContext {
                     userAuthenticated,
                     client,
                     clientSession,
+                    orchClientSession,
                     userLanguage,
                     clientSessionId,
                     orchSession);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/UserContext.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/UserContext.java
@@ -1,7 +1,6 @@
 package uk.gov.di.orchestration.shared.state;
 
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
@@ -18,7 +17,6 @@ public class UserContext {
     private final Optional<UserCredentials> userCredentials;
     private final boolean userAuthenticated;
     private final Optional<ClientRegistry> client;
-    private final ClientSession clientSession;
     private final OrchClientSessionItem orchClientSession;
     private final SupportedLanguage userLanguage;
     private final String clientSessionId;
@@ -31,7 +29,6 @@ public class UserContext {
             Optional<UserCredentials> userCredentials,
             boolean userAuthenticated,
             Optional<ClientRegistry> client,
-            ClientSession clientSession,
             OrchClientSessionItem orchClientSession,
             SupportedLanguage userLanguage,
             String clientSessionId,
@@ -42,7 +39,6 @@ public class UserContext {
         this.userCredentials = userCredentials;
         this.userAuthenticated = userAuthenticated;
         this.client = client;
-        this.clientSession = clientSession;
         this.orchClientSession = orchClientSession;
         this.userLanguage = userLanguage;
         this.clientSessionId = clientSessionId;
@@ -81,10 +77,6 @@ public class UserContext {
         return getClient().map(ClientRegistry::getClientName).orElse("");
     }
 
-    public ClientSession getClientSession() {
-        return clientSession;
-    }
-
     public OrchClientSessionItem getOrchClientSession() {
         return orchClientSession;
     }
@@ -112,7 +104,6 @@ public class UserContext {
         private Optional<UserCredentials> userCredentials = Optional.empty();
         private boolean userAuthenticated = false;
         private Optional<ClientRegistry> client = Optional.empty();
-        private ClientSession clientSession = null;
         private OrchClientSessionItem orchClientSession;
         private SupportedLanguage userLanguage;
         private String clientSessionId;
@@ -155,11 +146,6 @@ public class UserContext {
             return this;
         }
 
-        public Builder withClientSession(ClientSession clientSession) {
-            this.clientSession = clientSession;
-            return this;
-        }
-
         public Builder withOrchClientSession(OrchClientSessionItem orchClientSession) {
             this.orchClientSession = orchClientSession;
             return this;
@@ -188,7 +174,6 @@ public class UserContext {
                     userCredentials,
                     userAuthenticated,
                     client,
-                    clientSession,
                     orchClientSession,
                     userLanguage,
                     clientSessionId,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/VtrListUtils.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/VtrListUtils.java
@@ -1,0 +1,27 @@
+package uk.gov.di.orchestration.shared.utils;
+
+import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
+
+import java.util.List;
+
+public class VtrListUtils {
+    private VtrListUtils() {}
+
+    public static String getVtrLocsAsCommaSeparatedString(List<VectorOfTrust> vtrList) {
+        List<VectorOfTrust> orderedVtrList = VectorOfTrust.orderVtrList(vtrList);
+        StringBuilder strBuilder = new StringBuilder();
+        for (VectorOfTrust vtr : orderedVtrList) {
+            String loc =
+                    vtr.containsLevelOfConfidence()
+                            ? vtr.getLevelOfConfidence().getValue()
+                            : LevelOfConfidence.NONE.getValue();
+            strBuilder.append(loc).append(",");
+        }
+        if (!strBuilder.isEmpty()) {
+            strBuilder.setLength(strBuilder.length() - 1);
+            return strBuilder.toString();
+        }
+        return "";
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
@@ -2,16 +2,10 @@ package uk.gov.di.orchestration.shared.services;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
-import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
-import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
-import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 
-import java.time.LocalDateTime;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,11 +29,8 @@ class AuthCodeResponseGenerationServiceTest {
     private final SessionService sessionService = mock(SessionService.class);
     private OrchSessionItem orchSession;
     private Session session;
-    private ClientSession clientSession;
 
     private AuthCodeResponseGenerationService authCodeResponseGenerationService;
-    private static final CredentialTrustLevel lowestCredentialTrustLevel =
-            CredentialTrustLevel.LOW_LEVEL;
 
     @BeforeEach
     void setup() {
@@ -51,14 +42,6 @@ class AuthCodeResponseGenerationServiceTest {
         session = new Session();
         authCodeResponseGenerationService =
                 new AuthCodeResponseGenerationService(configurationService, dynamoService);
-        clientSession =
-                new ClientSession(
-                        new HashMap<>(),
-                        LocalDateTime.MIN,
-                        List.of(
-                                VectorOfTrust.of(
-                                        lowestCredentialTrustLevel, LevelOfConfidence.LOW_LEVEL)),
-                        CLIENT_NAME);
     }
 
     @Test
@@ -83,7 +66,7 @@ class AuthCodeResponseGenerationServiceTest {
 
         var actualValues =
                 authCodeResponseGenerationService.getDimensions(
-                        orchSession, clientSession, CLIENT_SESSION_ID, false, false);
+                        orchSession, CLIENT_NAME, CLIENT_SESSION_ID, false, false);
         assertEquals(expectedValues, actualValues);
     }
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
@@ -222,7 +222,7 @@ class DocAppAuthorisationServiceTest {
 
         var encryptedJWT =
                 authorisationService.constructRequestJWT(
-                        state, pairwise, clientRegistry, "client-session-id");
+                        state, pairwise.getValue(), clientRegistry, "client-session-id");
 
         var signedJWTResponse = decryptJWT(encryptedJWT);
 
@@ -275,7 +275,7 @@ class DocAppAuthorisationServiceTest {
 
         var encryptedJWT =
                 authorisationService.constructRequestJWT(
-                        state, pairwise, clientRegistry, "client-session-id");
+                        state, pairwise.getValue(), clientRegistry, "client-session-id");
 
         var signedJwt = decryptJWT(encryptedJWT);
         assertThat(signedJwt.getJWTClaimsSet().getAudience(), contains(newAudience));

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/utils/VtrListUtilsTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/utils/VtrListUtilsTest.java
@@ -1,0 +1,62 @@
+package uk.gov.di.orchestration.shared.utils;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
+import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
+import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VtrListUtilsTest {
+    @Test
+    void shouldBuildVtrLocListFromSingleVtr() {
+        var vtrList = List.of(vtrWithLoc(LevelOfConfidence.LOW_LEVEL));
+
+        var vtrStringList = VtrListUtils.getVtrLocsAsCommaSeparatedString(vtrList);
+        assertThat(vtrStringList, equalTo("P1"));
+    }
+
+    @Test
+    void shouldBuildVtrLocListFromMultipleVtrs() {
+        var vtrList =
+                List.of(
+                        vtrWithLoc(LevelOfConfidence.LOW_LEVEL),
+                        vtrWithLoc(LevelOfConfidence.MEDIUM_LEVEL));
+
+        var vtrStringList = VtrListUtils.getVtrLocsAsCommaSeparatedString(vtrList);
+        assertThat(vtrStringList, equalTo("P1,P2"));
+    }
+
+    @Test
+    void shouldBuildVtrLocListFromMultipleVtrsOutOfOrder() {
+        var vtrList =
+                List.of(
+                        vtrWithLoc(LevelOfConfidence.MEDIUM_LEVEL),
+                        vtrWithLoc(LevelOfConfidence.LOW_LEVEL));
+
+        var vtrStringList = VtrListUtils.getVtrLocsAsCommaSeparatedString(vtrList);
+        assertThat(vtrStringList, equalTo("P1,P2"));
+    }
+
+    @Test
+    void shouldBuildEmptyVtrLocListFromEmptyVtrList() {
+        var vtrStringList = VtrListUtils.getVtrLocsAsCommaSeparatedString(List.of());
+        assertTrue(vtrStringList.isEmpty());
+    }
+
+    @Test
+    void shouldBuildVtrLocListFromVtrListWithNoLocSet() {
+        var vtrList = List.of(vtrWithLoc(null));
+
+        var vtrStringList = VtrListUtils.getVtrLocsAsCommaSeparatedString(vtrList);
+        assertThat(vtrStringList, equalTo("P0"));
+    }
+
+    private static VectorOfTrust vtrWithLoc(LevelOfConfidence loc) {
+        return VectorOfTrust.of(CredentialTrustLevel.MEDIUM_LEVEL, loc);
+    }
+}


### PR DESCRIPTION
### Wider context of change

We are currently storing a dynamo client session alongside the existing redis client session. We also have logging to ensure that both client sessions are in sync. While there have been a few instances where the dynamo client session was out of sync, these cases were likely triggered by the user double-clicking on the login button after entering their credentials, and the fields that were out of sync were set again in the second run of the AuthenticationCallbackLambda and TokenLambda.

### What’s changed

Now we are happy with how synchronised the client sessions are, we can swap over to using the dynamo client session instead of the redis client session. Note that we still need to write to the redis client session as the auth code still uses it.

In places where we were just reading from the old client session, i've removed the old client session service as it is no longer needed.

This is quite a chunky PR, but reviewing commit by commit should break it up nicely

### Manual testing

Tested both auth and identity journey in dev. Both journeys were successful.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. n/a
- [x] Successfully run Authentication acceptance tests against sandpit or not required n/a
