### PR TITLE
ATO-1564: remove methods from Orch shared session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -95,7 +95,6 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setupOrchSession();
         var clientSessionId = "some-client-session-id";
         setupAuthUserInfo(clientSessionId);
-        redis.setVerifiedMfaMethodType(sessionID, MFAMethodType.AUTH_APP);
         var creationDate = LocalDateTime.now();
         var authRequestParams = generateAuthRequest().toParameters();
         redis.addAuthRequestToSession(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -264,9 +264,7 @@ class AuthCodeHandlerTest {
                 .processVectorOfTrust(eq(clientSession), any());
         var authorizationCode = new AuthorizationCode();
         var authRequest = generateValidSessionAndAuthRequest(requestedLevel, false);
-        session.setCurrentCredentialStrength(initialLevel)
-                .setNewAccount(AccountState.NEW)
-                .setVerifiedMfaMethodType(mfaMethodType);
+        session.setCurrentCredentialStrength(initialLevel).setNewAccount(AccountState.NEW);
         orchSession.setCurrentCredentialStrength(initialLevel);
         var authSuccessResponse =
                 new AuthenticationSuccessResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -151,7 +151,6 @@ class AuthenticationCallbackHandlerTest {
 
     private static final Session session =
             new Session()
-                    .setVerifiedMfaMethodType(MFAMethodType.EMAIL)
                     .setAuthenticated(false)
                     .setCurrentCredentialStrength(null)
                     .setEmailAddress(TEST_EMAIL_ADDRESS);
@@ -653,9 +652,7 @@ class AuthenticationCallbackHandlerTest {
     void shouldAuditMediumCredentialTrustLevelOn1FARequestWhenPreviously2FA()
             throws UnsuccessfulCredentialResponseException {
         Session mediumLevelSession =
-                new Session()
-                        .setVerifiedMfaMethodType(MFAMethodType.EMAIL)
-                        .setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
+                new Session().setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
         when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(mediumLevelSession));
         when(orchSessionService.getSession(SESSION_ID))
                 .thenReturn(Optional.of(new OrchSessionItem(SESSION_ID)));

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
-import uk.gov.di.orchestration.shared.entity.MFAMethodType;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
@@ -58,13 +57,6 @@ public class RedisExtension
     public Session addSessionWithId(Session session, String sessionId) throws Json.JsonException {
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
         return session;
-    }
-
-    public void setVerifiedMfaMethodType(String sessionId, MFAMethodType mfaMethodType)
-            throws Json.JsonException {
-        var session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.setVerifiedMfaMethodType(mfaMethodType);
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public String createSession() throws Json.JsonException {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -125,15 +125,6 @@ public class Session {
         return processingIdentityAttempts;
     }
 
-    public MFAMethodType getVerifiedMfaMethodType() {
-        return verifiedMfaMethodType;
-    }
-
-    public Session setVerifiedMfaMethodType(MFAMethodType verifiedMfaMethodType) {
-        this.verifiedMfaMethodType = verifiedMfaMethodType;
-        return this;
-    }
-
     private void initializeCodeRequestMap() {
         for (CodeRequestType requestType : CodeRequestType.values()) {
             codeRequestCountMap.put(requestType, 0);


### PR DESCRIPTION
### Wider context of change: 

- We've removed setting this value in auth and the setters and getters were unused in orchestration. This removes them

### What’s changed: 

- Removes setter usages from tests 
- Removes methods from session class

### Manual testing: 
- Just test code
### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
