### PR TITLE
ATO-1514: increment and reset processing identity count

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchSessionServiceIntegrationTest.java
@@ -50,7 +50,7 @@ class OrchSessionServiceIntegrationTest {
 
     @Test
     void shouldUpdatePreviousSessionWithNewId() {
-        withPreviousExistingAccountSession();
+        withPreviousExistingAccountSessionWithOneIdentityAttempt();
         assertTrue(orchSessionExtension.getSession(PREVIOUS_SESSION_ID).isPresent());
 
         orchSessionExtension.addOrUpdateSessionId(Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
@@ -62,15 +62,18 @@ class OrchSessionServiceIntegrationTest {
         assertThat(
                 retrievedSession.get().getIsNewAccount(),
                 equalTo(OrchSessionItem.AccountState.EXISTING));
+        assertThat(retrievedSession.get().getProcessingIdentityAttempts(), equalTo(0));
     }
 
     private void withSession() {
         orchSessionExtension.addSession(new OrchSessionItem(SESSION_ID));
     }
 
-    private void withPreviousExistingAccountSession() {
-        orchSessionExtension.addSession(
+    private void withPreviousExistingAccountSessionWithOneIdentityAttempt() {
+        var session =
                 new OrchSessionItem(PREVIOUS_SESSION_ID)
-                        .withAccountState(OrchSessionItem.AccountState.EXISTING));
+                        .withAccountState(OrchSessionItem.AccountState.EXISTING);
+        session.incrementProcessingIdentityAttempts();
+        orchSessionExtension.addSession(session);
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -127,6 +127,9 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
             var pairwiseSubjectId = (String) userInfo.getClaim("rp_pairwise_id");
 
             int processingAttempts = userSession.getSession().incrementProcessingIdentityAttempts();
+            // ATO-1514: Introducing this unused var, we will swap usages over to it in a future PR
+            int orchSessionProcessingIdentityAttempts =
+                    userSession.getOrchSession().incrementProcessingIdentityAttempts();
             LOG.info(
                     "Attempting to find identity credentials in dynamo. Attempt: {}",
                     processingAttempts);
@@ -138,6 +141,7 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
                     && userSession.getSession().getProcessingIdentityAttempts() == 1) {
                 processingStatus = IdentityProgressStatus.NO_ENTRY;
                 userSession.getSession().resetProcessingIdentityAttempts();
+                userSession.getOrchSession().resetProcessingIdentityAttempts();
             } else if (identityCredentials.isEmpty()) {
                 processingStatus = IdentityProgressStatus.ERROR;
             } else if (Objects.nonNull(identityCredentials.get().getCoreIdentityJWT())) {
@@ -169,6 +173,8 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
 
             sessionService.storeOrUpdateSession(
                     userSession.getSession(), userSession.getSessionId());
+
+            orchSessionService.updateSession(userSession.getOrchSession());
 
             LOG.info(
                     "Generating IdentityProgressResponse with IdentityProgressStatus: {}",

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -14,7 +14,9 @@ import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
+import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
@@ -140,6 +142,8 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             // ATO-1514: Introducing this unused var, we will swap usages over to it in a future PR
             int orchSessionProcessingIdentityAttempts =
                     userContext.getOrchSession().incrementProcessingIdentityAttempts();
+            // ATO-1514: Temporary logging to check the values are in sync.
+            logProcessingIdentityAttempts(userContext.getSession(), userContext.getOrchSession());
             LOG.info(
                     "Attempting to find identity credentials in dynamo. Attempt: {}",
                     processingAttempts);
@@ -234,5 +238,28 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                 200,
                 new ProcessingIdentityInterventionResponse(
                         ProcessingIdentityStatus.INTERVENTION, redirectUrl));
+    }
+
+    private void logProcessingIdentityAttempts(Session session, OrchSessionItem orchSession) {
+        try {
+
+            LOG.info(
+                    "Are processing identity attempts equal in both session stores: {}",
+                    Objects.equals(
+                            session.getProcessingIdentityAttempts(),
+                            orchSession.getProcessingIdentityAttempts()));
+
+            LOG.info(
+                    "Shared session processing identity attempts: {}",
+                    session.getProcessingIdentityAttempts());
+            LOG.info(
+                    "Orch session processing identity attempts: {}",
+                    orchSession.getProcessingIdentityAttempts());
+
+        } catch (Exception e) {
+            LOG.warn(
+                    "Exception when logging processing identity attempts: {}. Continuing as normal",
+                    e.getMessage());
+        }
     }
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -195,6 +195,8 @@ public class IdentityProgressFrontendHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST, CLIENT_ID, USER);
+        assertThat(session.getProcessingIdentityAttempts(), equalTo(1));
+        assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(1));
     }
 
     @Test
@@ -292,6 +294,7 @@ public class IdentityProgressFrontendHandlerTest {
                                         REDIRECT_URI,
                                         STATE))));
         assertThat(session.getProcessingIdentityAttempts(), equalTo(0));
