### PR TITLE
ATO-1514: remove getter for processing identity from shared session

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -682,6 +682,21 @@ data "aws_iam_policy_document" "dynamo_orch_session_encryption_key_cross_account
 }
 
 
+data "aws_iam_policy_document" "dynamo_orch_session_encryption_key_cross_account_encrypt_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+  statement {
+    sid    = "AllowOrchSessionEncryptionKeyCrossAccountEncryptAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt"
+    ]
+    resources = [
+      var.orch_session_table_encryption_key_arn,
+    ]
+  }
+}
+
+
 data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_and_delete_access_policy_document" {
   count = var.is_orch_stubbed ? 0 : 1
   statement {
@@ -714,6 +729,21 @@ data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_access_po
   }
 }
 
+data "aws_iam_policy_document" "dynamo_orch_session_cross_account_write_access_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  statement {
+    sid    = "AllowOrchSessionCrossAccountWriteAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem"
+    ]
+    resources = [
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Orch-Session",
+    ]
+  }
+}
 
 data "aws_iam_policy_document" "dynamo_orch_session_cross_account_delete_access_policy_document" {
   count = var.is_orch_stubbed ? 0 : 1
@@ -1098,6 +1128,17 @@ resource "aws_iam_policy" "dynamo_orch_client_session_encryption_key_cross_accou
   policy = data.aws_iam_policy_document.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy_document[count.index].json
 }
 
+resource "aws_iam_policy" "dynamo_orch_session_encryption_key_cross_account_encrypt_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-session-encryption-key-cross-account-encrypt-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing encrypt permissions to the orch session table's KMS encryption key"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_session_encryption_key_cross_account_encrypt_policy_document[count.index].json
+}
+
+
 resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_and_delete_access_policy" {
   count = var.is_orch_stubbed ? 0 : 1
 
@@ -1118,6 +1159,16 @@ resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_access_policy"
   policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_access_policy_document[count.index].json
 }
 
+
+resource "aws_iam_policy" "dynamo_orch_session_cross_account_write_access_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-session-cross-account-write-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing write permissions to the orch session table"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_write_access_policy_document[count.index].json
+}
 
 resource "aws_iam_policy" "dynamo_orch_session_cross_account_delete_access_policy" {
   count = var.is_orch_stubbed ? 0 : 1

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -11,7 +11,9 @@ module "identity_progress_role_1" {
     module.oidc_txma_audit.access_policy_arn,
     ], var.is_orch_stubbed ? [] : [
     aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn,
-    aws_iam_policy.dynamo_orch_client_session_cross_account_read_access_policy[0].arn
+    aws_iam_policy.dynamo_orch_client_session_cross_account_read_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_write_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_encrypt_policy[0].arn
   ])
   extra_tags = {
     Service = "identity-progress"

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -48,7 +48,9 @@ module "ipv_processing_identity_role_with_orch_session_table_access" {
     aws_iam_policy.dynamo_orch_session_cross_account_read_and_delete_access_policy[0].arn,
     aws_iam_policy.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy[0].arn,
     aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_access_policy[0].arn,
-    aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn
+    aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_encrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_write_access_policy[0].arn,
   ]
 }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchSessionServiceIntegrationTest.java
