### PR TITLE
ATO-1188: set orch AuthCode in Authentication Callback lambda

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -55,6 +55,7 @@ import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationT
 import uk.gov.di.orchestration.sharedtest.extensions.AuthExternalApiStubExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.OrchAuthCodeExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SnsTopicExtension;
@@ -94,6 +95,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED;
+import static uk.gov.di.authentication.testsupport.helpers.OrchAuthCodeAssertionHelper.assertOrchAuthCodeSaved;
 import static uk.gov.di.orchestration.shared.entity.VectorOfTrust.parseFromAuthRequestAttribute;
 import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.orchestration.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
@@ -132,6 +134,9 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     @RegisterExtension
     public static final SqsQueueExtension backChannelLogoutQueueExtension =
             new SqsQueueExtension("back-channel-logout-");
+
+    @RegisterExtension
+    public static final OrchAuthCodeExtension orchAuthCodeExtension = new OrchAuthCodeExtension();
 
     protected static ConfigurationService configurationService;
 
@@ -185,6 +190,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         assertUserInfoStoredAndRedirectedToRp(response);
         assertOrchSessionIsUpdatedWithUserInfoClaims();
+
+        assertOrchAuthCodeSaved(orchAuthCodeExtension, response);
     }
 
     @Test
@@ -355,6 +362,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         assertUserInfoStoredAndRedirectedToRp(response);
         assertOrchSessionIsUpdatedWithUserInfoClaims();
+
+        assertOrchAuthCodeSaved(orchAuthCodeExtension, response);
     }
 
     @Test
@@ -451,6 +460,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         assertUserInfoStoredAndRedirectedToRp(response);
         assertOrchSessionIsUpdatedWithUserInfoClaims();
+
+        assertOrchAuthCodeSaved(orchAuthCodeExtension, response);
     }
 
     @Test
@@ -502,6 +513,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         assertUserInfoStoredAndRedirectedToRp(response);
         assertOrchSessionIsUpdatedWithUserInfoClaims();
+
+        assertOrchAuthCodeSaved(orchAuthCodeExtension, response);
     }
 
     @Test
@@ -528,6 +541,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         assertUserInfoStoredAndRedirectedToRp(response);
         assertOrchSessionIsUpdatedWithUserInfoClaims();
+
+        assertOrchAuthCodeSaved(orchAuthCodeExtension, response);
     }
 
     @Test
@@ -595,6 +610,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         assertUserInfoStoredAndRedirectedToRp(response);
         assertOrchSessionIsUpdatedWithUserInfoClaims();
