### PR TITLE
ATO-1117: expand temporary logs for rpPairwiseId

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -358,9 +358,26 @@ public class IPVCallbackHandler
                     IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED, clientId, user);
 
             // TODO: ATO-1117: temporary logs to check values are as expected
-            LOG.info(
-                    "is rpPairwiseId the same on clientSession as calculated: {}",
-                    rpPairwiseSubject.getValue().equals(clientSession.getRpPairwiseId()));
+            if (Objects.equals(rpPairwiseSubject.getValue(), clientSession.getRpPairwiseId())) {
+                LOG.info(
+                        "calculated and given rpPairwiseId are the same, client-id = {}",
+                        clientRegistry.getClientID());
+            } else {
+                if (Objects.equals(
+                        rpPairwiseSubject.getValue(), userProfile.getPublicSubjectID())) {
+                    LOG.info(
+                            "subjectId is publicSubjectId, client-id = {}",
+                            clientRegistry.getClientID());
+                } else if (clientSession.getRpPairwiseId() == null) {
+                    LOG.info(
+                            "rpPairwiseId on client session is null, client-id = {}",
+                            clientRegistry.getClientID());
+                } else {
+                    LOG.info(
+                            "calculated and given rpPairwiseId are different, client-id = {}",
+                            clientRegistry.getClientID());
+                }
+            }
             if (orchSession.getInternalCommonSubjectId() != null
                     && !orchSession.getInternalCommonSubjectId().isBlank()) {
                 Optional<UserInfo> authUserInfo =


### PR DESCRIPTION
### Wider context of change
Email migration

### What’s changed
I think here, the only difference will be for the client which uses the PUBLIC subject type, but I just want to confirm this.

### Manual testing
n/.a

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.