### PR TITLE
ATO-1514: get processing identity attempts orch session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
@@ -228,7 +228,9 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
         orchClientSessionExtension.storeClientSession(orchClientSession);
         redis.addStateToRedis(STATE, SESSION_ID);
         if (incrementProcessIdentityAttempts) {
-            redis.incrementInitialProcessingIdentityAttemptsInSession(SESSION_ID);
+            var session = orchSessionExtension.getSession(SESSION_ID).orElseThrow();
+            session.incrementProcessingIdentityAttempts();
+            orchSessionExtension.updateSession(session);
         }
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -126,19 +126,20 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
 
             var pairwiseSubjectId = (String) userInfo.getClaim("rp_pairwise_id");
 
-            int processingAttempts = userSession.getSession().incrementProcessingIdentityAttempts();
-            // ATO-1514: Introducing this unused var, we will swap usages over to it in a future PR
-            int orchSessionProcessingIdentityAttempts =
+            // ATO-1514: Introducing this unused var, we will remove it in a future PR
+            int sharedSessionProcessingIdentityAttempts =
+                    userSession.getSession().incrementProcessingIdentityAttempts();
+            int processingIdentityAttempts =
                     userSession.getOrchSession().incrementProcessingIdentityAttempts();
             LOG.info(
                     "Attempting to find identity credentials in dynamo. Attempt: {}",
-                    processingAttempts);
+                    processingIdentityAttempts);
             var identityCredentials =
                     dynamoIdentityService.getIdentityCredentials(userSession.getClientSessionId());
 
             var processingStatus = IdentityProgressStatus.PROCESSING;
             if (identityCredentials.isEmpty()
-                    && userSession.getSession().getProcessingIdentityAttempts() == 1) {
+                    && userSession.getOrchSession().getProcessingIdentityAttempts() == 1) {
                 processingStatus = IdentityProgressStatus.NO_ENTRY;
                 userSession.getSession().resetProcessingIdentityAttempts();
                 userSession.getOrchSession().resetProcessingIdentityAttempts();

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -124,8 +124,6 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
             }
 
-            var pairwiseSubjectId = (String) userInfo.getClaim("rp_pairwise_id");
-
             int processingIdentityAttempts =
                     userSession.getOrchSession().incrementProcessingIdentityAttempts();
             LOG.info(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -126,9 +126,6 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
 
             var pairwiseSubjectId = (String) userInfo.getClaim("rp_pairwise_id");
 
-            // ATO-1514: Introducing this unused var, we will remove it in a future PR
-            int sharedSessionProcessingIdentityAttempts =
-                    userSession.getSession().incrementProcessingIdentityAttempts();
             int processingIdentityAttempts =
                     userSession.getOrchSession().incrementProcessingIdentityAttempts();
             LOG.info(
@@ -141,7 +138,6 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
             if (identityCredentials.isEmpty()
                     && userSession.getOrchSession().getProcessingIdentityAttempts() == 1) {
                 processingStatus = IdentityProgressStatus.NO_ENTRY;
-                userSession.getSession().resetProcessingIdentityAttempts();
                 userSession.getOrchSession().resetProcessingIdentityAttempts();
             } else if (identityCredentials.isEmpty()) {
                 processingStatus = IdentityProgressStatus.ERROR;
@@ -171,9 +167,6 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
                             .map(OrchestrationUserSession::getClientId)
                             .orElse(AuditService.UNKNOWN),
                     user);
-
-            sessionService.storeOrUpdateSession(
-                    userSession.getSession(), userSession.getSessionId());
 
             orchSessionService.updateSession(userSession.getOrchSession());
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -138,9 +138,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             userProfile.getSubjectID(),
                             URI.create(configurationService.getInternalSectorURI()),
                             authenticationService.getOrGenerateSalt(userProfile));
-            // ATO-1514: Introducing this unused var, we will remove it in a future PR
-            int sharedSessionProcessingIdentityAttempts =
-                    userContext.getSession().incrementProcessingIdentityAttempts();
             int processingAttempts =
                     userContext.getOrchSession().incrementProcessingIdentityAttempts();
             // ATO-1514: Temporary logging to check the values are in sync.
@@ -155,7 +152,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             if (identityCredentials.isEmpty()
                     && userContext.getOrchSession().getProcessingIdentityAttempts() == 1) {
                 processingStatus = ProcessingIdentityStatus.NO_ENTRY;
-                userContext.getSession().resetProcessingIdentityAttempts();
                 userContext.getOrchSession().resetProcessingIdentityAttempts();
             } else if (identityCredentials.isEmpty()) {
                 processingStatus = ProcessingIdentityStatus.ERROR;
@@ -187,8 +183,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             auditService.submitAuditEvent(
                     IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST, auditContext);
             orchSessionService.updateSession(userContext.getOrchSession());
-            sessionService.storeOrUpdateSession(
-                    userContext.getSession(), userContext.getSessionId());
             LOG.info(
                     "Generating ProcessingIdentityResponse with ProcessingIdentityStatus: {}",
                     processingStatus);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -14,9 +14,7 @@ import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
-import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
-import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
@@ -140,8 +138,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             authenticationService.getOrGenerateSalt(userProfile));
             int processingAttempts =
                     userContext.getOrchSession().incrementProcessingIdentityAttempts();
-            // ATO-1514: Temporary logging to check the values are in sync.
-            logProcessingIdentityAttempts(userContext.getSession(), userContext.getOrchSession());
             LOG.info(
                     "Attempting to find identity credentials in dynamo. Attempt: {}",
                     processingAttempts);
@@ -233,28 +229,5 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                 200,
                 new ProcessingIdentityInterventionResponse(
                         ProcessingIdentityStatus.INTERVENTION, redirectUrl));