+
+        assertOrchAuthCodeSaved(orchAuthCodeExtension, response);
     }
 
     void accountInterventionSetupWithIdentity() throws Json.JsonException {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/OrchAuthCodeAssertionHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/OrchAuthCodeAssertionHelper.java
@@ -1,0 +1,41 @@
+package uk.gov.di.authentication.testsupport.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
+import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
+import uk.gov.di.orchestration.sharedtest.extensions.OrchAuthCodeExtension;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OrchAuthCodeAssertionHelper {
+
+    public static void assertOrchAuthCodeSaved(
+            OrchAuthCodeExtension orchAuthCodeExtension, APIGatewayProxyResponseEvent response) {
+        String responseLocationHeader = response.getHeaders().get(ResponseHeaders.LOCATION);
+        String authCode = extractAuthCodeFromResponseLocationHeader(responseLocationHeader);
+
+        Optional<AuthCodeExchangeData> exchangeData =
+                orchAuthCodeExtension.getExchangeDataForCode(authCode);
+
+        assertTrue(exchangeData.isPresent());
+    }
+
+    private static String extractAuthCodeFromResponseLocationHeader(String responseLocationHeader) {
+        URI url = URI.create(responseLocationHeader);
+        String queryParams = url.getQuery();
+
+        String authCodePattern = "code=([^&]*)";
+        var pattern = Pattern.compile(authCodePattern);
+        var matcher = pattern.matcher(queryParams);
+
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        return null;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -63,6 +63,7 @@ import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
+import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
@@ -117,6 +118,7 @@ public class AuthenticationCallbackHandler
     private final AuthenticationUserInfoStorageService userInfoStorageService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final AuthorisationCodeService authorisationCodeService;
+    private final OrchAuthCodeService orchAuthCodeService;
     private final ClientService clientService;
     private final InitiateIPVAuthorisationService initiateIPVAuthorisationService;
     private final AccountInterventionService accountInterventionService;
@@ -145,6 +147,7 @@ public class AuthenticationCallbackHandler
                 new AuthenticationUserInfoStorageService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.authorisationCodeService = new AuthorisationCodeService(configurationService);
+        this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.clientService = new DynamoClientService(configurationService);
 
         this.initiateIPVAuthorisationService =
@@ -192,6 +195,7 @@ public class AuthenticationCallbackHandler
                         configurationService,
                         redisConnectionService,
                         SerializationService.getInstance());
+        this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.clientService = new DynamoClientService(configurationService);
         this.initiateIPVAuthorisationService =
                 new InitiateIPVAuthorisationService(
@@ -228,6 +232,7 @@ public class AuthenticationCallbackHandler
             AuthenticationUserInfoStorageService dynamoAuthUserInfoService,
             CloudwatchMetricsService cloudwatchMetricsService,
             AuthorisationCodeService authorisationCodeService,
+            OrchAuthCodeService orchAuthCodeService,
             ClientService clientService,
             InitiateIPVAuthorisationService initiateIPVAuthorisationService,
             AccountInterventionService accountInterventionService,
@@ -245,6 +250,7 @@ public class AuthenticationCallbackHandler
         this.userInfoStorageService = dynamoAuthUserInfoService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.authorisationCodeService = authorisationCodeService;
+        this.orchAuthCodeService = orchAuthCodeService;
         this.clientService = clientService;
         this.initiateIPVAuthorisationService = initiateIPVAuthorisationService;
         this.accountInterventionService = accountInterventionService;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -46,6 +46,7 @@ import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.Session.AccountState;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
+import uk.gov.di.orchestration.shared.exceptions.OrchAuthCodeException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
@@ -587,6 +588,24 @@ public class AuthenticationCallbackHandler
                                 clientSessionId,
                                 userInfo.getEmailAddress(),
                                 orchSession.getAuthTime());
+
+                /*
+                    TODO: ATO-1218:
+                     - Move the catch clause below to the bottom of this method and return the result of redirectToFrontendErrorPage (similar to the other catch clauses).
+                     - Update the log in the catch clause to be level 'error' and remove Redis references (as by this point the DynamoDB store will be the primary).
+                */
+                try {
+                    orchAuthCodeService.generateAndSaveAuthorisationCode(
+                            authCode,
+                            clientId,
+                            clientSessionId,
+                            userInfo.getEmailAddress(),
+                            orchSession.getAuthTime());
+                } catch (OrchAuthCodeException e) {
+                    LOG.warn(
+                            "Failed to generate and save authorisation code to orch auth code DynamoDB store. NOTE: Redis is still the primary at present. Error: {}",
+                            e.getMessage());
+                }
 
                 var authenticationResponse =
                         new AuthenticationSuccessResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -71,6 +71,7 @@ import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
+import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SessionService;
@@ -133,6 +134,7 @@ class AuthenticationCallbackHandlerTest {
             mock(CloudwatchMetricsService.class);
     private static final AuthorisationCodeService authorisationCodeService =
             mock(AuthorisationCodeService.class);
+    private static final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
     private static final InitiateIPVAuthorisationService initiateIPVAuthorisationService =
             mock(InitiateIPVAuthorisationService.class);
     private static final AccountInterventionService accountInterventionService =
@@ -264,6 +266,7 @@ class AuthenticationCallbackHandlerTest {
                         userInfoStorageService,
                         cloudwatchMetricsService,
                         authorisationCodeService,
+                        orchAuthCodeService,
                         clientService,
                         initiateIPVAuthorisationService,
                         accountInterventionService,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -60,6 +60,7 @@ import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
+import uk.gov.di.orchestration.shared.exceptions.OrchAuthCodeException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
@@ -91,16 +92,19 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -132,6 +136,8 @@ class AuthenticationCallbackHandlerTest {
             mock(AuthenticationUserInfoStorageService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
+
+    // TODO: ATO-1218: Remove the following mock for the auth code service.
     private static final AuthorisationCodeService authorisationCodeService =
             mock(AuthorisationCodeService.class);
     private static final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
@@ -208,12 +214,22 @@ class AuthenticationCallbackHandlerTest {
                 .thenReturn(
                         new AccountIntervention(
                                 new AccountInterventionState(false, false, false, false)));
+
+        // TODO: ATO-1218: Remove the following stub for the auth code service.
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(TEST_EMAIL_ADDRESS),
                         any(Long.class)))
                 .thenReturn(AUTH_CODE_RP_TO_ORCH);
+        when(orchAuthCodeService.generateAndSaveAuthorisationCode(
+                        any(AuthorizationCode.class),
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(TEST_EMAIL_ADDRESS),
+                        any(Long.class)))
+                .thenReturn(AUTH_CODE_RP_TO_ORCH);
+
         when(UNSUCCESSFUL_TOKEN_RESPONSE.indicatesSuccess()).thenReturn(false);
         when(UNSUCCESSFUL_TOKEN_RESPONSE.toErrorResponse())
                 .thenReturn(new TokenErrorResponse(new ErrorObject("1", TEST_ERROR_MESSAGE)));
@@ -238,6 +254,10 @@ class AuthenticationCallbackHandlerTest {
         reset(logoutService);
         reset(authorizationService);
         reset(noSessionOrchestrationService);
+
+        clearInvocations(authorisationCodeService);
+        clearInvocations(orchAuthCodeService);
+
         session.setCurrentCredentialStrength(null);
         when(USER_INFO.getBooleanClaim("new_account")).thenReturn(true);
         when(USER_INFO.getStringClaim(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue()))
@@ -353,6 +373,8 @@ class AuthenticationCallbackHandlerTest {
                         eq(pair("nonce", RP_NONCE.getValue())));
         assertOrchSessionUpdated();
         assertClientSessionUpdated();
+
+        assertAuthorisationCodeGeneratedAndSaved();
     }
 
     @Test
@@ -381,6 +403,8 @@ class AuthenticationCallbackHandlerTest {
 
         verifyNoInteractions(
                 tokenService, userInfoStorageService, cloudwatchMetricsService, logoutService);
+
+        assertNoAuthorisationCodeGeneratedAndSaved();
     }
 
     @Test
@@ -420,6 +444,8 @@ class AuthenticationCallbackHandlerTest {
                         TxmaAuditUser.user().withGovukSigninJourneyId(CLIENT_SESSION_ID));
 
         verifyNoInteractions(tokenService, userInfoStorageService, cloudwatchMetricsService);
+
+        assertNoAuthorisationCodeGeneratedAndSaved();
     }
 
     @Test
@@ -447,6 +473,8 @@ class AuthenticationCallbackHandlerTest {
 
         verifyNoInteractions(
                 tokenService, auditService, userInfoStorageService, cloudwatchMetricsService);
+
+        assertNoAuthorisationCodeGeneratedAndSaved();
     }
 
     @Test
@@ -486,6 +514,8 @@ class AuthenticationCallbackHandlerTest {
                         any());
 
         verifyNoInteractions(tokenService, userInfoStorageService, cloudwatchMetricsService);
+
+        assertNoAuthorisationCodeGeneratedAndSaved();
     }
 
     @Test
@@ -508,6 +538,8 @@ class AuthenticationCallbackHandlerTest {
                         OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED),
                 auditService);
         verifyNoInteractions(userInfoStorageService, cloudwatchMetricsService);
+
+        assertNoAuthorisationCodeGeneratedAndSaved();
     }
 
     @Test
@@ -534,6 +566,8 @@ class AuthenticationCallbackHandlerTest {
                         OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED),
                 auditService);
         verifyNoInteractions(userInfoStorageService, cloudwatchMetricsService);
