### PR TITLE
Bau/remove vavr

### DIFF
--- a/account-management-api/build.gradle
+++ b/account-management-api/build.gradle
@@ -19,8 +19,7 @@ dependencies {
 
     implementation configurations.nimbus,
             configurations.govuk_notify,
-            configurations.gson,
-            configurations.vavr
+            configurations.gson
 
     implementation project(":shared")
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
@@ -103,8 +103,8 @@ public class MFAMethodsDeleteHandler
 
         var deleteResult = mfaMethodsService.deleteMfaMethod(mfaIdentifier, userProfile);
 
-        if (deleteResult.isLeft()) {
-            var failureReason = deleteResult.getLeft();
+        if (deleteResult.isFailure()) {
+            var failureReason = deleteResult.getFailure();
             LOG.warn(
                     "Attempted to delete mfa with identifier {} but failed for reason {}",
                     mfaIdentifier,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -117,8 +117,8 @@ public class MFAMethodsPutHandler
                     mfaMethodsService.updateMfaMethod(
                             userProfile.getEmail(), mfaIdentifier, mfaMethodUpdateRequest);
 
-            if (result.isLeft()) {
-                var failureReason = result.getLeft();
+            if (result.isFailure()) {
+                var failureReason = result.getFailure();
                 var response = handleUpdateMfaFailureReason(failureReason);
                 if (response.getStatusCode() >= 500) {
                     LOG.error("Update failed due to unexpected error {}", failureReason);
@@ -130,7 +130,7 @@ public class MFAMethodsPutHandler
                 return response;
             }
 
-            var successfulUpdate = result.get();
+            var successfulUpdate = result.getSuccess();
 
             return generateApiGatewayProxyResponse(200, successfulUpdate, true);
         } catch (Json.JsonException e) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
@@ -99,15 +99,15 @@ public class MFAMethodsRetrieveHandler
 
         var retrieveResult = mfaMethodsService.getMfaMethods(maybeUserProfile.get().getEmail());
 
-        if (retrieveResult.isLeft()) {
-            return switch (retrieveResult.getLeft()) {
+        if (retrieveResult.isFailure()) {
+            return switch (retrieveResult.getFailure()) {
                 case ERROR_CONVERTING_MFA_METHOD_TO_MFA_METHOD_DATA -> generateApiGatewayProxyErrorResponse(
                         500, ErrorResponse.ERROR_1064);
                 case UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP -> generateApiGatewayProxyErrorResponse(
                         500, ErrorResponse.ERROR_1078);
             };
         }
-        var retrievedMethods = retrieveResult.get();
+        var retrievedMethods = retrieveResult.getSuccess();
 
         var serialisationService = SerializationService.getInstance();
         var response = serialisationService.writeValueAsStringCamelCase(retrievedMethods);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.google.gson.JsonParser;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -14,6 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.AuthAppMfaDetail;
 import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
@@ -129,7 +129,7 @@ class MFAMethodsCreateHandlerTest {
     void shouldReturn200AndCreateMfaSmsMfaMethod() {
         when(mfaMethodsService.addBackupMfa(any(), any()))
                 .thenReturn(
-                        Either.right(
+                        Result.success(
                                 new MfaMethodData(
                                         TEST_SMS_MFA_ID,
                                         PriorityIdentifier.BACKUP,
@@ -177,7 +177,7 @@ class MFAMethodsCreateHandlerTest {
     void shouldReturn200AndCreateAuthAppMfa() {
         when(mfaMethodsService.addBackupMfa(any(), any()))
                 .thenReturn(
-                        Either.right(
+                        Result.success(
                                 new MfaMethodData(
                                         TEST_AUTH_APP_ID,
                                         PriorityIdentifier.BACKUP,
@@ -295,7 +295,7 @@ class MFAMethodsCreateHandlerTest {
                 .thenReturn(Optional.of(userProfile));
         when(mfaMethodsService.addBackupMfa(any(), any()))
                 .thenReturn(
-                        Either.left(
+                        Result.failure(
                                 MfaCreateFailureReason.BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST));
 
         var result = handler.handleRequest(event, context);
@@ -314,7 +314,7 @@ class MFAMethodsCreateHandlerTest {
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
         when(mfaMethodsService.addBackupMfa(any(), any()))
-                .thenReturn(Either.left(MfaCreateFailureReason.PHONE_NUMBER_ALREADY_EXISTS));
+                .thenReturn(Result.failure(MfaCreateFailureReason.PHONE_NUMBER_ALREADY_EXISTS));
 
         var result = handler.handleRequest(event, context);
 
@@ -332,7 +332,7 @@ class MFAMethodsCreateHandlerTest {
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
         when(mfaMethodsService.addBackupMfa(any(), any()))
-                .thenReturn(Either.left(MfaCreateFailureReason.AUTH_APP_EXISTS));
+                .thenReturn(Result.failure(MfaCreateFailureReason.AUTH_APP_EXISTS));
 
         var result = handler.handleRequest(event, context);
 
@@ -350,7 +350,7 @@ class MFAMethodsCreateHandlerTest {
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
         when(mfaMethodsService.addBackupMfa(any(), any()))
-                .thenReturn(Either.left(MfaCreateFailureReason.ERROR_RETRIEVING_MFA_METHODS));
+                .thenReturn(Result.failure(MfaCreateFailureReason.ERROR_RETRIEVING_MFA_METHODS));
 
         var result = handler.handleRequest(event, context);
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandlerTest.java
@@ -3,13 +3,13 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
@@ -63,7 +63,7 @@ class MFAMethodsDeleteHandlerTest {
     @Test
     void shouldReturn204WhenFeatureFlagEnabled() {
         when(mfaMethodsService.deleteMfaMethod(MFA_IDENTIFIER_TO_DELETE, userProfile))
-                .thenReturn(Either.right(MFA_IDENTIFIER_TO_DELETE));
+                .thenReturn(Result.success(MFA_IDENTIFIER_TO_DELETE));
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
 
@@ -96,7 +96,7 @@ class MFAMethodsDeleteHandlerTest {
             int expectedStatusCode,
             ErrorResponse expectedErrorResponse) {
         when(mfaMethodsService.deleteMfaMethod(MFA_IDENTIFIER_TO_DELETE, userProfile))
-                .thenReturn(Either.left(failureReason));
+                .thenReturn(Result.failure(failureReason));
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.google.gson.JsonParser;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -12,6 +11,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MfaMethodCreateOrUpdateRequest;
 import uk.gov.di.authentication.shared.entity.mfa.MfaMethodData;
@@ -86,7 +86,7 @@ class MFAMethodsPutHandlerTest {
                 MfaMethodData.smsMethodData(
                         MFA_IDENTIFIER, PriorityIdentifier.DEFAULT, true, phoneNumber);
         when(mfaMethodsService.updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest))
-                .thenReturn(Either.right(List.of(updatedMfaMethod)));
+                .thenReturn(Result.success(List.of(updatedMfaMethod)));
 
         var result = handler.handleRequest(eventWithUpdateRequest, context);
 
@@ -167,7 +167,7 @@ class MFAMethodsPutHandlerTest {
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
         var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber));
         when(mfaMethodsService.updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest))
-                .thenReturn(Either.left(failureReason));
+                .thenReturn(Result.failure(failureReason));
         var result = handler.handleRequest(eventWithUpdateRequest, context);
 
         assertThat(result, hasStatus(expectedStatus));

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,6 +10,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MfaMethodData;
 import uk.gov.di.authentication.shared.entity.mfa.SmsMfaDetail;
@@ -77,7 +77,7 @@ class MFAMethodsRetrieveHandlerTest {
                         PriorityIdentifier.DEFAULT,
                         true,
                         new SmsMfaDetail("+44123456789"));
-        when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Either.right(List.of(method)));
+        when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of(method)));
 
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
 
@@ -144,7 +144,7 @@ class MFAMethodsRetrieveHandlerTest {
             ErrorResponse expectedErrorResponse) {
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
-        when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Either.left(error));
+        when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.failure(error));
 
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ ext {
         junit: "5.11.4",
         xray: "2.18.2",
         pact: "4.6.17",
-        vavr: "0.10.6"
     ]
 
     terraformEnvironment = project.properties["terraformEnvironment"] ?: "localstack"
@@ -113,7 +112,6 @@ subprojects {
         xray
         pact_consumer
         pact_provider
-        vavr
     }
 
     // Check dependencies using:
@@ -223,8 +221,6 @@ subprojects {
         pact_consumer "au.com.dius.pact.consumer:junit5:${dependencyVersions.pact}"
 
         pact_provider "au.com.dius.pact.provider:junit5:${dependencyVersions.pact}"
-
-        vavr "io.vavr:vavr:${dependencyVersions.vavr}"
     }
 }
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -20,8 +20,7 @@ dependencies {
             configurations.dynamodb,
             configurations.lettuce,
             configurations.lambda,
-            configurations.pact_provider,
-            configurations.vavr
+            configurations.pact_provider
 
     implementation project(":shared"), noXray
     implementation project(":orchestration-shared"), noXray

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -484,7 +484,7 @@ class DynamoServiceIntegrationTest {
                     dynamoService.updateAllMfaMethodsForUser(
                             TEST_EMAIL, List.of(promotedBackupMethod, demotedDefaultMethod));
 
-            var returnedMethods = result.get();
+            var returnedMethods = result.getSuccess();
             var defaultMethodAfterUpdate =
                     returnedMethods.stream()
                             .filter(m -> m.getPriority().equals(PriorityIdentifier.DEFAULT.name()))
@@ -545,8 +545,8 @@ class DynamoServiceIntegrationTest {
             var result =
                     dynamoService.updateAllMfaMethodsForUser(TEST_EMAIL, invalidMethodCombination);
 
-            assertTrue(result.isLeft());
-            assertEquals(expectedErrorString, result.getLeft());
+            assertTrue(result.isFailure());
+            assertEquals(expectedErrorString, result.getFailure());
 
             var userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -302,7 +302,7 @@ class DynamoServiceIntegrationTest {
                             PriorityIdentifier.valueOf(defaultPrioritySmsData.getPriority()),
                             defaultPrioritySmsData.getMfaIdentifier());
 
-            var returnedMethods = result.get();
+            var returnedMethods = result.getSuccess();
             var updatedDefaultMethod =
                     returnedMethods.stream()
                             .filter(m -> m.getPriority().equals(PriorityIdentifier.DEFAULT.name()))
@@ -344,7 +344,7 @@ class DynamoServiceIntegrationTest {
                             PriorityIdentifier.valueOf(defaultPriorityAuthAppData.getPriority()),
                             defaultPriorityAuthAppData.getMfaIdentifier());
 
-            var returnedMethods = result.get();
+            var returnedMethods = result.getSuccess();
             var updatedDefaultPriorityMethod =
                     returnedMethods.stream()
                             .filter(m -> m.getPriority().equals(PriorityIdentifier.DEFAULT.name()))
@@ -380,7 +380,7 @@ class DynamoServiceIntegrationTest {
 
             assertEquals(
                     "Mfa method with identifier some-other-identifier does not exist",
-                    result.getLeft());
+                    result.getFailure());
 
             var userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
 
@@ -402,7 +402,7 @@ class DynamoServiceIntegrationTest {
 
             assertEquals(
                     "Mfa method with identifier some-other-identifier does not exist",
-                    result.getLeft());
+                    result.getFailure());
 
             var userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
 
@@ -427,7 +427,7 @@ class DynamoServiceIntegrationTest {
                     format(
                             "Attempted to update phone number for non sms method with identifier %s",
                             defaultPriorityAuthAppData.getMfaIdentifier()),
-                    result.getLeft());
+                    result.getFailure());
 
             var userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
 
@@ -452,7 +452,7 @@ class DynamoServiceIntegrationTest {
                     format(
                             "Attempted to update auth app credential for non auth app method with identifier %s",
                             defaultPrioritySmsData.getMfaIdentifier()),
-                    result.getLeft());
+                    result.getFailure());
 
             var userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -564,7 +564,7 @@ class DynamoServiceIntegrationTest {
                     dynamoService.setMfaIdentifierForNonMigratedUserEnabledAuthApp(
                             TEST_EMAIL, identifier);
 
-            assertTrue(result.isRight());
+            assertTrue(result.isSuccess());
 
             var userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
             var mfaMethods = userCredentials.getMfaMethods();
@@ -593,10 +593,10 @@ class DynamoServiceIntegrationTest {
                     dynamoService.setMfaIdentifierForNonMigratedUserEnabledAuthApp(
                             TEST_EMAIL, identifier);
 
-            assertTrue(result.isLeft());
+            assertTrue(result.isFailure());
             assertEquals(
                     "Attempted to set mfa identifier for mfa method in user credentials but no enabled method found",
-                    result.getLeft());
+                    result.getFailure());
 
             var userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
             var mfaMethods = userCredentials.getMfaMethods();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.services;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
-import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -11,6 +10,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.AuthAppMfaDetail;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
@@ -1044,7 +1044,7 @@ class MFAMethodsServiceIntegrationTest {
 
             var result = mfaMethodsService.deleteMfaMethod(identifierToDelete, userProfile);
 
-            assertEquals(Either.right(identifierToDelete), result);
+            assertEquals(Result.success(identifierToDelete), result);
 
             var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
 
@@ -1062,7 +1062,7 @@ class MFAMethodsServiceIntegrationTest {
 
             var result = mfaMethodsService.deleteMfaMethod(identifierToDelete, userProfile);
 
-            assertEquals(Either.right(identifierToDelete), result);
+            assertEquals(Result.success(identifierToDelete), result);
 
             var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
 
@@ -1080,7 +1080,8 @@ class MFAMethodsServiceIntegrationTest {
 
             var result = mfaMethodsService.deleteMfaMethod(identifierToDelete, userProfile);
 
-            assertEquals(Either.left(MfaDeleteFailureReason.CANNOT_DELETE_DEFAULT_METHOD), result);
+            assertEquals(
+                    Result.failure(MfaDeleteFailureReason.CANNOT_DELETE_DEFAULT_METHOD), result);
 
             var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
 
@@ -1102,7 +1103,8 @@ class MFAMethodsServiceIntegrationTest {
             var result = mfaMethodsService.deleteMfaMethod(identifierToDelete, userProfile);
 
             assertEquals(
-                    Either.left(MfaDeleteFailureReason.MFA_METHOD_WITH_IDENTIFIER_DOES_NOT_EXIST),
+                    Result.failure(
+                            MfaDeleteFailureReason.MFA_METHOD_WITH_IDENTIFIER_DOES_NOT_EXIST),
                     result);
 
             var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
@@ -1124,7 +1126,7 @@ class MFAMethodsServiceIntegrationTest {
             var result = mfaMethodsService.deleteMfaMethod(mfaIdentifier, userProfile);
 
             assertEquals(
-                    Either.left(
+                    Result.failure(
                             MfaDeleteFailureReason.CANNOT_DELETE_MFA_METHOD_FOR_NON_MIGRATED_USER),
                     result);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
@@ -654,7 +654,8 @@ class MFAMethodsServiceIntegrationTest {
                                 true,
                                 AUTH_APP_CREDENTIAL_TWO);
 
-                var expectedUnchangedBackupMethod = MfaMethodData.from(backupPrioritySms).get();
+                var expectedUnchangedBackupMethod =
+                        MfaMethodData.from(backupPrioritySms).getSuccess();
 
                 assertEquals(
                         List.of(expectedUpdatedDefaultMethod, expectedUnchangedBackupMethod)
@@ -694,7 +695,8 @@ class MFAMethodsServiceIntegrationTest {
                                 true,
                                 aThirdPhoneNumber);
 
-                var expectedUnchangedBackupMethod = MfaMethodData.from(backupPrioritySms).get();
+                var expectedUnchangedBackupMethod =
+                        MfaMethodData.from(backupPrioritySms).getSuccess();
 
                 assertEquals(
                         List.of(expectedUpdatedDefaultMethod, expectedUnchangedBackupMethod)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
@@ -462,7 +462,7 @@ class MFAMethodsServiceIntegrationTest {
             var result =
                     mfaMethodsService
                             .addBackupMfa(MFAMethodsServiceIntegrationTest.EMAIL, mfaMethod)
-                            .get();
+                            .getSuccess();
 
             List<MFAMethod> mfaMethods =
                     userStoreExtension.getMfaMethod(MFAMethodsServiceIntegrationTest.EMAIL);
@@ -494,7 +494,7 @@ class MFAMethodsServiceIntegrationTest {
             var result =
                     mfaMethodsService
                             .addBackupMfa(MFAMethodsServiceIntegrationTest.EMAIL, mfaMethod)
-                            .get();
+                            .getSuccess();
 
             List<MFAMethod> mfaMethods =
                     userStoreExtension.getMfaMethod(MFAMethodsServiceIntegrationTest.EMAIL);
@@ -527,7 +527,7 @@ class MFAMethodsServiceIntegrationTest {
                     mfaMethodsService.addBackupMfa(
                             MFAMethodsServiceIntegrationTest.EMAIL, request.mfaMethod());
 
-            assertEquals(MfaCreateFailureReason.INVALID_PRIORITY_IDENTIFIER, result.getLeft());
+            assertEquals(MfaCreateFailureReason.INVALID_PRIORITY_IDENTIFIER, result.getFailure());
         }
 
         @Test
@@ -546,7 +546,7 @@ class MFAMethodsServiceIntegrationTest {
 
             assertEquals(
                     MfaCreateFailureReason.BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST,
-                    result.getLeft());
+                    result.getFailure());
         }
 
         @Test
@@ -562,7 +562,7 @@ class MFAMethodsServiceIntegrationTest {
                     mfaMethodsService.addBackupMfa(
                             MFAMethodsServiceIntegrationTest.EMAIL, request.mfaMethod());
 
-            assertEquals(MfaCreateFailureReason.PHONE_NUMBER_ALREADY_EXISTS, result.getLeft());
+            assertEquals(MfaCreateFailureReason.PHONE_NUMBER_ALREADY_EXISTS, result.getFailure());
         }
 
         @Test
@@ -579,7 +579,7 @@ class MFAMethodsServiceIntegrationTest {
                     mfaMethodsService.addBackupMfa(
                             MFAMethodsServiceIntegrationTest.EMAIL, request.mfaMethod());
 
-            assertEquals(MfaCreateFailureReason.AUTH_APP_EXISTS, result.getLeft());
+            assertEquals(MfaCreateFailureReason.AUTH_APP_EXISTS, result.getFailure());
         }
 
         @Nested

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
@@ -94,7 +94,7 @@ class MFAMethodsServiceIntegrationTest {
             var mfaIdentifier = UUID.randomUUID().toString();
             userStoreExtension.setPhoneNumberMfaIdentifer(email, mfaIdentifier);
 
-            var result = mfaMethodsService.getMfaMethods(email).get();
+            var result = mfaMethodsService.getMfaMethods(email).getSuccess();
 
             var smsMfaDetail = new SmsMfaDetail(PHONE_NUMBER);
             var expectedData =
@@ -108,7 +108,7 @@ class MFAMethodsServiceIntegrationTest {
         void shouldStoreAnMfaIdentifierForANonMigratedSmsMethodOnRead(String email) {
             userStoreExtension.addVerifiedPhoneNumber(email, PHONE_NUMBER);
 
-            var result = mfaMethodsService.getMfaMethods(email).get();
+            var result = mfaMethodsService.getMfaMethods(email).getSuccess();
 
             userProfile = userStoreExtension.getUserProfileFromEmail(email).get();
             var mfaIdentifier = userProfile.getMfaIdentifier();
@@ -128,7 +128,7 @@ class MFAMethodsServiceIntegrationTest {
             userStoreExtension.addAuthAppMethodWithIdentifier(
                     email, true, true, AUTH_APP_CREDENTIAL, mfaIdentifier);
 
-            var result = mfaMethodsService.getMfaMethods(email).get();
+            var result = mfaMethodsService.getMfaMethods(email).getSuccess();
 
             var authAppDetail = new AuthAppMfaDetail(AUTH_APP_CREDENTIAL);
             var expectedData =
@@ -142,7 +142,7 @@ class MFAMethodsServiceIntegrationTest {
         void shouldStoreAnMfaIdentifierForANonMigratedAuthAppOnRead(String email) {
             userStoreExtension.addAuthAppMethod(email, true, true, AUTH_APP_CREDENTIAL);
 
-            var result = mfaMethodsService.getMfaMethods(email).get();
+            var result = mfaMethodsService.getMfaMethods(email).getSuccess();
 
             var retrievedMethodsFromDatabase = userStoreExtension.getMfaMethod(email);
             assertEquals(1, retrievedMethodsFromDatabase.size());
@@ -168,7 +168,7 @@ class MFAMethodsServiceIntegrationTest {
             userStoreExtension.addAuthAppMethodWithIdentifier(
                     email, true, true, AUTH_APP_CREDENTIAL, mfaIdentifier);
 
-            var result = mfaMethodsService.getMfaMethods(email).get();
+            var result = mfaMethodsService.getMfaMethods(email).getSuccess();
 
             var authAppDetail = new AuthAppMfaDetail(AUTH_APP_CREDENTIAL);
             var expectedData =
@@ -182,7 +182,7 @@ class MFAMethodsServiceIntegrationTest {
         void shouldReturnNoMethodsWhenAuthAppMethodNotEnabled(String email) {
             userStoreExtension.addAuthAppMethod(email, true, false, AUTH_APP_CREDENTIAL);
 
-            var result = mfaMethodsService.getMfaMethods(email).get();
+            var result = mfaMethodsService.getMfaMethods(email).getSuccess();
 
             assertEquals(result, List.of());
         }
@@ -193,7 +193,7 @@ class MFAMethodsServiceIntegrationTest {
             userStoreExtension.setPhoneNumberAndVerificationStatus(
                     email, PHONE_NUMBER, false, true);
 
-            var result = mfaMethodsService.getMfaMethods(email).get();
+            var result = mfaMethodsService.getMfaMethods(email).getSuccess();
 
             assertEquals(result, List.of());
         }
@@ -400,7 +400,7 @@ class MFAMethodsServiceIntegrationTest {
             // but regardless for a migrated user we will ignore this entry
             userStoreExtension.addVerifiedPhoneNumber(EMAIL, "+44987654321");
 
-            var result = mfaMethodsService.getMfaMethods(EMAIL).get();
+            var result = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
             var expectedData = mfaMethodDataFrom(defaultPrioritySms);
             assertEquals(List.of(expectedData), result);
@@ -410,7 +410,7 @@ class MFAMethodsServiceIntegrationTest {
         void shouldReturnSingleAuthAppMethodWhenEnabled() {
             userStoreExtension.addMfaMethodSupportingMultiple(EMAIL, defaultPriorityAuthApp);
 
-            var result = mfaMethodsService.getMfaMethods(EMAIL).get();
+            var result = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
             var expectedData = mfaMethodDataFrom(defaultPriorityAuthApp);
             assertEquals(result, List.of(expectedData));
@@ -431,7 +431,7 @@ class MFAMethodsServiceIntegrationTest {
                     mfaMethod ->
                             userStoreExtension.addMfaMethodSupportingMultiple(EMAIL, mfaMethod));
 
-            var result = mfaMethodsService.getMfaMethods(EMAIL).get();
+            var result = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
             var expectedData =
                     mfaMethods.stream()
@@ -627,7 +627,7 @@ class MFAMethodsServiceIntegrationTest {
 
             assertEquals(MfaUpdateFailureReason.UNKOWN_MFA_IDENTIFIER, result.getLeft());
 
-            var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+            var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
             assertEquals(List.of(mfaMethodDataFrom(defaultPriorityAuthApp)), remainingMfaMethods);
         }
 
@@ -663,7 +663,7 @@ class MFAMethodsServiceIntegrationTest {
                                 .toList(),
                         result.get());
 
-                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 var expectedRemainingMethods =
                         List.of(expectedUpdatedDefaultMethod, expectedUnchangedBackupMethod);
                 assertEquals(
@@ -704,7 +704,9 @@ class MFAMethodsServiceIntegrationTest {
                         result.get());
 
                 var methodsInDatabase =
-                        mfaMethodsService.getMfaMethods(EMAIL).get().stream().sorted().toList();
+                        mfaMethodsService.getMfaMethods(EMAIL).getSuccess().stream()
+                                .sorted()
+                                .toList();
                 var expectedMethods =
                         List.of(expectedUpdatedDefaultMethod, expectedUnchangedBackupMethod)
                                 .stream()
@@ -732,7 +734,9 @@ class MFAMethodsServiceIntegrationTest {
                         result.getLeft());
 
                 var methodsInDatabase =
-                        mfaMethodsService.getMfaMethods(EMAIL).get().stream().sorted().toList();
+                        mfaMethodsService.getMfaMethods(EMAIL).getSuccess().stream()
+                                .sorted()
+                                .toList();
                 var expectedMethods =
                         List.of(
                                         mfaMethodDataFrom(backupPrioritySms),
@@ -758,7 +762,7 @@ class MFAMethodsServiceIntegrationTest {
                         MfaUpdateFailureReason.CANNOT_CHANGE_PRIORITY_OF_DEFAULT_METHOD,
                         result.getLeft());
 
-                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(
                         List.of(mfaMethodDataFrom(defaultPriorityAuthApp)), remainingMfaMethods);
             }
@@ -785,7 +789,7 @@ class MFAMethodsServiceIntegrationTest {
                 assertEquals(
                         MfaUpdateFailureReason.CANNOT_CHANGE_TYPE_OF_MFA_METHOD, result.getLeft());
 
-                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(existingMethod)), remainingMfaMethods);
             }
 
@@ -812,7 +816,7 @@ class MFAMethodsServiceIntegrationTest {
                         MfaUpdateFailureReason.REQUEST_TO_UPDATE_MFA_METHOD_WITH_NO_CHANGE,
                         result.getLeft());
 
-                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(existingMethod)), remainingMfaMethods);
             }
         }
@@ -832,7 +836,7 @@ class MFAMethodsServiceIntegrationTest {
                 var result =
                         mfaMethodsService.updateMfaMethod(
                                 EMAIL, backupPrioritySms.getMfaIdentifier(), request);
-                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
                 var expectedDefaultMethod =
                         MfaMethodData.smsMethodData(
@@ -877,7 +881,7 @@ class MFAMethodsServiceIntegrationTest {
                 assertEquals(
                         MfaUpdateFailureReason.CANNOT_CHANGE_TYPE_OF_MFA_METHOD, result.getLeft());
 
-                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(existingMethod)), remainingMfaMethods);
             }
 
@@ -908,7 +912,7 @@ class MFAMethodsServiceIntegrationTest {
                         MfaUpdateFailureReason.REQUEST_TO_UPDATE_MFA_METHOD_WITH_NO_CHANGE,
                         result.getLeft());
 
-                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(existingMethod)), remainingMfaMethods);
             }
 
@@ -931,7 +935,9 @@ class MFAMethodsServiceIntegrationTest {
                         result.getLeft());
 
                 var methodsInDatabase =
-                        mfaMethodsService.getMfaMethods(EMAIL).get().stream().sorted().toList();
+                        mfaMethodsService.getMfaMethods(EMAIL).getSuccess().stream()
+                                .sorted()
+                                .toList();
                 var expectedMethods =
                         List.of(
                                         mfaMethodDataFrom(backupPrioritySms),
@@ -962,7 +968,9 @@ class MFAMethodsServiceIntegrationTest {
                         result.getLeft());
 
                 var methodsInDatabase =
-                        mfaMethodsService.getMfaMethods(EMAIL).get().stream().sorted().toList();
+                        mfaMethodsService.getMfaMethods(EMAIL).getSuccess().stream()
+                                .sorted()
+                                .toList();
                 var expectedMethods =
                         List.of(
                                         mfaMethodDataFrom(backupPriorityAuthApp),
@@ -1000,7 +1008,7 @@ class MFAMethodsServiceIntegrationTest {
                         MfaUpdateFailureReason.REQUEST_TO_UPDATE_MFA_METHOD_WITH_NO_CHANGE,
                         result.getLeft());
 
-                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(existingMethod)), remainingMfaMethods);
             }
 
@@ -1020,7 +1028,7 @@ class MFAMethodsServiceIntegrationTest {
                         MfaUpdateFailureReason.ATTEMPT_TO_UPDATE_BACKUP_WITH_NO_DEFAULT_METHOD,
                         result.getLeft());
 
-                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+                var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(backupPrioritySms)), remainingMfaMethods);
             }
         }
@@ -1046,7 +1054,7 @@ class MFAMethodsServiceIntegrationTest {
 
             assertEquals(Result.success(identifierToDelete), result);
 
-            var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+            var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
             assertEquals(List.of(mfaMethodDataFrom(defaultPrioritySms)), remainingMfaMethods);
         }
@@ -1064,7 +1072,7 @@ class MFAMethodsServiceIntegrationTest {
 
             assertEquals(Result.success(identifierToDelete), result);
 
-            var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+            var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
             assertEquals(List.of(mfaMethodDataFrom(defaultPriorityAuthApp)), remainingMfaMethods);
         }
@@ -1083,7 +1091,7 @@ class MFAMethodsServiceIntegrationTest {
             assertEquals(
                     Result.failure(MfaDeleteFailureReason.CANNOT_DELETE_DEFAULT_METHOD), result);
 
-            var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+            var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
             var expectedRemainingMfaMethods =
                     mfaMethods.stream().map(MFAMethodsServiceIntegrationTest::mfaMethodDataFrom);
@@ -1107,7 +1115,7 @@ class MFAMethodsServiceIntegrationTest {
                             MfaDeleteFailureReason.MFA_METHOD_WITH_IDENTIFIER_DOES_NOT_EXIST),
                     result);
 
-            var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).get();
+            var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
             var expectedRemainingMfaMethods =
                     mfaMethods.stream().map(MFAMethodsServiceIntegrationTest::mfaMethodDataFrom);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
@@ -625,7 +625,7 @@ class MFAMethodsServiceIntegrationTest {
 
             var result = mfaMethodsService.updateMfaMethod(EMAIL, "some-other-identifier", request);
 
-            assertEquals(MfaUpdateFailureReason.UNKOWN_MFA_IDENTIFIER, result.getLeft());
+            assertEquals(MfaUpdateFailureReason.UNKOWN_MFA_IDENTIFIER, result.getFailure());
 
             var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
             assertEquals(List.of(mfaMethodDataFrom(defaultPriorityAuthApp)), remainingMfaMethods);
@@ -662,7 +662,7 @@ class MFAMethodsServiceIntegrationTest {
                                 .stream()
                                 .sorted()
                                 .toList(),
-                        result.get());
+                        result.getSuccess());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 var expectedRemainingMethods =
@@ -703,7 +703,7 @@ class MFAMethodsServiceIntegrationTest {
                                 .stream()
                                 .sorted()
                                 .toList(),
-                        result.get());
+                        result.getSuccess());
 
                 var methodsInDatabase =
                         mfaMethodsService.getMfaMethods(EMAIL).getSuccess().stream()
@@ -733,7 +733,7 @@ class MFAMethodsServiceIntegrationTest {
 
                 assertEquals(
                         MfaUpdateFailureReason.ATTEMPT_TO_UPDATE_PHONE_NUMBER_WITH_BACKUP_NUMBER,
-                        result.getLeft());
+                        result.getFailure());
 
                 var methodsInDatabase =
                         mfaMethodsService.getMfaMethods(EMAIL).getSuccess().stream()
@@ -762,7 +762,7 @@ class MFAMethodsServiceIntegrationTest {
 
                 assertEquals(
                         MfaUpdateFailureReason.CANNOT_CHANGE_PRIORITY_OF_DEFAULT_METHOD,
-                        result.getLeft());
+                        result.getFailure());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(
@@ -789,7 +789,8 @@ class MFAMethodsServiceIntegrationTest {
                                 EMAIL, existingMethod.getMfaIdentifier(), request);
 
                 assertEquals(
-                        MfaUpdateFailureReason.CANNOT_CHANGE_TYPE_OF_MFA_METHOD, result.getLeft());
+                        MfaUpdateFailureReason.CANNOT_CHANGE_TYPE_OF_MFA_METHOD,
+                        result.getFailure());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(existingMethod)), remainingMfaMethods);
@@ -816,7 +817,7 @@ class MFAMethodsServiceIntegrationTest {
 
                 assertEquals(
                         MfaUpdateFailureReason.REQUEST_TO_UPDATE_MFA_METHOD_WITH_NO_CHANGE,
-                        result.getLeft());
+                        result.getFailure());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(existingMethod)), remainingMfaMethods);
@@ -855,7 +856,8 @@ class MFAMethodsServiceIntegrationTest {
                 var expectedMethodsAfterUpdate =
                         Stream.of(expectedDefaultMethod, expectedBackupMethod).sorted().toList();
 
-                assertEquals(expectedMethodsAfterUpdate, result.get().stream().sorted().toList());
+                assertEquals(
+                        expectedMethodsAfterUpdate, result.getSuccess().stream().sorted().toList());
 
                 assertEquals(
                         expectedMethodsAfterUpdate, remainingMfaMethods.stream().sorted().toList());
@@ -881,7 +883,8 @@ class MFAMethodsServiceIntegrationTest {
                                 EMAIL, existingMethod.getMfaIdentifier(), request);
 
                 assertEquals(
-                        MfaUpdateFailureReason.CANNOT_CHANGE_TYPE_OF_MFA_METHOD, result.getLeft());
+                        MfaUpdateFailureReason.CANNOT_CHANGE_TYPE_OF_MFA_METHOD,
+                        result.getFailure());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(existingMethod)), remainingMfaMethods);
@@ -912,7 +915,7 @@ class MFAMethodsServiceIntegrationTest {
 
                 assertEquals(
                         MfaUpdateFailureReason.REQUEST_TO_UPDATE_MFA_METHOD_WITH_NO_CHANGE,
-                        result.getLeft());
+                        result.getFailure());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(existingMethod)), remainingMfaMethods);
@@ -934,7 +937,7 @@ class MFAMethodsServiceIntegrationTest {
 
                 assertEquals(
                         MfaUpdateFailureReason.ATTEMPT_TO_UPDATE_BACKUP_METHOD_PHONE_NUMBER,
-                        result.getLeft());
+                        result.getFailure());
 
                 var methodsInDatabase =
                         mfaMethodsService.getMfaMethods(EMAIL).getSuccess().stream()
@@ -967,7 +970,7 @@ class MFAMethodsServiceIntegrationTest {
 
                 assertEquals(
                         MfaUpdateFailureReason.ATTEMPT_TO_UPDATE_BACKUP_METHOD_AUTH_APP_CREDENTIAL,
-                        result.getLeft());
+                        result.getFailure());
 
                 var methodsInDatabase =
                         mfaMethodsService.getMfaMethods(EMAIL).getSuccess().stream()
@@ -1008,7 +1011,7 @@ class MFAMethodsServiceIntegrationTest {
 
                 assertEquals(
                         MfaUpdateFailureReason.REQUEST_TO_UPDATE_MFA_METHOD_WITH_NO_CHANGE,
-                        result.getLeft());
+                        result.getFailure());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(existingMethod)), remainingMfaMethods);
@@ -1028,7 +1031,7 @@ class MFAMethodsServiceIntegrationTest {
 
                 assertEquals(
                         MfaUpdateFailureReason.ATTEMPT_TO_UPDATE_BACKUP_WITH_NO_DEFAULT_METHOD,
-                        result.getLeft());
+                        result.getFailure());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(mfaMethodDataFrom(backupPrioritySms)), remainingMfaMethods);

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -18,7 +18,6 @@ dependencies {
             configurations.sqs,
             configurations.ssm,
             configurations.cloudwatch,
-            configurations.vavr,
             "org.eclipse.jetty:jetty-server:12.0.18",
             "com.google.code.gson:gson:2.12.1"
 

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -26,8 +26,7 @@ dependencies {
             configurations.cloudwatch,
             configurations.gson,
             configurations.apache,
-            configurations.vavr
-    implementation("software.amazon.awssdk:cloudwatchlogs:${dependencyVersions.aws_sdk_v2_version}")
+            implementation("software.amazon.awssdk:cloudwatchlogs:${dependencyVersions.aws_sdk_v2_version}")
 
     testImplementation configurations.tests,
             configurations.lambda_tests,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Result.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Result.java
@@ -35,6 +35,10 @@ public sealed interface Result<F, S> permits Result.Failure, Result.Success {
 
     <T> Result<F, T> map(Function<S, T> mapper);
 
+    <T> Result<F, T> flatMap(Function<S, Result<F, T>> mapper);
+
+    <T> Result<T, S> mapFailure(Function<F, T> mapper);
+
     record Failure<F, S>(F value) implements Result<F, S> {
         @Override
         public boolean isFailure() {
@@ -59,6 +63,16 @@ public sealed interface Result<F, S> permits Result.Failure, Result.Success {
         @Override
         public <T> Result<F, T> map(Function<S, T> mapper) {
             return new Failure<>(value);
+        }
+
+        @Override
+        public <T> Result<F, T> flatMap(Function<S, Result<F, T>> mapper) {
+            return new Failure<>(value);
+        }
+
+        @Override
+        public <T> Result<T, S> mapFailure(Function<F, T> mapper) {
+            return new Failure<>(mapper.apply(value));
         }
     }
 
@@ -86,6 +100,16 @@ public sealed interface Result<F, S> permits Result.Failure, Result.Success {
         @Override
         public <T> Result<F, T> map(Function<S, T> mapper) {
             return new Success<>(mapper.apply(value));
+        }
+
+        @Override
+        public <T> Result<F, T> flatMap(Function<S, Result<F, T>> mapper) {
+            return mapper.apply(value);
+        }
+
+        @Override
+        public <T> Result<T, S> mapFailure(Function<F, T> mapper) {
+            return new Success<>(value);
         }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Result.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Result.java
@@ -1,0 +1,63 @@
+package uk.gov.di.authentication.shared.entity;
+
+public sealed interface Result<F, S> permits Result.Failure, Result.Success {
+    boolean isFailure();
+
+    boolean isSuccess();
+
+    F getFailure();
+
+    S getSuccess();
+
+    static <F, S> Result<F, S> failure(F value) {
+        return new Failure<>(value);
+    }
+
+    static <F, S> Result<F, S> success(S value) {
+        return new Success<>(value);
+    }
+
+    record Failure<F, S>(F value) implements Result<F, S> {
+        @Override
+        public boolean isFailure() {
+            return true;
+        }
+
+        @Override
+        public boolean isSuccess() {
+            return false;
+        }
+
+        @Override
+        public F getFailure() {
+            return value;
+        }
+
+        @Override
+        public S getSuccess() {
+            throw new IllegalStateException("No success value present in Failure");
+        }
+    }
+
+    record Success<F, S>(S value) implements Result<F, S> {
+        @Override
+        public boolean isFailure() {
+            return false;
+        }
+
+        @Override
+        public boolean isSuccess() {
+            return true;
+        }
+
+        @Override
+        public F getFailure() {
+            throw new IllegalStateException("No failure value present in Success");
+        }
+
+        @Override
+        public S getSuccess() {
+            return value;
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/MfaMethodData.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/MfaMethodData.java
@@ -1,9 +1,9 @@
 package uk.gov.di.authentication.shared.entity.mfa;
 
 import com.google.gson.annotations.Expose;
-import io.vavr.control.Either;
 import org.jetbrains.annotations.NotNull;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.result.Result;
 import uk.gov.di.authentication.shared.validation.Required;
 
 public record MfaMethodData(
@@ -13,23 +13,23 @@ public record MfaMethodData(
         @Expose @Required MfaDetail method)
         implements Comparable<MfaMethodData> {
 
-    public static Either<String, MfaMethodData> from(MFAMethod mfaMethod) {
+    public static Result<String, MfaMethodData> from(MFAMethod mfaMethod) {
         if (mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())) {
-            return Either.right(
+            return Result.success(
                     smsMethodData(
                             mfaMethod.getMfaIdentifier(),
                             PriorityIdentifier.valueOf(mfaMethod.getPriority()),
                             mfaMethod.isMethodVerified(),
                             mfaMethod.getDestination()));
         } else if (mfaMethod.getMfaMethodType().equals(MFAMethodType.AUTH_APP.getValue())) {
-            return Either.right(
+            return Result.success(
                     authAppMfaData(
                             mfaMethod.getMfaIdentifier(),
                             PriorityIdentifier.valueOf(mfaMethod.getPriority()),
                             mfaMethod.isMethodVerified(),
                             mfaMethod.getCredentialValue()));
         } else {
-            return Either.left("Unsupported MFA method type: " + mfaMethod.getMfaMethodType());
+            return Result.failure("Unsupported MFA method type: " + mfaMethod.getMfaMethodType());
         }
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/MfaMethodData.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/MfaMethodData.java
@@ -3,7 +3,7 @@ package uk.gov.di.authentication.shared.entity.mfa;
 import com.google.gson.annotations.Expose;
 import org.jetbrains.annotations.NotNull;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
-import uk.gov.di.authentication.shared.entity.result.Result;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.validation.Required;
 
 public record MfaMethodData(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -2,13 +2,13 @@ package uk.gov.di.authentication.shared.services;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
 import io.vavr.control.Either;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.User;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
-import uk.gov.di.authentication.shared.entity.result.Result;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -100,7 +100,7 @@ public interface AuthenticationService {
     Either<String, List<MFAMethod>> updateMigratedAuthAppCredential(
             String email, String updatedCredential, String mfaMethodIdentifier);
 
-    Either<String, List<MFAMethod>> updateAllMfaMethodsForUser(
+    Result<String, List<MFAMethod>> updateAllMfaMethodsForUser(
             String email, List<MFAMethod> updatedMfaMethods);
 
     Result<String, Void> setMfaIdentifierForNonMigratedUserEnabledAuthApp(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.shared.services;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
-import io.vavr.control.Either;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.User;
@@ -94,10 +93,10 @@ public interface AuthenticationService {
 
     void deleteMfaMethodByIdentifier(String email, String mfaMethodIdentifier);
 
-    Either<String, List<MFAMethod>> updateMigratedMethodPhoneNumber(
+    Result<String, List<MFAMethod>> updateMigratedMethodPhoneNumber(
             String email, String updatedPhoneNumber, String mfaMethodIdentifier);
 
-    Either<String, List<MFAMethod>> updateMigratedAuthAppCredential(
+    Result<String, List<MFAMethod>> updateMigratedAuthAppCredential(
             String email, String updatedCredential, String mfaMethodIdentifier);
 
     Result<String, List<MFAMethod>> updateAllMfaMethodsForUser(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -8,6 +8,7 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.result.Result;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -102,7 +103,7 @@ public interface AuthenticationService {
     Either<String, List<MFAMethod>> updateAllMfaMethodsForUser(
             String email, List<MFAMethod> updatedMfaMethods);
 
-    Either<String, Void> setMfaIdentifierForNonMigratedUserEnabledAuthApp(
+    Result<String, Void> setMfaIdentifierForNonMigratedUserEnabledAuthApp(
             String email, String mfaMethodIdentifier);
 
     void setMfaIdentifierForNonMigratedSmsMethod(String email, String smsMfaIdentifier);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -23,6 +23,7 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.result.Result;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -906,7 +907,7 @@ public class DynamoService implements AuthenticationService {
     }
 
     @Override
-    public Either<String, Void> setMfaIdentifierForNonMigratedUserEnabledAuthApp(
+    public Result<String, Void> setMfaIdentifierForNonMigratedUserEnabledAuthApp(
             String email, String mfaMethodIdentifier) {
         var userCredentials =
                 dynamoUserCredentialsTable.getItem(
@@ -930,9 +931,9 @@ public class DynamoService implements AuthenticationService {
                                     .setMfaMethod(
                                             method.get().withMfaIdentifier(mfaMethodIdentifier)))
                     .withUpdated(dateTime);
-            return Either.right(null);
+            return Result.success(null);
         } else {
-            return Either.left(
+            return Result.failure(
                     "Attempted to set mfa identifier for mfa method in user credentials but no enabled method found");
         }
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
@@ -120,10 +120,10 @@ public class MFAMethodsService {
                 var result =
                         persistentService.setMfaIdentifierForNonMigratedUserEnabledAuthApp(
                                 userProfile.getEmail(), mfaIdentifier);
-                if (result.isLeft()) {
+                if (result.isFailure()) {
                     LOG.error(
                             "Unexpected error updating non migrated auth app mfa identifier: {}",
-                            result.getLeft());
+                            result.getFailure());
                     return Result.failure(
                             MfaRetrieveFailureReason
                                     .UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
@@ -77,10 +77,10 @@ public class MFAMethodsService {
                 .map(Value::toJavaList);
     }
 
-    public Either<MfaDeleteFailureReason, String> deleteMfaMethod(
+    public Result<MfaDeleteFailureReason, String> deleteMfaMethod(
             String mfaIdentifier, UserProfile userProfile) {
         if (!userProfile.getMfaMethodsMigrated()) {
-            return Either.left(
+            return Result.failure(
                     MfaDeleteFailureReason.CANNOT_DELETE_MFA_METHOD_FOR_NON_MIGRATED_USER);
         }
 
@@ -95,15 +95,15 @@ public class MFAMethodsService {
                         .findFirst();
 
         if (maybeMethodToDelete.isEmpty()) {
-            return Either.left(MfaDeleteFailureReason.MFA_METHOD_WITH_IDENTIFIER_DOES_NOT_EXIST);
+            return Result.failure(MfaDeleteFailureReason.MFA_METHOD_WITH_IDENTIFIER_DOES_NOT_EXIST);
         }
 
         if (!BACKUP.name().equals(maybeMethodToDelete.get().getPriority())) {
-            return Either.left(MfaDeleteFailureReason.CANNOT_DELETE_DEFAULT_METHOD);
+            return Result.failure(MfaDeleteFailureReason.CANNOT_DELETE_DEFAULT_METHOD);
         }
 
         persistentService.deleteMfaMethodByIdentifier(userProfile.getEmail(), mfaIdentifier);
-        return Either.right(mfaIdentifier);
+        return Result.success(mfaIdentifier);
     }
 
     private Either<MfaRetrieveFailureReason, Optional<MfaMethodData>>

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ResultTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ResultTest.java
@@ -1,0 +1,32 @@
+package uk.gov.di.authentication.shared.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResultTest {
+    @Test
+    void aFailureShouldActAppropriately() {
+        var failureValue = "failure";
+        var failure = Result.failure(failureValue);
+
+        assertEquals(failureValue, failure.getFailure());
+        assertTrue(failure.isFailure());
+        assertFalse(failure.isSuccess());
+        assertThrows(IllegalStateException.class, failure::getSuccess);
+    }
+
+    @Test
+    void aSuccessShouldActAppropriately() {
+        var successValue = "success";
+        var success = Result.success(successValue);
+
+        assertEquals(successValue, success.getSuccess());
+        assertFalse(success.isFailure());
+        assertTrue(success.isSuccess());
+        assertThrows(IllegalStateException.class, success::getFailure);
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ResultTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ResultTest.java
@@ -1,7 +1,12 @@
 package uk.gov.di.authentication.shared.entity;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -28,5 +33,84 @@ class ResultTest {
         assertFalse(success.isFailure());
         assertTrue(success.isSuccess());
         assertThrows(IllegalStateException.class, success::getFailure);
+    }
+
+    @Nested
+    class SequenceSuccessTests {
+        @Test
+        void sequenceSuccessShouldBeAbleToTransformAListOfSuccessIntoASuccessOfAList() {
+            var results = List.of(Result.success(1), Result.success(2), Result.success(3));
+
+            var expectedAfterSequencing = Result.success(List.of(1, 2, 3));
+
+            assertEquals(expectedAfterSequencing, Result.sequenceSuccess(results));
+        }
+
+        @Test
+        void sequenceSuccessShouldReturnAFailureBasedOnTheFirstFailureInTheList() {
+            var firstFailureValue = "firstFailure";
+            var secondFailureValue = "secondFailure";
+            List<Result<String, Integer>> results =
+                    List.of(
+                            Result.success(1),
+                            Result.failure(firstFailureValue),
+                            Result.success(2),
+                            Result.failure(secondFailureValue));
+
+            assertEquals(Result.failure(firstFailureValue), Result.sequenceSuccess(results));
+        }
+    }
+
+    @Nested
+    class MapTests {
+        @Test
+        void aSuccessShouldSuccessfullyMapToASuccessOfTheSameType() {
+            var number = 1;
+            var success = Result.success(number);
+
+            var result = success.map(n -> n + 1);
+            assertEquals(Result.success(2), result);
+        }
+
+        @Test
+        void aSuccessShouldSuccessfullyMapToASuccessOfADifferentType() {
+            var number = 1;
+            var success = Result.success(number);
+
+            var result = success.map(Object::toString);
+            assertEquals(Result.success("1"), result);
+        }
+
+        @Test
+        void aSuccessShouldBeAbleToProduceSideEffectsFromWithinTheFunctionPassedToIt() {
+            var logs = new ArrayList<>();
+            var number = 1;
+            var success = Result.success(number);
+
+            var result =
+                    success.map(
+                            n -> {
+                                logs.add(format("Processing number %d", n));
+                                return n + 1;
+                            });
+            assertEquals(Result.success(2), result);
+            assertEquals(1, logs.size());
+            assertEquals("Processing number 1", logs.get(0));
+        }
+
+        @Test
+        void aFailureShouldReturnTheFailureWhenMappedWithNoOtherEffects() {
+            var logs = new ArrayList<>();
+            var failure = Result.<String, Integer>failure("This failed");
+
+            var result =
+                    failure.map(
+                            n -> {
+                                logs.add(format("Processing number %d", n));
+                                return n + 1;
+                            });
+            assertEquals(failure, result);
+            assertEquals(0, logs.size());
+        }
     }
 }


### PR DESCRIPTION
## What

Removes the Vavr library (currently used in Method Management API to represent errors as values via its Either type) since we want to eliminate the dependency on this third party library.

Instead this introduces our own hand-rolled version: a Result type that can be either a Failure or a Success, which is equivalent to Either / Left / Right.

Also introduces some of the functional methods on this type that makes it nicer to deal with (map, flatMap and sequence). Note here that I have deliberately implemented the minimal changes possible (so, for example, I haven't super genericised the types to take super/sub types which would probably be the case in a full library handling these, since we don't need this yet and I wanted to keep it as comprehensible as possible for now)

## How to review

While I did try and do this refactor in small steps, it might be easier to look at the overall diff since most of the code changes are pretty comprehensibly like-for-like. And then review the new interface and methods added (Result, Success and Failure files)
