### PR TITLE
ATO-1435: Make vtr_list custom param consistent with vtr custom param

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -14,7 +14,7 @@ public record StartRequest(
                 CredentialTrustLevel currentCredentialStrength,
         @Expose @SerializedName("cookie_consent") String cookieConsent,
         @Expose @SerializedName("_ga") String ga,
-        @Expose @SerializedName("vtr_list") String vtrList,
+        @Expose @SerializedName("vtr") String vtr,
         @Expose @SerializedName("state") String state,
         @Expose @SerializedName("client_id") String clientId,
         @Expose @SerializedName("redirect_uri") String redirectUri,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -4,6 +4,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 
+import java.util.List;
+
 public record StartRequest(
         @Expose @SerializedName("previous-session-id") String previousSessionId,
         @Expose @SerializedName("rp-pairwise-id-for-reauth") String rpPairwiseIdForReauth,
@@ -14,7 +16,7 @@ public record StartRequest(
                 CredentialTrustLevel currentCredentialStrength,
         @Expose @SerializedName("cookie_consent") String cookieConsent,
         @Expose @SerializedName("_ga") String ga,
-        @Expose @SerializedName("vtr") String vtr,
+        @Expose @SerializedName("vtr") List<String> vtr,
         @Expose @SerializedName("state") String state,
         @Expose @SerializedName("client_id") String clientId,
         @Expose @SerializedName("redirect_uri") String redirectUri,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -367,6 +367,7 @@ public class StartHandler
 
     private static void logIfNewFieldsDoNotMatchClientSessionAuthParameters(
             StartRequest startRequest, ClientSession clientSession) {
+        LOG.info("Checking if new fields match client session auth parameters");
         if (!Objects.equals(
                 startRequest.cookieConsent(),
                 getAuthRequestParam(clientSession, "cookie_consent"))) {
@@ -381,10 +382,7 @@ public class StartHandler
                         .orElse(null);
         var startRequestVtrList =
                 Optional.ofNullable(startRequest.vtr())
-                        .map(vtrStringList -> List.of(vtrStringList.split(" ")))
-                        .map(
-                                vtrStringList ->
-                                        List.of(VectorOfTrust.parseVtrStringList(vtrStringList)))
+                        .map(vtr -> List.of(VectorOfTrust.parseVtrStringList(vtr)))
                         .orElse(null);
         if (!Objects.equals(startRequestVtrList, authRequestVtrList)) {
             LOG.warn("\"vtr\" field does match custom parameter in auth request params");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -380,14 +380,14 @@ public class StartHandler
                         .map(vtr -> List.of(VectorOfTrust.parseFromAuthRequestAttribute(vtr)))
                         .orElse(null);
         var startRequestVtrList =
-                Optional.ofNullable(startRequest.vtrList())
+                Optional.ofNullable(startRequest.vtr())
                         .map(vtrStringList -> List.of(vtrStringList.split(" ")))
                         .map(
                                 vtrStringList ->
                                         List.of(VectorOfTrust.parseVtrStringList(vtrStringList)))
                         .orElse(null);
         if (!Objects.equals(startRequestVtrList, authRequestVtrList)) {
-            LOG.warn("\"vtr_list\" field does match custom parameter in auth request params");
+            LOG.warn("\"vtr\" field does match custom parameter in auth request params");
         }
         if (!Objects.equals(startRequest.state(), getAuthRequestParam(clientSession, "state"))) {
             LOG.warn("\"state\" field does match custom parameter in auth request params");

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1704,7 +1704,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertResponseJarHasClaimsWithValues(
                 response,
                 Map.of(
-                        "vtr_list",
+                        "vtr",
                         "Cl.Cm Cl",
                         "_ga",
                         "12345",
@@ -1748,7 +1748,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertResponseJarHasClaimsWithValues(
                 response,
                 Map.of(
-                        "vtr_list",
+                        "vtr",
                         "Cl.Cm Cl",
                         "_ga",
                         "12345",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1705,7 +1705,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 response,
                 Map.of(
                         "vtr",
-                        "Cl.Cm Cl",
+                        List.of("Cl.Cm", "Cl"),
                         "_ga",
                         "12345",
                         "cookie_consent",
@@ -1749,7 +1749,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 response,
                 Map.of(
                         "vtr",
-                        "Cl.Cm Cl",
+                        List.of("Cl.Cm", "Cl"),
                         "_ga",
                         "12345",
                         "cookie_consent",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -69,7 +69,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     + "\"state\": \"%s\","
                     + "\"client_id\": \"%s\","
                     + "\"redirect_uri\": \"%s\","
-                    + "\"vtr_list\": \"%s\", "
+                    + "\"vtr\": \"%s\", "
                     + "\"scope\": \"%s\""
                     + "}";
 
@@ -372,7 +372,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                             "redirect_uri", REDIRECT_URI.toString(),
                                             "scope", scope.toString(),
                                             "client_id", CLIENT_ID,
-                                            "vtr_list", "Cl.Cm"))),
+                                            "vtr", "Cl.Cm"))),
                     standardHeadersWithSessionId(sessionId),
                     Map.of());
 
@@ -393,7 +393,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                             "redirect_uri", REDIRECT_URI.toString(),
                                             "scope", scope.toString(),
                                             "client_id", CLIENT_ID,
-                                            "vtr_list", jsonArrayOf("Cl.Cm")))),
+                                            "vtr", jsonArrayOf("Cl.Cm")))),
                     standardHeadersWithSessionId(sessionId),
                     Map.of());
 
