### PR TITLE
ATO-1215: set orch AuthCode in AuthCode handler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/OrchAuthCodeAssertionHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/OrchAuthCodeAssertionHelper.java
@@ -16,6 +16,12 @@ public class OrchAuthCodeAssertionHelper {
     public static void assertOrchAuthCodeSaved(
             OrchAuthCodeExtension orchAuthCodeExtension, APIGatewayProxyResponseEvent response) {
         String responseLocationHeader = response.getHeaders().get(ResponseHeaders.LOCATION);
+
+        assertOrchAuthCodeSaved(orchAuthCodeExtension, responseLocationHeader);
+    }
+
+    public static void assertOrchAuthCodeSaved(
+            OrchAuthCodeExtension orchAuthCodeExtension, String responseLocationHeader) {
         String authCode = extractAuthCodeFromResponseLocationHeader(responseLocationHeader);
 
         Optional<AuthCodeExchangeData> exchangeData =

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -39,6 +39,7 @@ import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
+import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
@@ -79,6 +80,7 @@ public class AuthCodeHandler
     private final AuthenticationUserInfoStorageService authUserInfoStorageService;
     private final AuthCodeResponseGenerationService authCodeResponseService;
     private final AuthorisationCodeService authorisationCodeService;
+    private final OrchAuthCodeService orchAuthCodeService;
     private final OrchestrationAuthorizationService orchestrationAuthorizationService;
     private final OrchClientSessionService orchClientSessionService;
     private final AuditService auditService;
@@ -92,6 +94,7 @@ public class AuthCodeHandler
             AuthenticationUserInfoStorageService authUserInfoStorageService,
             AuthCodeResponseGenerationService authCodeResponseService,
             AuthorisationCodeService authorisationCodeService,
+            OrchAuthCodeService orchAuthCodeService,
             OrchestrationAuthorizationService orchestrationAuthorizationService,
             OrchClientSessionService orchClientSessionService,
             AuditService auditService,
@@ -103,6 +106,7 @@ public class AuthCodeHandler
         this.authUserInfoStorageService = authUserInfoStorageService;
         this.authCodeResponseService = authCodeResponseService;
         this.authorisationCodeService = authorisationCodeService;
+        this.orchAuthCodeService = orchAuthCodeService;
         this.orchestrationAuthorizationService = orchestrationAuthorizationService;
         this.orchClientSessionService = orchClientSessionService;
         this.auditService = auditService;
@@ -116,6 +120,7 @@ public class AuthCodeHandler
         orchSessionService = new OrchSessionService(configurationService);
         authUserInfoStorageService = new AuthenticationUserInfoStorageService(configurationService);
         authorisationCodeService = new AuthorisationCodeService(configurationService);
+        orchAuthCodeService = new OrchAuthCodeService(configurationService);
         orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(configurationService);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
@@ -133,6 +138,7 @@ public class AuthCodeHandler
         orchSessionService = new OrchSessionService(configurationService);
         authUserInfoStorageService = new AuthenticationUserInfoStorageService(configurationService);
         authorisationCodeService = new AuthorisationCodeService(configurationService);
+        orchAuthCodeService = new OrchAuthCodeService(configurationService);
         orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(configurationService);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -53,6 +53,7 @@ import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
+import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
@@ -109,6 +110,7 @@ class AuthCodeHandlerTest {
     private final AuditService auditService = mock(AuditService.class);
     private final AuthorisationCodeService authorisationCodeService =
             mock(AuthorisationCodeService.class);
+    private final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
     private final OrchClientSessionItem orchClientSession = mock(OrchClientSessionItem.class);
     private final OrchClientSessionService orchClientSessionService =
             mock(OrchClientSessionService.class);
@@ -179,6 +181,7 @@ class AuthCodeHandlerTest {
                         authUserInfoService,
                         authCodeResponseService,
                         authorisationCodeService,
+                        orchAuthCodeService,
                         orchestrationAuthorizationService,
                         orchClientSessionService,
                         auditService,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -275,7 +275,16 @@ class AuthCodeHandlerTest {
                         authRequest.getResponseMode());
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
+
+        // TODO: ATO-1218: Remove the following stub for the auth code service.
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(EMAIL),
+                        any(Long.class)))
+                .thenReturn(authorizationCode);
+        when(orchAuthCodeService.generateAndSaveAuthorisationCode(
+                        any(AuthorizationCode.class),
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(EMAIL),
@@ -389,8 +398,17 @@ class AuthCodeHandlerTest {
         when(orchClientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(requestedLevel)));
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
+
+        // TODO: ATO-1218: Remove the following stub for the auth code service.
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
                         eq(CLIENT_ID.getValue()), eq(CLIENT_SESSION_ID), eq(null), any(Long.class)))
+                .thenReturn(authorizationCode);
+        when(orchAuthCodeService.generateAndSaveAuthorisationCode(
+                        any(AuthorizationCode.class),
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(null),
+                        any(Long.class)))
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(
                         eq(orchSession),
@@ -700,7 +718,16 @@ class AuthCodeHandlerTest {
         when(orchClientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(MEDIUM_LEVEL)));
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
+
+        // TODO: ATO-1218: Remove the following stub for the auth code service.
         when(authorisationCodeService.generateAndSaveAuthorisationCode(
+                        eq(CLIENT_ID.getValue()),
+                        eq(CLIENT_SESSION_ID),
+                        eq(EMAIL),
+                        any(Long.class)))
+                .thenReturn(authorizationCode);
+        when(orchAuthCodeService.generateAndSaveAuthorisationCode(
+                        any(AuthorizationCode.class),
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(EMAIL),


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Currently RP issued auth codes are stored in Redis. We are migrating away from Redis to DynamoDB. The auth code store is being migrated under the parent ticket.

A new entity and service has been previously added under #6220. Write policy was added to this lambda under #6190.

This work stores the auth code in DynamoDB for the AuthCode lambda using the new service. Note that we do not wish to remove the Redis setter call - this will be done under ATO-1218.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Added call to the `generateAndSaveAuthorisationCode` method on the orch auth code service
- Added test stubs for the new orch auth code service
- Added unit and integration tests for checking we are (or are not) writing to the new DynamoDB table
- Added method overload to test assertion helper to accept a response location header string

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to Orch dev, ran through an identity journey (sandpit RP stub, selected "P2" level of confidence, clicked continue, signed in, clicked continue on the IPV stub form using the default values, redirected to user info screen).

Redirected successfully to the user information screen. The `AuthCodeFunction` lambda logs showed a call being made to the new orch auth code service.

Reviewed the `dev-Orch-Auth-Code` DynamoDB table - the expected item and attribute values were found: auth code, exchange data, IsUsed=false, and a 5 minute TTL (expected value based on config).

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.
  - (Write policy (`OrchAuthCodeTableWriteAccessPolicy`) previously added to the `AuthCodeFunction` CloudFormation. Writing as expected - see manual testing section above.)

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or **not required**.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or **not required**.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or **not required**.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or **not required**.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or **not required**.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Entity and service - #6220
- Update to use the same auth code for both stores to enable consistency checks - #6221
- DynamoDB write policy additions to lambdas - #6190
