### PR TITLE
ATO-1189: set orch AuthCode in IPV Callback lambda

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -46,6 +46,7 @@ import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationT
 import uk.gov.di.orchestration.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.IPVStubExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.OrchAuthCodeExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SnsTopicExtension;
@@ -77,6 +78,7 @@ import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_SPOT_REQ
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_UNSUCCESSFUL_AUTHORISATION_RESPONSE_RECEIVED;
+import static uk.gov.di.authentication.testsupport.helpers.OrchAuthCodeAssertionHelper.assertOrchAuthCodeSaved;
 import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VOT;
 import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VTM;
 import static uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper.calculatePairwiseIdentifier;
@@ -100,6 +102,9 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     @RegisterExtension
     protected static final AuthenticationCallbackUserInfoStoreExtension userInfoStorageExtension =
             new AuthenticationCallbackUserInfoStoreExtension(180);
+
+    @RegisterExtension
+    public static final OrchAuthCodeExtension orchAuthCodeExtension = new OrchAuthCodeExtension();
 
     protected static final ConfigurationService configurationService =
             new IPVCallbackHandlerIntegrationTest.TestConfigurationService(
@@ -609,6 +614,8 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 response.getHeaders().get(ResponseHeaders.LOCATION),
                 startsWith(REDIRECT_URI + "?code"));
         assertSessionUpdatedWhenReturnCodeRequestedAndPresent();
