### PR TITLE
ATO-1116: add more logs to verify what subjectId by clientId

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
@@ -60,7 +60,21 @@ public class BackChannelLogoutService {
                 getSubject(user.get(), clientRegistry, authenticationService, internalSectorUri)
                         .getValue();
 
-        LOGGER.info("are subjects the same: {}", Objects.equals(subjectId, rpPairwiseId));
+        if (Objects.equals(subjectId, rpPairwiseId)) {
+            LOGGER.info(
+                    "calculated and given rpPairwiseId are the same, client-id = {}",
+                    clientRegistry.getClientID());
+        } else {
+            if (Objects.equals(subjectId, user.get().getPublicSubjectID())) {
+                LOGGER.info(
+                        "subjectId is publicSubjectId, client-id = {}",
+                        clientRegistry.getClientID());
+            } else {
+                LOGGER.info(
+                        "calculated and given rpPairwiseId are different, client-id = {}",
+                        clientRegistry.getClientID());
+            }
+        }
 
         var message =
                 new BackChannelLogoutMessage(


### PR DESCRIPTION
### Wider context of change
Part of email migration

### What’s changed
rpPairwiseId is out of sync, but the logs don't make it clear when. I'm almost certain now it's just for one clientId, but the attached client-id is misleading. If I trigger the logout from one client-id, that client-id remains attached to the logs even as I backchannel logout of another RP. 

### Manual testing
n/a

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.
