### PR TITLE
ATO-1435: Fix type of expected vtr_list parameter in StartHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -4,8 +4,6 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 
-import java.util.List;
-
 public record StartRequest(
         @Expose @SerializedName("previous-session-id") String previousSessionId,
         @Expose @SerializedName("rp-pairwise-id-for-reauth") String rpPairwiseIdForReauth,
@@ -16,7 +14,7 @@ public record StartRequest(
                 CredentialTrustLevel currentCredentialStrength,
         @Expose @SerializedName("cookie_consent") String cookieConsent,
         @Expose @SerializedName("_ga") String ga,
-        @Expose @SerializedName("vtr_list") List<String> vtrList,
+        @Expose @SerializedName("vtr_list") String vtrList,
         @Expose @SerializedName("state") String state,
         @Expose @SerializedName("client_id") String clientId,
         @Expose @SerializedName("redirect_uri") String redirectUri,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -381,6 +381,7 @@ public class StartHandler
                         .orElse(null);
         var startRequestVtrList =
                 Optional.ofNullable(startRequest.vtrList())
+                        .map(vtrStringList -> List.of(vtrStringList.split(" ")))
                         .map(
                                 vtrStringList ->
                                         List.of(VectorOfTrust.parseVtrStringList(vtrStringList)))


### PR DESCRIPTION
### Wider context of change

We recently merged a PR that will accept new claims from the auth frontend, and compare them with the claims on the client session authRequestParams, logging if they are different. 

We had some trouble with the frontend part of the issue, so we had to revert those changes. However, while testing the new frontend changes I spotted an issue with the format of the `vtr_list` parameter we are expecting in the auth backend:

The format of the `vtr_list` passed from orch (in the AuthorisationHandler) is a space separated list 
  e.g `"Cl.Cm P0.Cl.Cm"`
but the format of the parameter we are expecting in the auth backend (in StartHandler) is a jsonArray 
 e.g `["Cl.Cm", "P0.Cl.Cm"]`

It's slightly confusing because the parameter we are looking to replace (`vtr` on the authRequestParams) is stored as a jsonArray.
 
### What’s changed

This PR updates StartHandler to expect a `vtr_list` of the correct type (that is - a space separated list as a string).

### Manual testing

Have deployed this to sandpit with the other PRs for sending these fields from orch to auth backend, and the fields are what we are expecting.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

Need to merge the fix for sending the `vtr_list` with the correct type first: https://github.com/govuk-one-login/authentication-api/pull/6219

Then we can merge this PR for passing the fields from the frontend to the backend: https://github.com/govuk-one-login/authentication-frontend/pull/2680
