### PR TITLE
AUT-4123: Initial mfa property analysis lambda

### DIFF
--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -245,6 +245,10 @@ output "user_profile_kms_key_arn" {
   value = aws_kms_key.user_profile_table_encryption_key.arn
 }
 
+output "user_credentials_kms_key_arn" {
+  value = aws_kms_key.user_credentials_table_encryption_key.arn
+}
+
 output "authentication_attempt_kms_key_arn" {
   value = aws_kms_key.authentication_attempt_encryption_key.arn
 }

--- a/ci/terraform/utils/authdev1.tfvars
+++ b/ci/terraform/utils/authdev1.tfvars
@@ -9,6 +9,7 @@ bulk_user_email_email_sending_enabled             = false
 bulk_user_email_included_terms_and_conditions     = "1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8"
 bulk_user_email_max_audience_load_user_batch_size = 5
 bulk_user_email_max_audience_load_user_count      = 10
+mfa_method_analysis_enabled                       = true
 
 # Logging
 cloudwatch_log_retention = 30

--- a/ci/terraform/utils/authdev2.tfvars
+++ b/ci/terraform/utils/authdev2.tfvars
@@ -9,6 +9,7 @@ bulk_user_email_email_sending_enabled             = false
 bulk_user_email_included_terms_and_conditions     = "1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8"
 bulk_user_email_max_audience_load_user_batch_size = 5
 bulk_user_email_max_audience_load_user_count      = 10
+mfa_method_analysis_enabled                       = true
 
 # Logging
 cloudwatch_log_retention = 30

--- a/ci/terraform/utils/dev.tfvars
+++ b/ci/terraform/utils/dev.tfvars
@@ -17,5 +17,7 @@ bulk_user_email_batch_query_limit     = 25
 bulk_user_email_max_batch_count       = 100
 bulk_user_email_batch_pause_duration  = 0
 
+mfa_method_analysis_enabled = true
+
 # Sizing
 email_check_results_writer_provisioned_concurrency = 0

