### PR TITLE
AUT-4125: Sensibly create the ssm resources

### DIFF
--- a/ci/terraform/shared/session-manager.tf
+++ b/ci/terraform/shared/session-manager.tf
@@ -1,6 +1,5 @@
 locals {
-  # session_manager_resource_count = module.primary_environment.is_primary_environment ? 1 : 0
-  session_manager_resource_count = 1
+  session_manager_resource_count = module.primary_environment.is_primary_environment ? 1 : 0
 }
 data "aws_iam_policy_document" "ssm_kms_access" {
   count = local.session_manager_resource_count
@@ -117,7 +116,7 @@ resource "aws_kms_key" "ssm_access_key" {
 resource "aws_kms_alias" "ssm_key_alias" {
   count = local.session_manager_resource_count
 
-  name          = "alias/kms/${var.aws_region}-session-manager-key"
+  name          = "alias/kms/${var.aws_region}-session-manager-logs-key"
   target_key_id = aws_kms_key.ssm_access_key[count.index].id
 }
 


### PR DESCRIPTION
## What

- Resources were being created in all accounts - this was a dev setting
  that wasn't removed before merging.
- The SSM alias was looking for the wrong key, because of a rename that
  was only half completed.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

Code review
