### PR TITLE
ATO-1513: get PreservedAuthCountsForAudit from AuthSessionItem

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -159,9 +159,9 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                                         .getAuthSession()
                                         .getPreservedReauthCountsForAuditMap()));
 
-                if (userContext.getSession().getPreservedReauthCountsForAudit() != null) {
+                if (userContext.getAuthSession().getPreservedReauthCountsForAuditMap() != null) {
                     metadataBuilder.withAllIncorrectAttemptCounts(
-                            userContext.getSession().getPreservedReauthCountsForAudit());
+                            userContext.getAuthSession().getPreservedReauthCountsForAuditMap());
                 } else {
                     LOG.warn("No preserved reauth counts found for reauth journey");
                 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -276,6 +276,10 @@ class AuthenticationAuthCodeHandlerTest {
                     Map.ofEntries(
                             Map.entry(CountType.ENTER_PASSWORD, existingPasswordCount),
                             Map.entry(CountType.ENTER_EMAIL, existingEmailCount)));
+            authSession.setPreservedReauthCountsForAuditMap(
+                    Map.ofEntries(
+                            Map.entry(CountType.ENTER_PASSWORD, existingPasswordCount),
+                            Map.entry(CountType.ENTER_EMAIL, existingEmailCount)));
 
             var body =
                     format(
@@ -335,6 +339,7 @@ class AuthenticationAuthCodeHandlerTest {
                     .thenReturn(new Subject(CALCULATED_PAIRWISE_ID));
             // This is already the case but just to make it explicit here
             session.setPreservedReauthCountsForAudit(null);
+            authSession.setPreservedReauthCountsForAuditMap(null);
 
             var body =
                     format(


### PR DESCRIPTION
### Wider context of change

Part of the split session work. Migrating PreservedAuthCountsForAudit onto AuthSessionItem from shared Session.

### What’s changed

PreservedAuthCountsForAudit is now gotten from AuthSessionItem.

### Manual testing

Ran a reauth journey on dev env

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