--- a/ci/terraform/utils/mfa_method_analysis_lambda.tf
+++ b/ci/terraform/utils/mfa_method_analysis_lambda.tf
@@ -1,0 +1,96 @@
+data "aws_iam_policy_document" "mfa_method_analysis_dynamo_access" {
+  count = var.mfa_method_analysis_enabled ? 1 : 0
+  statement {
+    sid    = "AllowAccessToFetchUserTablesData"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Scan",
+      "dynamodb:GetItem",
+    ]
+
+    resources = [
+      data.aws_dynamodb_table.user_profile.arn,
+      data.aws_dynamodb_table.user_credentials.arn,
+    ]
+  }
+
+  statement {
+    sid    = "AllowAccessToKms"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = [local.user_profile_kms_key_arn, local.user_credentials_kms_key_arn]
+  }
+}
+
+# data "aws_dynamodb_table" "user_profile" {
+#   name = "${var.environment}-user-profile"
+# }
+#
+# data "aws_dynamodb_table" "user_credentials" {
+#   name = "${var.environment}-user-credentials"
+# }
+
+resource "aws_iam_policy" "mfa_method_analysis_dynamo_access" {
+  count       = var.mfa_method_analysis_enabled ? 1 : 0
+  name_prefix = "account-metrics-dynamo-access-policy"
+  description = "IAM policy for managing permissions to for the MFA method analysis lambda"
+
+  policy = data.aws_iam_policy_document.mfa_method_analysis_dynamo_access[0].json
+}
+
+module "mfa_method_analysis_lambda_role" {
+  count  = var.mfa_method_analysis_enabled ? 1 : 0
+  source = "../modules/lambda-role"
+
+  environment = var.environment
+  role_name   = "mfa-method-analysis-lambda-role"
+
+  policies_to_attach = [
+    aws_iam_policy.mfa_method_analysis_dynamo_access[0].arn,
+  ]
+}
+
+resource "aws_lambda_function" "mfa_method_analysis_lambda" {
+  count         = var.mfa_method_analysis_enabled ? 1 : 0
+  function_name = "${var.environment}-mfa-method-analysis-lambda"
+  role          = module.mfa_method_analysis_lambda_role[0].arn
+  handler       = "uk.gov.di.authentication.utils.lambda.MFAMethodAnalysisHandler::handleRequest"
+  timeout       = 900
+  memory_size   = 4096
+  runtime       = "java17"
+  publish       = true
+
+  s3_bucket         = aws_s3_object.utils_release_zip.bucket
+  s3_key            = aws_s3_object.utils_release_zip.key
+  s3_object_version = aws_s3_object.utils_release_zip.version_id
+
+  environment {
+    variables = merge({
+      ENVIRONMENT = var.environment
+    })
+  }
+}
+
+resource "aws_cloudwatch_log_group" "mfa_method_analysis_lambda_log_group" {
+  count             = var.mfa_method_analysis_enabled ? 1 : 0
+  name              = "/aws/lambda/${aws_lambda_function.mfa_method_analysis_lambda[0].function_name}"
+  kms_key_id        = local.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
+}
+
+
+resource "aws_cloudwatch_log_subscription_filter" "mfa_method_analysis_log_subscription" {
+  count           = (var.mfa_method_analysis_enabled && length(var.logging_endpoint_arns) > 0) ? length(var.logging_endpoint_arns) : 0
+  name            = "${aws_lambda_function.mfa_method_analysis_lambda[0].function_name}-log-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.mfa_method_analysis_lambda_log_group[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}

--- a/ci/terraform/utils/sandpit.tfvars
+++ b/ci/terraform/utils/sandpit.tfvars
@@ -9,6 +9,7 @@ bulk_user_email_email_sending_enabled             = false
 bulk_user_email_included_terms_and_conditions     = "1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8"
 bulk_user_email_max_audience_load_user_batch_size = 5
 bulk_user_email_max_audience_load_user_count      = 10
+mfa_method_analysis_enabled                       = true
 
 # Logging
 cloudwatch_log_retention = 30

--- a/ci/terraform/utils/shared.tf
+++ b/ci/terraform/utils/shared.tf
@@ -25,6 +25,7 @@ locals {
   }
   common_passwords_encryption_policy_arn = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
   user_profile_kms_key_arn               = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
+  user_credentials_kms_key_arn           = data.terraform_remote_state.shared.outputs.user_credentials_kms_key_arn
 
   slack_event_sns_topic_arn = data.terraform_remote_state.shared.outputs.slack_event_sns_topic_arn
   aws_account_alias         = data.terraform_remote_state.shared.outputs.aws_account_alias

--- a/ci/terraform/utils/staging.tfvars
+++ b/ci/terraform/utils/staging.tfvars
@@ -2,7 +2,8 @@ utils_release_zip_file = "./artifacts/utils.zip"
 shared_state_bucket    = "di-auth-staging-tfstate"
 
 # App-specific
-internal_sector_uri = "https://identity.staging.account.gov.uk"
+internal_sector_uri         = "https://identity.staging.account.gov.uk"
+mfa_method_analysis_enabled = true
 
 allow_bulk_test_users                         = true
 bulk_user_email_included_terms_and_conditions = "1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8"

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -177,3 +177,9 @@ variable "support_email_check_enabled" {
   type        = bool
   description = "Feature flag which toggles the Experian email check on and off"
 }
+
+variable "mfa_method_analysis_enabled" {
+  default     = false
+  type        = bool
+  description = "Feature flag which toggles the deployment of the MFA method analysis lambda"
+}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandler.java
@@ -1,0 +1,90 @@
+package uk.gov.di.authentication.utils.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.text.MessageFormat.format;
+import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
+
+public class MFAMethodAnalysisHandler implements RequestHandler<String, Integer> {
+
+    private static final Logger LOG = LogManager.getLogger(MFAMethodAnalysisHandler.class);
+    private final ConfigurationService configurationService;
+    private final DynamoDbClient client;
+
+    public MFAMethodAnalysisHandler(
+            ConfigurationService configurationService, DynamoDbClient client) {
+        this.configurationService = configurationService;
+        this.client = client;
+    }
+
+    public MFAMethodAnalysisHandler() {
+        this.configurationService = ConfigurationService.getInstance();
+        client = createDynamoClient(configurationService);
+    }
+
+    @Override
+    public Integer handleRequest(String input, Context context) {
+        Map<String, String> expressionAttributeNames = new HashMap<>();
+        Map<String, AttributeValue> lastKey;
+        expressionAttributeNames.put("#mfa_methods", UserCredentials.ATTRIBUTE_MFA_METHODS);
+
+        int matches = 0;
+        do {
+            ScanRequest scanRequest =
+                    ScanRequest.builder()
+                            .tableName(
+                                    format(
+                                            "{0}-user-credentials",
+                                            configurationService.getEnvironment()))
+                            .filterExpression("attribute_exists(#mfa_methods)")
+                            .expressionAttributeNames(expressionAttributeNames)
+                            .build();
+
+            ScanResponse scanResponse = client.scan(scanRequest);
+
+            for (Map<String, AttributeValue> userCredentialsItem : scanResponse.items()) {
+                String email = userCredentialsItem.get(UserCredentials.ATTRIBUTE_EMAIL).s();
+
+                Map<String, AttributeValue> keyToGet = new HashMap<>();
+                keyToGet.put(
+                        UserProfile.ATTRIBUTE_EMAIL, AttributeValue.builder().s(email).build());
+                GetItemRequest getItemRequest =
+                        GetItemRequest.builder()
+                                .tableName(
+                                        format(
+                                                "{0}-user-profile",
+                                                configurationService.getEnvironment()))
+                                .key(keyToGet)
+                                .build();
+
+                GetItemResponse userProfileResponse = client.getItem(getItemRequest);
+                Map<String, AttributeValue> userProfileItem = userProfileResponse.item();
+
+                if (userProfileItem != null && !userProfileItem.isEmpty()) {
+                    matches++;
+                }
+            }
+
+            lastKey = scanResponse.lastEvaluatedKey();
+        } while (lastKey != null && !lastKey.isEmpty());
+
+        LOG.info("Found {} credentials/profile matches with AUTH_APP", matches);
+
+        return matches;
+    }
+}

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandlerTest.java
@@ -1,0 +1,66 @@
+package uk.gov.di.authentication.utils.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MFAMethodAnalysisHandlerTest {
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final DynamoDbClient client = mock(DynamoDbClient.class);
+
+    private final MFAMethodAnalysisHandler handler =
+            new MFAMethodAnalysisHandler(configurationService, client);
+
+    @Test
+    void shouldFindTheNumberOfMatches() {
+        when(configurationService.getEnvironment()).thenReturn("test");
+
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("Email", AttributeValue.builder().s("test@example.com").build());
+
+        Map<String, String> expressionAttributeNames = new HashMap<>();
+        expressionAttributeNames.put("#mfa_methods", UserCredentials.ATTRIBUTE_MFA_METHODS);
+        when(client.scan(
+                        ScanRequest.builder()
+                                .tableName("test-user-credentials")
+                                .filterExpression("attribute_exists(#mfa_methods)")
+                                .expressionAttributeNames(expressionAttributeNames)
+                                .build()))
+                .thenReturn(
+                        ScanResponse.builder()
+                                .items(Collections.singletonList(item))
+                                .count(1)
+                                .scannedCount(1)
+                                .build());
+
+        Map<String, AttributeValue> keyToGet = new HashMap<>();
+        keyToGet.put(
+                UserProfile.ATTRIBUTE_EMAIL,
+                AttributeValue.builder().s("test@example.com").build());
+        when(client.getItem(
+                        GetItemRequest.builder()
+                                .tableName("test-user-profile")
+                                .key(keyToGet)
+                                .build()))
+                .thenReturn(GetItemResponse.builder().item(item).build());
+
+        assertEquals(1, handler.handleRequest("", mock(Context.class)));
+    }
+}


### PR DESCRIPTION
# What

We need to assess MFA property values across two DynamoDB tables in production to be confident we have not missed any combinations in our understanding before continuing part of the method management work.

Here this initial lambda will be tested in staging. It contains the logic for the more complex data fetch we'll need to do. After testing we can expand on what the lambda is doing with the data.

This lambda exists so we do not need to access any prod data directly. The lambda is expected to return the analysis results, not the source data itself.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
