### PR TITLE
ATO-1564: cleanup verified mfa type getters

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -550,7 +550,7 @@ class VerifyCodeHandlerTest {
         var result = makeCallWithCode(CODE, MFA_SMS.toString(), journeyType);
 
         assertThat(result, hasStatus(204));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         verify(codeStorageService).deleteOtpCode(EMAIL, MFA_SMS);
         verify(accountModifiersService)
                 .removeAccountRecoveryBlockIfPresent(INTERNAL_COMMON_SUBJECT_ID);
@@ -601,7 +601,7 @@ class VerifyCodeHandlerTest {
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
 
         assertThat(result, hasStatus(204));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         verify(codeStorageService).deleteOtpCode(EMAIL, MFA_SMS);
         verify(accountModifiersService, never()).removeAccountRecoveryBlockIfPresent(anyString());
         verify(sessionService, times(2)).storeOrUpdateSession(session, SESSION_ID);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -249,7 +249,7 @@ class VerifyMfaCodeHandlerTest {
                                 AUTH_APP_SECRET));
 
         assertThat(result, hasStatus(204));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         assertThat(
@@ -335,7 +335,7 @@ class VerifyMfaCodeHandlerTest {
                                 AUTH_APP_SECRET));
 
         assertThat(result, hasStatus(204));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         assertThat(
@@ -381,7 +381,7 @@ class VerifyMfaCodeHandlerTest {
                                 CommonTestVariables.UK_MOBILE_NUMBER));
 
         assertThat(result, hasStatus(204));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         assertThat(
@@ -427,7 +427,7 @@ class VerifyMfaCodeHandlerTest {
                                 AUTH_APP_SECRET));
 
         assertThat(result, hasStatus(204));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         assertThat(
@@ -479,7 +479,7 @@ class VerifyMfaCodeHandlerTest {
                                 CommonTestVariables.UK_MOBILE_NUMBER));
 
         assertThat(result, hasStatus(204));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         assertThat(
@@ -528,7 +528,7 @@ class VerifyMfaCodeHandlerTest {
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(204));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
@@ -565,7 +565,7 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1002));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
         verifyNoInteractions(auditService);
         verifyNoInteractions(authAppCodeProcessor);
         verifyNoInteractions(codeStorageService);
@@ -588,7 +588,7 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1002));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
         verifyNoInteractions(auditService);
         verifyNoInteractions(authAppCodeProcessor);
         verifyNoInteractions(codeStorageService);
@@ -623,7 +623,7 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1042));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
         if (journeyType != REAUTHENTICATION) {
             verify(codeStorageService)
                     .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, 900L);
@@ -664,7 +664,7 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1042));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
@@ -703,7 +703,7 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1043));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
@@ -742,7 +742,7 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1034));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
         long blockTime = 900L;
         if (List.of(CodeRequestType.SMS_REGISTRATION, CodeRequestType.SMS_ACCOUNT_RECOVERY)
                 .contains(codeRequestType)) {
@@ -780,7 +780,7 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1034));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService, never()).saveBlockedForEmail(EMAIL, codeBlockedPrefix, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
         verifyNoInteractions(cloudwatchMetricsService);
@@ -815,7 +815,7 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1037));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
+        assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -104,7 +104,6 @@ class StartServiceTest {
     void shouldOverwriteSessionWithNewSessionUsingExistingSessionAndClientSessionIds() {
         var currentClientSessionId = "some-client-session-id";
         SESSION.addClientSession("previous-session-client-session-id");
-        SESSION.setVerifiedMfaMethodType(MFAMethodType.AUTH_APP);
         SESSION.setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
 
         var session =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -112,7 +112,6 @@ class StartServiceTest {
                         SESSION_ID, currentClientSessionId);
 
         assertThat(session.getCurrentCredentialStrength(), equalTo(null));
-        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         assertTrue(session.getClientSessions().contains("some-client-session-id"));
         assertFalse(session.getClientSessions().contains("previous-session-client-session-id"));
         verify(sessionService).storeOrUpdateSession(session, SESSION_ID);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -60,13 +60,6 @@ public class RedisExtension
         return sessionId;
     }
 
-    public void setVerifiedMfaMethodType(String sessionId, MFAMethodType mfaMethodType)
-            throws Json.JsonException {
-        var session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.setVerifiedMfaMethodType(mfaMethodType);
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
-    }
-
     public String createSession() throws Json.JsonException {
         return createSession(IdGenerator.generate());
     }


### PR DESCRIPTION
### Wider context of change: 

We've migrated the getters to the auth session for this value a while ago. This removes any getters in test code and replaces them with the auth session

### What’s changed:

- Removes usages of the getter for the verifiedMfaType from the shared session 

### Manual testing:
- N/A Just test code

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
