### PR TITLE
ATO-1565: remove orch setters

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -2036,10 +2036,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         return sessionId;
     }
 
-    private String givenAnExistingSession(CredentialTrustLevel credentialTrustLevel)
-            throws Json.JsonException {
-        String sessionId = redis.createSession();
-        redis.setSessionCredentialTrustLevel(sessionId, credentialTrustLevel);
+    private String givenAnExistingSession(CredentialTrustLevel credentialTrustLevel) {
+        var sessionId = IdGenerator.generate();
+        orchSessionExtension.addSession(new OrchSessionItem(sessionId));
         return sessionId;
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -251,7 +251,6 @@ public class AuthCodeHandler
                             emailOptional,
                             orchClientSession.getVtrList(),
                             clientSessionId,
-                            session,
                             orchSession);
 
             authenticationResponse =
@@ -453,16 +452,9 @@ public class AuthCodeHandler
             Optional<String> emailOptional,
             List<VectorOfTrust> vtrList,
             String clientSessionId,
-            Session session,
             OrchSessionItem orchSession) {
         CredentialTrustLevel lowestRequestedCredentialTrustLevel =
                 VectorOfTrust.getLowestCredentialTrustLevel(vtrList);
-        if (isNull(session.getCurrentCredentialStrength())
-                || lowestRequestedCredentialTrustLevel.compareTo(
-                                session.getCurrentCredentialStrength())
-                        > 0) {
-            session.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
-        }
         CredentialTrustLevel currentCredentialStrength = orchSession.getCurrentCredentialStrength();
 
         if (isNull(currentCredentialStrength)

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -470,7 +470,7 @@ public class AuthenticationCallbackHandler
                 CredentialTrustLevel requestedCredentialTrustLevel =
                         VectorOfTrust.getLowestCredentialTrustLevel(clientSession.getVtrList());
                 CredentialTrustLevel credentialTrustLevel =
-                        Optional.ofNullable(session.getCurrentCredentialStrength())
+                        Optional.ofNullable(orchSession.getCurrentCredentialStrength())
                                 .map(
                                         sessionValue ->
                                                 CredentialTrustLevel.max(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -566,12 +566,6 @@ public class AuthenticationCallbackHandler
 
                 CredentialTrustLevel lowestRequestedCredentialTrustLevel =
                         VectorOfTrust.getLowestCredentialTrustLevel(clientSession.getVtrList());
-                if (isNull(session.getCurrentCredentialStrength())
-                        || lowestRequestedCredentialTrustLevel.compareTo(
-                                        session.getCurrentCredentialStrength())
-                                > 0) {
-                    session.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
-                }
 
                 var authCode =
                         orchAuthCodeService.generateAndSaveAuthorisationCode(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -600,18 +600,7 @@ public class AuthenticationCallbackHandler
                             orchSession.withCurrentCredentialStrength(
                                     CredentialTrustLevel.valueOf(currentCredentialStrength)));
                 }
-                // ATO-975 logging to make sure there are no differences in production
-                LOG.info(
-                        "Shared session current credential strength: {}",
-                        session.getCurrentCredentialStrength());
-                LOG.info(
-                        "Orch session current credential strength: {}",
-                        orchSession.getCurrentCredentialStrength());
-                LOG.info(
-                        "Is shared session CCS equal to Orch session CCS: {}",
-                        Objects.equals(
-                                session.getCurrentCredentialStrength(),
-                                orchSession.getCurrentCredentialStrength()));
+
                 cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
                 cloudwatchMetricsService.incrementSignInByClient(
                         orchAccountState, clientId, clientSession.getClientName(), isTestJourney);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -193,6 +193,8 @@ class AuthCodeHandlerTest {
         doAnswer(
                         (i) -> {
                             session.setNewAccount(EXISTING_DOC_APP_JOURNEY);
+                            orchSession.withAccountState(
+                                    OrchSessionItem.AccountState.EXISTING_DOC_APP_JOURNEY);
                             return null;
                         })
                 .when(authCodeResponseService)
@@ -201,6 +203,9 @@ class AuthCodeHandlerTest {
         doAnswer(
                         (i) -> {
                             session.setAuthenticated(true).setNewAccount(EXISTING);
+                            orchSession
+                                    .withAuthenticated(true)
+                                    .withAccountState(OrchSessionItem.AccountState.EXISTING);
                             return null;
                         })
                 .when(authCodeResponseService)
@@ -267,7 +272,7 @@ class AuthCodeHandlerTest {
                 .processVectorOfTrust(any(OrchClientSessionItem.class), any());
         var authorizationCode = new AuthorizationCode();
         var authRequest = generateValidSessionAndAuthRequest(requestedLevel, false);
-        session.setCurrentCredentialStrength(initialLevel).setNewAccount(AccountState.NEW);
+        session.setNewAccount(AccountState.NEW);
         orchSession.setCurrentCredentialStrength(initialLevel);
         var authSuccessResponse =
                 new AuthenticationSuccessResponse(
@@ -305,9 +310,8 @@ class AuthCodeHandlerTest {
         assertThat(response, hasStatus(200));
         var authCodeResponse = objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
         assertThat(authCodeResponse.getLocation(), equalTo(authSuccessResponse.toURI().toString()));
-        assertThat(session.getCurrentCredentialStrength(), equalTo(finalLevel));
-        assertThat(session.getCurrentCredentialStrength(), equalTo(finalLevel));
-        assertTrue(session.isAuthenticated());
+        assertThat(orchSession.getCurrentCredentialStrength(), equalTo(finalLevel));
+        assertTrue(orchSession.getAuthenticated());
 
         verify(authCodeResponseService, times(1))
                 .saveSession(
@@ -428,9 +432,8 @@ class AuthCodeHandlerTest {
         assertThat(response, hasStatus(200));
         var authCodeResponse = objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
         assertThat(authCodeResponse.getLocation(), equalTo(authSuccessResponse.toURI().toString()));
-        assertThat(session.getCurrentCredentialStrength(), equalTo(requestedLevel));
         assertThat(orchSession.getCurrentCredentialStrength(), equalTo(requestedLevel));
-        assertFalse(session.isAuthenticated());
+        assertFalse(orchSession.getAuthenticated());
         verify(authCodeResponseService, times(1))
                 .saveSession(
                         anyBoolean(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -155,10 +155,7 @@ class AuthenticationCallbackHandlerTest {
     private static final String SESSION_ID = "a-session-id";
 
     private static final Session session =
-            new Session()
-                    .setAuthenticated(false)
-                    .setCurrentCredentialStrength(null)
-                    .setEmailAddress(TEST_EMAIL_ADDRESS);
+            new Session().setAuthenticated(false).setEmailAddress(TEST_EMAIL_ADDRESS);
     public static final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID)
                     .withAuthenticated(false)
@@ -246,7 +243,6 @@ class AuthenticationCallbackHandlerTest {
 
         clearInvocations(orchAuthCodeService);
 
-        session.setCurrentCredentialStrength(null);
         when(USER_INFO.getBooleanClaim("new_account")).thenReturn(true);
         when(USER_INFO.getStringClaim(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue()))
                 .thenReturn(null);
@@ -1519,9 +1515,6 @@ class AuthenticationCallbackHandlerTest {
         var sessionSaveCaptor = ArgumentCaptor.forClass(Session.class);
         verify(sessionService, times(2))
                 .storeOrUpdateSession(sessionSaveCaptor.capture(), anyString());
-        assertThat(
-                sessionSaveCaptor.getAllValues().get(0).getCurrentCredentialStrength(),
-                equalTo(lowestCredentialTrustLevel));
         assertThat(
                 Session.AccountState.NEW,
                 equalTo(sessionSaveCaptor.getAllValues().get(0).isNewAccount()));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -671,11 +671,11 @@ class AuthenticationCallbackHandlerTest {
     @Test
     void shouldAuditMediumCredentialTrustLevelOn1FARequestWhenPreviously2FA()
             throws UnsuccessfulCredentialResponseException {
-        Session mediumLevelSession =
-                new Session().setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
-        when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(mediumLevelSession));
-        when(orchSessionService.getSession(SESSION_ID))
-                .thenReturn(Optional.of(new OrchSessionItem(SESSION_ID)));
+        var mediumLevelSession =
+                new OrchSessionItem(SESSION_ID)
+                        .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
+        when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(new Session()));
+        when(orchSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(mediumLevelSession));
         usingValidClientSession();
         usingValidClient();
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -723,7 +723,7 @@ class AuthorisationHandlerTest {
 
         @Test
         void shouldRedirectToLoginWhenUserNeedsToBeUplifted() {
-            session.setCurrentCredentialStrength(CredentialTrustLevel.LOW_LEVEL);
+            orchSession.setCurrentCredentialStrength(CredentialTrustLevel.LOW_LEVEL);
             withExistingSession(session);
             var authRequestParams =
                     generateAuthRequest(Optional.of(jsonArrayOf("Cl.Cm"))).toParameters();

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
-import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
@@ -145,13 +144,6 @@ public class RedisExtension
     public void addEmailToSession(String sessionId, String emailAddress) throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
         session.setEmailAddress(emailAddress);
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
-    }
-
-    public void setSessionCredentialTrustLevel(
-            String sessionId, CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
-        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.setCurrentCredentialStrength(credentialTrustLevel);
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -85,15 +85,6 @@ public class Session {
         return this;
     }
 
-    public CredentialTrustLevel getCurrentCredentialStrength() {
-        return currentCredentialStrength;
-    }
-
-    public Session setCurrentCredentialStrength(CredentialTrustLevel currentCredentialStrength) {
-        this.currentCredentialStrength = currentCredentialStrength;
-        return this;
-    }
-
     public AccountState isNewAccount() {
         return isNewAccount;
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -92,17 +92,5 @@ public class AuthCodeResponseGenerationService {
                             .withAuthenticated(true)
                             .withAccountState(OrchSessionItem.AccountState.EXISTING));
         }
-        // ATO-975 logging to make sure there are no differences in production
-        LOG.info(
-                "Shared session current credential strength: {}",
-                session.getCurrentCredentialStrength());
-        LOG.info(
-                "Orch session current credential strength: {}",
-                orchSession.getCurrentCredentialStrength());
-        LOG.info(
-                "Is shared session CCS equal to Orch session CCS: {}",
-                Objects.equals(
-                        session.getCurrentCredentialStrength(),
-                        orchSession.getCurrentCredentialStrength()));
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -36,7 +36,7 @@ public class SessionService {
 
     public Session copySessionForMaxAge(Session previousSession) {
         var copiedSession = new Session(previousSession);
-        copiedSession.setAuthenticated(false).setCurrentCredentialStrength(null);
+        copiedSession.setAuthenticated(false);
         copiedSession.resetClientSessions();
         return copiedSession;
     }


### PR DESCRIPTION
### Wider context of change: 
We previously migrated this field to the separate session stores for both Auth and Orch. However we continued to set the value in orchestration and left in logging which checked if the values were in sync. We've stopped reading the value in [auth](https://github.com/govuk-one-login/authentication-api/pull/6234) and we only get this in Orch in a few places:

- To log comparison with the Orch session
- To check if null before setting
- One usage in auditing in the authorisation handler

Once we remove these we can stop setting in Authentication.

### What’s changed:
- Swaps the audited value in the authorisation handler with the Orch session value
- Removes comparison logging 
- Removes setting this value in Auth callback 
- Removes setting this value in Auth code response generation service 
- Removes setting in Auth code handler

### Manual testing: 
- Deployed to dev and ran through an uplift journey - no issues

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->