### PR TITLE
ATO-1205: use orch auth code store in token handler

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -34,7 +34,6 @@ import uk.gov.di.orchestration.shared.exceptions.TokenAuthUnsupportedMethodExcep
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
-import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
@@ -84,7 +83,6 @@ public class TokenHandler
     private final TokenService tokenService;
     private final DynamoService dynamoService;
     private final ConfigurationService configurationService;
-    private final AuthorisationCodeService authorisationCodeService;
     private final OrchAuthCodeService orchAuthCodeService;
     private final ClientSessionService clientSessionService;
     private final OrchClientSessionService orchClientSessionService;
@@ -100,7 +98,6 @@ public class TokenHandler
             TokenService tokenService,
             DynamoService dynamoService,
             ConfigurationService configurationService,
-            AuthorisationCodeService authorisationCodeService,
             OrchAuthCodeService orchAuthCodeService,
             ClientSessionService clientSessionService,
             OrchClientSessionService orchClientSessionService,
@@ -111,7 +108,6 @@ public class TokenHandler
         this.tokenService = tokenService;
         this.dynamoService = dynamoService;
         this.configurationService = configurationService;
-        this.authorisationCodeService = authorisationCodeService;
         this.orchAuthCodeService = orchAuthCodeService;
         this.clientSessionService = clientSessionService;
         this.orchClientSessionService = orchClientSessionService;
@@ -130,9 +126,6 @@ public class TokenHandler
         this.tokenService =
                 new TokenService(configurationService, this.redisConnectionService, kms, oidcApi);
         this.dynamoService = new DynamoService(configurationService);
-        this.authorisationCodeService =
-                new AuthorisationCodeService(
-                        configurationService, redisConnectionService, objectMapper);
         this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.clientSessionService =
                 new ClientSessionService(configurationService, redisConnectionService);
@@ -156,9 +149,6 @@ public class TokenHandler
         this.tokenService =
                 new TokenService(configurationService, this.redisConnectionService, kms, oidcApi);
         this.dynamoService = new DynamoService(configurationService);
-        this.authorisationCodeService =
-                new AuthorisationCodeService(
-                        configurationService, redisConnectionService, objectMapper);
         this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.clientSessionService =
                 new ClientSessionService(configurationService, redisConnectionService);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -244,32 +244,6 @@ public class TokenHandler
             Optional<AuthCodeExchangeData> orchAuthCodeExchangeDataMaybe =
                     orchAuthCodeService.getExchangeDataForCode(requestBody.get("code"));
 
