### PR TITLE
ATO-1514: add cross account write policy

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -749,6 +749,22 @@ data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_write_del
   }
 }
 
+data "aws_iam_policy_document" "dynamo_orch_session_cross_account_write_access_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  statement {
+    sid    = "AllowOrchSessionCrossAccountWriteAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+    ]
+    resources = [
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Orch-Session",
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "dynamo_orch_session_cross_account_delete_access_policy_document" {
   count = var.is_orch_stubbed ? 0 : 1
   statement {
@@ -1163,6 +1179,15 @@ resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_access_policy"
   policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_access_policy_document[count.index].json
 }
 
+resource "aws_iam_policy" "dynamo_orch_session_cross_account_write_access_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-session-cross-account-write-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing write permissions to the orch session table"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_write_access_policy_document[count.index].json
+}
 
 resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_write_delete_access_policy" {
   count = var.is_orch_stubbed ? 0 : 1

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -682,6 +682,22 @@ data "aws_iam_policy_document" "dynamo_orch_session_encryption_key_cross_account
 }
 
 
+data "aws_iam_policy_document" "dynamo_orch_session_encryption_key_cross_account_encrypt_decrypt_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+  statement {
+    sid    = "AllowOrchSessionEncryptionKeyCrossAccountEncryptAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+    ]
+    resources = [
+      var.orch_session_table_encryption_key_arn,
+    ]
+  }
+}
+
+
 data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_and_delete_access_policy_document" {
   count = var.is_orch_stubbed ? 0 : 1
   statement {
@@ -714,6 +730,24 @@ data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_access_po
   }
 }
 
+data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_write_delete_access_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  statement {
+    sid    = "AllowOrchSessionCrossAccountReadWriteDeleteAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem",
+    ]
+    resources = [
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Orch-Session",
+    ]
+  }
+}
 
 data "aws_iam_policy_document" "dynamo_orch_session_cross_account_delete_access_policy_document" {
   count = var.is_orch_stubbed ? 0 : 1
@@ -1098,6 +1132,17 @@ resource "aws_iam_policy" "dynamo_orch_client_session_encryption_key_cross_accou
   policy = data.aws_iam_policy_document.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy_document[count.index].json
 }
 
+resource "aws_iam_policy" "dynamo_orch_session_encryption_key_cross_account_encrypt_decrypt_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-session-encryption-key-cross-account-encrypt-decrypt-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing encrypt and decrypt permissions to the orch session table's KMS encryption key"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_session_encryption_key_cross_account_encrypt_decrypt_policy_document[count.index].json
+}
+
+
 resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_and_delete_access_policy" {
   count = var.is_orch_stubbed ? 0 : 1
 
@@ -1118,6 +1163,16 @@ resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_access_policy"
   policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_access_policy_document[count.index].json
 }
 
+
+resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_write_delete_access_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-session-cross-account-read-write-delete-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing read, write and delete permissions to the orch session table"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_write_delete_access_policy_document[count.index].json
+}
 
 resource "aws_iam_policy" "dynamo_orch_session_cross_account_delete_access_policy" {
   count = var.is_orch_stubbed ? 0 : 1

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -11,7 +11,9 @@ module "identity_progress_role_1" {
     module.oidc_txma_audit.access_policy_arn,
     ], var.is_orch_stubbed ? [] : [
     aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn,
-    aws_iam_policy.dynamo_orch_client_session_cross_account_read_access_policy[0].arn
+    aws_iam_policy.dynamo_orch_client_session_cross_account_read_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_encrypt_decrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_write_access_policy[0].arn
   ])
   extra_tags = {
     Service = "identity-progress"

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -52,6 +52,38 @@ module "ipv_processing_identity_role_with_orch_session_table_access" {
   ]
 }
 
+//ATO-1514: Duplicated the above role but with the write permissions policy.
+// As we're hitting a policy limit adding the write perms in a separate policy,
+// this duplicated role will be created so there is a role available to swap
+// over to when we change this in a subsequent PR.
+module "ipv_processing_identity_role_with_orch_session_table_read_write_delete_access" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-processing-identity-role-with-orch-session-combined-access"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.pepper_parameter_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    local.identity_credentials_encryption_policy_arn,
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_encrypt_decrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_read_write_delete_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn
+  ]
+}
 
 module "processing-identity" {
   source = "../modules/endpoint-module-v2"

--- a/template.yaml
+++ b/template.yaml
@@ -424,7 +424,7 @@ Resources:
             Condition:
               ArnLike:
                 kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
-          - Sid: AllowKeyDecryptionAccess
+          - Sid: AllowKeyEncryptDecryptActions
             Effect: Allow
             Principal:
               AWS: !Sub
@@ -437,6 +437,7 @@ Resources:
                     ]
             Action:
               - kms:Decrypt
+              - kms:Encrypt
             Resource: "*"
 
   OrchSessionTable:

--- a/template.yaml
+++ b/template.yaml
@@ -496,6 +496,21 @@ Resources:
                         !Ref Environment,
                         authAccountId,
                       ]
+            - Sid: AllowOrchSessionTableCrossAccountWriteAccess
+              Effect: Allow
+              Action:
+                - dynamodb:PutItem
+                - dynamodb:UpdateItem
+              Resource: "*"
+              Principal:
+                AWS: !Sub
+                  - arn:aws:iam::${AuthAccountId}:root
+                  - AuthAccountId:
+                      !FindInMap [
+                        EnvironmentConfiguration,
+                        !Ref Environment,
+                        authAccountId,
+                      ]
 
   #endregion
 


### PR DESCRIPTION
### Wider context of change: 

We're planning to start writing the value of processing identity attempts in the orch session in the processing identity handler (and identity progress frontend handler, but unused). This requires us to setup the permissions to be able to do the cross account write for these lambdas

### What’s changed:
- Adds new role with cross account write permissions for processing identity handler 
- We will swap to the unused role in a subsequent PR

### Manual testing:

- Deployed to sandpit and ran through identity journey

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