@@ -431,7 +431,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 customAuthParams.get("state"),
                 customAuthParams.get("client_id"),
                 customAuthParams.get("redirect_uri"),
-                customAuthParams.get("vtr_list"),
+                customAuthParams.get("vtr"),
                 customAuthParams.get("scope"));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -69,7 +69,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     + "\"state\": \"%s\","
                     + "\"client_id\": \"%s\","
                     + "\"redirect_uri\": \"%s\","
-                    + "\"vtr\": \"%s\", "
+                    + "\"vtr\": %s, "
                     + "\"scope\": \"%s\""
                     + "}";
 
@@ -88,10 +88,10 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static Stream<Arguments> successfulRequests() {
         return Stream.of(
-                Arguments.of("Cl.Cm", false, false),
-                Arguments.of("Cl.Cm", false, true),
-                Arguments.of("Cl.Cm P0.Cl.Cm", false, false),
-                Arguments.of("P2.Cl.Cm", true, false));
+                Arguments.of(jsonArrayOf("Cl.Cm"), false, false),
+                Arguments.of(jsonArrayOf("Cl.Cm"), false, true),
+                Arguments.of(jsonArrayOf("Cl.Cm", "P0.Cl.Cm"), false, false),
+                Arguments.of(jsonArrayOf("P2.Cl.Cm"), true, false));
     }
 
     @ParameterizedTest
@@ -114,7 +114,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .customParameter("client_id", CLIENT_ID)
                         .customParameter("redirect_uri", REDIRECT_URI.toString())
                         .customParameter("state", state.getValue())
-                        .customParameter("vtr", jsonArrayOf(vtrStringList.split(" ")))
+                        .customParameter("vtr", vtrStringList)
                         .state(state);
         var authRequest = builder.build();
 
@@ -372,7 +372,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                             "redirect_uri", REDIRECT_URI.toString(),
                                             "scope", scope.toString(),
                                             "client_id", CLIENT_ID,
-                                            "vtr", "Cl.Cm"))),
+                                            "vtr", jsonArrayOf("Cl.Cm")))),
                     standardHeadersWithSessionId(sessionId),
                     Map.of());
 
