### PR TITLE
BAU: move response_mode validation earlier

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -57,6 +57,9 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
         }
         var redirectURI = authRequest.getRedirectionURI();
 
+        var responseMode = Optional.ofNullable(authRequest.getResponseMode());
+        responseMode.ifPresent(mode -> validateResponseMode(mode.getValue()));
+
         if (authRequest.getState() == null) {
             logErrorInProdElseWarn("State is missing from authRequest");
             return Optional.of(
@@ -175,10 +178,6 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
                             redirectURI,
                             state));
         }
-
-        var responseMode = Optional.ofNullable(authRequest.getResponseMode());
-
-        responseMode.ifPresent(mode -> validateResponseMode(mode.getValue()));
 
         return Optional.empty();
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -97,6 +97,12 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
 
             var redirectURI = URI.create((String) jwtClaimsSet.getClaim("redirect_uri"));
 
+            var responseMode = jwtClaimsSet.getStringClaim("response_mode");
+
+            if (Objects.nonNull(responseMode)) {
+                validateResponseMode(responseMode);
+            }
+
             if (Objects.isNull(jwtClaimsSet.getClaim("state"))) {
                 logErrorInProdElseWarn("State is missing from authRequest");
                 return errorResponse(
@@ -224,12 +230,6 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
 
             if (maxAgeError.isPresent()) {
                 return errorResponse(redirectURI, maxAgeError.get(), state);
-            }
-
-            var responseMode = jwtClaimsSet.getStringClaim("response_mode");
-
-            if (Objects.nonNull(responseMode)) {
-                validateResponseMode(responseMode);
             }
 
             LOG.info("RequestObject has passed initial validation");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
@@ -1,9 +1,5 @@
 package uk.gov.di.authentication.oidc.services;
 
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.crypto.RSADecrypter;
-import com.nimbusds.jwt.EncryptedJWT;
-import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
@@ -915,11 +911,6 @@ class QueryParamsAuthorizeValidatorTest {
         claimsRequest.ifPresent(authRequestBuilder::claims);
 
         return authRequestBuilder.build();
-    }
-
-    private SignedJWT decryptJWT(EncryptedJWT encryptedJWT) throws JOSEException {
-        encryptedJWT.decrypt(new RSADecrypter(privateKey));
-        return encryptedJWT.getPayload().toSignedJWT();
     }
 
     private KeyPair generateRsaKeyPair() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
@@ -818,6 +818,28 @@ class QueryParamsAuthorizeValidatorTest {
                 () -> queryParamsAuthorizeValidator.validate(authRequestBuilder.build()));
     }
 
+    @Test
+    void shouldThrowWhenResponseModeIsInvalidBeforeValidatingARedirectingError() {
+        ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        when(dynamoClientService.getClient(CLIENT_ID.toString()))
+                .thenReturn(
+                        Optional.of(
+                                generateClientRegistry(
+                                        REDIRECT_URI.toString(), CLIENT_ID.toString())));
+
+        // No state is an error we redirect back to the RP with an error message with
+        AuthenticationRequest.Builder authRequestBuilder =
+                new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
+                        .nonce(NONCE)
+                        .responseMode(new ResponseMode("code"));
+
+        assertThrows(
+                InvalidResponseModeException.class,
+                () -> queryParamsAuthorizeValidator.validate(authRequestBuilder.build()));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"query", "fragment"})
     void shouldAllowValidResponseModes(String responseMode) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -427,6 +427,25 @@ class RequestObjectAuthorizeValidatorTest {
         assertThrows(InvalidResponseModeException.class, () -> service.validate(authRequest));
     }
 
+    @Test
+    void shouldThrowErrorForInvalidResponseModeBeforeValidatingARedirectingError()
+            throws JOSEException {
+        // No state is an error we redirect back to the  RP for
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(OIDC_BASE_AUTHORIZE_URI.toString())
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", "openid")
+                        .claim("nonce", NONCE.getValue())
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .claim("response_mode", "code")
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
+        assertThrows(InvalidResponseModeException.class, () -> service.validate(authRequest));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"query", "fragment"})
     void shouldNotErrorIfResponseModeValid(String responseMode)


### PR DESCRIPTION
### Wider context of change

We introduced validation of the response_mode previously, to align with the OIDC spec and handle an exception that was being thrown.

However, we added this to the end of the of the respective validation which mean that when we redirected in any other invalid request error cases we were not handling the invalid response mode. The spec says we should return a Bad Request in any cases we don't understand this field, and therefore we need to validate it first given it dictates __how__
we should return responses to the RP.


### What’s changed: 
- Moves response_mode validation to before redirecting errors 
- Removes an unused test method

### Manual testing: 
- N/A

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
