### PR TITLE
BAU: Keep a copy of the notify templates

### DIFF
--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-added-backup-method.email.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-added-backup-method.email.notify
@@ -1,0 +1,29 @@
+Template Name:
+
+di-account-management-en-cy-added-backup-method
+
+Subject:
+
+You’ve added a back-up method for getting security codes | Rydych wedi ychwanegu dull wrth gefn ar gyfer cael codau diogelwch
+
+Message:
+
+You’ve added a back-up method for getting security codes to sign in to your GOV.UK One Login.
+
+If you did not do this, contact us: https://home.account.gov.uk/contact-gov-uk-one-login?referer=addedBackupEmail
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Rydych wedi ychwanegu dull wrth gefn ar gyfer cael codau diogelwch
+
+Rydych wedi ychwanegu dull wrth gefn ar gyfer cael codau diogelwch i fewngofnodi i'ch GOV.UK One Login.
+
+Os na wnaethoch hyn, cysylltwch â ni: https://home.account.gov.uk/contact-gov-uk-one-login?referer=addedBackupEmail&lng=cy
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-changed-authenticator-app.email.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-changed-authenticator-app.email.notify
@@ -1,0 +1,30 @@
+Template Name:
+
+di-account-management-en-cy-changed-authenticator-app
+
+Subject:
+
+You’ve changed the authenticator app you use to sign in | Rydych wedi newid yr ap dilysydd rydych yn ei ddefnyddio i fewngofnodi
+
+Message:
+
+You’ve changed the authenticator app you use to sign in to your GOV.UK One Login.
+
+If you did not do this, contact us: https://home.account.gov.uk/contact-gov-uk-one-login?referer=changedAuthAppEmail
+
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Rydych wedi newid yr ap dilysydd rydych yn ei ddefnyddio i fewngofnodi
+
+Rydych wedi newid yr ap dilysydd rydych yn ei ddefnyddio i fewngofnodi i'ch GOV.UK One Login.
+
+Os na wnaethoch hyn, cysylltwch â ni: https://home.account.gov.uk/contact-gov-uk-one-login?referer=changedAuthAppEmail&lng=cy
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-changed-default-mfa.email.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-changed-default-mfa.email.notify
@@ -1,0 +1,29 @@
+Template Name:
+
+di-account-management-en-cy-changed-default-mfa
+
+Subject:
+
+You’ve changed your default method for getting security codes | Rydych wedi newid eich dull diofyn ar gyfer cael codau diogelwch
+
+Message:
+
+You’ve changed your default method for getting security codes to sign in to your GOV.UK One Login.
+
+If you did not do this, contact us: https://home.account.gov.uk/contact-gov-uk-one-login?referer=changedDefaultEmail
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Rydych wedi newid eich dull diofyn ar gyfer cael codau diogelwch
+
+Rydych wedi newid eich dull diofyn ar gyfer cael codau diogelwch i fewngofnodi i'ch GOV.UK One Login.
+
+Os na wnaethoch hyn, cysylltwch â ni: https://home.account.gov.uk/contact-gov-uk-one-login?referer=changedDefaultEmail&lng=cy
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-changed-email.email.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-changed-email.email.notify
@@ -1,0 +1,29 @@
+Template Name:
+
+di-account-management-en-cy-changed-email
+
+Subject:
+
+The email address for your GOV.UK One Login has been changed | Mae'r cyfeiriad e-bost ar gyfer eich GOV.UK One Login wedi ei newid
+
+Message:
+
+The email address for your GOV.UK One Login has been changed.
+
+If you did not change your email address, contact us: ((contact-us-link)).
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Mae'r cyfeiriad e-bost ar gyfer eich GOV.UK One Login wedi ei newid
+
+Mae'r cyfeiriad e-bost ar gyfer eich GOV.UK One Login wedi ei newid.
+
+Os na wnaethoch newid eich cyfeiriad e-bost, cysylltwch â ni: ((contact-us-link))
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-changed-password.email.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-changed-password.email.notify
@@ -1,0 +1,27 @@
+Template name:
+
+di-account-management-en-cy-changed-password
+
+Subject:
+
+The password for your GOV.UK One Login has been changed | Mae'r cyfrinair ar gyfer eich GOV.UK One Login wedi ei newid
+
+Message:
+
+The password for your GOV.UK One Login has been changed
+
+If you did not change your password, contact us: ((contact-us-link)).
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Mae'r cyfrinair ar gyfer eich GOV.UK One Login wedi ei newid
+
+Os na wnaethoch newid eich cyfrinair, cysylltwch â ni: ((contact-us-link))
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-changed-phone-number.email.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-changed-phone-number.email.notify
@@ -1,0 +1,34 @@
+Template Name:
+
+di-account-management-en-cy-changed-phone-number
+
+Subject:
+
+You’ve changed the phone number for your GOV.UK One Login | Rydych chi wedi newid y rhif ffôn ar gyfer eich GOV.UK One Login
+
+Message:
+
+You’ve changed the phone number for your GOV.UK One Login.
+
+We’ll use this number to send you security codes when you sign in to your GOV.UK One Login.
+
+If you did not do this, contact us: ((contact-us-link))
+
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Rydych chi wedi newid y rhif ffôn ar gyfer eich GOV.UK One Login
+
+Rydych chi wedi newid y rhif ffôn ar gyfer eich GOV.UK One Login.
+
+Byddwn yn defnyddio'r rhif hwn i anfon codau diogelwch atoch pan fyddwch yn mewngofnodi i'ch GOV.UK One Login.
+
+Os nad ydych wedi gwneud hyn, cysylltwch â ni: ((contact-us-link))
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-confirm-your-email.email.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-confirm-your-email.email.notify
@@ -1,0 +1,37 @@
+Template Name:
+
+di-account-management-en-cy-confirm-your-email
+
+Subject:
+
+Your security code for your GOV.UK One Login | Eich cod diogelwch ar gyfer eich GOV.UK One Login
+
+Message:
+
+Use this security code to confirm you want to change the email address for your GOV.UK One Login.
+
+^((validation-code))
+
+The code will expire after 15 minutes.
+
+If you did not ask to change the email address for your GOV.UK One Login, or you need help using the code, contact us: ((contact-us-link))
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Eich cod diogelwch ar gyfer eich GOV.UK One Login
+
+Defnyddiwch y cod diogelwch hwn i gadarnhau yr ydych eisiau newid y cyfeiriad e-bost am eich GOV.UK One Login.
+
+^((validation-code))
+
+Bydd y cod yn dod i ben ar ôl 15 munud.
+
+Os na wnaethoch ofyn i newid y cyfeiriad e-bost ar gyfer eich GOV.UK One Login, neu rydych angen help i ddefnyddio'r cod, cysylltwch â ni: ((contact-us-link))
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-confirm-your-phone-number.sms.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-confirm-your-phone-number.sms.notify
@@ -1,0 +1,13 @@
+Template Name:
+
+di-account-management-en-cy-confirm-your-phone-number
+
+Message:
+
+((validation-code)) is your GOV.UK One Login security code.
+
+It expires in 15 minutes.
+
+((validation-code)) yw eich cod diogelwch GOV.UK One Login.
+
+Mae'n dod i ben mewn 15 munud.

