### PR TITLE
AUT-4123: Use BatchGetItem to improve performance

### DIFF
--- a/ci/terraform/utils/mfa_method_analysis_lambda.tf
+++ b/ci/terraform/utils/mfa_method_analysis_lambda.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "mfa_method_analysis_dynamo_access" {
     actions = [
       "dynamodb:DescribeTable",
       "dynamodb:Scan",
-      "dynamodb:GetItem",
+      "dynamodb:BatchGetItem",
     ]
 
     resources = [

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandler.java
@@ -6,21 +6,24 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
-import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.text.MessageFormat.format;
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
 
-public class MFAMethodAnalysisHandler implements RequestHandler<String, Integer> {
+public class MFAMethodAnalysisHandler implements RequestHandler<String, Long> {
 
     private static final Logger LOG = LogManager.getLogger(MFAMethodAnalysisHandler.class);
     private final ConfigurationService configurationService;
@@ -38,46 +41,47 @@ public class MFAMethodAnalysisHandler implements RequestHandler<String, Integer>
     }
 
     @Override
-    public Integer handleRequest(String input, Context context) {
+    public Long handleRequest(String input, Context context) {
         Map<String, String> expressionAttributeNames = new HashMap<>();
-        Map<String, AttributeValue> lastKey;
+        Map<String, AttributeValue> lastKey = null;
         expressionAttributeNames.put("#mfa_methods", UserCredentials.ATTRIBUTE_MFA_METHODS);
 
-        int matches = 0;
+        long matches = 0;
+        long recordsProcessed = 0;
+
+        String userCredentialsTableName =
+                format("{0}-user-credentials", configurationService.getEnvironment());
+        String userProfileTableName =
+                format("{0}-user-profile", configurationService.getEnvironment());
+
         do {
             ScanRequest scanRequest =
                     ScanRequest.builder()
-                            .tableName(
-                                    format(
-                                            "{0}-user-credentials",
-                                            configurationService.getEnvironment()))
+                            .tableName(userCredentialsTableName)
                             .filterExpression("attribute_exists(#mfa_methods)")
                             .expressionAttributeNames(expressionAttributeNames)
+                            .exclusiveStartKey(lastKey)
                             .build();
 
             ScanResponse scanResponse = client.scan(scanRequest);
 
+            List<String> emailsToGet = new ArrayList<>();
             for (Map<String, AttributeValue> userCredentialsItem : scanResponse.items()) {
-                String email = userCredentialsItem.get(UserCredentials.ATTRIBUTE_EMAIL).s();
-
-                Map<String, AttributeValue> keyToGet = new HashMap<>();
-                keyToGet.put(
-                        UserProfile.ATTRIBUTE_EMAIL, AttributeValue.builder().s(email).build());
-                GetItemRequest getItemRequest =
-                        GetItemRequest.builder()
-                                .tableName(
-                                        format(
-                                                "{0}-user-profile",
-                                                configurationService.getEnvironment()))
-                                .key(keyToGet)
-                                .build();
-
-                GetItemResponse userProfileResponse = client.getItem(getItemRequest);
-                Map<String, AttributeValue> userProfileItem = userProfileResponse.item();
-
-                if (userProfileItem != null && !userProfileItem.isEmpty()) {
-                    matches++;
+                recordsProcessed++;
+                if (recordsProcessed % 100000 == 0) {
+                    LOG.info("Processed {} user credentials records", recordsProcessed);
                 }
+                String email = userCredentialsItem.get(UserCredentials.ATTRIBUTE_EMAIL).s();
+                emailsToGet.add(email);
+
+                if (emailsToGet.size() >= 100) {
+                    matches += batchGetUserProfiles(emailsToGet, userProfileTableName);
+                    emailsToGet.clear();
+                }
+            }
+
+            if (!emailsToGet.isEmpty()) {
+                matches += batchGetUserProfiles(emailsToGet, userProfileTableName);
             }
 
             lastKey = scanResponse.lastEvaluatedKey();
@@ -86,5 +90,31 @@ public class MFAMethodAnalysisHandler implements RequestHandler<String, Integer>
         LOG.info("Found {} credentials/profile matches with AUTH_APP", matches);
 
         return matches;
+    }
+
+    private long batchGetUserProfiles(List<String> emails, String userProfileTableName) {
+        if (emails.isEmpty()) {
+            return 0;
+        }
+
+        Map<String, KeysAndAttributes> requestItems = new HashMap<>();
+        List<Map<String, AttributeValue>> keys = new ArrayList<>();
+        for (String email : emails) {
+            Map<String, AttributeValue> key = new HashMap<>();
+            key.put(UserProfile.ATTRIBUTE_EMAIL, AttributeValue.builder().s(email).build());
+            keys.add(key);
+        }
+        requestItems.put(userProfileTableName, KeysAndAttributes.builder().keys(keys).build());
+
+        BatchGetItemRequest batchGetItemRequest =
+                BatchGetItemRequest.builder().requestItems(requestItems).build();
+
+        BatchGetItemResponse batchGetItemResponse = client.batchGetItem(batchGetItemRequest);
+        Map<String, List<Map<String, AttributeValue>>> results = batchGetItemResponse.responses();
+
+        if (results.containsKey(userProfileTableName)) {
+            return results.get(userProfileTableName).size();
+        }
+        return 0;
     }
 }


### PR DESCRIPTION
## What 

After seeing a timeout at 15 mins of lambda runtime in staging, here we batch get requests for user-profile in bundles of 100 before making requests

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.

## Related PRs

- https://github.com/govuk-one-login/authentication-api/pull/6276