### PR TITLE
ATO-1513: remove preservedReauthCountsForAudit from Session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -33,7 +33,6 @@ import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.net.URI;
 import java.util.Map;
-import java.util.Objects;
 
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_REAUTH_SUCCESS;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
@@ -151,14 +150,6 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                                 .getValue();
                 var metadataBuilder = ReauthMetadataBuilder.builder(rpPairwiseId);
 
-                LOG.info(
-                        "Preserved reauth counts for audit migration check {}",
-                        Objects.equals(
-                                userContext.getSession().getPreservedReauthCountsForAudit(),
-                                userContext
-                                        .getAuthSession()
-                                        .getPreservedReauthCountsForAuditMap()));
-
                 if (userContext.getAuthSession().getPreservedReauthCountsForAuditMap() != null) {
                     metadataBuilder.withAllIncorrectAttemptCounts(
                             userContext.getAuthSession().getPreservedReauthCountsForAuditMap());
@@ -171,9 +162,6 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                         CloudwatchMetrics.REAUTH_SUCCESS.getValue(),
                         Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
                 LOG.info("reauthentication successful");
-                sessionService.storeOrUpdateSession(
-                        userContext.getSession().setPreservedReauthCountsForAudit(null),
-                        userContext.getAuthSession().getSessionId());
                 authSessionService.updateSession(
                         userContext.getAuthSession().withPreservedReauthCountsForAuditMap(null));
             }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -21,7 +21,6 @@ import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