+
+        assertNoAuthorisationCodeGeneratedAndSaved();
     }
 
     @Test
@@ -617,12 +651,6 @@ class AuthenticationCallbackHandlerTest {
         when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(mediumRequestOrchSession));
 
-        when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        eq(CLIENT_ID.getValue()),
-                        eq(CLIENT_SESSION_ID),
-                        eq(TEST_EMAIL_ADDRESS),
-                        any(Long.class)))
-                .thenReturn(AUTH_CODE_RP_TO_ORCH);
         usingValidClient();
 
         var event = new APIGatewayProxyRequestEvent();
@@ -732,6 +760,41 @@ class AuthenticationCallbackHandlerTest {
         assertCurrentCredentialSetCorrectly(correctCurrentCredentialStrengthSet);
     }
 
+    // TODO: ATO-1218: Following the handler changes, update this method to test
+    // shouldRedirectToFrontendErrorPageWhenCallToOrchAuthCodeServiceThrowsException.
+    @Test
+    void shouldCatchWhenCallToOrchAuthCodeServiceThrowsException()
+            throws UnsuccessfulCredentialResponseException {
+        usingValidSession();
+        usingValidClientSession();
+        usingValidClient();
+
+        var event = new APIGatewayProxyRequestEvent();
+        setValidHeadersAndQueryParameters(event);
+
+        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+
+        when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
+
+        when(orchAuthCodeService.generateAndSaveAuthorisationCode(
+                        any(AuthorizationCode.class),
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(TEST_EMAIL_ADDRESS),
+                        anyLong()))
+                .thenThrow(OrchAuthCodeException.class);
+
+        assertDoesNotThrow(() -> handler.handleRequest(event, CONTEXT));
+
+        verify(orchAuthCodeService, times(1))
+                .generateAndSaveAuthorisationCode(
+                        any(AuthorizationCode.class),
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(TEST_EMAIL_ADDRESS),
+                        anyLong());
+    }
+
     @Nested
     class AuthTime {
 
@@ -829,6 +892,8 @@ class AuthenticationCallbackHandlerTest {
                                         + "&state="
                                         + RP_STATE));
                 assertOrchSessionUpdated();