+        assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(0));
         verify(cloudwatchMetricsService)
                 .incrementCounter(
                         "ProcessingIdentity",

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -197,6 +197,8 @@ class ProcessingIdentityHandlerTest {
                                 ENVIRONMENT,
                                 "Status",
                                 ProcessingIdentityStatus.COMPLETED.toString()));
+        assertThat(session.getProcessingIdentityAttempts(), equalTo(1));
+        assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(1));
     }
 
     @Test
@@ -356,6 +358,7 @@ class ProcessingIdentityHandlerTest {
                                 new ProcessingIdentityResponse(
                                         ProcessingIdentityStatus.NO_ENTRY))));
         assertThat(session.getProcessingIdentityAttempts(), equalTo(0));
+        assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(0));
         verify(cloudwatchMetricsService)
                 .incrementCounter(
                         "ProcessingIdentity",

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -806,6 +806,7 @@ public class AuthorisationHandler
                         .withCurrentCredentialStrength(null)
                         .withAuthenticated(false)
                         .withPreviousSessionId(newSessionIdForPreviousSession);
+        newSession.resetProcessingIdentityAttempts();
         orchSessionService.addSession(newSession);
 
         return newSession;

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -2719,6 +2719,7 @@ class AuthorisationHandlerTest {
             when(clientService.getClient(anyString()))
                     .thenReturn(Optional.of(generateClientRegistry().withMaxAgeEnabled(true)));
             when(configService.supportMaxAgeEnabled()).thenReturn(true);
+            orchSession.incrementProcessingIdentityAttempts();
             withExistingOrchSession(orchSession.withAuthenticated(true).withAuthTime(authTime));
             var requestParams =
                     buildRequestParams(
@@ -2861,6 +2862,8 @@ class AuthorisationHandlerTest {
                 assertEquals(
                         newOrchSession.getPreviousSessionId(),
                         updatedPreviousSession.getSessionId());
+                assertEquals(0, newOrchSession.getProcessingIdentityAttempts());
+
             } else {
                 verify(orchSessionService, times(1)).addSession(addSessionCaptor.capture());
                 OrchSessionItem updatedSession = addSessionCaptor.getAllValues().get(0);
@@ -2875,6 +2878,7 @@ class AuthorisationHandlerTest {
                 assertTrue(
                         updatedSession.getTimeToLive()
                                 > timeNow + configService.getSessionExpiry() - 100);
+                assertEquals(0, updatedSession.getProcessingIdentityAttempts());
 
                 verify(orchSessionService).deleteSession(orchSession.getSessionId());
             }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
@@ -65,6 +65,7 @@ public class OrchSessionService extends BaseDynamoService<OrchSessionItem> {
                 oldItem = getSession(previousSessionId.get());
             }
             if (oldItem.isPresent()) {
+                oldItem.get().resetProcessingIdentityAttempts();
                 newItem =
                         oldItem.get()
                                 .withSessionId(newSessionId)

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -38,6 +38,7 @@ public class SessionService {
         var copiedSession = new Session(previousSession);
         copiedSession.setAuthenticated(false).setCurrentCredentialStrength(null);
         copiedSession.resetClientSessions();
+        copiedSession.resetProcessingIdentityAttempts();
         return copiedSession;
     }
 


### PR DESCRIPTION
### Wider context of change: 

- We're now migrating the processing identity attempts field to the orch session from the redis one. We have previously setup the new field on the Orch session object and added the cross account write permissions. We can now increment and reset this value in the same places as the redis one. 

### What’s changed: 

- Processing Identity Handler now increments and resets the `ProcessingIdentityAttempts` field and writes the value to the Orch session store
- Same for Identity Progress Frontend Handler - although is unused in production
- Noticed when handling a copying a max_age session we're not resetting the processing identity attempts value on the shared session, see commit: [ef2ace2](https://github.com/govuk-one-login/authentication-api/pull/6212/commits/ef2ace243efe818d7b2b0e0469a35e6656cf3e12). I've updated the code and added tests to ensure this. 

### Manual testing: 
- [x] Deploy to sandpit 
- [x] Run through a journey 
-  [x] Observe handed back to stub user info page 
-  [x] Observe orch session value is updated
- [x] See logs comparing consistency

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.
- See: https://github.com/govuk-one-login/authentication-api/pull/6251
- And: https://github.com/govuk-one-login/authentication-api/pull/6211

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked. N/A

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [X] Changes have been made to contract tests or not required. N/A

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [X] Changes have been made to the simulator or not required. N/A

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [X] Changes have been made to stubs or not required. N/A

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [X] Successfully deployed to authdev or not required. N/A

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [X] Successfully run Authentication acceptance tests against sandpit or not required. N/A

### Related PRs: 
- https://github.com/govuk-one-login/authentication-api/pull/6251
- https://github.com/govuk-one-login/authentication-api/pull/6211
- https://github.com/govuk-one-login/authentication-api/pull/6210