--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-delete-account.email.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-delete-account.email.notify
@@ -1,0 +1,41 @@
+Template name:
+
+di-account-management-en-cy-delete-account
+
+Subject:
+
+You’ve deleted your GOV.UK One Login | Rydych wedi dileu eich GOV.UK One Login
+
+Message:
+
+You’ve permanently deleted your GOV.UK One Login.
+
+If you had GOV.UK email subscriptions, these have also been deleted.
+
+This has not deleted the personal information held by services you’ve used with your GOV.UK One Login.
+
+If you need a GOV.UK One Login in the future, you’ll have to create a new one.
+
+If you have any feedback or you did not want to delete your GOV.UK One Login, contact us: ((contact-us-link))
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Rydych wedi dileu eich GOV.UK One Login yn barhaol.
+
+Rydych wedi dileu eich GOV.UK One Login yn barhaol.
+
+Os oedd gennych danysgrifiadau e-bost GOV.UK, mae'r rhain hefyd wedi'u dileu.
+
+Nid yw hyn wedi dileu'r wybodaeth bersonol a gedwir gan wasanaethau rydych wedi'u defnyddio gyda'ch GOV.UK One Login.
+
+Os byddwch angen GOV.UK One Login yn y dyfodol, bydd yn rhaid i chi greu un newydd.
+
+Os oes gennych unrhyw adborth neu nad oeddech am ddileu eich GOV.UK One Login, cysylltwch â ni: ((contact-us-link))
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-removed-backup-method.email.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-removed-backup-method.email.notify
@@ -1,0 +1,30 @@
+Template name:
+
+di-account-management-en-cy-removed-backup-method
+
+Subject:
+
+You’ve removed your back-up method for getting security codes | Rydych wedi dileu eich dull wrth gefn ar gyfer cael codau diogelwch
+
+Message:
+
+You’ve removed your back-up method for getting security codes to sign in to your GOV.UK One Login.
+
+If you did not do this, contact us: https://home.account.gov.uk/contact-gov-uk-one-login?referer=removedBackupEmail
+
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Rydych wedi dileu eich dull wrth gefn ar gyfer cael codau diogelwch
+
+Rydych wedi dileu eich dull wrth gefn ar gyfer cael codau diogelwch i fewngofnodi i'ch GOV.UK One Login.
+
+Os na wnaethoch hyn, cysylltwch â ni: https://home.account.gov.uk/contact-gov-uk-one-login?referer=removedBackupEmail&lng=cy
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-report-confirmation.email.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-report-confirmation.email.notify
@@ -1,0 +1,87 @@
+Template name:
+
+di-account-management-en-cy-report-confirmation
+
+Subject:
+
+You’ve reported activity in your GOV.UK One Login | Rydych chi wedi adrodd am weithgaredd yn eich GOV.UK One Login
+
+Message:
+
+You’ve reported activity you do not recognise in your GOV.UK One Login.
+
+Your report number is ((ticketId)).
+
+# The activity you reported
+
+
+You visited:
+
+^ ## ((clientNameEn))
+((showHomeHintText??^This includes ‘Security’ and ‘Your services’))
+((showHomeHintText??^))
+^ ((dateEn)) (UK time)
+
+# Change your password
+
+If you have not done this already, change your password at: https://home.account.gov.uk/security
+
+Changing your password is the best way to keep your GOV.UK One Login secure.
+
+We recommend that you:
+
+* create a secure and memorable password, for example by using 3 random words
+* use a different password to the one you use to sign in to your email
+
+# What happens next
+
+The GOV.UK One Login team will investigate your report.
+
+We’ll only email you again if you need to do something to help protect your GOV.UK One Login.
+
+We’ll always include your report number when we email you.
+
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+
+Rydych chi wedi adrodd am weithgaredd nad ydych yn ei adnabod yn eich GOV.UK One Login.
+
+Rhif eich adroddiad yw ((ticketId)).
+
+# Y gweithgaredd rydych wedi adrodd amdano
+
+Rydych wedi ymweld â:
+
+^ ## ((clientNameCy))
+((showHomeHintText??^Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'))
+((showHomeHintText??^))
+^ ((dateCy)) (Amser y DU)
+
+# Newid eich cyfrinair
+
+Os nad ydych wedi gwneud hyn yn barod, newidiwch eich cyfrinair yn: https://home.account.gov.uk/security
+
+Newid eich cyfrinair yw'r ffordd orau i gadw'ch GOV.UK One Login yn ddiogel.
+
+Rydym yn argymell eich bod yn:
+
+* creu cyfrinair diogel a chofiadwy, er enghraifft trwy ddefnyddio 3 gair ar hap
+* defnyddio cyfrinair gwahanol i'r un a ddefnyddiwch i fewngofnodi i'ch e-bost
+
+# Beth sy'n digwydd nesaf
+
+Bydd y tîm GOV.UK One Login yn ymchwilio i'ch adroddiad.
+
+Byddwn ond yn anfon e-bost atoch eto os oes angen i chi wneud rhywbeth i helpu i amddiffyn eich GOV.UK One Login.
+
+Byddwn bob amser yn cynnwys eich rhif adroddiad pan fyddwn yn anfon e-bost atoch.
+
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn – mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/account-management/en+cy/di-account-management-en-cy-switched-mfa-methods.email.notify
+++ b/notifications/templates/account-management/en+cy/di-account-management-en-cy-switched-mfa-methods.email.notify
@@ -1,0 +1,30 @@
+Template name:
+
+di-account-management-en-cy-switched-mfa-methods
+
+Subject:
+
+You’ve switched your back-up and default methods for getting security codes | Rydych wedi newid eich dulliau wrth gefn a diofyn ar gyfer cael codau diogelwch
+
+Message:
+
+You’ve switched your back-up and default methods for getting security codes to sign in to your GOV.UK One Login.
+
+If you did not do this, contact us: https://home.account.gov.uk/contact-gov-uk-one-login?referer=switchedMethodsEmail
+
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Rydych wedi newid eich dulliau wrth gefn a diofyn ar gyfer cael codau diogelwch
+
+Rydych wedi newid eich dulliau wrth gefn a diofyn ar gyfer cael codau diogelwch i fewngofnodi i'ch GOV.UK One Login.
+
+Os na wnaethoch hyn, cysylltwch â ni: https://home.account.gov.uk/contact-gov-uk-one-login?referer=switchedMethodsEmail&lng=cy
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/frontend/en+cy/di-authentication-en-cy-account-created-confirmation.email.notify
+++ b/notifications/templates/frontend/en+cy/di-authentication-en-cy-account-created-confirmation.email.notify
@@ -1,0 +1,59 @@
+Template name:
+
+di-authentication-en-cy-account-created-confirmation
+
+Subject:
+
+Your GOV.UK One Login | Eich GOV.UK One Login
+
+Message:
+
+You’ve created your GOV.UK One Login.
+
+Sign in to your GOV.UK One Login to:
+
+* manage your sign in details
+* see and access the services you've used with it
+
+Sign in: ((gov-uk-accounts-url))
+
+GOV.UK One Login is new. At the moment you can only use it to access some government services.
+
+It does not work with all government accounts and services yet (for example Universal Credit).
+
+Over time, GOV.UK One Login will replace all other ways to sign in to services on GOV.UK, including Government Gateway.
+
+Read more about using your GOV.UK One Login: https://www.gov.uk/using-your-gov-uk-one-login
+
+If you have questions, problems or suggestions for how we could make your GOV.UK One Login better, you can contact us: ((contact-us-link))
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Eich GOV.UK One Login
+
+Rydych wedi creu eich GOV.UK One Login.
+
+Mewngofnodwch i'ch GOV.UK One Login i:
+
+* reoli eich manylion mewngofnodi
+* gweld a chael mynediad at y gwasanaethau rydych chi wedi'u defnyddio gydag ef
+
+Mewngofnodi: ((gov-uk-accounts-url))
+
+Mae GOV.UK One Login yn newydd. Ar hyn o bryd gallwch ond ei ddefnyddio i gael mynediad i rai gwasanaethau’r llywodraeth.
+
+Nid yw'n gweithio gyda holl gyfrifon a gwasanaethau'r llywodraeth eto (er enghraifft Credyd Cynhwysol).
+
+Dros amser, bydd GOV.UK One Login yn disodli'r holl ffyrdd eraill o fewngofnodi i wasanaethau ar GOV.UK, gan gynnwys Porth y Llywodraeth.
+
+Darllenwch fwy am ddefnyddio eich GOV.UK One Login: https://www.gov.uk/defnyddio-eich-gov-uk-one-login
+
+Os oes gennych gwestiynau, problemau neu awgrymiadau am sut y gallem wneud eich GOV.UK One Login yn well, gallwch gysylltu â ni: ((contact-us-link))
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/frontend/en+cy/di-authentication-en-cy-change-how-get-security-codes-confirmation.email.notify
+++ b/notifications/templates/frontend/en+cy/di-authentication-en-cy-change-how-get-security-codes-confirmation.email.notify
@@ -1,0 +1,29 @@
+Template name:
+
+di-authentication-en-cy-change-how-get-security-codes-confirmation
+
+Subject:
+
+You've changed how you get security codes | Rydych wedi newid sut rydych yn cael codau diogelwch
+
+Message:
+
+You've changed how you get security codes when you sign in to GOV.UK One Login.
+
+If you did not do this, contact us: ((contact-us-link))
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Rydych wedi newid sut rydych yn cael codau diogelwch
+
+Rydych wedi newid sut rydych yn cael codau diogelwch pan rydych yn mewngofnodi i GOV.UK One Login.
+
+Os na wnaethoch hyn, cysylltwch â ni: ((contact-us-link))
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/frontend/en+cy/di-authentication-en-cy-confirm-your-email.email.notify
+++ b/notifications/templates/frontend/en+cy/di-authentication-en-cy-confirm-your-email.email.notify
@@ -1,0 +1,33 @@
+Template name:
+
+di-authentication-en-cy-confirm-your-email
+
+Subject:
+
+Your security code for your GOV.UK One Login | Eich cod diogelwch ar gyfer eich GOV.UK One Login
+
+Message:
+
+Use this security code to confirm the email address for your GOV.UK One Login.
+
+^((validation-code))
+
+The code will expire after one hour.
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Eich cod diogelwch ar gyfer eich GOV.UK One Login
+
+Defnyddiwch y cod diogelwch hwn i gadarnhau eich cyfeiriad e-bost ar gyfer eich GOV.UK One Login.
+
+^((validation-code))
+
+Bydd y cod yn dod i ben ar ôl awr.
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/frontend/en+cy/di-authentication-en-cy-confirm-your-phone-number.sms.notify
+++ b/notifications/templates/frontend/en+cy/di-authentication-en-cy-confirm-your-phone-number.sms.notify
@@ -1,0 +1,13 @@
+Template name:
+
+di-authentication-en-cy-confirm-your-phone-number
+
+Message:
+
+((validation-code)) is your GOV.UK One Login security code.
+
+It expires in 15 minutes.
+
+((validation-code)) yw eich cod diogelwch GOV.UK One Login.
+
+Mae'n dod i ben mewn 15 munud.

--- a/notifications/templates/frontend/en+cy/di-authentication-en-cy-mfa-sms.sms.notify
+++ b/notifications/templates/frontend/en+cy/di-authentication-en-cy-mfa-sms.sms.notify
@@ -1,0 +1,13 @@
+Template name:
+
+di-authentication-en-cy-mfa-sms
+
+Message:
+
+((validation-code)) is your GOV.UK One Login security code.
+
+It expires in 15 minutes.
+
+((validation-code)) yw eich cod diogelwch GOV.UK One Login.
+
+Mae'n dod i ben mewn 15 munud.

--- a/notifications/templates/frontend/en+cy/di-authentication-en-cy-password-reset-confirmation.email.notify
+++ b/notifications/templates/frontend/en+cy/di-authentication-en-cy-password-reset-confirmation.email.notify
@@ -1,0 +1,27 @@
+Template name:
+
+di-authentication-en-cy-password-reset-confirmation
+
+Subject:
+
+The password for your GOV.UK One Login has been reset | Mae'r cyfrinair ar gyfer eich GOV.UK One Login wedi cael ei ail osod
+
+Message:
+
+The password for your GOV.UK One Login has been reset.
+
+If you did not do this, contact us: ((contact-us-link)).
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Mae'r cyfrinair ar gyfer eich GOV.UK One Login wedi cael ei ail osod
+
+Os nad chi sydd wedi gwneud hyn, cysylltwch â ni: ((contact-us-link)).
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb fonitro.

--- a/notifications/templates/frontend/en+cy/di-authentication-en-cy-reset-password-confirmation.sms.notify
+++ b/notifications/templates/frontend/en+cy/di-authentication-en-cy-reset-password-confirmation.sms.notify
@@ -1,0 +1,14 @@
+Template name:
+
+di-authentication-en-cy-reset-password-confirmation
+
+Message:
+
+The password for your GOV.UK One Login has been reset.
+
+If you did not do this, contact us ((contact-us-link))
+
+
+Mae'r cyfrinair ar gyfer eich GOV.​UK One Login wedi cael ei ail osod.
+
+Os nad chi sydd wedi gwneud hyn, cysylltwch â ni: ((contact-us-link))

--- a/notifications/templates/frontend/en+cy/di-authentication-en-cy-reset-password-with-code.email.notify
+++ b/notifications/templates/frontend/en+cy/di-authentication-en-cy-reset-password-with-code.email.notify
@@ -1,0 +1,30 @@
+Template name:
+
+di-authentication-en-cy-reset-password-with-code
+
+Subject:
+
+Your security code for your GOV.UK One Login | Eich cod diogelwch ar gyfer eich GOV.UK One Login
+
+Message:
+
+Your GOV.UK One Login security code is:
+
+^((validation-code))
+
+The code will expire after 15 minutes.
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+Eich cod diogelwch GOV.UK One Login yw:
+
+^((validation-code))
+
+Bydd y cod yn dod i ben ar ôl 15 munud.
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.

--- a/notifications/templates/frontend/en+cy/di-authentication-en-cy-verify-change-how-get-security-codes.email.notify
+++ b/notifications/templates/frontend/en+cy/di-authentication-en-cy-verify-change-how-get-security-codes.email.notify
@@ -1,0 +1,33 @@
+Template name:
+
+di-authentication-en-cy-verify-change-how-get-security-codes
+
+Subject:
+
+Your security code for your GOV.UK One Login | Eich cod diogelwch ar gyfer eich GOV.UK One Login
+
+Message:
+
+Use this security code to change how you get security codes when you sign in to your GOV.UK One Login.
+
+^((validation-code))
+
+The code will expire after 15 minutes.
+
+---
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.
+
+---
+
+# Eich cod diogelwch ar gyfer eich GOV.UK One Login
+
+Defnyddiwch y cod diogelwch hwn i newid sut rydych yn cael codau diogelwch pan fyddwch yn mewngofnodi i'ch GOV.UK One Login.
+
+^((validation-code))
+
+Bydd y cod yn dod i ben ar ôl 15 munud.
+
+---
+
+Peidiwch ag ymateb i’r e-bost hwn - mae’n neges awtomatig o gyfrif heb ei fonitro.


### PR DESCRIPTION
## What

Keep a copy of the notify templates

Maintains an offline backup of the templates.
The code that populates the templates is in this repo so you can trace the path of the templates variables in the code.

## How to review

1. Code Review