+
+                assertAuthorisationCodeGeneratedAndSaved();
             }
 
             @Test
@@ -848,6 +913,8 @@ class AuthenticationCallbackHandlerTest {
                                 event,
                                 CLIENT_ID.toString(),
                                 intervention);
+
+                assertNoAuthorisationCodeGeneratedAndSaved();
             }
 
             @Test
@@ -867,6 +934,8 @@ class AuthenticationCallbackHandlerTest {
                                 event,
                                 CLIENT_ID.toString(),
                                 intervention);
+
+                assertNoAuthorisationCodeGeneratedAndSaved();
             }
 
             @Test
@@ -886,6 +955,8 @@ class AuthenticationCallbackHandlerTest {
                                 event,
                                 CLIENT_ID.toString(),
                                 intervention);
+
+                assertNoAuthorisationCodeGeneratedAndSaved();
             }
 
             @Test
@@ -907,6 +978,8 @@ class AuthenticationCallbackHandlerTest {
                                         + AUTH_CODE_RP_TO_ORCH
                                         + "&state="
                                         + RP_STATE));
+
+                assertAuthorisationCodeGeneratedAndSaved();
             }
 
             @Test
@@ -926,6 +999,8 @@ class AuthenticationCallbackHandlerTest {
                                 event,
                                 CLIENT_ID.getValue(),
                                 intervention);
+
+                assertNoAuthorisationCodeGeneratedAndSaved();
             }
         }
 
@@ -965,6 +1040,8 @@ class AuthenticationCallbackHandlerTest {
                         .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
+
+                assertNoAuthorisationCodeGeneratedAndSaved();
             }
 
             @Test
@@ -989,6 +1066,8 @@ class AuthenticationCallbackHandlerTest {
                         .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
+
+                assertNoAuthorisationCodeGeneratedAndSaved();
             }
 
             @Test
@@ -1018,6 +1097,8 @@ class AuthenticationCallbackHandlerTest {
                         .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
+
+                assertNoAuthorisationCodeGeneratedAndSaved();
             }
 
             @Test