@@ -50,7 +50,7 @@ class OrchSessionServiceIntegrationTest {
 
     @Test
     void shouldUpdatePreviousSessionWithNewId() {
-        withPreviousExistingAccountSession();
+        withPreviousExistingAccountSessionWithOneIdentityAttempt();
         assertTrue(orchSessionExtension.getSession(PREVIOUS_SESSION_ID).isPresent());
 
         orchSessionExtension.addOrUpdateSessionId(Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
@@ -62,15 +62,18 @@ class OrchSessionServiceIntegrationTest {
         assertThat(
                 retrievedSession.get().getIsNewAccount(),
                 equalTo(OrchSessionItem.AccountState.EXISTING));
+        assertThat(retrievedSession.get().getProcessingIdentityAttempts(), equalTo(0));
     }
 
     private void withSession() {
         orchSessionExtension.addSession(new OrchSessionItem(SESSION_ID));
     }
 
-    private void withPreviousExistingAccountSession() {
-        orchSessionExtension.addSession(
+    private void withPreviousExistingAccountSessionWithOneIdentityAttempt() {
+        var session =
                 new OrchSessionItem(PREVIOUS_SESSION_ID)
-                        .withAccountState(OrchSessionItem.AccountState.EXISTING));
+                        .withAccountState(OrchSessionItem.AccountState.EXISTING);
+        session.incrementProcessingIdentityAttempts();
+        orchSessionExtension.addSession(session);
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -96,8 +96,6 @@ class AuthOrchSerializationServicesIntegrationTest {
         var authSession = authSessionService.getSession(SESSION_ID).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
         authSessionService.storeOrUpdateSession(authSession, SESSION_ID);
-        orchSession = orchSessionService.getSession(SESSION_ID).get();
-        assertThat(orchSession.getProcessingIdentityAttempts(), is(equalTo(1)));
     }
 
     @Test
@@ -140,6 +138,5 @@ class AuthOrchSerializationServicesIntegrationTest {
         authSessionService.storeOrUpdateSession(authSession, SESSION_ID);
         orchSession = orchSessionService.getSession(SESSION_ID).get();
         assertThat(orchSession.getClientSessions(), is(empty()));
-        assertThat(orchSession.getProcessingIdentityAttempts(), is(equalTo(1)));
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -134,6 +134,9 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
             var pairwiseSubjectId = (String) userInfo.getClaim("rp_pairwise_id");
 
             int processingAttempts = userSession.getSession().incrementProcessingIdentityAttempts();
+            // ATO-1514: Introducing this unused var, we will swap usages over to it in a future PR
+            int orchSessionProcessingIdentityAttempts =
+                    userSession.getOrchSession().incrementProcessingIdentityAttempts();
             LOG.info(
                     "Attempting to find identity credentials in dynamo. Attempt: {}",
                     processingAttempts);
@@ -145,6 +148,7 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
                     && userSession.getSession().getProcessingIdentityAttempts() == 1) {
                 processingStatus = IdentityProgressStatus.NO_ENTRY;
                 userSession.getSession().resetProcessingIdentityAttempts();
+                userSession.getOrchSession().resetProcessingIdentityAttempts();
             } else if (identityCredentials.isEmpty()) {
                 processingStatus = IdentityProgressStatus.ERROR;
             } else if (Objects.nonNull(identityCredentials.get().getCoreIdentityJWT())) {
@@ -176,6 +180,8 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
 
             sessionService.storeOrUpdateSession(
                     userSession.getSession(), userSession.getSessionId());
+
+            orchSessionService.updateSession(userSession.getOrchSession());
 
             LOG.info(
                     "Generating IdentityProgressResponse with IdentityProgressStatus: {}",

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -133,19 +133,20 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
 
             var pairwiseSubjectId = (String) userInfo.getClaim("rp_pairwise_id");
 
-            int processingAttempts = userSession.getSession().incrementProcessingIdentityAttempts();
-            // ATO-1514: Introducing this unused var, we will swap usages over to it in a future PR
-            int orchSessionProcessingIdentityAttempts =
+            // ATO-1514: Introducing this unused var, we will remove it in a future PR
+            int sharedSessionProcessingIdentityAttempts =
+                    userSession.getSession().incrementProcessingIdentityAttempts();
+            int processingIdentityAttempts =
                     userSession.getOrchSession().incrementProcessingIdentityAttempts();
             LOG.info(
                     "Attempting to find identity credentials in dynamo. Attempt: {}",
-                    processingAttempts);
+                    processingIdentityAttempts);
             var identityCredentials =
                     dynamoIdentityService.getIdentityCredentials(userSession.getClientSessionId());
 
             var processingStatus = IdentityProgressStatus.PROCESSING;
             if (identityCredentials.isEmpty()
-                    && userSession.getSession().getProcessingIdentityAttempts() == 1) {
+                    && userSession.getOrchSession().getProcessingIdentityAttempts() == 1) {
                 processingStatus = IdentityProgressStatus.NO_ENTRY;
                 userSession.getSession().resetProcessingIdentityAttempts();
                 userSession.getOrchSession().resetProcessingIdentityAttempts();

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -139,9 +139,10 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             userProfile.getSubjectID(),
                             URI.create(configurationService.getInternalSectorURI()),
                             authenticationService.getOrGenerateSalt(userProfile));
-            int processingAttempts = userContext.getSession().incrementProcessingIdentityAttempts();
-            // ATO-1514: Introducing this unused var, we will swap usages over to it in a future PR
-            int orchSessionProcessingIdentityAttempts =
+            // ATO-1514: Introducing this unused var, we will remove it in a future PR
+            int sharedSessionProcessingIdentityAttempts =
+                    userContext.getSession().incrementProcessingIdentityAttempts();
+            int processingAttempts =
                     userContext.getOrchSession().incrementProcessingIdentityAttempts();
             LOG.info(
                     "Attempting to find identity credentials in dynamo. Attempt: {}",
@@ -151,7 +152,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                     dynamoIdentityService.getIdentityCredentials(userContext.getClientSessionId());
             var processingStatus = ProcessingIdentityStatus.PROCESSING;
             if (identityCredentials.isEmpty()
-                    && userContext.getSession().getProcessingIdentityAttempts() == 1) {
+                    && userContext.getOrchSession().getProcessingIdentityAttempts() == 1) {
                 processingStatus = ProcessingIdentityStatus.NO_ENTRY;
                 userContext.getSession().resetProcessingIdentityAttempts();
                 userContext.getOrchSession().resetProcessingIdentityAttempts();

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -140,6 +140,9 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             URI.create(configurationService.getInternalSectorURI()),
                             authenticationService.getOrGenerateSalt(userProfile));
             int processingAttempts = userContext.getSession().incrementProcessingIdentityAttempts();
+            // ATO-1514: Introducing this unused var, we will swap usages over to it in a future PR
+            int orchSessionProcessingIdentityAttempts =
+                    userContext.getOrchSession().incrementProcessingIdentityAttempts();
             LOG.info(
                     "Attempting to find identity credentials in dynamo. Attempt: {}",
                     processingAttempts);
@@ -151,6 +154,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                     && userContext.getSession().getProcessingIdentityAttempts() == 1) {
                 processingStatus = ProcessingIdentityStatus.NO_ENTRY;
                 userContext.getSession().resetProcessingIdentityAttempts();
+                userContext.getOrchSession().resetProcessingIdentityAttempts();
             } else if (identityCredentials.isEmpty()) {
                 processingStatus = ProcessingIdentityStatus.ERROR;
             } else if (Objects.nonNull(identityCredentials.get().getCoreIdentityJWT())) {
@@ -180,6 +184,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
 
             auditService.submitAuditEvent(
                     IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST, auditContext);
+            orchSessionService.updateSession(userContext.getOrchSession());
             sessionService.storeOrUpdateSession(
                     userContext.getSession(), userContext.getSessionId());
             LOG.info(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -249,6 +249,7 @@ public class IdentityProgressFrontendHandlerTest {
     void shouldReturnERRORStatusWhenNoEntryIsFoundInDynamoAfterSecondAttempt()
             throws Json.JsonException {
         session.incrementProcessingIdentityAttempts();
+        orchSession.incrementProcessingIdentityAttempts();
         usingValidSession();
         when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
                 .thenReturn(Optional.empty());

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -306,6 +306,7 @@ public class IdentityProgressFrontendHandlerTest {
                                         REDIRECT_URI,
                                         STATE))));
         assertThat(session.getProcessingIdentityAttempts(), equalTo(0));
+        assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(0));
         verify(cloudwatchMetricsService)
                 .incrementCounter(
                         "ProcessingIdentity",

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -306,7 +306,6 @@ public class IdentityProgressFrontendHandlerTest {
                                         CLIENT_NAME,
                                         REDIRECT_URI,
                                         STATE))));
-        assertThat(session.getProcessingIdentityAttempts(), equalTo(0));
         assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(0));
         verify(cloudwatchMetricsService)
                 .incrementCounter(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -372,6 +372,7 @@ class ProcessingIdentityHandlerTest {
                                 new ProcessingIdentityResponse(
                                         ProcessingIdentityStatus.NO_ENTRY))));
         assertThat(session.getProcessingIdentityAttempts(), equalTo(0));
+        assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(0));
         verify(cloudwatchMetricsService)
                 .incrementCounter(
                         "ProcessingIdentity",

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -371,7 +371,6 @@ class ProcessingIdentityHandlerTest {
                         objectMapper.writeValueAsString(
                                 new ProcessingIdentityResponse(
                                         ProcessingIdentityStatus.NO_ENTRY))));
-        assertThat(session.getProcessingIdentityAttempts(), equalTo(0));
         assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(0));
         verify(cloudwatchMetricsService)
                 .incrementCounter(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -143,10 +143,6 @@ public class Session {
         return this;
     }
 
-    public int getProcessingIdentityAttempts() {
-        return processingIdentityAttempts;
-    }
-
     public void resetProcessingIdentityAttempts() {
         this.processingIdentityAttempts = 0;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchSessionService.java
@@ -65,6 +65,7 @@ public class OrchSessionService extends BaseDynamoService<OrchSessionItem> {
                 oldItem = getSession(previousSessionId.get());
             }
             if (oldItem.isPresent()) {
+                oldItem.get().resetProcessingIdentityAttempts();
                 newItem =
                         oldItem.get()
                                 .withSessionId(newSessionId)


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
