### PR TITLE
ATO-1571: Add test for auth request missing vtr parameter

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1757,6 +1757,33 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertResponseJarHasClaims(response, List.of("state"));
     }
 
+    @Test
+    void shouldUseDefaultVtrWhenNoVtrProvidedInRequest() {
+        setupForAuthJourney();
+        var baseParams = constructQueryStringParameters(CLIENT_ID, null, "openid", "");
+        Map<String, String> queryParams = new HashMap<>(baseParams);
+        queryParams.remove("vtr");
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(Optional.empty()),
+                        queryParams,
+                        Optional.of("GET"));
+        assertThat(response, hasStatus(302));
+        assertResponseJarHasClaimsWithValues(
+                response,
+                Map.of(
+                        "vtr",
+                        List.of("Cl.Cm"),
+                        "client_id",
+                        configuration.getOrchestrationClientId(),
+                        "scope",
+                        "openid",
+                        "redirect_uri",
+                        configuration.getOrchestrationRedirectURI()));
+        assertResponseJarHasClaims(response, List.of("state"));
+    }
+
     private Map<String, String> constructQueryStringParameters(
             String clientId, String prompt, String scopes, String vtr) {
         return constructQueryStringParameters(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -900,9 +900,8 @@ public class AuthorisationHandler
         orchestrationAuthorizationService.storeState(sessionId, clientSessionId, state);
 
         var vtrList =
-                Optional.ofNullable(authenticationRequest.getCustomParameter(VTR_PARAM))
-                        .map(VectorOfTrust::parseVtrStringListFromAuthRequestAttribute)
-                        .orElse(null);
+                VectorOfTrust.parseVtrStringListFromAuthRequestAttribute(
+                        authenticationRequest.getCustomParameter(VTR_PARAM));
         String reauthSub = null;
         String reauthSid = null;
         if (reauthRequested) {


### PR DESCRIPTION
### Wider context of change

We have been working on passing new fields from orch to auth frontend to auth backend, with the goal of eventually replacing the need for the auth client session. We have the code for sending the fields from orch to auth frontend, and the code for receiving the fields from auth frontend to auth backend, already merged. 

We tried to merge the PR for passing the field on in auth frontend, but encountered issues with how the vtr field is handled in orch.
 
RPs are not required to send a vtr field to the authorise endpoint. If the vtr field is not provided, the default vtr value is used. The changes we made to pass the vtr field on to the auth frontend did not use the default value, instead using `null`, which in the JWT to auth frontend, was the same as not setting the field. As a result, any RP that sent a request without a vtr would get an error in the auth frontend, complaining that it was missing the required vtr field.

We didn't have any test coverage for this, so this PR is for adding that coverage.

### What’s changed

This PR adds an integration test which asserts that if an auth request is sent to the /authorise endpoint with no vtr field set, then it should use the default vtr value and use this in the JWT that orch send to auth frontend 

### Checklist


- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

