### PR TITLE
AUT-4123: Count AUTH_APP enabled users with no verified MFA methods

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandler.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.TimeUnit;
@@ -26,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 import static java.text.MessageFormat.format;
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
 
-public class MFAMethodAnalysisHandler implements RequestHandler<String, Long> {
+public class MFAMethodAnalysisHandler implements RequestHandler<String, String> {
 
     private static final Logger LOG = LogManager.getLogger(MFAMethodAnalysisHandler.class);
     private final DynamoDbClient client;
@@ -48,55 +49,82 @@ public class MFAMethodAnalysisHandler implements RequestHandler<String, Long> {
     }
 
     @Override
-    public Long handleRequest(String input, Context context) {
+    public String handleRequest(String input, Context context) {
+        MFAMethodAnalysis finalMFAMethodAnalysis = new MFAMethodAnalysis();
         long totalBatches = 0;
-        long totalMatches = 0;
         long totalUserCredentialsFetched = 0;
-        List<ForkJoinTask<Long>> batchTasks = new ArrayList<>();
+        List<ForkJoinTask<MFAMethodAnalysis>> batchTasks = new ArrayList<>();
         ForkJoinPool forkJoinPool = new ForkJoinPool(100);
 
         try {
             Map<String, AttributeValue> lastKey = null;
             do {
-                Map<String, String> expressionAttributeNames = new HashMap<>();
-                expressionAttributeNames.put("#mfa_methods", UserCredentials.ATTRIBUTE_MFA_METHODS);
                 ScanRequest scanRequest =
                         ScanRequest.builder()
                                 .tableName(userCredentialsTableName)
-                                .filterExpression("attribute_exists(#mfa_methods)")
-                                .expressionAttributeNames(expressionAttributeNames)
+                                .filterExpression("attribute_exists(MfaMethods)")
+                                .projectionExpression("Email,MfaMethods")
                                 .exclusiveStartKey(lastKey)
                                 .build();
 
                 ScanResponse scanResponse = client.scan(scanRequest);
 
-                List<String> currentBatchEmails = new ArrayList<>();
+                List<UserCredentialsProfileJoin> currentBatch = new ArrayList<>();
                 for (Map<String, AttributeValue> userCredentialsItem : scanResponse.items()) {
                     totalUserCredentialsFetched++;
                     if (totalUserCredentialsFetched % 100000 == 0) {
                         LOG.info(
                                 "Fetched {} user credentials records", totalUserCredentialsFetched);
                     }
-                    String email = userCredentialsItem.get(UserCredentials.ATTRIBUTE_EMAIL).s();
-                    currentBatchEmails.add(email);
 
-                    if (currentBatchEmails.size() >= 100) {
+                    String email = userCredentialsItem.get(UserCredentials.ATTRIBUTE_EMAIL).s();
+
+                    Map<String, AttributeValue> firstMfaMethod = null;
+                    if (userCredentialsItem.containsKey("MfaMethods")) {
+                        List<AttributeValue> mfaList = userCredentialsItem.get("MfaMethods").l();
+                        if (!mfaList.isEmpty()) {
+                            firstMfaMethod = mfaList.get(0).m();
+                        }
+                    }
+
+                    Optional<Boolean> enabled =
+                            Optional.ofNullable(firstMfaMethod)
+                                    .map(map -> map.get("Enabled"))
+                                    .map(AttributeValue::n)
+                                    .map(n -> n.equals("1"));
+
+                    Optional<Boolean> methodVerified =
+                            Optional.ofNullable(firstMfaMethod)
+                                    .map(map -> map.get("MethodVerified"))
+                                    .map(AttributeValue::n)
+                                    .map(n -> n.equals("1"));
+
+                    currentBatch.add(
+                            new UserCredentialsProfileJoin(email, enabled, methodVerified));
+
+                    if (currentBatch.size() >= 100) {
                         totalBatches++;
-                        queueBatch(forkJoinPool, currentBatchEmails, totalBatches, batchTasks);
-                        currentBatchEmails = new ArrayList<>();
+                        queueBatch(forkJoinPool, currentBatch, totalBatches, batchTasks);
+                        currentBatch = new ArrayList<>();
                     }
                 }
 
-                if (!currentBatchEmails.isEmpty()) {
+                if (!currentBatch.isEmpty()) {
                     totalBatches++;
-                    queueBatch(forkJoinPool, currentBatchEmails, totalBatches, batchTasks);
+                    queueBatch(forkJoinPool, currentBatch, totalBatches, batchTasks);
                 }
 
                 lastKey = scanResponse.lastEvaluatedKey();
             } while (lastKey != null && !lastKey.isEmpty());
 
-            for (ForkJoinTask<Long> task : batchTasks) {
-                totalMatches += task.join();
+            for (ForkJoinTask<MFAMethodAnalysis> task : batchTasks) {
+                MFAMethodAnalysis taskResult = task.join();
+                finalMFAMethodAnalysis.incrementCountOfUsersAssessed(
+                        taskResult.getCountOfUsersAssessed());
+                finalMFAMethodAnalysis
+                        .incrementCountOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods(
+                                taskResult
+                                        .getCountOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods());
             }
 
             gracefulPoolShutdown(forkJoinPool);
@@ -104,8 +132,8 @@ public class MFAMethodAnalysisHandler implements RequestHandler<String, Long> {
             forcePoolShutdown(forkJoinPool);
         }
 
-        LOG.info("Found {} credentials/profile matches with AUTH_APP", totalMatches);
-        return totalMatches;
+        LOG.info("Found {} credentials/profile matches with AUTH_APP", finalMFAMethodAnalysis);
+        return finalMFAMethodAnalysis.toString();
     }
 
     private void gracefulPoolShutdown(ForkJoinPool forkJoinPool) {
@@ -128,39 +156,133 @@ public class MFAMethodAnalysisHandler implements RequestHandler<String, Long> {
 
     private void queueBatch(
             ForkJoinPool forkJoinPool,
-            List<String> emails,
-            long batch,
-            List<ForkJoinTask<Long>> batchTasks) {
-        batchTasks.add(forkJoinPool.submit(() -> batchGetUserProfiles(batch, emails)));
+            List<UserCredentialsProfileJoin> batch,
+            long batchNumber,
+            List<ForkJoinTask<MFAMethodAnalysis>> batchTasks) {
+        batchTasks.add(forkJoinPool.submit(() -> batchGetUserProfiles(batchNumber, batch)));
     }
 
-    private long batchGetUserProfiles(long batch, List<String> emails) {
-        if (batch % 1000 == 0) {
-            LOG.info("Executing user profile batch {}", batch);
+    private MFAMethodAnalysis batchGetUserProfiles(
+            long batchNumber, List<UserCredentialsProfileJoin> batch) {
+        if (batchNumber % 1000 == 0) {
+            LOG.info("Executing user profile batch {}", batchNumber);
         }
 
-        if (emails.isEmpty()) {
-            return 0;
+        if (batch.isEmpty()) {
+            return new MFAMethodAnalysis();
         }
 
         Map<String, KeysAndAttributes> requestItems = new HashMap<>();
         List<Map<String, AttributeValue>> keys = new ArrayList<>();
-        for (String email : emails) {
+        for (UserCredentialsProfileJoin item : batch) {
             Map<String, AttributeValue> key = new HashMap<>();
-            key.put(UserProfile.ATTRIBUTE_EMAIL, AttributeValue.builder().s(email).build());
+            key.put(
+                    UserProfile.ATTRIBUTE_EMAIL,
+                    AttributeValue.builder().s(item.getEmail()).build());
             keys.add(key);
         }
-        requestItems.put(userProfileTableName, KeysAndAttributes.builder().keys(keys).build());
+        requestItems.put(
+                userProfileTableName,
+                KeysAndAttributes.builder()
+                        .keys(keys)
+                        .projectionExpression("Email,PhoneNumberVerified")
+                        .build());
 
         BatchGetItemRequest batchGetItemRequest =
                 BatchGetItemRequest.builder().requestItems(requestItems).build();
 
         BatchGetItemResponse batchGetItemResponse = client.batchGetItem(batchGetItemRequest);
-        Map<String, List<Map<String, AttributeValue>>> results = batchGetItemResponse.responses();
+        List<Map<String, AttributeValue>> results =
+                batchGetItemResponse.responses().get(userProfileTableName);
 
-        if (results.containsKey(userProfileTableName)) {
-            return results.get(userProfileTableName).size();
+        for (Map<String, AttributeValue> item : results) {
+            String email =
+                    Optional.ofNullable(item.get("Email")).map(AttributeValue::s).orElse(null);
+
+            if (email != null) {
+                Optional<Boolean> phoneNumberVerified =
+                        Optional.ofNullable(item.get("PhoneNumberVerified"))
+                                .map(AttributeValue::n)
+                                .map(n -> n.equals("1"));
+
+                batch.stream()
+                        .filter(user -> email.equalsIgnoreCase(user.getEmail()))
+                        .findFirst()
+                        .ifPresent(user -> user.setPhoneNumberVerified(phoneNumberVerified));
+            }
         }
-        return 0;
+
+        MFAMethodAnalysis mfaMethodAnalysis = new MFAMethodAnalysis();
+        mfaMethodAnalysis.incrementCountOfUsersAssessed(batch.size());
+        mfaMethodAnalysis
+                .incrementCountOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods(
+                        batch.stream()
+                                .filter(
+                                        UserCredentialsProfileJoin
+                                                ::userHasAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods)
+                                .count());
+
+        return mfaMethodAnalysis;
+    }
+
+    private static class UserCredentialsProfileJoin {
+        private final String email;
+        private final Optional<Boolean> enabled;
+        private final Optional<Boolean> methodVerified;
+        private Optional<Boolean> phoneNumberVerified = Optional.empty();
+
+        public UserCredentialsProfileJoin(
+                String email, Optional<Boolean> enabled, Optional<Boolean> methodVerified) {
+            this.email = email;
+            this.enabled = enabled;
+            this.methodVerified = methodVerified;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setPhoneNumberVerified(Optional<Boolean> phoneNumberVerified) {
+            this.phoneNumberVerified = phoneNumberVerified;
+        }
+
+        public boolean userHasAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods() {
+            if (methodVerified.isEmpty() || phoneNumberVerified.isEmpty() || enabled.isEmpty()) {
+                return false;
+            }
+            return !methodVerified.get() && !phoneNumberVerified.get() && enabled.get();
+        }
+    }
+
+    private static class MFAMethodAnalysis {
+        private long countOfUsersAssessed = 0;
+        private long countOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods = 0;
+
+        public long getCountOfUsersAssessed() {
+            return countOfUsersAssessed;
+        }
+
+        public void incrementCountOfUsersAssessed(long i) {
+            this.countOfUsersAssessed += i;
+        }
+
+        public long getCountOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods() {
+            return countOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods;
+        }
+
+        public void incrementCountOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods(
+                long i) {
+            this.countOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods += i;
+        }
+
+        @Override
+        public String toString() {
+            return "MFAMethodAnalysis{"
+                    + "countOfUsersAssessed="
+                    + countOfUsersAssessed
+                    + ", countOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods="
+                    + countOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods
+                    + '}';
+        }
     }
 }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandlerTest.java
@@ -9,7 +9,6 @@ import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
-import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
@@ -35,10 +34,12 @@ class MFAMethodAnalysisHandlerTest {
         mockCredentialsScan(items, 0);
 
         List<Map<String, AttributeValue>> requestKeys = new ArrayList<>();
-        mockProfileBatchGetItem(requestKeys, items, 0, 0);
+        mockProfileBatchGetItem(requestKeys, items);
 
         var handler = new MFAMethodAnalysisHandler(configurationService, client);
-        assertEquals(0, handler.handleRequest("", mock(Context.class)));
+        assertEquals(
+                "MFAMethodAnalysis{countOfUsersAssessed=0, countOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods=0}",
+                handler.handleRequest("", mock(Context.class)));
     }
 
     @Test
@@ -63,27 +64,77 @@ class MFAMethodAnalysisHandlerTest {
             requestKeys.add(key);
 
             if (i % 100 == 0) {
-                mockProfileBatchGetItem(requestKeys, items, i - 100, i);
+                mockProfileBatchGetItem(requestKeys, items.subList(i - 100, i));
                 requestKeys = new ArrayList<>();
             }
         }
 
         if (!requestKeys.isEmpty()) {
-            mockProfileBatchGetItem(requestKeys, items, size - requestKeys.size(), size);
+            mockProfileBatchGetItem(requestKeys, items.subList(size - requestKeys.size(), size));
         }
 
         var handler = new MFAMethodAnalysisHandler(configurationService, client);
-        assertEquals(size, handler.handleRequest("", mock(Context.class)));
+        assertEquals(
+                "MFAMethodAnalysis{countOfUsersAssessed=%s, countOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods=0}"
+                        .formatted(size),
+                handler.handleRequest("", mock(Context.class)));
+    }
+
+    @Test
+    void shouldCountUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods() {
+        when(configurationService.getEnvironment()).thenReturn("test");
+
+        int size = 20;
+        List<Map<String, AttributeValue>> credentialItems = new ArrayList<>();
+        for (int i = 1; i < size + 1; i++) {
+            Map<String, AttributeValue> item = new HashMap<>();
+            item.put("Email", AttributeValue.builder().s(getTestEmail(i)).build());
+            Map<String, AttributeValue> mfaMethodEntry = new HashMap<>();
+            mfaMethodEntry.put(
+                    "Enabled", AttributeValue.builder().n(i % 3 == 0 ? "1" : "0").build());
+            mfaMethodEntry.put(
+                    "MethodVerified", AttributeValue.builder().n(i % 3 == 0 ? "0" : "1").build());
+            AttributeValue mfaMethods =
+                    AttributeValue.builder()
+                            .l(AttributeValue.builder().m(mfaMethodEntry).build())
+                            .build();
+            item.put("MfaMethods", mfaMethods);
+            credentialItems.add(item);
+        }
+        mockCredentialsScan(credentialItems, size);
+
+        List<Map<String, AttributeValue>> requestKeys = new ArrayList<>();
+        for (int i = 1; i < size + 1; i++) {
+            Map<String, AttributeValue> key = new HashMap<>();
+            key.put(
+                    UserProfile.ATTRIBUTE_EMAIL,
+                    AttributeValue.builder().s(getTestEmail(i)).build());
+            requestKeys.add(key);
+        }
+        List<Map<String, AttributeValue>> profileItems = new ArrayList<>();
+        for (int i = 1; i < size + 1; i++) {
+            Map<String, AttributeValue> item = new HashMap<>();
+            item.put("Email", AttributeValue.builder().s(getTestEmail(i)).build());
+            item.put(
+                    "PhoneNumberVerified",
+                    AttributeValue.builder().n(i % 3 == 0 ? "0" : "1").build());
+            profileItems.add(item);
+        }
+        mockProfileBatchGetItem(requestKeys, profileItems);
+
+        var handler = new MFAMethodAnalysisHandler(configurationService, client);
+        assertEquals(
+                "MFAMethodAnalysis{countOfUsersAssessed=%s, countOfUsersWithAuthAppEnabledButNoVerifiedSMSOrAuthAppMFAMethods=6}"
+                        .formatted(size),
+                handler.handleRequest("", mock(Context.class)));
     }
 
     private void mockCredentialsScan(List<Map<String, AttributeValue>> items, int size) {
-        Map<String, String> expressionAttributeNames = new HashMap<>();
-        expressionAttributeNames.put("#mfa_methods", UserCredentials.ATTRIBUTE_MFA_METHODS);
         when(client.scan(
                         ScanRequest.builder()
                                 .tableName("test-user-credentials")
-                                .filterExpression("attribute_exists(#mfa_methods)")
-                                .expressionAttributeNames(expressionAttributeNames)
+                                .filterExpression("attribute_exists(MfaMethods)")
+                                .projectionExpression("Email,MfaMethods")
                                 .exclusiveStartKey(null)
                                 .build()))
                 .thenReturn(
@@ -91,15 +142,17 @@ class MFAMethodAnalysisHandlerTest {
     }
 
     private void mockProfileBatchGetItem(
-            List<Map<String, AttributeValue>> keys,
-            List<Map<String, AttributeValue>> items,
-            int returnItemsFromIndex,
-            int returnItemsToIndex) {
+            List<Map<String, AttributeValue>> keys, List<Map<String, AttributeValue>> items) {
         Map<String, KeysAndAttributes> requestItems = new HashMap<>();
-        requestItems.put("test-user-profile", KeysAndAttributes.builder().keys(keys).build());
+        requestItems.put(
+                "test-user-profile",
+                KeysAndAttributes.builder()
+                        .keys(keys)
+                        .projectionExpression("Email,PhoneNumberVerified")
+                        .build());
 
         Map<String, List<Map<String, AttributeValue>>> responses = new HashMap<>();
-        responses.put("test-user-profile", items.subList(returnItemsFromIndex, returnItemsToIndex));
+        responses.put("test-user-profile", items);
 
         when(client.batchGetItem(BatchGetItemRequest.builder().requestItems(requestItems).build()))
                 .thenReturn(BatchGetItemResponse.builder().responses(responses).build());


### PR DESCRIPTION
## What

One statistic we need to check is if there are any users that have enabled an AUTH_APP MFA method but with no verified AUTH_APP or SMS MFA methods.

This commits updates the query to only return the data we need to do that calculation from the user-credentials scan and user-profile batch get items.

A new class `MFAMethodAnalysis` is used to collate the statistic across forked batches and is returned by the handler as a string.

## How to review

1. Code Review
## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.