### PR TITLE
ATO-1558: remove setEmailAddress from tests

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -123,7 +123,7 @@ class AccountInterventionsHandlerTest {
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
 
     private static final ClientSession clientSession = getClientSession();
-    private final Session session = new Session().setEmailAddress(EMAIL);
+    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
@@ -62,7 +62,7 @@ class AccountRecoveryHandlerTest {
     private final String internalCommonSubjectId =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT_ID.getValue(), "test.account.gov.uk", SALT);
-    private final Session session = new Session().setEmailAddress(EMAIL);
+    private final Session session = new Session();
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
 
     private final AuditContext auditContext =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -117,7 +117,7 @@ class AuthenticationAuthCodeHandlerTest {
 
     @BeforeEach
     void setUp() throws Json.JsonException {
-        session = new Session().setEmailAddress(CommonTestVariables.EMAIL);
+        session = new Session();
         authSession =
                 new AuthSessionItem()
                         .withSessionId(SESSION_ID)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
@@ -72,7 +72,7 @@ class CheckEmailFraudBlockHandlerTest {
     private static UserContext userContext;
     private static AuthSessionService authSessionServiceMock;
 
-    private final Session session = new Session().setEmailAddress(EMAIL);
+    private final Session session = new Session();
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
     private CheckEmailFraudBlockHandler handler;
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -89,7 +89,7 @@ class CheckReAuthUserHandlerTest {
     private static final APIGatewayProxyRequestEvent API_REQUEST_EVENT_WITH_VALID_HEADERS =
             apiRequestEventWithHeadersAndBody(VALID_HEADERS, null);
 
-    private final Session session = new Session().setEmailAddress(EMAIL_USED_TO_SIGN_IN);
+    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem().withSessionId(SESSION_ID).withEmailAddress(EMAIL_USED_TO_SIGN_IN);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -105,7 +105,7 @@ class LoginHandlerReauthenticationRedisTest {
                     .withMfaMethodType(MFAMethodType.AUTH_APP.getValue())
                     .withMethodVerified(true)
                     .withEnabled(true);
-    private static final Session session = new Session().setEmailAddress(EMAIL);
+    private static final Session session = new Session();
     private LoginHandler handler;
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -125,7 +125,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     .withMfaMethodType(MFAMethodType.AUTH_APP.getValue())
                     .withMethodVerified(true)
                     .withEnabled(true);
-    private static final Session session = new Session().setEmailAddress(EMAIL);
+    private static final Session session = new Session();
     private final Context context = mock(Context.class);
     private final Subject subject = mock(Subject.class);
     private final String expectedCommonSubject =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -116,7 +116,7 @@ class LoginHandlerTest {
                     .withMethodVerified(true)
                     .withEnabled(true);
     private static final Json objectMapper = SerializationService.getInstance();
-    private static final Session session = new Session().setEmailAddress(EMAIL);
+    private static final Session session = new Session();
     private LoginHandler handler;
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -121,7 +121,7 @@ class MfaHandlerTest {
                     DI_PERSISTENT_SESSION_ID,
                     Optional.of(ENCODED_DEVICE_DETAILS));
 
-    private final Session session = new Session().setEmailAddress(EMAIL);
+    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -135,7 +135,7 @@ class ResetPasswordHandlerTest {
                     Optional.of(ENCODED_DEVICE_DETAILS));
 
     private ResetPasswordHandler handler;
-    private final Session session = new Session().setEmailAddress(EMAIL);
+    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem().withSessionId(SESSION_ID).withEmailAddress(EMAIL);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -134,7 +134,7 @@ class ResetPasswordRequestHandlerTest {
                                     CommonTestVariables.EMAIL,
                                     "jb2@digital.cabinet-office.gov.uk"));
 
-    private final Session session = new Session().setEmailAddress(CommonTestVariables.EMAIL);
+    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
@@ -105,7 +105,7 @@ class ReverificationResultHandlerTest {
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
     private final String subjectId = "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
-    private final Session session = new Session().setEmailAddress(EMAIL);
+    private final Session session = new Session();
     private final AuditContext auditContextWithAllUserInfo =
             new AuditContext(
                     CLIENT_ID,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -134,7 +134,7 @@ class SendNotificationHandlerTest {
     private final Context context = mock(Context.class);
     private static final Json objectMapper = SerializationService.getInstance();
 
-    private final Session session = new Session().setEmailAddress(EMAIL);
+    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -91,7 +91,7 @@ class UpdateProfileHandlerTest {
 
     private final String TERMS_AND_CONDITIONS_VERSION =
             configurationService.getTermsAndConditionsVersion();
-    private final Session session = new Session().setEmailAddress(EMAIL);
+    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -131,7 +131,7 @@ class VerifyCodeHandlerTest {
     private final String expectedPairwiseId =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     TEST_SUBJECT_ID, CLIENT_SECTOR_HOST, SALT);
-    private final Session session = new Session().setEmailAddress(EMAIL);
+    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -383,7 +383,6 @@ class VerifyCodeHandlerTest {
         when(configurationService.getTestClientVerifyEmailOTP())
                 .thenReturn(Optional.of(TEST_CLIENT_CODE));
         when(codeStorageService.getOtpCode(email, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
-        session.setEmailAddress(email);
         authSession.setEmailAddress(email);
         String body =
                 format(
@@ -419,7 +418,6 @@ class VerifyCodeHandlerTest {
         when(configurationService.getTestClientVerifyEmailOTP())
                 .thenReturn(Optional.of(TEST_CLIENT_CODE));
         when(codeStorageService.getOtpCode(email, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
-        session.setEmailAddress(email);
         authSession.setEmailAddress(email);
         String body =
                 format("{ \"code\": \"%s\", \"notificationType\": \"%s\"  }", CODE, VERIFY_EMAIL);
@@ -746,7 +744,6 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(TEST_CLIENT_CODE));
         when(codeStorageService.getOtpCode(TEST_CLIENT_EMAIL, RESET_PASSWORD_WITH_CODE))
                 .thenReturn(Optional.of(CODE));
-        session.setEmailAddress(TEST_CLIENT_EMAIL);
         authSession.setEmailAddress(TEST_CLIENT_EMAIL);
         String body =
                 format(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -127,7 +127,7 @@ class VerifyMfaCodeHandlerTest {
     private final String expectedRpPairwiseSubjectId =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     TEST_SUBJECT_ID, CLIENT_SECTOR_HOST, SALT);
-    private final Session session = new Session().setEmailAddress(EMAIL);
+    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -53,7 +53,7 @@ import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_B
 class PhoneNumberCodeProcessorTest {
 
     private PhoneNumberCodeProcessor phoneNumberCodeProcessor;
-    private final Session session = new Session().setEmailAddress(EMAIL);
+    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -137,7 +137,7 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
 
     private Map<String, String> getHeadersForAuthenticatedSession() throws Json.JsonException {
         Map<String, String> headers = new HashMap<>();
-        var sessionId = redis.createAuthenticatedSessionWithEmail(TEST_EMAIL_ADDRESS);
+        var sessionId = redis.createSession();
         authSessionServiceExtension.addSession(sessionId);
 
         var clientSession =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
@@ -68,7 +68,6 @@ public class AccountRecoveryIntegrationTest extends ApiGatewayHandlerIntegration
         var sessionId = redis.createSession();
         authSessionServiceExtension.addSession(sessionId);
         accountModifiersStore.setAccountRecoveryBlock(internalCommonSubjectId);
-        redis.addEmailToSession(sessionId, EMAIL);
         redis.createClientSession(CLIENT_SESSION_ID, createClientSession());
         Map<String, String> headers = new HashMap<>();
         headers.put("Session-Id", sessionId);
@@ -88,7 +87,6 @@ public class AccountRecoveryIntegrationTest extends ApiGatewayHandlerIntegration
         var sessionId = redis.createSession();
         authSessionServiceExtension.addSession(sessionId);
         userStore.signUp(EMAIL, "password-1", SUBJECT);
-        redis.addEmailToSession(sessionId, EMAIL);
         redis.createClientSession(CLIENT_SESSION_ID, createClientSession());
 
         Map<String, String> headers = new HashMap<>();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -140,7 +140,6 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
 
     private String setupSession() throws Json.JsonException {
         var sessionId = redis.createSession();
-        redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         return sessionId;

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -548,7 +548,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldRedirectToLoginUriWhenUserHasPreviousSession() throws Exception {
         setupForAuthJourney();
         String previousSessionId = givenAnExistingSession(MEDIUM_LEVEL);
-        redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
         registerUser();
         withExistingOrchSessionAndBsid(previousSessionId);
 
@@ -592,7 +591,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldRedirectToLoginUriWhenUserHasPreviousSessionButRequiresIdentity() throws Exception {
         setupForAuthJourney();
         String previousSessionId = givenAnExistingSession(MEDIUM_LEVEL);
-        redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
         registerUser();
         withExistingOrchSessionAndBsid(previousSessionId);
 
@@ -635,7 +633,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             throws Exception {
         setupForAuthJourney();
         String sessionId = givenAnExistingSession(MEDIUM_LEVEL);
-        redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         registerUser();
 
         var response =
@@ -687,7 +684,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldNotPromptForLoginWhenPromptNoneAndUserAuthenticated() throws Exception {
         setupForAuthJourney();
         String previousSessionId = givenAnExistingSession(MEDIUM_LEVEL);
-        redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
         registerUser();
         withExistingOrchSessionAndBsid(previousSessionId);
 
@@ -733,7 +729,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldPromptForLoginWhenPromptLoginAndUserAuthenticated() throws Exception {
         setupForAuthJourney();
         String previousSessionId = givenAnExistingSession(MEDIUM_LEVEL);
-        redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
         registerUser();
         withExistingOrchSessionAndBsid(previousSessionId);
 
@@ -781,7 +776,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldRequireUpliftWhenHighCredentialLevelOfTrustRequested() throws Exception {
         setupForAuthJourney();
         String previousSessionId = givenAnExistingSession(LOW_LEVEL);
-        redis.addEmailToSession(previousSessionId, TEST_EMAIL_ADDRESS);
         registerUser();
         withExistingOrchSessionAndBsid(previousSessionId);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
@@ -68,7 +68,6 @@ public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegr
         authSessionExtension.addSession(sessionId);
         dynamoEmailCheckResultService.saveEmailCheckResult(
                 EMAIL, EmailCheckResultStatus.ALLOW, unixTimePlusNDays(), "test-reference");
-        redis.addEmailToSession(sessionId, EMAIL);
         redis.createClientSession(CLIENT_SESSION_ID, createClientSession());
         Map<String, String> headers = new HashMap<>();
         headers.put("Session-Id", sessionId);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
@@ -98,7 +98,7 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
     @BeforeEach
     void setup() throws Json.JsonException {
 
-        var sessionId = redis.createAuthenticatedSessionWithEmail(TEST_EMAIL);
+        var sessionId = redis.createSession();
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, TEST_EMAIL);
         requestHeaders = createHeaders(sessionId);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -119,7 +119,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             throws JsonException {
         var emailAddress = "joe.bloggs+1@digital.cabinet-office.gov.uk";
 
-        String sessionId = redis.createUnauthenticatedSessionWithEmail(emailAddress);
+        String sessionId = redis.createSession();
         authSessionStore.addSession(sessionId);
         var codeRequestType =
                 CodeRequestType.getCodeRequestType(MFAMethodType.AUTH_APP, JourneyType.SIGN_IN);
@@ -193,7 +193,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldCallUserExistsEndpointAndReturnErrorResponse1045WhenUserAccountIsLocked()
             throws JsonException {
         String emailAddress = "joe.bloggs+2@digital.cabinet-office.gov.uk";
-        String sessionId = redis.createUnauthenticatedSessionWithEmail(emailAddress);
+        String sessionId = redis.createSession();
         authSessionStore.addSession(sessionId);
         redis.blockMfaCodesForEmail(
                 emailAddress,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -107,7 +107,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var email = "joe.bloggs+3@digital.cabinet-office.gov.uk";
         var password = "password-1";
         var sessionId = IdGenerator.generate();
-        redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
+        redis.createSession(sessionId);
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, email);
 
@@ -190,7 +190,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var email = "joe.bloggs+3@digital.cabinet-office.gov.uk";
         var password = "password-1";
         var sessionId = IdGenerator.generate();
-        redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
+        redis.createSession(sessionId);
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, email);
 
@@ -220,7 +220,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         userStore.signUp(email, "wrong-password");
 
         var sessionId = IdGenerator.generate();
-        redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
+        redis.createSession(sessionId);
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, email);
         redis.createClientSession(
@@ -242,7 +242,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String password = "password-1";
         userStore.signUp(email, "wrong-password");
         var sessionId = IdGenerator.generate();
-        redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
+        redis.createSession(sessionId);
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, email);
         var headers = validHeadersWithSessionId(sessionId);
@@ -279,7 +279,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String password = "password-1";
         userStore.signUp(email, "wrong-password");
         var sessionId = IdGenerator.generate();
-        redis.createUnauthenticatedSessionWithIdAndEmail(sessionId, email);
+        redis.createSession(sessionId);
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, email);
         var headers = validHeadersWithSessionId(sessionId);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
@@ -38,7 +38,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         handler = new MfaHandler(TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
         txmaAuditQueue.clear();
         String subjectId = "new-subject";
-        SESSION_ID = redis.createUnauthenticatedSessionWithEmail(USER_EMAIL);
+        SESSION_ID = redis.createSession();
         authSessionStore.addSession(SESSION_ID);
         authSessionStore.addEmailToSession(SESSION_ID, USER_EMAIL);
         userStore.signUp(USER_EMAIL, USER_PASSWORD, new Subject(subjectId));
@@ -105,7 +105,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenReauthenticating()
             throws Json.JsonException {
-        var authenticatedSessionId = redis.createAuthenticatedSessionWithEmail(USER_EMAIL);
+        var authenticatedSessionId = redis.createSession();
         authSessionStore.addSession(authenticatedSessionId);
         authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
 
@@ -128,7 +128,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn400WhenRequestingACodeForReauthenticationWhichBreachesTheMaxThreshold()
             throws Json.JsonException {
-        var authenticatedSessionId = redis.createAuthenticatedSessionWithEmail(USER_EMAIL);
+        var authenticatedSessionId = redis.createSession();
         authSessionStore.addSession(authenticatedSessionId);
 
         aUserHasEnteredAnOTPIncorrectlyTheMaximumAllowedTimes(authenticatedSessionId);
@@ -158,7 +158,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturn400WhenInvalidMFAJourneyCombination() throws Json.JsonException {
-        var authenticatedSessionId = redis.createAuthenticatedSessionWithEmail(USER_EMAIL);
+        var authenticatedSessionId = redis.createSession();
         authSessionStore.addSession(authenticatedSessionId);
 
         var response =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
@@ -172,7 +172,7 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
     }
 
     private void setUpSession() throws Json.JsonException {
-        sessionId = redis.createAuthenticatedSessionWithEmail(USER_EMAIL);
+        sessionId = redis.createSession();
     }
 
     private void addSessionToSessionStore(String internalCommonSubjectId) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -51,7 +51,6 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         authSessionStore.addSession(sessionId);
         authSessionStore.addEmailToSession(sessionId, email);
         String persistentSessionId = "test-persistent-id";
-        redis.addEmailToSession(sessionId, email);
         var clientSessionId = IdGenerator.generate();
         setUpClientSession(email, clientSessionId, CLIENT_ID, CLIENT_NAME, REDIRECT_URI);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ReverificationResultHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ReverificationResultHandlerIntegrationTest.java
@@ -115,7 +115,7 @@ class ReverificationResultHandlerIntegrationTest extends ApiGatewayHandlerIntegr
     void setup() throws Json.JsonException {
         handler = new ReverificationResultHandler(redisConnectionService);
 
-        sessionId = redis.createAuthenticatedSessionWithEmail(USER_EMAIL);
+        sessionId = redis.createSession();
         internalCommonSubjectId =
                 ClientSubjectHelper.calculatePairwiseIdentifier(
                         new Subject().getValue(),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
@@ -38,7 +38,7 @@ class SendNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         handler =
                 new SendNotificationHandler(
                         TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
-        SESSION_ID = redis.createUnauthenticatedSessionWithEmail(USER_EMAIL);
+        SESSION_ID = redis.createSession();
         authSessionExtension.addSession(SESSION_ID);
         authSessionStore.addEmailToSession(SESSION_ID, USER_EMAIL);
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -71,7 +71,6 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
         Scope scope = new Scope();
         scope.add(OIDCScopeValue.OPENID);
         scope.add(OIDCScopeValue.EMAIL);
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         authSessionStore.addSession(sessionId);
         authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
         AuthenticationRequest authRequest =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -468,7 +468,6 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
     }
 
     private void setUpTestWithoutSignUp(String sessionId, Scope scope) throws Json.JsonException {
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         authSessionExtension.addEmailToSession(sessionId, EMAIL_ADDRESS);
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -883,10 +883,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @EnumSource(
             value = JourneyType.class,
             names = {"REGISTRATION", "ACCOUNT_RECOVERY"})
-    void whenPhoneNumberCodeIsBlockedReturn400(JourneyType journeyType) throws Json.JsonException {
+    void whenPhoneNumberCodeIsBlockedReturn400(JourneyType journeyType) {
         setUpSmsRequest(journeyType, PHONE_NUMBER);
 
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         authSessionExtension.addEmailToSession(sessionId, EMAIL_ADDRESS);
         var codeRequestType = CodeRequestType.getCodeRequestType(MFAMethodType.SMS, journeyType);
         var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
@@ -920,10 +919,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @EnumSource(
             value = JourneyType.class,
             names = {"REGISTRATION", "ACCOUNT_RECOVERY"})
-    void whenPhoneNumberCodeRetriesLimitExceededBlockEmailAndReturn400(JourneyType journeyType)
-            throws Json.JsonException {
+    void whenPhoneNumberCodeRetriesLimitExceededBlockEmailAndReturn400(JourneyType journeyType) {
         setUpSmsRequest(journeyType, PHONE_NUMBER);
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         authSessionExtension.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
         var codeRequest =
@@ -989,7 +986,6 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private void setUpTest(String sessionId, Scope scope) throws Json.JsonException {
         userStore.addUnverifiedUser(EMAIL_ADDRESS, USER_PASSWORD);
-        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         authSessionExtension.addEmailToSession(sessionId, EMAIL_ADDRESS);
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
@@ -65,12 +65,9 @@ class LogoutRequestTest {
     private static final String ARBITRARY_UNIX_TIMESTAMP = "1700558480962";
     private static final String PERSISTENT_SESSION_ID =
             IdGenerator.generate() + "--" + ARBITRARY_UNIX_TIMESTAMP;
-    private static final URI DEFAULT_LOGOUT_URI =
-            URI.create("https://di-authentication-frontend.london.cloudapps.digital/signed-out");
     private static final URI CLIENT_LOGOUT_URI = URI.create("http://localhost/logout");
     private SignedJWT signedIDToken;
     private static final Subject SUBJECT = new Subject();
-    private static final String EMAIL = "joe.bloggs@test.com";
     private final ClientRegistry clientRegistry = createClientRegistry();
     private String idTokenHint;
     private String rpPairwiseId;
@@ -107,7 +104,7 @@ class LogoutRequestTest {
 
     @BeforeEach
     void sessionExistsSetup() throws ParseException {
-        session = generateSession().setEmailAddress(EMAIL);
+        session = generateSession();
         orchSession =
                 new OrchSessionItem(SESSION_ID).withInternalCommonSubjectId(SUBJECT.getValue());
         idTokenHint = signedIDToken.serialize();
@@ -222,7 +219,7 @@ class LogoutRequestTest {
 
     @Test
     void shouldCorrectlyParseALogoutRequestWithNoTokenHint() {
-        session = generateSession().setEmailAddress(EMAIL);
+        session = generateSession();
         APIGatewayProxyRequestEvent event =
                 generateRequestEvent(
                         Map.of(
@@ -260,7 +257,7 @@ class LogoutRequestTest {
 
     @Test
     void shouldCorrectlyParseALogoutRequestWhenSignatureIdTokenIsInvalid() throws JOSEException {
-        session = generateSession().setEmailAddress(EMAIL);
+        session = generateSession();
         ECKey ecSigningKey =
                 new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();
         SignedJWT signedJWT =
@@ -310,7 +307,7 @@ class LogoutRequestTest {
     @Test
     void shouldCorrectlyParseALogoutRequestWhenClientIsNotFoundInClientRegistry()
             throws JOSEException {
-        session = generateSession().setEmailAddress(EMAIL);
+        session = generateSession();
         ECKey ecSigningKey =
                 new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();
         SignedJWT signedJWT =
@@ -360,7 +357,7 @@ class LogoutRequestTest {
 
     @Test
     void shouldCorrectlyParseLogoutRequestWhenRedirectUriIsMissing() {
-        session = generateSession().setEmailAddress(EMAIL);
+        session = generateSession();
         session.getClientSessions().add(CLIENT_SESSION_ID);
         generateSessionFromCookie(session, orchSession);
         when(dynamoClientService.getClient("client-id")).thenReturn(Optional.of(clientRegistry));
@@ -398,7 +395,7 @@ class LogoutRequestTest {
 
     @Test
     void shouldCorrectlyParseLogoutRequestWhenLogoutUriInRequestDoesNotMatchClientRegistry() {
-        session = generateSession().setEmailAddress(EMAIL);
+        session = generateSession();
         when(tokenValidationService.isTokenSignatureValid(signedIDToken.serialize()))
                 .thenReturn(true);
         when(dynamoClientService.getClient("client-id")).thenReturn(Optional.of(clientRegistry));

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -182,7 +182,7 @@ class LogoutServiceTest {
         audience = idToken.getJWTClaimsSet().getAudience().stream().findFirst();
         rpPairwiseId = Optional.of(idToken.getJWTClaimsSet().getSubject());
 
-        session = new Session().setEmailAddress(EMAIL);
+        session = new Session();
         setUpClientSession(CLIENT_SESSION_ID, CLIENT_ID, rpPairwiseId.get());
         when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
         destroySessionsRequest =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -49,32 +49,13 @@ public class RedisExtension
     }
 
     public String createSession(String sessionId) throws Json.JsonException {
-        return createSession(sessionId, Optional.empty());
-    }
-
-    private String createSession(String sessionId, Optional<String> email)
-            throws Json.JsonException {
         Session session = new Session();
-        email.ifPresent(session::setEmailAddress);
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
         return sessionId;
     }
 
     public String createSession() throws Json.JsonException {
         return createSession(IdGenerator.generate());
-    }
-
-    public String createUnauthenticatedSessionWithEmail(String email) throws Json.JsonException {
-        return createSession(IdGenerator.generate(), Optional.of(email));
-    }
-
-    public void createUnauthenticatedSessionWithIdAndEmail(String sessionId, String email)
-            throws Json.JsonException {
-        createSession(sessionId, Optional.of(email));
-    }
-
-    public String createAuthenticatedSessionWithEmail(String email) throws Json.JsonException {
-        return createSession(IdGenerator.generate(), Optional.of(email));
     }
 
     public void addStateToRedis(State state, String sessionId) throws Json.JsonException {
@@ -127,12 +108,6 @@ public class RedisExtension
                                 VectorOfTrust.getDefaults(),
                                 clientName)),
                 3600);
-    }
-
-    public void addEmailToSession(String sessionId, String emailAddress) throws Json.JsonException {
-        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.setEmailAddress(emailAddress);
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public void setSessionCredentialTrustLevel(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
@@ -136,7 +136,7 @@ class TestClientHelperTest {
                         .withClientName("some-client")
                         .withTestClient(isTestClient)
                         .withTestClientEmailAllowlist(allowedEmails);
-        var session = new Session().setEmailAddress(TEST_EMAIL_ADDRESS);
+        var session = new Session();
         var authSession = new AuthSessionItem().withEmailAddress(TEST_EMAIL_ADDRESS);
         return UserContext.builder(session)
                 .withClient(clientRegistry)


### PR DESCRIPTION
### Wider context of change

Part of the session split. Removing setEmailAddress from tests.

### What’s changed

Removing setEmailAddress from tests.

### Manual testing

Ran tests.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**