### PR TITLE
ATO-1512: remove setters for ResetPasswordCount

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -150,10 +150,6 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
 
             emitPasswordResetRequestedAuditEvent(input, request, userContext, isTestClient);
 
-            sessionService.storeOrUpdateSession(
-                    userContext.getSession().incrementPasswordResetCount(),
-                    userContext.getAuthSession().getSessionId());
-
             authSessionService.updateSession(
                     userContext.getAuthSession().incrementPasswordResetCount());
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -187,9 +187,6 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                 userContext.getAuthSession().getEmailAddress(),
                 codeRequestBlockedKeyPrefix,
                 configurationService.getLockoutDuration());
-        sessionService.storeOrUpdateSession(
-                userContext.getSession().resetPasswordResetCount(),
-                userContext.getAuthSession().getSessionId());
         authSessionService.updateSession(userContext.getAuthSession().resetPasswordResetCount());
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -199,10 +199,6 @@ class ResetPasswordRequestHandlerTest {
 
         public static APIGatewayProxyRequestEvent validEvent;
 
-        private boolean isSessionWithEmailSent(Session session) {
-            return authSession.getEmailAddress().equals(CommonTestVariables.EMAIL);
-        }
-
         private boolean isAuthSessionWithCountAndResetState(
                 AuthSessionItem authSession, int count, AuthSessionItem.ResetPasswordState state) {
             return authSession.getPasswordResetCount() == count
@@ -257,8 +253,6 @@ class ResetPasswordRequestHandlerTest {
                             TEST_SIX_DIGIT_CODE,
                             CODE_EXPIRY_TIME,
                             RESET_PASSWORD_WITH_CODE);
-            verify(sessionService)
-                    .storeOrUpdateSession(argThat(this::isSessionWithEmailSent), eq(SESSION_ID));
             verify(authSessionService, atLeastOnce())
                     .updateSession(
                             argThat(
@@ -356,8 +350,6 @@ class ResetPasswordRequestHandlerTest {
                             TEST_SIX_DIGIT_CODE,
                             CODE_EXPIRY_TIME,
                             RESET_PASSWORD_WITH_CODE);
-            verify(sessionService)
-                    .storeOrUpdateSession(argThat(this::isSessionWithEmailSent), eq(SESSION_ID));
             verify(authSessionService, atLeastOnce())
                     .updateSession(
                             argThat(
@@ -483,8 +475,6 @@ class ResetPasswordRequestHandlerTest {
             assertEquals(400, result.getStatusCode());
             assertThat(result, hasJsonBody(ErrorResponse.ERROR_1022));
             verifyNoInteractions(awsSqsClient);
-            verify(sessionService, atLeastOnce())
-                    .storeOrUpdateSession(any(Session.class), eq(SESSION_ID));
             verify(authSessionService, atLeastOnce())
                     .updateSession(argThat(as -> as.getPasswordResetCount() == 0));
         }
@@ -597,7 +587,6 @@ class ResetPasswordRequestHandlerTest {
     }
 
     private void usingSessionWithPasswordResetCount(int passwordResetCount) {
-        session.resetPasswordResetCount();
         authSession.resetPasswordResetCount();
         IntStream.range(0, passwordResetCount)
                 .forEach((i) -> authSession.incrementPasswordResetCount());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -600,8 +600,6 @@ class ResetPasswordRequestHandlerTest {
         session.resetPasswordResetCount();
         authSession.resetPasswordResetCount();
         IntStream.range(0, passwordResetCount)
-                .forEach((i) -> session.incrementPasswordResetCount());
-        IntStream.range(0, passwordResetCount)
                 .forEach((i) -> authSession.incrementPasswordResetCount());
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -73,11 +73,6 @@ public class Session {
         return this;
     }
 
-    public Session resetPasswordResetCount() {
-        this.passwordResetCount = 0;
-        return this;
-    }
-
     public Session setPreservedReauthCountsForAudit(
             Map<CountType, Integer> reauthCountsBeforeDeletionFromCountStore) {
         this.preservedReauthCountsForAudit = reauthCountsBeforeDeletionFromCountStore;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -73,11 +73,6 @@ public class Session {
         return this;
     }
 
-    public Session incrementPasswordResetCount() {
-        this.passwordResetCount = passwordResetCount + 1;
-        return this;
-    }
-
     public Session resetPasswordResetCount() {
         this.passwordResetCount = 0;
         return this;


### PR DESCRIPTION
### Wider context of change
- We've now migrated the getters and setters to use the value of `ResetPasswordCount` from the auth session. We've also removed the getters for this value so we can now stop setting it

### What’s changed
- Removes the increment and reset calls from the ResetPasswordRequest handler 
- Removes the methods from the session class

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
