### PR TITLE
ATO-1198: add orch AuthCode consistency checks

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -43,6 +43,7 @@ import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
@@ -84,6 +85,7 @@ public class TokenHandler
     private final DynamoService dynamoService;
     private final ConfigurationService configurationService;
     private final AuthorisationCodeService authorisationCodeService;
+    private final OrchAuthCodeService orchAuthCodeService;
     private final ClientSessionService clientSessionService;
     private final OrchClientSessionService orchClientSessionService;
     private final TokenValidationService tokenValidationService;
@@ -99,6 +101,7 @@ public class TokenHandler
             DynamoService dynamoService,
             ConfigurationService configurationService,
             AuthorisationCodeService authorisationCodeService,
+            OrchAuthCodeService orchAuthCodeService,
             ClientSessionService clientSessionService,
             OrchClientSessionService orchClientSessionService,
             TokenValidationService tokenValidationService,
@@ -109,6 +112,7 @@ public class TokenHandler
         this.dynamoService = dynamoService;
         this.configurationService = configurationService;
         this.authorisationCodeService = authorisationCodeService;
+        this.orchAuthCodeService = orchAuthCodeService;
         this.clientSessionService = clientSessionService;
         this.orchClientSessionService = orchClientSessionService;
         this.tokenValidationService = tokenValidationService;
@@ -129,6 +133,7 @@ public class TokenHandler
         this.authorisationCodeService =
                 new AuthorisationCodeService(
                         configurationService, redisConnectionService, objectMapper);
+        this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.clientSessionService =
                 new ClientSessionService(configurationService, redisConnectionService);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
@@ -154,6 +159,7 @@ public class TokenHandler
         this.authorisationCodeService =
                 new AuthorisationCodeService(
                         configurationService, redisConnectionService, objectMapper);
+        this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.clientSessionService =
                 new ClientSessionService(configurationService, redisConnectionService);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
@@ -233,6 +239,49 @@ public class TokenHandler
                     400, OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString());
         }
         AuthCodeExchangeData authCodeExchangeData = authCodeExchangeDataMaybe.get();
+
+        try {
+            Optional<AuthCodeExchangeData> orchAuthCodeExchangeDataMaybe =
+                    orchAuthCodeService.getExchangeDataForCode(requestBody.get("code"));
+
+            // TODO: ATO-1205: Remove these logs after consistency checks are complete.
+            if (orchAuthCodeExchangeDataMaybe.isEmpty()) {
+                LOG.warn(
+                        "OrchAuthCode consistency check error: Record present in Redis but not in DynamoDB. ClientId: {}. ClientSessionId: {}. NOTE: Redis is still the primary at present.",
+                        authCodeExchangeData.getClientId(),
+                        authCodeExchangeData.getClientSessionId());
+            } else {
+                AuthCodeExchangeData orchAuthCodeExchangeData = orchAuthCodeExchangeDataMaybe.get();
+
+                LOG.info(
+                        "OrchAuthCode consistency check: AuthCode and OrchAuthCode client ID equal? {}",
+                        Objects.equals(
+                                authCodeExchangeData.getClientId(),
+                                orchAuthCodeExchangeData.getClientId()));
+                LOG.info(
+                        "OrchAuthCode consistency check: AuthCode and OrchAuthCode client session ID equal? {}",
+                        Objects.equals(
+                                authCodeExchangeData.getClientSessionId(),
+                                orchAuthCodeExchangeData.getClientSessionId()));
+                LOG.info(
+                        "OrchAuthCode consistency check: AuthCode and OrchAuthCode auth time equal? {}",
+                        Objects.equals(
+                                authCodeExchangeData.getAuthTime(),
+                                orchAuthCodeExchangeData.getAuthTime()));
+            }
+
+            /*
+                TODO: ATO-1205:
+                 - Need to rethrow exceptions (as RuntimeException?) or return a 500 api gateway proxy response ourselves.
+                 - Update the log in the catch clause to be level 'error' and remove Redis references (as by this point the DynamoDB store will be the primary).
+                 - Following the above updates, ensure the unit test which ensures unchecked exceptions are caught during consistency checks is updated.
+            */
+        } catch (Exception e) {
+            LOG.warn(
+                    "Failed to retrieve authorisation code from orch auth code DynamoDB store. NOTE: Redis is still the primary at present. Error: {}",
+                    e.getMessage());
+        }
+
         if (!Objects.equals(authCodeExchangeData.getClientId(), clientRegistry.getClientID())) {
             LOG.warn("Client ID from auth code does not match client ID from request body");
             return generateApiGatewayProxyResponse(

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchAuthCodeExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchAuthCodeExtension.java
@@ -77,7 +77,7 @@ public class OrchAuthCodeExtension extends DynamoExtension implements AfterEachC
 
     public AuthorizationCode generateAndSaveAuthorisationCode(
             String clientId, String clientSessionId, String email, Long authTime) {
-        // TODO: ATO-1198: Remove generation of this authorisation code after consistency checks are
+        // TODO: ATO-1205: Remove generation of this authorisation code after consistency checks are
         // complete - the method in orchAuthCodeService needs to generate this itself.
         AuthorizationCode authorizationCode = new AuthorizationCode();
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
@@ -46,7 +46,7 @@ public class OrchAuthCodeService extends BaseDynamoService<OrchAuthCodeItem> {
         this.objectMapper = SerializationService.getInstance();
     }
 
-    // TODO: ATO-1198: Move generation of the authorisation code back into this method (removing the
+    // TODO: ATO-1205: Move generation of the authorisation code back into this method (removing the
     // parameter) after consistency checks are complete.
     public AuthorizationCode generateAndSaveAuthorisationCode(
             AuthorizationCode authorizationCode,


### PR DESCRIPTION
~~Note: Wait for #6250 to be merged~~

### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Currently RP issued auth codes are stored in Redis. We are migrating away from Redis to DynamoDB. The auth code store is being migrated under the parent ticket.

We're now writing to the new DynamoDB table using the new service in the four lambdas: #6278, #6250, #6244, #6223.

We wish to read from the DynamoDB table, using the new service, in the TokenFunction lambda. The DynamoDB table read policy was added to the `TokenFunction` CloudFormation under #6190.

We wish to check the consistency of this data compared to that retrieved from the Redis store. Note that we do not wish to remove the Redis getter call (as this should remain the primary) - this will be done under ATO-1205.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Added call to the `getExchangeDataForCode` method on the orch auth code service
- Added consistency checks within logs
- Updated unit tests to check for calls to the new orch auth code service

Note that the integration tests will be updated as part of ATO-1205 - under this ticket's changes we are only catching and logging retrieval errors from the new store and not returning any of these.

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to Orch dev, ran through an auth only journey successfully. Reviewed the TokenFunction lambda logs and verified consistency logs were present. Reviewed the DynamoDB table, the associated item had its `isUsed` attribute set to true as expected.

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.
  - (Read policy (`OrchAuthCodeTableReadAccessPolicy `) previously added to the `TokenFunction` CloudFormation - see  #6190. Reading as expected - see manual testing section above.)

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or **not required**.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or **not required**.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or **not required**.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or **not required**.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or **not required**.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Entity and service - #6220
- Update to use the same auth code for both stores to enable consistency checks - #6221
- DynamoDB write policy additions to lambdas - #6190
- Writing in lambdas - #6278, #6250, #6244, #6223