@@ -379,9 +378,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             AuditContext auditContext,
             ClientRegistry client,
             Optional<String> maybeRpPairwiseId) {
-        var session = userContext.getSession();
         var authSession = userContext.getAuthSession();
-        var sessionId = authSession.getSessionId();
         var notificationType = codeRequest.notificationType();
         int loginFailureCount =
                 codeStorageService.getIncorrectMfaCodeAttemptsCount(authSession.getEmailAddress());
@@ -411,7 +408,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
         if (configurationService.isAuthenticationAttemptsServiceEnabled() && subjectId != null) {
             preserveReauthCountsForAuditIfJourneyIsReauth(
-                    journeyType, subjectId, session, authSession, sessionId, maybeRpPairwiseId);
+                    journeyType, subjectId, authSession, maybeRpPairwiseId);
             clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
             maybeRpPairwiseId.ifPresentOrElse(
                     this::clearReauthErrorCountsForSuccessfullyAuthenticatedUser,
@@ -429,9 +426,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     void preserveReauthCountsForAuditIfJourneyIsReauth(
             JourneyType journeyType,
             String subjectId,
-            Session session,
             AuthSessionItem authSession,
-            String sessionId,
             Optional<String> maybeRpPairwiseId) {
         if (journeyType == JourneyType.REAUTHENTICATION
                 && configurationService.supportReauthSignoutEnabled()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -445,8 +445,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                                             JourneyType.REAUTHENTICATION)
                             : authenticationAttemptsService.getCountsByJourney(
                                     subjectId, JourneyType.REAUTHENTICATION);
-            var updatedSession = session.setPreservedReauthCountsForAudit(counts);
-            sessionService.storeOrUpdateSession(updatedSession, sessionId);
             var updatedAuthSession = authSession.withPreservedReauthCountsForAuditMap(counts);
             authSessionService.updateSession(updatedAuthSession);
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -341,9 +341,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         } else {
             auditSuccess(codeRequest, authSession, auditContext);
             processSuccessfulCodeSession(
-                    session,
                     userContext.getAuthSession(),
-                    sessionId,
                     input,
                     subjectId,
                     codeRequest,
@@ -435,9 +433,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
     }
 
     private void processSuccessfulCodeSession(
-            Session session,
             AuthSessionItem authSession,
-            String sessionId,
             APIGatewayProxyRequestEvent input,
             String subjectId,
             VerifyMfaCodeRequest codeRequest,
@@ -448,12 +444,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 && codeRequest.getMfaMethodType() == MFAMethodType.AUTH_APP
                 && subjectId != null) {
             preserveReauthCountsForAuditIfJourneyIsReauth(
-                    codeRequest.getJourneyType(),
-                    subjectId,
-                    session,
-                    authSession,
-                    sessionId,
-                    maybeRpPairwiseId);
+                    codeRequest.getJourneyType(), subjectId, authSession, maybeRpPairwiseId);
             clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
             maybeRpPairwiseId.ifPresentOrElse(
                     this::clearReauthErrorCountsForSuccessfullyAuthenticatedUser,
@@ -493,9 +484,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
     void preserveReauthCountsForAuditIfJourneyIsReauth(
             JourneyType journeyType,
             String subjectId,
-            Session session,
             AuthSessionItem authSession,
-            String sessionId,
             Optional<String> maybeRpPairwiseId) {
         if (journeyType == JourneyType.REAUTHENTICATION
                 && configurationService.supportReauthSignoutEnabled()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -509,8 +509,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                                             JourneyType.REAUTHENTICATION)
                             : authenticationAttemptsService.getCountsByJourney(
                                     subjectId, JourneyType.REAUTHENTICATION);
-            var updatedSession = session.setPreservedReauthCountsForAudit(counts);
-            sessionService.storeOrUpdateSession(updatedSession, sessionId);
             var updatedAuthSession = authSession.withPreservedReauthCountsForAuditMap(counts);
             authSessionService.updateSession(updatedAuthSession);
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -272,10 +272,6 @@ class AuthenticationAuthCodeHandlerTest {
                     .thenReturn(new Subject(CALCULATED_PAIRWISE_ID));
             var existingPasswordCount = 1;
             var existingEmailCount = 2;
-            session.setPreservedReauthCountsForAudit(
-                    Map.ofEntries(
-                            Map.entry(CountType.ENTER_PASSWORD, existingPasswordCount),
-                            Map.entry(CountType.ENTER_EMAIL, existingEmailCount)));
             authSession.setPreservedReauthCountsForAuditMap(
                     Map.ofEntries(
                             Map.entry(CountType.ENTER_PASSWORD, existingPasswordCount),
@@ -310,10 +306,6 @@ class AuthenticationAuthCodeHandlerTest {
                     .incrementCounter(
                             CloudwatchMetrics.REAUTH_SUCCESS.getValue(),
                             Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
-            verify(sessionService, atLeastOnce())
-                    .storeOrUpdateSession(
-                            argThat(s -> Objects.isNull(s.getPreservedReauthCountsForAudit())),
-                            eq(SESSION_ID));
             verify(authSessionService, atLeastOnce())
                     .updateSession(
                             argThat(s -> Objects.isNull(s.getPreservedReauthCountsForAuditMap())));
@@ -338,7 +330,6 @@ class AuthenticationAuthCodeHandlerTest {
                                             eq(userProfile), any(), any(), any()))
                     .thenReturn(new Subject(CALCULATED_PAIRWISE_ID));
             // This is already the case but just to make it explicit here
-            session.setPreservedReauthCountsForAudit(null);
             authSession.setPreservedReauthCountsForAuditMap(null);
 
             var body =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -783,13 +783,6 @@ class VerifyCodeHandlerTest {
                                                 any()));
 
         if (journeyType == REAUTHENTICATION) {
-            verify(sessionService, atLeastOnce())
-                    .storeOrUpdateSession(
-                            argThat(
-                                    s ->
-                                            s.getPreservedReauthCountsForAudit()
-                                                    .equals(existingCounts)),
-                            eq(SESSION_ID));
             verify(authSessionService, atLeastOnce())
                     .updateSession(
                             argThat(
@@ -797,14 +790,6 @@ class VerifyCodeHandlerTest {
                                             s.getPreservedReauthCountsForAuditMap()
                                                     .equals(existingCounts)));
         } else {
-            verify(sessionService, never())
-                    .storeOrUpdateSession(
-                            argThat(
-                                    s ->
-                                            Objects.equals(
-                                                    s.getPreservedReauthCountsForAudit(),
-                                                    existingCounts)),
-                            eq(SESSION_ID));
             verify(authSessionService, never())
                     .updateSession(
                             argThat(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -910,10 +910,6 @@ class VerifyMfaCodeHandlerTest {
                                                 eq(JourneyType.REAUTHENTICATION),
                                                 any()));
 
-        verify(sessionService, atLeastOnce())
-                .storeOrUpdateSession(
-                        argThat(s -> s.getPreservedReauthCountsForAudit().equals(existingCounts)),
-                        eq(SESSION_ID));
         verify(authSessionService, atLeastOnce())
                 .updateSession(
                         argThat(
@@ -946,14 +942,6 @@ class VerifyMfaCodeHandlerTest {
                         JourneyType.REAUTHENTICATION,
                         CountType.ENTER_AUTH_APP_CODE);
 
-        verify(sessionService, never())
-                .storeOrUpdateSession(
-                        argThat(
-                                s ->
-                                        Objects.equals(
-                                                s.getPreservedReauthCountsForAudit(),
-                                                existingCounts)),
-                        eq(SESSION_ID));
         verify(authSessionService, never())
                 .updateSession(
                         argThat(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -32,8 +32,6 @@ public class Session {
 
     @Expose private Map<CodeRequestType, Integer> codeRequestCountMap;
 
-    @Expose private Map<CountType, Integer> preservedReauthCountsForAudit;
-
     @Expose private CredentialTrustLevel currentCredentialStrength;
 
     @Expose private AccountState isNewAccount;
@@ -67,16 +65,6 @@ public class Session {
     public Session setEmailAddress(String emailAddress) {
         this.emailAddress = emailAddress;
         return this;
-    }
-
-    public Session setPreservedReauthCountsForAudit(
-            Map<CountType, Integer> reauthCountsBeforeDeletionFromCountStore) {
-        this.preservedReauthCountsForAudit = reauthCountsBeforeDeletionFromCountStore;
-        return this;
-    }
-
-    public Map<CountType, Integer> getPreservedReauthCountsForAudit() {
-        return preservedReauthCountsForAudit;
     }
 
     public Session setCurrentCredentialStrength(CredentialTrustLevel currentCredentialStrength) {


### PR DESCRIPTION
### Wider context of change

Part of the session migration. Removing preservedReauthCountsForAudit from shared session

### What’s changed

Remove all instances of preservedReauthCountsForAudit from Session.

### Manual testing

Ran reauth journey and checked logs from previous PRs. Checked this isn't used in orch (which it isn't).

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**