+
+        assertOrchAuthCodeSaved(orchAuthCodeExtension, response);
     }
 
     @Test

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -36,6 +36,7 @@ import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
+import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
@@ -60,6 +61,7 @@ public class IPVCallbackHelper {
     private final AuditService auditService;
     private final AuthCodeResponseGenerationService authCodeResponseService;
     private final AuthorisationCodeService authorisationCodeService;
+    private final OrchAuthCodeService orchAuthCodeService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final DynamoClientService dynamoClientService;
     private final DynamoIdentityService dynamoIdentityService;
@@ -73,6 +75,7 @@ public class IPVCallbackHelper {
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.authorisationCodeService = new AuthorisationCodeService(configurationService);
+        this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);
         this.dynamoIdentityService = new DynamoIdentityService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
@@ -96,6 +99,7 @@ public class IPVCallbackHelper {
         this.authorisationCodeService =
                 new AuthorisationCodeService(
                         configurationService, redis, SerializationService.getInstance());
+        this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);
         this.dynamoIdentityService = new DynamoIdentityService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
@@ -116,6 +120,7 @@ public class IPVCallbackHelper {
             AuditService auditService,
             AuthCodeResponseGenerationService authCodeResponseService,
             AuthorisationCodeService authorisationCodeService,
+            OrchAuthCodeService orchAuthCodeService,
             CloudwatchMetricsService cloudwatchMetricsService,
             DynamoClientService dynamoClientService,
             DynamoIdentityService dynamoIdentityService,
@@ -128,6 +133,7 @@ public class IPVCallbackHelper {
         this.auditService = auditService;
         this.authCodeResponseService = authCodeResponseService;
         this.authorisationCodeService = authorisationCodeService;
+        this.orchAuthCodeService = orchAuthCodeService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.dynamoClientService = dynamoClientService;
         this.dynamoIdentityService = dynamoIdentityService;

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -44,6 +44,7 @@ import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
+import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
@@ -75,8 +76,11 @@ class IPVCallbackHelperTest {
     private final AuditService auditService = mock(AuditService.class);
     private final AuthCodeResponseGenerationService authCodeResponseService =
             mock(AuthCodeResponseGenerationService.class);
+
+    // TODO: ATO-1218: Remove the following mock for the auth code service.
     private final AuthorisationCodeService authorisationCodeService =
             mock(AuthorisationCodeService.class);
+    private static final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
@@ -150,6 +154,7 @@ class IPVCallbackHelperTest {
                         auditService,
                         authCodeResponseService,
                         authorisationCodeService,
+                        orchAuthCodeService,
                         cloudwatchMetricsService,
                         dynamoClientService,
                         dynamoIdentityService,
@@ -288,6 +293,7 @@ class IPVCallbackHelperTest {
                         auditService,
                         authCodeResponseService,
                         authorisationCodeService,
+                        orchAuthCodeService,
                         cloudwatchMetricsService,
                         dynamoClientService,
                         dynamoIdentityService,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -104,6 +104,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -275,6 +276,8 @@ class IPVCallbackHandlerTest {
 
     @BeforeEach
     void setUp() {
+        clearInvocations(ipvCallbackHelper);
+
         handler =
                 new IPVCallbackHandler(
                         configService,
@@ -573,11 +576,15 @@ class IPVCallbackHandlerTest {
                                         .add(ValidClaims.CORE_IDENTITY_JWT.getValue())
                                         .add(ValidClaims.RETURN_CODE.getValue()));
         var testAuthRequestParams = generateAuthRequest(claimsRequest).toParameters();
+
+        List<VectorOfTrust> vtrList = List.of();
+
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(
                         Optional.of(
                                 new ClientSession(
-                                        testAuthRequestParams, null, List.of(), CLIENT_NAME)));
+                                        testAuthRequestParams, null, vtrList, CLIENT_NAME)));
+
         when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(
                         Optional.of(
@@ -585,10 +592,10 @@ class IPVCallbackHandlerTest {
                                         CLIENT_SESSION_ID,
                                         testAuthRequestParams,
                                         null,
-                                        List.of(),
+                                        vtrList,
                                         CLIENT_NAME)));
         when(responseService.validateResponse(anyMap(), anyString())).thenReturn(Optional.empty());
-        when(ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, VTR_LIST))
+        when(ipvCallbackHelper.validateUserIdentityResponse(userIdentityUserInfo, vtrList))
                 .thenReturn(Optional.of(OAuth2Error.ACCESS_DENIED));
         when(ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
                         any(),
@@ -613,6 +620,22 @@ class IPVCallbackHandlerTest {
                         getApiGatewayProxyRequestEvent(userIdentityUserInfo, clientRegistry));
 
         assertDoesRedirectToFrontendPage(response, FRONT_END_IPV_CALLBACK_URI);
+
+        verify(ipvCallbackHelper)
+                .generateReturnCodeAuthenticationResponse(
+                        any(),
+                        eq(CLIENT_SESSION_ID),
+                        eq(userProfile),
+                        eq(session),
+                        eq(SESSION_ID),
+                        any(OrchSessionItem.class),
+                        eq(CLIENT_NAME),
+                        any(Subject.class),
+                        anyString(),
+                        eq(userIdentityUserInfo),
+                        anyString(),
+                        eq(PERSISTENT_SESSION_ID),
+                        eq(CLIENT_ID.getValue()));
     }
 
     @Test


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Currently RP issued auth codes are stored in Redis. We are migrating away from Redis to DynamoDB. The auth code store is being migrated under the parent ticket.

A new entity and service has been previously added under #6220. Write policy was added to this lambda under #6190.

This work stores the auth code in DynamoDB for the IPV Callback lambda using the new service. Note that we do not wish to remove the Redis setter call - this will be done under ATO-1218.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Added call to the `generateAndSaveAuthorisationCode` method on the orch auth code service
- Added test stubs for the new orch auth code service
- Added unit and integration tests for checking we are (or are not) writing to the new DynamoDB table
- Fixed broken unit test - see d92fc3b76b463cdbdd5d2b4f516d2eb3304f8c52

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to Orch dev, ran through an identity journey (sandpit RP stub, checked "return code" claim, selected "P2" level of confidence, clicked continue, signed in, on the IPV stub form removed the `vot` value, clicked continue, redirected to user info screen).

Observed a request being made to the ipv callback endpoint (for this IPV Callback lambda). This returned 302 and continued on to the main callback, redirecting successfully to the user information screen. The lambda logs showed a call being made to the new orch auth code service.

Reviewed the `dev-Orch-Auth-Code` DynamoDB table - the expected item and attribute values were found: auth code, exchange data, IsUsed=false, and a 5 minute TTL (expected value based on config).

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.
  - (Write policy (`OrchAuthCodeTableWriteAccessPolicy`) previously added to the `IPVCallbackFunction` CloudFormation. Writing as expected - see manual testing section above.)

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or **not required**.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or **not required**.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or **not required**.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or **not required**.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or **not required**.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Entity and service - #6220
- Update to use the same auth code for both stores to enable consistency checks - #6221
- DynamoDB write policy additions to lambdas - #6190