-            // TODO: ATO-1205: Remove these logs after consistency checks are complete.
-            if (orchAuthCodeExchangeDataMaybe.isEmpty()) {
-                LOG.warn(
-                        "OrchAuthCode consistency check error: Record present in Redis but not in DynamoDB. ClientId: {}. ClientSessionId: {}. NOTE: Redis is still the primary at present.",
-                        authCodeExchangeData.getClientId(),
-                        authCodeExchangeData.getClientSessionId());
-            } else {
-                AuthCodeExchangeData orchAuthCodeExchangeData = orchAuthCodeExchangeDataMaybe.get();
-
-                LOG.info(
-                        "OrchAuthCode consistency check: AuthCode and OrchAuthCode client ID equal? {}",
-                        Objects.equals(
-                                authCodeExchangeData.getClientId(),
-                                orchAuthCodeExchangeData.getClientId()));
-                LOG.info(
-                        "OrchAuthCode consistency check: AuthCode and OrchAuthCode client session ID equal? {}",
-                        Objects.equals(
-                                authCodeExchangeData.getClientSessionId(),
-                                orchAuthCodeExchangeData.getClientSessionId()));
-                LOG.info(
-                        "OrchAuthCode consistency check: AuthCode and OrchAuthCode auth time equal? {}",
-                        Objects.equals(
-                                authCodeExchangeData.getAuthTime(),
-                                orchAuthCodeExchangeData.getAuthTime()));
-            }
-
             /*
                 TODO: ATO-1205:
                  - Need to rethrow exceptions (as RuntimeException?) or return a 500 api gateway proxy response ourselves.

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -227,34 +227,25 @@ public class TokenHandler
                                     getSigningAlgorithm(clientRegistry)));
         }
 
-        Optional<AuthCodeExchangeData> authCodeExchangeDataMaybe =
-                segmentedFunctionCall(
-                        "authorisationCodeService",
-                        () ->
-                                authorisationCodeService.getExchangeDataForCode(
-                                        requestBody.get("code")));
+        Optional<AuthCodeExchangeData> authCodeExchangeDataMaybe;
+
+        try {
+            authCodeExchangeDataMaybe =
+                    orchAuthCodeService.getExchangeDataForCode(requestBody.get("code"));
+        } catch (Exception e) {
+            LOG.error(
+                    "Failed to retrieve authorisation code from orch auth code DynamoDB store. Error: {}",
+                    e.getMessage());
+            return generateApiGatewayProxyResponse(500, "Internal server error");
+        }
+
         if (authCodeExchangeDataMaybe.isEmpty()) {
             LOG.warn("Could not retrieve session data from code");
             return generateApiGatewayProxyResponse(
                     400, OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString());
         }
+
         AuthCodeExchangeData authCodeExchangeData = authCodeExchangeDataMaybe.get();
-
-        try {
-            Optional<AuthCodeExchangeData> orchAuthCodeExchangeDataMaybe =
-                    orchAuthCodeService.getExchangeDataForCode(requestBody.get("code"));
-
-            /*
-                TODO: ATO-1205:
-                 - Need to rethrow exceptions (as RuntimeException?) or return a 500 api gateway proxy response ourselves.
-                 - Update the log in the catch clause to be level 'error' and remove Redis references (as by this point the DynamoDB store will be the primary).
-                 - Following the above updates, ensure the unit test which ensures unchecked exceptions are caught during consistency checks is updated.
-            */
-        } catch (Exception e) {
-            LOG.warn(
-                    "Failed to retrieve authorisation code from orch auth code DynamoDB store. NOTE: Redis is still the primary at present. Error: {}",
-                    e.getMessage());
-        }
 
         if (!Objects.equals(authCodeExchangeData.getClientId(), clientRegistry.getClientID())) {
             LOG.warn("Client ID from auth code does not match client ID from request body");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -60,7 +60,6 @@ import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
-import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -166,8 +165,6 @@ public class TokenHandlerTest {
             mock(TokenClientAuthValidatorFactory.class);
     private final TokenClientAuthValidator tokenClientAuthValidator =
             mock(TokenClientAuthValidator.class);
-    private final AuthorisationCodeService authorisationCodeService =
-            mock(AuthorisationCodeService.class);
     private final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final OrchClientSessionService orchClientSessionService =
@@ -192,7 +189,6 @@ public class TokenHandlerTest {
                         tokenService,
                         dynamoService,
                         configurationService,
-                        authorisationCodeService,
                         orchAuthCodeService,
                         clientSessionService,
                         orchClientSessionService,
@@ -689,8 +685,6 @@ public class TokenHandlerTest {
                         anyString(), any()))
                 .thenReturn(clientRegistry);
         String authCode = new AuthorizationCode().toString();
-        when(authorisationCodeService.getExchangeDataForCode(authCode))
-                .thenReturn(Optional.empty());
         when(orchAuthCodeService.getExchangeDataForCode(authCode)).thenReturn(Optional.empty());
 
         APIGatewayProxyResponseEvent result =
@@ -1543,8 +1537,6 @@ public class TokenHandlerTest {
                         .setClientSessionId(CLIENT_SESSION_ID)
                         .setAuthTime(AUTH_TIME)
                         .setClientId(clientId);
-        when(authorisationCodeService.getExchangeDataForCode(authCode))
-                .thenReturn(Optional.of(authCodeExchangeData));
         when(orchAuthCodeService.getExchangeDataForCode(authCode))
                 .thenReturn(Optional.of(authCodeExchangeData));
         var orchClientSession =
@@ -1567,8 +1559,6 @@ public class TokenHandlerTest {
                         .setClientSessionId(CLIENT_SESSION_ID)
                         .setAuthTime(AUTH_TIME)
                         .setClientId(CLIENT_ID);
-        when(authorisationCodeService.getExchangeDataForCode(anyString()))
-                .thenReturn(Optional.of(authCodeExchangeData));
         when(orchAuthCodeService.getExchangeDataForCode(anyString()))
                 .thenReturn(Optional.of(authCodeExchangeData));
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -96,7 +96,6 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -707,10 +706,7 @@ public class TokenHandlerTest {
                                 CLIENT.getValue(),
                                 CLIENT_ID));
 
-        // TODO: ATO-1205: Update this to call assertAuthCodeExchangeDataRetrieved instead. We can't
-        // make this assertion at present as no call is made to orchAuthCodeService (as we fail when
-        // the call to authorisationCodeService fails).
-        verify(authorisationCodeService, times(1)).getExchangeDataForCode(eq(authCode));
+        assertAuthCodeExchangeDataRetrieved(authCode);
     }
 
     @Test
@@ -1463,10 +1459,8 @@ public class TokenHandlerTest {
         assertClaimsRequestIfPresent(oidcClaimsRequest, true);
     }
 
-    // TODO: ATO-1205: Update this test to handle new behaviour when unchecked exceptions are
-    // encountered -- see TODO comment in the handler.
     @Test
-    void shouldCatchAnyUncheckedOrchAuthCodeGetExchangeDataForCodeExceptions()
+    void shouldReturn500ForTokenRequestIfOrchAuthCodeGetExchangeDataThrowsException()
             throws JOSEException, TokenAuthInvalidException {
         KeyPair keyPair = generateRsaKeyPair();
         UserProfile userProfile = generateUserProfile();
@@ -1515,8 +1509,13 @@ public class TokenHandlerTest {
                         new RuntimeException(
                                 "Some unchecked exception during orch auth code exchange data retrieval."));
 
-        assertDoesNotThrow(
-                () -> generateApiGatewayRequest(privateKeyJWT, authCode, CLIENT_ID, true));
+        APIGatewayProxyResponseEvent result =
+                generateApiGatewayRequest(privateKeyJWT, authCode, CLIENT_ID, true);
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasBody("Internal server error"));
+        verify(cloudwatchMetricsService, never())
+                .incrementCounter(eq(SUCCESSFUL_TOKEN_ISSUED.getValue()), anyMap());
 
         assertAuthCodeExchangeDataRetrieved(authCode);
     }
@@ -1784,8 +1783,6 @@ public class TokenHandlerTest {
     }
 
     private void assertAuthCodeExchangeDataRetrieved(String authCode) {
-        verify(authorisationCodeService, times(1)).getExchangeDataForCode(eq(authCode));
-
         verify(orchAuthCodeService, times(1)).getExchangeDataForCode(eq(authCode));
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchAuthCodeExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchAuthCodeExtension.java
@@ -77,8 +77,8 @@ public class OrchAuthCodeExtension extends DynamoExtension implements AfterEachC
 
     public AuthorizationCode generateAndSaveAuthorisationCode(
             String clientId, String clientSessionId, String email, Long authTime) {
-        // TODO: ATO-1205: Remove generation of this authorisation code after consistency checks are
-        // complete - the method in orchAuthCodeService needs to generate this itself.
+        // TODO: ATO-1579: Move the generation of this authorisation code into the
+        // orchAuthCodeService.
         AuthorizationCode authorizationCode = new AuthorizationCode();
 
         return orchAuthCodeService.generateAndSaveAuthorisationCode(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeService.java
@@ -7,8 +7,6 @@ import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 
-import java.util.Optional;
-
 public class AuthorisationCodeService {
 
     private static final Logger LOG = LogManager.getLogger(AuthorisationCodeService.class);
@@ -57,18 +55,5 @@ public class AuthorisationCodeService {
             LOG.error("Error persisting auth code to cache");
             throw new RuntimeException(e);
         }
-    }
-
-    public Optional<AuthCodeExchangeData> getExchangeDataForCode(String code) {
-        return Optional.ofNullable(redisConnectionService.popValue(AUTH_CODE_PREFIX.concat(code)))
-                .map(
-                        s -> {
-                            try {
-                                return objectMapper.readValue(s, AuthCodeExchangeData.class);
-                            } catch (JsonException e) {
-                                LOG.error("Error deserialising auth code data from cache");
-                                throw new RuntimeException(e);
-                            }
-                        });
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
@@ -46,8 +46,8 @@ public class OrchAuthCodeService extends BaseDynamoService<OrchAuthCodeItem> {
         this.objectMapper = SerializationService.getInstance();
     }
 
-    // TODO: ATO-1205: Move generation of the authorisation code back into this method (removing the
-    // parameter) after consistency checks are complete.
+    // TODO: ATO-1579: Move generation of the authorisation code back into this method (removing the
+    // parameter).
     public AuthorizationCode generateAndSaveAuthorisationCode(
             AuthorizationCode authorizationCode,
             String clientId,

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthorisationCodeServiceTest.java
@@ -41,11 +41,4 @@ class AuthorisationCodeServiceTest {
         verify(redisConnectionService)
                 .saveWithExpiry(startsWith("auth-code-"), eq(expectedJson), eq(123L));
     }
-
-    @Test
-    void shouldPrefixAuthCodeWhenLoadingFromRedis() {
-        authCodeService.getExchangeDataForCode("test");
-
-        verify(redisConnectionService).popValue("auth-code-test");
-    }
 }


### PR DESCRIPTION
**NOTE:**
- Merge dependent on results of consistency checks (#6287)
- Merge dependent on results of #6316
- Might be easiest to review this PR commit by commit

### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Currently RP issued auth codes are stored in Redis. We are migrating away from Redis to DynamoDB. The auth code store is being migrated under the parent ticket.

We're now writing to the new DynamoDB table using the new service in the four lambdas: https://github.com/govuk-one-login/authentication-api/pull/6278, https://github.com/govuk-one-login/authentication-api/pull/6250, https://github.com/govuk-one-login/authentication-api/pull/6244, https://github.com/govuk-one-login/authentication-api/pull/6223. We are reading from the DynamoDB table, using the new service, in the TokenFunction lambda (#6287), but not using the retrieved item yet (apart from logging).

Following consistency checks, added in #6287, we now wish to remove the Redis getter call, making DynamoDB the primary. We will stop writing to the Redis store in ATO-1218.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Remove consistency check logging
- Remove call to `authorisationCodeService.getExchangeDataForCode`
	- Making `orchAuthCodeService.getExchangeDataForCode` the primary
- Remove references to `authorisationCodeService`
- Remove `getExchangeDataForCode` method from `AuthorisationCodeService` (dead code following changes)
- Update unit test to return 500 when get method throws exception
- Update integration tests to get auth code from the orch auth code generation method

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to Orch dev, ran through auth only, identity (P2), and doc app journeys successfully.

Reviewed the TokenFunction lambda logs and verified retrieval logs (`Retrieving authorisation code exchange data from orch auth code store`) were present with no errors. Reviewed the DynamoDB table, the associated items all had their `isUsed` attributes set to true as expected. AuthExchangeData looked as expected (email and authTime set to null for a doc app journey).

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.
  - No additional permissions added, read/write access already granted under prior PRs and in use by changes under #6287.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required. **- N/A**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required. **- N/A**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required. **- N/A**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required. **- N/A**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required. **- N/A**

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Entity and service - #6220
- Update to use the same auth code for both stores to enable consistency checks - #6221
- DynamoDB write policy additions to lambdas - #6190
- Writing in lambdas - #6278, #6250, #6244, #6223
- Consistency checks - #6287
