### PR TITLE
ATO-1480 validate session auth session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -177,7 +177,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                 return generateApiGatewayProxyErrorResponse(400, userHasRequestedTooManyOTPs.get());
             }
 
-            if (!userContext.getSession().validateSession(email)) {
+            if (!userContext.getAuthSession().validateSession(email)) {
                 LOG.warn("Email does not match Email in Request");
                 auditService.submitAuditEvent(
                         AUTH_MFA_MISMATCHED_EMAIL, auditContext, metadataPairs);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -132,7 +132,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         LOG.info("Processing request");
         try {
             if (Objects.isNull(userContext.getAuthSession().getEmailAddress())
-                    || !userContext.getSession().validateSession(request.getEmail())) {
+                    || !userContext.getAuthSession().validateSession(request.getEmail())) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
             }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -184,7 +184,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
         try {
-            if (!userContext.getSession().validateSession(request.getEmail())) {
+            if (!userContext.getAuthSession().validateSession(request.getEmail())) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
             }
             if (CONFIRMATION_NOTIFICATION_TYPES.contains(request.getNotificationType())) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -118,7 +118,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
         String ipAddress = IpAddressHelper.extractIpAddress(input);
 
-        if (!session.validateSession(request.getEmail())) {
+        if (!authSession.validateSession(request.getEmail())) {
             LOG.info("Invalid session");
             return generateErrorResponse(
                     ErrorResponse.ERROR_1000,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
@@ -40,6 +40,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String subjectId = "new-subject";
         SESSION_ID = redis.createUnauthenticatedSessionWithEmail(USER_EMAIL);
         authSessionStore.addSession(SESSION_ID);
+        authSessionStore.addEmailToSession(SESSION_ID, USER_EMAIL);
         userStore.signUp(USER_EMAIL, USER_PASSWORD, new Subject(subjectId));
         userStore.addVerifiedPhoneNumber(USER_EMAIL, USER_PHONE_NUMBER);
     }
@@ -106,6 +107,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             throws Json.JsonException {
         var authenticatedSessionId = redis.createAuthenticatedSessionWithEmail(USER_EMAIL);
         authSessionStore.addSession(authenticatedSessionId);
+        authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
 
         var response =
                 makeRequest(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -208,7 +208,7 @@ public class AuthSessionItem {
         this.emailAddress = emailAddress;
         return this;
     }
-    
+
     public boolean validateSession(String emailAddress) {
         return this.emailAddress.equals(emailAddress);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -208,6 +208,10 @@ public class AuthSessionItem {
         this.emailAddress = emailAddress;
         return this;
     }
+    
+    public boolean validateSession(String emailAddress) {
+        return this.emailAddress.equals(emailAddress);
+    }
 
     @DynamoDbAttribute(ATTRIBUTE_PASSWORD_RESET_COUNT)
     public int getPasswordResetCount() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -60,10 +60,6 @@ public class Session {
         return this;
     }
 
-    public boolean validateSession(String emailAddress) {
-        return this.emailAddress.equals(emailAddress);
-    }
-
     public String getEmailAddress() {
         return emailAddress;
     }


### PR DESCRIPTION
### Wider context of change

One of the final pieces of the email migration. Validates the email address on the auth session instead of the shared session.

### What’s changed

Validating the email address on the auth session instead of the shared session.

### Manual testing

Logs for the initial email migration.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
