### PR TITLE
ATO-1481: improve back channel logout

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/PostRequestFailureException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/PostRequestFailureException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+public class PostRequestFailureException extends RuntimeException {
+    public PostRequestFailureException(String message) {
+        super(message);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.oidc.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -9,6 +10,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.authentication.oidc.exceptions.PostRequestFailureException;
 import uk.gov.di.authentication.oidc.services.HttpRequestService;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.entity.BackChannelLogoutMessage;
@@ -23,6 +25,8 @@ import uk.gov.di.orchestration.shared.services.TokenService;
 import java.net.URI;
 import java.time.Clock;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -77,9 +81,19 @@ public class BackChannelLogoutRequestHandler implements RequestHandler<SQSEvent,
 
         attachLogFieldToLogs(LogLineHelper.LogFieldName.AWS_REQUEST_ID, context.getAwsRequestId());
 
-        event.getRecords().forEach(this::sendLogoutMessage);
+        List<SQSBatchResponse.BatchItemFailure> batchItemFailures = new ArrayList<>();
 
-        return null;
+        for (SQSEvent.SQSMessage message : event.getRecords()) {
+            try {
+                sendLogoutMessage(message);
+            } catch (PostRequestFailureException e) {
+                LOG.warn(e.getMessage());
+                batchItemFailures.add(
+                        new SQSBatchResponse.BatchItemFailure(message.getMessageId()));
+            }
+        }
+
+        return new SQSBatchResponse(batchItemFailures);
     }
 
     private void sendLogoutMessage(SQSMessage record) {

--- a/template.yaml
+++ b/template.yaml
@@ -63,6 +63,7 @@ Conditions:
       !Equals [production, !Ref Environment],
     ]
   IsNotProduction: !Not [!Equals [!Ref Environment, production]]
+  IsNotIntegration: !Not [!Equals [!Ref Environment, integration]]
   IsNotDevOrProd:
     !Not [
       !Or [
@@ -1262,6 +1263,8 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt BackChannelLogoutQueue.Arn
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
       Environment:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
@@ -4355,6 +4358,29 @@ Resources:
       KeyUsage: ENCRYPT_DECRYPT
       KeySpec: SYMMETRIC_DEFAULT
       EnableKeyRotation: true
+
+  BackChannelLogoutDLQAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsNotIntegration
+    Properties:
+      AlarmName: !Sub ${Environment}-backchannel-logout-dlq-alarm
+      AlarmDescription: !Sub "${Environment} backchannel logout DLQ has a message.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/spaces/Orch/pages/5292228639/Runbook+Backchannel+Logout+DLQ+Alarm"
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref SlackEvents
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value:
+            Fn::GetAtt:
+              - BackChannelLogoutDeadLetterQueue
+              - QueueName
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
   #endregion
 
   #region Storage Token Jwk Lambda


### PR DESCRIPTION
### Wider context of change

We want to improve the back channel logout logic to send an alarm if it fails.

### What’s changed

New cloudwatch alarm and HttpRequestService now throws if status isn't 200

### Manual testing

Tested on dev with a stub with backchannel logout url. Also removed authorize lambda to test it passes too.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**