### PR TITLE
ATO-1514: Swap to new role

### DIFF
--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -23,6 +23,8 @@ module "ipv_processing_identity_role" {
   }
 }
 
+//ATO-1514: Duplicate role which is now unused and replaced by the one below
+// with write access. Will be removed in subsequent PR.
 module "ipv_processing_identity_role_with_orch_session_table_access" {
   count = var.is_orch_stubbed ? 0 : 1
 
@@ -52,10 +54,6 @@ module "ipv_processing_identity_role_with_orch_session_table_access" {
   ]
 }
 
-//ATO-1514: Duplicated the above role but with the write permissions policy.
-// As we're hitting a policy limit adding the write perms in a separate policy,
-// this duplicated role will be created so there is a role available to swap
-// over to when we change this in a subsequent PR.
 module "ipv_processing_identity_role_with_orch_session_table_read_write_delete_access" {
   count = var.is_orch_stubbed ? 0 : 1
 
@@ -130,7 +128,7 @@ module "processing-identity" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
-  lambda_role_arn                        = var.is_orch_stubbed ? module.ipv_processing_identity_role.arn : module.ipv_processing_identity_role_with_orch_session_table_access[0].arn
+  lambda_role_arn                        = var.is_orch_stubbed ? module.ipv_processing_identity_role.arn : module.ipv_processing_identity_role_with_orch_session_table_read_write_delete_access[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention


### PR DESCRIPTION
### Wider context of change:

- In a previous PR we created a new role, now we can swap to it. This gives the processing identity handler write access to the orch session. 
- The previous PR also added the resource policies to the CMK and table to make these cross account actions possible

### What’s changed: 
- Swaps to new role `ipv_processing_identity_role_with_orch_session_table_read_write_delete_access` for processing identity handler


### Manual testing: 
- Deployed to sandpit and ran through an identity journey

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs: 
- https://github.com/govuk-one-login/authentication-api/pull/6211
