### PR TITLE
ATO-1481 improve back channel logout test

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/BackChannelLogoutPostRequestException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/BackChannelLogoutPostRequestException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+public class BackChannelLogoutPostRequestException extends RuntimeException {
+    public BackChannelLogoutPostRequestException(String message) {
+        super(message);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
@@ -116,12 +116,13 @@ public class BackChannelLogoutRequestHandler implements RequestHandler<SQSEvent,
 
             httpRequestService.post(URI.create(payload.getLogoutUri()), "logout_token=" + body);
 
+            throw new BackChannelLogoutPostRequestException("Post request failed");
+
         } catch (JsonException e) {
             LOG.error("Could not parse logout request payload");
         } catch (Exception e) {
             LOG.warn("Post request failed");
-            throw new BackChannelLogoutPostRequestException(
-                    "Could not parse logout request payload");
+            throw new BackChannelLogoutPostRequestException("Post request failed");
         }
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandlerTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.oidc.services.HttpRequestService;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.entity.BackChannelLogoutMessage;
 import uk.gov.di.orchestration.shared.helpers.NowHelper.NowClock;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.TokenService;
 
@@ -47,13 +48,15 @@ class BackChannelLogoutRequestHandlerTest {
     private final TokenService tokenService = mock(TokenService.class);
     private final Context context = mock(Context.class);
     private final Instant fixedDate = Instant.now();
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
 
     private final BackChannelLogoutRequestHandler handler =
             new BackChannelLogoutRequestHandler(
                     oidcApi,
                     request,
                     tokenService,
-                    new NowClock(fixed(fixedDate, systemDefault())));
+                    new NowClock(fixed(fixedDate, systemDefault())),
+                    configurationService);
 
     @BeforeEach
     void setup() {

--- a/template.yaml
+++ b/template.yaml
@@ -90,6 +90,7 @@ Conditions:
       !Equals [!Ref Environment, integration],
       !Equals [!Ref Environment, production],
     ]
+  IsBuild: !Equals [!Ref Environment, build]
   SupportMaxAgeEnabled:
     !Or [
       !Equals [dev, !Ref Environment],
@@ -4231,6 +4232,7 @@ Resources:
 
   BackChannelLogoutDLQAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: IsBuild
     Properties:
       AlarmName: !Sub ${Environment}-backchannel-logout-dlq-alarm
       AlarmDescription: !Sub "${Environment} backchannel logout DLQ has a message.ACCOUNT: di-orchestration-${Environment}. Runbook: TBC"

--- a/template.yaml
+++ b/template.yaml
@@ -4228,6 +4228,29 @@ Resources:
       KeyUsage: ENCRYPT_DECRYPT
       KeySpec: SYMMETRIC_DEFAULT
       EnableKeyRotation: true
+
+  BackChannelLogoutDLQAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${Environment}-backchannel-logout-dlq-alarm
+      AlarmDescription: !Sub "${Environment} backchannel logout DLQ has a message.ACCOUNT: di-orchestration-${Environment}. Runbook: TBC"
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref SlackEvents
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value:
+            Fn::GetAtt:
+              - BackChannelLogoutDeadLetterQueue
+              - QueueName
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+
   #endregion
 
   #region Storage Token Jwk Lambda


### PR DESCRIPTION
### Wider context of change

We want to improve the back channel logout logic to send an alarm if it fails. Currently this is looking to work only in the build env.

### What’s changed

New cloudwatch alarm
Using BatchItemsFailure for DLQ

### Manual testing

Checked cloudwatch alarm sends message if in DLQ. Need to run on build to test if BatchItemsFailure works.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**