### PR TITLE
ATO-1436: Add new properties onto AuthSessionItem

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -49,6 +49,8 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
+import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.retrieveCredentialTrustLevel;
+import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.retrieveLevelOfConfidence;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
@@ -179,6 +181,13 @@ public class StartHandler
                             Optional.ofNullable(startRequest.previousSessionId()),
                             sessionId,
                             startRequest.currentCredentialStrength());
+            authSession.setRequestedCredentialStrength(
+                    retrieveCredentialTrustLevel(startRequest.requestedCredentialStrength()));
+            if (startRequest.requestedLevelOfConfidence() != null) {
+                authSession.setRequestedLevelOfConfidence(
+                        retrieveLevelOfConfidence(startRequest.requestedLevelOfConfidence()));
+            }
+            authSession.setClientId(startRequest.clientId());
 
             isUserAuthenticatedWithValidProfile =
                     startRequest.authenticated() && !startService.isUserProfileEmpty(authSession);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -31,6 +31,7 @@ import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
 import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
+import uk.gov.di.orchestration.shared.services.SerializationService;
 
 import java.net.URI;
 import java.security.KeyPair;
@@ -126,10 +127,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         registerWebClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR());
         var requestedVtr = VectorOfTrust.parseFromAuthRequestAttribute(List.of(vtrStringList));
-        var levelOfConfidence =
-                requestedVtr.containsLevelOfConfidence()
-                        ? requestedVtr.getLevelOfConfidence()
-                        : LevelOfConfidence.NONE;
+        var levelOfConfidenceOpt = Optional.ofNullable(requestedVtr.getLevelOfConfidence());
         var credentialTrustLevel = requestedVtr.getCredentialTrustLevel();
         var response =
                 makeRequest(
@@ -137,7 +135,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 makeRequestBody(
                                         isAuthenticated,
                                         authRequest,
-                                        levelOfConfidence.getValue(),
+                                        levelOfConfidenceOpt,
                                         credentialTrustLevel.getValue())),
                         standardHeadersWithSessionId(sessionId),
                         Map.of());
@@ -179,6 +177,13 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(authSessionExtension.getSession(sessionId).isPresent(), equalTo(true));
         assertTxmaAuditEventsSubmittedWithMatchingNames(
                 txmaAuditQueue, List.of(AUTH_START_INFO_FOUND));
+        var actualAuthSession = authSessionExtension.getSession(sessionId).orElseThrow();
+        assertThat(
+                actualAuthSession.getRequestedCredentialStrength(), equalTo(credentialTrustLevel));
+        assertThat(
+                actualAuthSession.getRequestedLevelOfConfidence(),
+                equalTo(levelOfConfidenceOpt.orElse(null)));
+        assertThat(actualAuthSession.getClientId(), equalTo(CLIENT_ID));
     }
 
     @Test
@@ -209,7 +214,12 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         var response =
                 makeRequest(
-                        Optional.of(makeRequestBody(true, authRequest, "P1", "Cl.Cm")),
+                        Optional.of(
+                                makeRequestBody(
+                                        true,
+                                        authRequest,
+                                        Optional.of(LevelOfConfidence.LOW_LEVEL),
+                                        "Cl.Cm")),
                         headers,
                         Map.of());
         assertThat(response, hasStatus(200));
@@ -451,27 +461,49 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     private String makeRequestBody(boolean isAuthenticated, AuthenticationRequest authRequest) {
-        return makeRequestBody(isAuthenticated, authRequest, "P0", "Cl.Cm");
+        return makeRequestBody(isAuthenticated, authRequest, Optional.empty(), "Cl.Cm");
     }
 
     private String makeRequestBody(
             boolean isAuthenticated,
             AuthenticationRequest authRequest,
-            String levelOfConfidence,
+            Optional<LevelOfConfidence> levelOfConfidenceOpt,
             String credentialStrength) {
-        return String.format(
-                REQUEST_BODY,
-                isAuthenticated,
-                authRequest.getState().getValue(),
-                Optional.ofNullable(authRequest.getCustomParameter("client_id"))
-                        .map(l -> l.get(0))
-                        .orElse(null),
-                Optional.ofNullable(authRequest.getCustomParameter("redirect_uri"))
-                        .map(l -> l.get(0))
-                        .orElse(null),
-                levelOfConfidence,
-                credentialStrength,
-                authRequest.getScope().toString());
+        return makeRequestBody(
+                isAuthenticated, authRequest, levelOfConfidenceOpt, credentialStrength, Map.of());
+    }
+
+    private String makeRequestBody(
+            boolean isAuthenticated,
+            AuthenticationRequest authRequest,
+            Optional<LevelOfConfidence> levelOfConfidenceOpt,
+            String credentialStrength,
+            Map<String, Object> paramOverrides) {
+        Map<String, Object> requestBodyMap =
+                new HashMap<>(
+                        Map.of(
+                                "previous-session-id",
+                                "4waJ14KA9IyxKzY7bIGIA3hUDos",
+                                "authenticated",
+                                isAuthenticated,
+                                "state",
+                                authRequest.getState().getValue(),
+                                "requested_credential_strength",
+                                credentialStrength,
+                                "scope",
+                                authRequest.getScope().toString()));
+        Optional.ofNullable(authRequest.getCustomParameter("client_id"))
+                .map(l -> l.get(0))
+                .ifPresent(clientId -> requestBodyMap.put("client_id", clientId));
+        Optional.ofNullable(authRequest.getCustomParameter("redirect_uri"))
+                .map(l -> l.get(0))
+                .ifPresent(redirectUri -> requestBodyMap.put("redirect_uri", redirectUri));
+        levelOfConfidenceOpt.ifPresent(
+                levelOfConfidence ->
+                        requestBodyMap.put(
+                                "requested_level_of_confidence", levelOfConfidence.getValue()));
+        requestBodyMap.putAll(paramOverrides);
+        return SerializationService.getInstance().writeValueAsString(requestBodyMap);
     }
 
     private String makeRequestBody(boolean isAuthenticated, Map<String, Object> customAuthParams) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 
 import java.util.HashMap;
