### PR TITLE
ATO-1514: Reset attempts when updating existing session

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -776,6 +776,7 @@ public class AuthorisationHandler
                 new OrchSessionItem(previousSession)
                         .withSessionId(newSessionId)
                         .withTimeToLive(timeNow + configurationService.getSessionExpiry());
+        updatedSession.resetProcessingIdentityAttempts();
         orchSessionService.addSession(updatedSession);
         orchSessionService.deleteSession(previousSession.getSessionId());
         LOG.info(


### PR DESCRIPTION

### Wider context of change:
We previously added this field to the orch session and incremented and reset it's value in the appropriate handlers. However we forgot to reset it in the case of returning users

### What’s changed: 

Our previously introduced consistency logs indicated these values were out of sync some of the time. This was because we did not reset the value when updating an existing orch session in the same way we do in the `UpdateWithNewSessionId` method. This meant that for users returning after an identity journey did not have this value reset when updating their existing Orch session

### Manual testing: 
- Added a unit test to ensure this is now covered

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