@@ -1040,6 +1121,8 @@ class AuthenticationCallbackHandlerTest {
                 verifyNoInteractions(initiateIPVAuthorisationService);
                 verify(sessionService)
                         .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
+
+                assertNoAuthorisationCodeGeneratedAndSaved();
             }
 
             @Test
@@ -1069,6 +1152,8 @@ class AuthenticationCallbackHandlerTest {
                         .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
+
+                assertNoAuthorisationCodeGeneratedAndSaved();
             }
 
             @Test
@@ -1089,6 +1174,8 @@ class AuthenticationCallbackHandlerTest {
                                 CLIENT_ID.toString(),
                                 intervention);
                 verifyNoInteractions(initiateIPVAuthorisationService);
+
+                assertNoAuthorisationCodeGeneratedAndSaved();
             }
         }
     }
@@ -1422,6 +1509,36 @@ class AuthenticationCallbackHandlerTest {
                 expectedUserInfoRequest.getHeaderMap(), userInfoRequest.getValue().getHeaderMap());
     }
 
+    private void assertAuthorisationCodeGeneratedAndSaved() {
+        verify(authorisationCodeService, times(1))
+                .generateAndSaveAuthorisationCode(
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(TEST_EMAIL_ADDRESS),
+                        anyLong());
+
+        verify(orchAuthCodeService, times(1))
+                .generateAndSaveAuthorisationCode(
+                        eq(AUTH_CODE_RP_TO_ORCH),
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(TEST_EMAIL_ADDRESS),
+                        anyLong());
+    }
+
+    private void assertNoAuthorisationCodeGeneratedAndSaved() {
+        verify(authorisationCodeService, times(0))
+                .generateAndSaveAuthorisationCode(anyString(), anyString(), anyString(), anyLong());
+
+        verify(orchAuthCodeService, times(0))
+                .generateAndSaveAuthorisationCode(
+                        any(AuthorizationCode.class),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyLong());
+    }
+
     private void assertSessionUpdatedAuthJourney() {
         var sessionSaveCaptor = ArgumentCaptor.forClass(Session.class);
         verify(sessionService, times(2))
@@ -1459,12 +1576,7 @@ class AuthenticationCallbackHandlerTest {
     private void clientSessionWithCredentialTrustValue(CredentialTrustLevel credentialTrustLevel) {
         ClientSession clientSessionWithCredentialTrustLevel =
                 createClientSession(credentialTrustLevel);
-        when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        eq(CLIENT_ID.getValue()),
-                        eq(CLIENT_SESSION_ID),
-                        eq(TEST_EMAIL_ADDRESS),
-                        any(Long.class)))
-                .thenReturn(AUTH_CODE_RP_TO_ORCH);
+
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(clientSessionWithCredentialTrustLevel));
         var orchClientSessionWithCredentialTrustLevel =


### PR DESCRIPTION
~~NOTE: This is dependent on #6221 being merged first.~~ - merged

### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Currently RP issued auth codes are stored in Redis. We are migrating away from Redis to DynamoDB. The auth code store is being migrated under the parent ticket.

A new entity and service has been previously added under #6220. Write policy was added to this lambda under #6190.

This work stores the auth code in DynamoDB for the Authentication Callback lambda using the new service. Note that we do not wish to remove the Redis setter call - this will be done under ATO-1218.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Added call to the `generateAndSaveAuthorisationCode` method on the orch auth code service
- Added test stubs for the new orch auth code service

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to Orch dev, ran through an auth only journey on sandpit. Observed a request being made to the `orchestration-redirect` endpoint (for this Auth Callback lambda). This returned 302 and continued on to the callback, redirecting successfully.

Reviewed the `dev-Orch-Auth-Code` DynamoDB table - the expected item and attribute values were found: auth code, exchange data, IsUsed=false, and a 5 minute TTL (expected value based on config).

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.
  - (Write policy (`OrchAuthCodeTableWriteAccessPolicy`) previously added to the `AuthenticationCallbackFunction` CloudFormation. Writing as expected - see manual testing section above.)

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or **not required**.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or **not required**.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or **not required**.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or **not required**.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or **not required**.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Entity and service - #6220
- Update to use the same auth code for both stores to enable consistency checks - #6221
- DynamoDB write policy additions to lambdas - #6190