@@ -405,7 +405,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     private String makeRequestBody(boolean isAuthenticated, AuthenticationRequest authRequest) {
-        return makeRequestBody(isAuthenticated, authRequest, "Cl.Cm");
+        return makeRequestBody(isAuthenticated, authRequest, jsonArrayOf("Cl.Cm"));
     }
 
     private String makeRequestBody(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -962,7 +962,7 @@ public class AuthorisationHandler
                         .claim(
                                 "current_credential_strength",
                                 orchSession.getCurrentCredentialStrength())
-                        .claim("vtr_list", String.join(" ", vtrStringList))
+                        .claim("vtr", String.join(" ", vtrStringList))
                         .claim("scope", authenticationRequest.getScope().toString());
 
         previousSessionId.ifPresent(id -> claimsBuilder.claim("previous_session_id", id));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -101,7 +101,6 @@ import static com.nimbusds.oauth2.sdk.OAuth2Error.VALIDATION_FAILED;
 import static java.util.Objects.isNull;
 import static uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService.VTR_PARAM;
 import static uk.gov.di.orchestration.shared.conditions.IdentityHelper.identityRequired;
-import static uk.gov.di.orchestration.shared.entity.VectorOfTrust.parseVtrStringListFromAuthRequestAttribute;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.orchestration.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -899,9 +898,10 @@ public class AuthorisationHandler
         var state = new State();
         orchestrationAuthorizationService.storeState(sessionId, clientSessionId, state);
 
-        List<String> vtrStringList =
-                parseVtrStringListFromAuthRequestAttribute(
-                        authenticationRequest.getCustomParameter(VTR_PARAM));
+        var vtrList =
+                Optional.ofNullable(authenticationRequest.getCustomParameter(VTR_PARAM))
+                        .map(VectorOfTrust::parseVtrStringListFromAuthRequestAttribute)
+                        .orElse(null);
         String reauthSub = null;
         String reauthSid = null;
         if (reauthRequested) {
@@ -910,7 +910,7 @@ public class AuthorisationHandler
                 reauthSub = reauthIdToken.getJWTClaimsSet().getSubject();
                 reauthSid = reauthIdToken.getJWTClaimsSet().getStringClaim("sid");
                 if (isNull(authenticationRequest.getCustomParameter(VTR_PARAM))) {
-                    vtrStringList = extractVoTStringListFromIdTokenHint(reauthIdToken);
+                    vtrList = extractVoTStringListFromIdTokenHint(reauthIdToken);
                 }
             } catch (RuntimeException e) {
                 return generateErrorResponse(
@@ -962,7 +962,7 @@ public class AuthorisationHandler
                         .claim(
                                 "current_credential_strength",
                                 orchSession.getCurrentCredentialStrength())
-                        .claim("vtr", String.join(" ", vtrStringList))
+                        .claim("vtr", vtrList)
                         .claim("scope", authenticationRequest.getScope().toString());
 
         previousSessionId.ifPresent(id -> claimsBuilder.claim("previous_session_id", id));


### PR DESCRIPTION
### Wider context of change

We recently added a vtr_list parameter, to be passed from orch to auth backend. The format of this parameter was a space separated string (e.g `"Cl.Cm P0.Cl.Cm"`). This decision was made because deserialisation of a list of strings was initially failing. We identified the cause of this failure, which was due to incorrectly serialising the list in orch.

We already use `vtr` as a custom parameter, which is in the format of a list of strings (e.g `["Cl.Cm", "P0.Cl.Cm"]`). It would be nice to keep consistent with the existing parameter, so as to not confuse us in the future. 

We have merged PRs for sending these fields from orch, and receiving these fields in auth backend, but we have not merged in the PR to pass the fields on in the auth frontend. This means that the fields are not doing anything at the moment. This is therefore a good opportunity to make this change, as once we merge the last PR in that passes the fields on, we will need to perform extra steps in order to rename/restructure the custom parameter.

### What’s changed

This PR renames the custom parameter we are sending to auth backend to match existing parameters that represent the same data. (We always use `vtr` as a parameter name elsewhere in the codebase, not `vtr_list`)

This also changes the format to match these existing parameters.

Since we are not using these fields yet, it is safe to rename them on the sending and receiving side.

We will also need to update the orch stub to reflect this change.

### Manual testing

Thoroughly tested passing all the new fields from orch to auth backend in sandpit. 
- The fields were all in sync, and the vtr parameter is passed as a list of vtr strings, like elsewhere in the codebase.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required - Done (see related PRs)
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs
- Updating orch stub: https://github.com/govuk-one-login/authentication-stubs/pull/300
- PR to pass from auth frontend to auth backend: https://github.com/govuk-one-login/authentication-frontend/pull/2680