### PR TITLE
ATO-1205: fallback to strongly consistent reads during orch auth code retrieval

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
@@ -85,6 +85,15 @@ public class BaseDynamoService<T> {
                                 .build()));
     }
 
+    public Optional<T> getWithConsistentRead(String partition) {
+        return Optional.ofNullable(
+                dynamoTable.getItem(
+                        GetItemEnhancedRequest.builder()
+                                .consistentRead(true)
+                                .key(Key.builder().partitionValue(partition).build())
+                                .build()));
+    }
+
     public void delete(String partition) {
         get(partition).ifPresent(dynamoTable::deleteItem);
     }


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Currently RP issued auth codes are stored in Redis. We are migrating away from Redis to DynamoDB. The auth code store is being migrated under the parent ticket.

We're now writing to the new DynamoDB table using the new service in the four lambdas: https://github.com/govuk-one-login/authentication-api/pull/6278, https://github.com/govuk-one-login/authentication-api/pull/6250, https://github.com/govuk-one-login/authentication-api/pull/6244, https://github.com/govuk-one-login/authentication-api/pull/6223.

Redis is still the primary, but we are now reading from the DynamoDB table, using the new service, in the TokenFunction lambda to check data consistency (#6287). There are a very small number of instances where no item is found in the DynamoDB table, despite the item being stored. This is likely related to DynamoDB’s eventual consistency. More details can be found in [this Jira comment](https://govukverify.atlassian.net/browse/ATO-1198?focusedCommentId=214630).

The wider project is looking into strongly consistent reads and their effect on performance (so we want to hold off on always using strongly consistent reads for the time being). In the meantime, this PR implements retry behaviour when an item is not found - retrying once with strongly consistent reads enabled. This should not be invoked for the vast majority of requests.

Note that the call to `getExchangeDataForCode` in TokenHandler is wrapped with a try-catch which catches both checked and unchecked exceptions.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Added "strongly consistent reads" retry behaviour when items are not found (a very small proportion of requests)
- Added additional unit tests to cover "eventually consistent read" <--> "strongly consistent read" cases

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

**TODO: Waiting for orch dev but will run through a few journeys**

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing. **- N/A, read permissions already in place**

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required. **- not required**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required. **- not required**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required. **- not required**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required. **- not required**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required. **- not required**

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Consistency checks - #6287

Other semi-related:
- Entity and service - #6220
- Update to use the same auth code for both stores to enable consistency checks - #6221
- DynamoDB write policy additions to lambdas - #6190
- Writing in lambdas - #6278, #6250, #6244, #6223
