### PR TITLE
ATO-1513: add Auth Session DynamoDB table write permission to authentication-auth-code

### DIFF
--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -19,7 +19,8 @@ module "frontend_api_orch_auth_code_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     local.email_check_results_encryption_policy_arn,
-    aws_iam_policy.dynamo_auth_session_read_policy.arn
+    aws_iam_policy.dynamo_auth_session_read_policy.arn,
+    aws_iam_policy.dynamo_auth_session_write_policy.arn
   ]
   extra_tags = {
     Service = "orch-auth-code"


### PR DESCRIPTION
### Wider context of change

Add Auth Session DynamoDB table write permissions to authentication-auth-code for the PreservedReauthCountsForAudit migration.

### What’s changed

Add write permissions to authentication-auth-code for Auth Session DynamoDB table.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/6200
