### PR TITLE
ATO-1567: add public subject id to orch client session

### DIFF
--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -210,13 +210,14 @@ class IPVCallbackHandlerTest {
                     CLIENT_NAME);
     private final OrchClientSessionItem orchClientSession =
             new OrchClientSessionItem(
-                    CLIENT_SESSION_ID,
-                    authRequestParams,
-                    null,
-                    List.of(
-                            new VectorOfTrust(CredentialTrustLevel.LOW_LEVEL),
-                            new VectorOfTrust(CredentialTrustLevel.MEDIUM_LEVEL)),
-                    CLIENT_NAME);
+                            CLIENT_SESSION_ID,
+                            authRequestParams,
+                            null,
+                            List.of(
+                                    new VectorOfTrust(CredentialTrustLevel.LOW_LEVEL),
+                                    new VectorOfTrust(CredentialTrustLevel.MEDIUM_LEVEL)),
+                            CLIENT_NAME)
+                    .withPublicSubjectId(PUBLIC_SUBJECT.getValue());
     private final Json objectMapper = SerializationService.getInstance();
 
     private static Stream<Arguments> additionalClaims() {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -445,6 +445,8 @@ public class AuthenticationCallbackHandler
                         userInfo.getStringClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue()));
                 orchClientSession.setRpPairwiseId(
                         userInfo.getStringClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue()));
+                orchClientSession.setPublicSubjectId(
+                        userInfo.getStringClaim(AuthUserInfoClaims.PUBLIC_SUBJECT_ID.getValue()));
 
                 sessionService.storeOrUpdateSession(session, sessionId);
                 orchSessionService.updateSession(orchSession);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -167,6 +167,7 @@ class AuthenticationCallbackHandlerTest {
     private static final String CLIENT_NAME = "client-name";
     private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
     private static final Subject RP_PAIRWISE_ID = new Subject();
+    private static final Subject PUBLIC_SUBJECT_ID = new Subject();
     private static final URI REDIRECT_URI = URI.create("https://test.rp.redirect.uri");
     private static final URI IPV_REDIRECT_URI = URI.create("https://test.ipv.redirect.uri");
     private static final State RP_STATE = new State();
@@ -239,6 +240,8 @@ class AuthenticationCallbackHandlerTest {
                 .thenReturn(RP_PAIRWISE_ID.getValue());
         when(USER_INFO.getStringClaim(AuthUserInfoClaims.RP_PAIRWISE_ID.getValue()))
                 .thenReturn(RP_PAIRWISE_ID.getValue());
+        when(USER_INFO.getStringClaim(AuthUserInfoClaims.PUBLIC_SUBJECT_ID.getValue()))
+                .thenReturn(PUBLIC_SUBJECT_ID.getValue());
         when(USER_INFO.getPhoneNumber()).thenReturn("1234");
         when(USER_INFO.getClaim(
                         AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(), String.class))
@@ -1571,6 +1574,9 @@ class AuthenticationCallbackHandlerTest {
                 .updateStoredClientSession(orchClientSessionCaptor.capture());
         assertEquals(
                 RP_PAIRWISE_ID.getValue(), orchClientSessionCaptor.getValue().getRpPairwiseId());
+        assertEquals(
+                PUBLIC_SUBJECT_ID.getValue(),
+                orchClientSessionCaptor.getValue().getPublicSubjectId());
     }
 
     private void clientSessionWithCredentialTrustValue(CredentialTrustLevel credentialTrustLevel) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
@@ -19,6 +19,7 @@ public class OrchClientSessionItem {
     private static final String ATTRIBUTE_CREATION_DATE = "CreationDate";
     private static final String ATTRIBUTE_VTR_LIST = "VtrList";
     private static final String ATTRIBUTE_RP_PAIRWISE_ID = "RpPairwiseId";
+    private static final String ATTRIBUTE_PUBLIC_SUBJECT_ID = "PublicSubjectId";
     private static final String ATTRIBUTE_DOC_APP_SUBJECT_ID = "DocAppSubjectId";
     private static final String ATTRIBUTE_CLIENT_NAME = "ClientName";
     private static final String ATTRIBUTE_TTL = "ttl";
@@ -28,6 +29,7 @@ public class OrchClientSessionItem {
     private LocalDateTime creationDate;
     private List<VectorOfTrust> vtrList;
     private String rpPairwiseId;
+    private String publicSubjectId;
     private String docAppSubjectId;
     private String clientName;
     private long timeToLive;
@@ -141,6 +143,20 @@ public class OrchClientSessionItem {
 
     public OrchClientSessionItem withRpPairwiseId(String rpPairwiseId) {
         this.rpPairwiseId = rpPairwiseId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_PUBLIC_SUBJECT_ID)
+    public String getPublicSubjectId() {
+        return publicSubjectId;
+    }
+
+    public void setPublicSubjectId(String publicSubjectId) {
+        this.publicSubjectId = publicSubjectId;
+    }
+
+    public OrchClientSessionItem withPublicSubjectId(String publicSubjectId) {
+        this.publicSubjectId = publicSubjectId;
         return this;
     }
 


### PR DESCRIPTION
### Wider context of change
We need to have access to the publicSubjectId in Orchestration. This is currently done by getting it from UserProfile, which we won't have access to. Hence, we need to add it onto the OrchClientSession. It is currently a claim we request from Auth if the "am" claim is present ("Account Management").

### What’s changed
Added a field to OrchClientSession and set to it AuthenticationCallbackHandler

### Manual testing
n/a

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing. **yes**

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required. **N/A**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required. **N/A**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required. **N/A**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required. **N/A**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**

### Related PRs
PR to always request publicSubjectId for clients with a PUBLIC subjectType https://github.com/govuk-one-login/authentication-api/pull/6271