-    }
-
-    private void logProcessingIdentityAttempts(Session session, OrchSessionItem orchSession) {
-        try {
-
-            LOG.info(
-                    "Are processing identity attempts equal in both session stores: {}",
-                    Objects.equals(
-                            session.getProcessingIdentityAttempts(),
-                            orchSession.getProcessingIdentityAttempts()));
-
-            LOG.info(
-                    "Shared session processing identity attempts: {}",
-                    session.getProcessingIdentityAttempts());
-            LOG.info(
-                    "Orch session processing identity attempts: {}",
-                    orchSession.getProcessingIdentityAttempts());
-
-        } catch (Exception e) {
-            LOG.warn(
-                    "Exception when logging processing identity attempts: {}. Continuing as normal",
-                    e.getMessage());
-        }
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -138,9 +138,10 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             userProfile.getSubjectID(),
                             URI.create(configurationService.getInternalSectorURI()),
                             authenticationService.getOrGenerateSalt(userProfile));
-            int processingAttempts = userContext.getSession().incrementProcessingIdentityAttempts();
-            // ATO-1514: Introducing this unused var, we will swap usages over to it in a future PR
-            int orchSessionProcessingIdentityAttempts =
+            // ATO-1514: Introducing this unused var, we will remove it in a future PR
+            int sharedSessionProcessingIdentityAttempts =
+                    userContext.getSession().incrementProcessingIdentityAttempts();
+            int processingAttempts =
                     userContext.getOrchSession().incrementProcessingIdentityAttempts();
             // ATO-1514: Temporary logging to check the values are in sync.
             logProcessingIdentityAttempts(userContext.getSession(), userContext.getOrchSession());
@@ -152,7 +153,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                     dynamoIdentityService.getIdentityCredentials(userContext.getClientSessionId());
             var processingStatus = ProcessingIdentityStatus.PROCESSING;
             if (identityCredentials.isEmpty()
-                    && userContext.getSession().getProcessingIdentityAttempts() == 1) {
+                    && userContext.getOrchSession().getProcessingIdentityAttempts() == 1) {
                 processingStatus = ProcessingIdentityStatus.NO_ENTRY;
                 userContext.getSession().resetProcessingIdentityAttempts();
                 userContext.getOrchSession().resetProcessingIdentityAttempts();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -240,7 +240,7 @@ public class IdentityProgressFrontendHandlerTest {
     @Test
     void shouldReturnERRORStatusWhenNoEntryIsFoundInDynamoAfterSecondAttempt()
             throws Json.JsonException {
-        session.incrementProcessingIdentityAttempts();
+        orchSession.incrementProcessingIdentityAttempts();
         usingValidSession();
         when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
                 .thenReturn(Optional.empty());

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -195,7 +195,6 @@ public class IdentityProgressFrontendHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST, CLIENT_ID, USER);
-        assertThat(session.getProcessingIdentityAttempts(), equalTo(1));
         assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(1));
     }
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -315,7 +315,7 @@ class ProcessingIdentityHandlerTest {
     @Test
     void shouldReturnERRORStatusWhenNoEntryIsFoundInDynamoAfterSecondAttempt()
             throws Json.JsonException {
-        session.incrementProcessingIdentityAttempts();
+        orchSession.incrementProcessingIdentityAttempts();
         usingValidSession();
         when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
                 .thenReturn(Optional.empty());

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -197,7 +197,6 @@ class ProcessingIdentityHandlerTest {
                                 ENVIRONMENT,
                                 "Status",
                                 ProcessingIdentityStatus.COMPLETED.toString()));
-        assertThat(session.getProcessingIdentityAttempts(), equalTo(1));
         assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(1));
     }
 


### PR DESCRIPTION
Wider context of change:

We're now migrating the processing identity attempts field to the orch session from the redis one. We have previously setup the new field on the Orch session and have been incrementing and resetting in the same places. We also added consistency logging to ensure the values were the same. 

What’s changed:
- Swaps to using the orch session for this value instead of the shared session
- Removes setting as this is only done in one handler

### Manual testing: 
- Added logging in a previous PR and can see the values are now in sync
- Deployed to dev and ran through an identity journey

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
