### PR TITLE
AUT-4123: Use ForkJoinPool to parallel BatchGetItem

### DIFF
--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandlerTest.java
@@ -14,7 +14,6 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,20 +24,59 @@ import static org.mockito.Mockito.when;
 
 class MFAMethodAnalysisHandlerTest {
 
-    public static final String TEST_EMAIL = "test@example.com";
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoDbClient client = mock(DynamoDbClient.class);
 
-    private final MFAMethodAnalysisHandler handler =
-            new MFAMethodAnalysisHandler(configurationService, client);
+    @Test
+    void shouldHandleZero() {
+        when(configurationService.getEnvironment()).thenReturn("test");
+
+        List<Map<String, AttributeValue>> items = new ArrayList<>();
+        mockCredentialsScan(items, 0);
+
+        List<Map<String, AttributeValue>> requestKeys = new ArrayList<>();
+        mockProfileBatchGetItem(requestKeys, items, 0, 0);
+
+        var handler = new MFAMethodAnalysisHandler(configurationService, client);
+        assertEquals(0, handler.handleRequest("", mock(Context.class)));
+    }
 
     @Test
     void shouldFindTheNumberOfMatches() {
         when(configurationService.getEnvironment()).thenReturn("test");
 
-        Map<String, AttributeValue> item = new HashMap<>();
-        item.put("Email", AttributeValue.builder().s(TEST_EMAIL).build());
+        int size = 100_123;
+        List<Map<String, AttributeValue>> items = new ArrayList<>();
+        for (int i = 1; i < size + 1; i++) {
+            Map<String, AttributeValue> item = new HashMap<>();
+            item.put("Email", AttributeValue.builder().s(getTestEmail(i)).build());
+            items.add(item);
+        }
+        mockCredentialsScan(items, size);
 
+        List<Map<String, AttributeValue>> requestKeys = new ArrayList<>();
+        for (int i = 1; i < size + 1; i++) {
+            Map<String, AttributeValue> key = new HashMap<>();
+            key.put(
+                    UserProfile.ATTRIBUTE_EMAIL,
+                    AttributeValue.builder().s(getTestEmail(i)).build());
+            requestKeys.add(key);
+
+            if (i % 100 == 0) {
+                mockProfileBatchGetItem(requestKeys, items, i - 100, i);
+                requestKeys = new ArrayList<>();
+            }
+        }
+
+        if (!requestKeys.isEmpty()) {
+            mockProfileBatchGetItem(requestKeys, items, size - requestKeys.size(), size);
+        }
+
+        var handler = new MFAMethodAnalysisHandler(configurationService, client);
+        assertEquals(size, handler.handleRequest("", mock(Context.class)));
+    }
+
+    private void mockCredentialsScan(List<Map<String, AttributeValue>> items, int size) {
         Map<String, String> expressionAttributeNames = new HashMap<>();
         expressionAttributeNames.put("#mfa_methods", UserCredentials.ATTRIBUTE_MFA_METHODS);
         when(client.scan(
@@ -46,26 +84,28 @@ class MFAMethodAnalysisHandlerTest {
                                 .tableName("test-user-credentials")
                                 .filterExpression("attribute_exists(#mfa_methods)")
                                 .expressionAttributeNames(expressionAttributeNames)
+                                .exclusiveStartKey(null)
                                 .build()))
                 .thenReturn(
-                        ScanResponse.builder()
-                                .items(Collections.singletonList(item))
-                                .count(1)
-                                .scannedCount(1)
-                                .build());
+                        ScanResponse.builder().items(items).count(size).scannedCount(size).build());
+    }
 
+    private void mockProfileBatchGetItem(
+            List<Map<String, AttributeValue>> keys,
+            List<Map<String, AttributeValue>> items,
+            int returnItemsFromIndex,
+            int returnItemsToIndex) {
         Map<String, KeysAndAttributes> requestItems = new HashMap<>();
-
-        List<Map<String, AttributeValue>> keys = new ArrayList<>();
-        Map<String, AttributeValue> key = new HashMap<>();
-        key.put(UserProfile.ATTRIBUTE_EMAIL, AttributeValue.builder().s(TEST_EMAIL).build());
-        keys.add(key);
         requestItems.put("test-user-profile", KeysAndAttributes.builder().keys(keys).build());
+
         Map<String, List<Map<String, AttributeValue>>> responses = new HashMap<>();
-        responses.put("test-user-profile", List.of(item));
+        responses.put("test-user-profile", items.subList(returnItemsFromIndex, returnItemsToIndex));
+
         when(client.batchGetItem(BatchGetItemRequest.builder().requestItems(requestItems).build()))
                 .thenReturn(BatchGetItemResponse.builder().responses(responses).build());
+    }
 
-        assertEquals(1, handler.handleRequest("", mock(Context.class)));
+    private String getTestEmail(int counter) {
+        return "test-" + counter + "@example.com";
     }
 }


### PR DESCRIPTION
## What

Last commit was an improvement, but we're being throttled by running a single BatchGetItem request at a time.

Here we use a ForkJoinPool to allow some parallel requests.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