@@ -83,10 +84,20 @@ class AuthSessionServiceIntegrationTest {
         var session = withStoredSession(SESSION_ID);
 
         session.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
+        session.setRequestedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
+        session.setRequestedLevelOfConfidence(LevelOfConfidence.MEDIUM_LEVEL);
+        session.setClientId("test-client-id");
         authSessionExtension.updateSession(session);
         var updatedSession = authSessionExtension.getSession(SESSION_ID).get();
         assertThat(
                 updatedSession.getIsNewAccount(), equalTo(AuthSessionItem.AccountState.EXISTING));
+        assertThat(
+                updatedSession.getRequestedCredentialStrength(),
+                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(
+                updatedSession.getRequestedLevelOfConfidence(),
+                equalTo(LevelOfConfidence.MEDIUM_LEVEL));
+        assertThat(updatedSession.getClientId(), equalTo("test-client-id"));
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -34,6 +34,11 @@ public class AuthSessionItem {
             "PreservedReauthCountsForAuditMap";
     public static final String ATTRIBUTE_ACHIEVED_CREDENTIAL_STRENGTH =
             "AchievedCredentialStrength";
+    public static final String ATTRIBUTE_REQUESTED_CREDENTIAL_STRENGTH =
+            "RequestedCredentialStrength";
+    public static final String ATTRIBUTE_REQUESTED_LEVEL_OF_CONFIDENCE =
+            "RequestedLevelOfConfidence";
+    public static final String ATTRIBUTE_CLIENT_ID = "ClientId";
 
     public enum AccountState {
         NEW,
@@ -68,6 +73,9 @@ public class AuthSessionItem {
     private int passwordResetCount;
     private Map<CountType, Integer> preservedReauthCountsForAuditMap;
     private CredentialTrustLevel achievedCredentialStrength;
+    private CredentialTrustLevel requestedCredentialStrength;
+    private LevelOfConfidence requestedLevelOfConfidence;
+    private String clientId;
 
     public AuthSessionItem() {
         this.codeRequestCountMap = new HashMap<>();
@@ -321,6 +329,50 @@ public class AuthSessionItem {
 
     public AuthSessionItem withAchievedCredentialStrength(CredentialTrustLevel credentialStrength) {
         this.achievedCredentialStrength = credentialStrength;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_REQUESTED_CREDENTIAL_STRENGTH)
+    public CredentialTrustLevel getRequestedCredentialStrength() {
+        return requestedCredentialStrength;
+    }
+
+    public void setRequestedCredentialStrength(CredentialTrustLevel requestedCredentialStrength) {
+        this.requestedCredentialStrength = requestedCredentialStrength;
+    }
+
+    public AuthSessionItem withRequestedCredentialStrength(
+            CredentialTrustLevel requestedCredentialStrength) {
+        this.requestedCredentialStrength = requestedCredentialStrength;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_REQUESTED_LEVEL_OF_CONFIDENCE)
+    public LevelOfConfidence getRequestedLevelOfConfidence() {
+        return requestedLevelOfConfidence;
+    }
+
+    public void setRequestedLevelOfConfidence(LevelOfConfidence requestedLevelOfConfidence) {
+        this.requestedLevelOfConfidence = requestedLevelOfConfidence;
+    }
+
+    public AuthSessionItem withRequestedLevelOfConfidence(
+            LevelOfConfidence requestedLevelOfConfidence) {
+        this.requestedLevelOfConfidence = requestedLevelOfConfidence;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_CLIENT_ID)
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public AuthSessionItem withClientId(String clientId) {
+        this.clientId = clientId;
         return this;
     }
 


### PR DESCRIPTION
### Wider context of change

We should now have fields available in the auth backend we can use to replace usages of the clientSession.getAuthParams() method. Some of these usages are outside of the StartHandler however, so we need to add these to the auth session so we can keep track of them.

### What’s changed

This PR adds 3 new fields to the AuthSessionItem: `requestedCredentialStrength`, `requestedLevelOfConfidence` and `clientId`. These fields are also set in the StartHandler.

### Manual testing

Added tests coverage for new fields being set.

Deployed to sandpit, verified that new fields were set on AuthSessionItem in dynamo

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. n/a
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a
