### PR TITLE
ATO-1188: accept auth code as a param to enable consistency checks

### DIFF
--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchAuthCodeExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchAuthCodeExtension.java
@@ -76,10 +76,13 @@ public class OrchAuthCodeExtension extends DynamoExtension implements AfterEachC
     }
 
     public AuthorizationCode generateAndSaveAuthorisationCode(
-            String clientId, String clientSessionId, String email, Long authTime)
-            throws Json.JsonException {
+            String clientId, String clientSessionId, String email, Long authTime) {
+        // TODO: ATO-1198: Remove generation of this authorisation code after consistency checks are
+        // complete - the method in orchAuthCodeService needs to generate this itself.
+        AuthorizationCode authorizationCode = new AuthorizationCode();
+
         return orchAuthCodeService.generateAndSaveAuthorisationCode(
-                clientId, clientSessionId, email, authTime);
+                authorizationCode, clientId, clientSessionId, email, authTime);
     }
 
     public Optional<AuthCodeExchangeData> getExchangeDataForCode(String code) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
@@ -46,10 +46,15 @@ public class OrchAuthCodeService extends BaseDynamoService<OrchAuthCodeItem> {
         this.objectMapper = SerializationService.getInstance();
     }
 
+    // TODO: ATO-1198: Move generation of the authorisation code back into this method (removing the
+    // parameter) after consistency checks are complete.
     public AuthorizationCode generateAndSaveAuthorisationCode(
-            String clientId, String clientSessionId, String email, Long authTime) {
+            AuthorizationCode authorizationCode,
+            String clientId,
+            String clientSessionId,
+            String email,
+            Long authTime) {
         LOG.info("Generating and saving authorisation code to orch auth code store");
-        AuthorizationCode authorizationCode = new AuthorizationCode();
 
         var exchangeData =
                 new AuthCodeExchangeData()

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.orchestration.shared.services;
 
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -61,8 +62,10 @@ class OrchAuthCodeServiceTest {
 
     @Test
     void shouldStoreOrchAuthCodeItem() throws Json.JsonException {
+        AuthorizationCode authorizationCode = new AuthorizationCode();
+
         orchAuthCodeService.generateAndSaveAuthorisationCode(
-                CLIENT_ID, CLIENT_SESSION_ID, EMAIL, AUTH_TIME);
+                authorizationCode, CLIENT_ID, CLIENT_SESSION_ID, EMAIL, AUTH_TIME);
 
         var orchAuthCodeItemCaptor = ArgumentCaptor.forClass(OrchAuthCodeItem.class);
         verify(table).putItem(orchAuthCodeItemCaptor.capture());
@@ -82,13 +85,15 @@ class OrchAuthCodeServiceTest {
 
     @Test
     void shouldThrowWhenFailingToStoreOrchAuthCode() {
+        AuthorizationCode authorizationCode = new AuthorizationCode();
+
         withFailedPut();
 
         assertThrows(
                 OrchAuthCodeException.class,
                 () ->
                         orchAuthCodeService.generateAndSaveAuthorisationCode(
-                                CLIENT_ID, CLIENT_SESSION_ID, EMAIL, AUTH_TIME));
+                                authorizationCode, CLIENT_ID, CLIENT_SESSION_ID, EMAIL, AUTH_TIME));
     }
 
     @Test


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Currently RP issued auth codes are stored in Redis. We are migrating away from Redis to DynamoDB. The auth code store is being migrated under the parent ticket.

To perform consistency checks (ATO-1198), Redis and DynamoDB will need to use the same auth code when storing the data. We will use the auth code the "authorisation code service" generates, so the generation method in the "orch auth code service" needs to accept this as a parameter.

These changes can be reverted after this consistency check has been completed.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Extracted auth code generation from the new orch auth code generation function, now accepted as a parameter
- Updated related tests.

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to Orch dev without any issues. These methods aren't used at present so shouldn't have any effect.

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing. **- N/A**

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or **not required**. - new service not being used at present

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or **not required**.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or **not required**. - service not being used at present

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or **not required**. - service not being used at present

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or **not required**. - service not being used at present

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- #6220