### PR TITLE
ATO-1514: remove setters for processing identity attempts

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
@@ -228,7 +228,9 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
         orchClientSessionExtension.storeClientSession(orchClientSession);
         redis.addStateToRedis(STATE, SESSION_ID);
         if (incrementProcessIdentityAttempts) {
-            redis.incrementInitialProcessingIdentityAttemptsInSession(SESSION_ID);
+            var orchSession = orchSessionExtension.getSession(SESSION_ID).orElseThrow();
+            orchSession.incrementProcessingIdentityAttempts();
+            orchSessionExtension.updateSession(orchSession);
         }
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -91,7 +91,6 @@ class AuthOrchSerializationServicesIntegrationTest {
     @Test
     void orchCanReadUnsharedFieldAfterAuthUpdatesSession() {
         var orchSession = orchSessionService.generateSession();
-        orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
         authSession.addClientSession(CLIENT_SESSION_ID);
@@ -132,7 +131,6 @@ class AuthOrchSerializationServicesIntegrationTest {
     void authCanResetSharedFieldsWithoutOverridingUnsharedFields() {
         var orchSession = orchSessionService.generateSession();
         orchSession.addClientSession(CLIENT_SESSION_ID);
-        orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = new Session();
         authSessionService.storeOrUpdateSession(authSession, SESSION_ID);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -148,7 +148,6 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
             if (identityCredentials.isEmpty()
                     && userSession.getOrchSession().getProcessingIdentityAttempts() == 1) {
                 processingStatus = IdentityProgressStatus.NO_ENTRY;
-                userSession.getSession().resetProcessingIdentityAttempts();
                 userSession.getOrchSession().resetProcessingIdentityAttempts();
             } else if (identityCredentials.isEmpty()) {
                 processingStatus = IdentityProgressStatus.ERROR;

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandler.java
@@ -133,9 +133,6 @@ public class IdentityProgressFrontendHandler extends BaseOrchestrationFrontendHa
 
             var pairwiseSubjectId = (String) userInfo.getClaim("rp_pairwise_id");
 
-            // ATO-1514: Introducing this unused var, we will remove it in a future PR
-            int sharedSessionProcessingIdentityAttempts =
-                    userSession.getSession().incrementProcessingIdentityAttempts();
             int processingIdentityAttempts =
                     userSession.getOrchSession().incrementProcessingIdentityAttempts();
             LOG.info(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -139,9 +139,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             userProfile.getSubjectID(),
                             URI.create(configurationService.getInternalSectorURI()),
                             authenticationService.getOrGenerateSalt(userProfile));
-            // ATO-1514: Introducing this unused var, we will remove it in a future PR
-            int sharedSessionProcessingIdentityAttempts =
-                    userContext.getSession().incrementProcessingIdentityAttempts();
             int processingAttempts =
                     userContext.getOrchSession().incrementProcessingIdentityAttempts();
             LOG.info(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -154,7 +154,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             if (identityCredentials.isEmpty()
                     && userContext.getOrchSession().getProcessingIdentityAttempts() == 1) {
                 processingStatus = ProcessingIdentityStatus.NO_ENTRY;
-                userContext.getSession().resetProcessingIdentityAttempts();
                 userContext.getOrchSession().resetProcessingIdentityAttempts();
             } else if (identityCredentials.isEmpty()) {
                 processingStatus = ProcessingIdentityStatus.ERROR;

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -248,7 +248,6 @@ public class IdentityProgressFrontendHandlerTest {
     @Test
     void shouldReturnERRORStatusWhenNoEntryIsFoundInDynamoAfterSecondAttempt()
             throws Json.JsonException {
-        session.incrementProcessingIdentityAttempts();
         orchSession.incrementProcessingIdentityAttempts();
         usingValidSession();
         when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -325,7 +325,6 @@ class ProcessingIdentityHandlerTest {
     @Test
     void shouldReturnERRORStatusWhenNoEntryIsFoundInDynamoAfterSecondAttempt()
             throws Json.JsonException {
-        session.incrementProcessingIdentityAttempts();
         usingValidSession();
         when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
                 .thenReturn(Optional.empty());

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -108,13 +108,6 @@ public class RedisExtension
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
-    public void incrementInitialProcessingIdentityAttemptsInSession(String sessionId)
-            throws Json.JsonException {
-        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.incrementProcessingIdentityAttempts();
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
-    }
-
     public void addAuthRequestToSession(
             String clientSessionId,
             String sessionId,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -143,10 +143,6 @@ public class Session {
         return this;
     }
 
-    public void resetProcessingIdentityAttempts() {
-        this.processingIdentityAttempts = 0;
-    }
-
     public int incrementProcessingIdentityAttempts() {
         this.processingIdentityAttempts += 1;
         return processingIdentityAttempts;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -143,11 +143,6 @@ public class Session {
         return this;
     }
 
-    public int incrementProcessingIdentityAttempts() {
-        this.processingIdentityAttempts += 1;
-        return processingIdentityAttempts;
-    }
-
     public MFAMethodType getVerifiedMfaMethodType() {
         return verifiedMfaMethodType;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -63,7 +63,6 @@ public class SessionService {
     public Session updateWithNewSessionId(
             Session session, String oldSessionId, String newSessionId) {
         try {
-            session.resetProcessingIdentityAttempts();
             storeOrUpdateSession(session, oldSessionId, newSessionId);
             redisConnectionService.deleteValue(oldSessionId);
             return session;


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
