### PR TITLE
ATO-1515: Add client sessions to orch session item

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchSessionServiceIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,6 +47,7 @@ class OrchSessionServiceIntegrationTest {
         assertThat(
                 retrievedSession.get().getIsNewAccount(),
                 equalTo(OrchSessionItem.AccountState.UNKNOWN));
+        assertThat(retrievedSession.get().getClientSessions(), equalTo(new ArrayList<>()));
     }
 
     @Test

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -4,6 +4,9 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttri
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @DynamoDbBean
 public class OrchSessionItem {
 
@@ -18,6 +21,7 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH = "CurrentCredentialStrength";
     public static final String ATTRIBUTE_PROCESSING_IDENTITY_ATTEMPTS =
             "ProcessingIdentityAttempts";
+    public static final String ATTRIBUTE_CLIENT_SESSIONS = "ClientSessions";
 
     public enum AccountState {
         NEW,
@@ -37,6 +41,7 @@ public class OrchSessionItem {
     private Long authTime;
     private CredentialTrustLevel currentCredentialStrength;
     private int processingIdentityAttempts;
+    private List<String> clientSessions;
 
     public OrchSessionItem() {}
 
@@ -44,6 +49,7 @@ public class OrchSessionItem {
         this.sessionId = sessionId;
         this.isNewAccount = AccountState.UNKNOWN;
         this.processingIdentityAttempts = 0;
+        this.clientSessions = new ArrayList<>();
     }
 
     public OrchSessionItem(OrchSessionItem orchSessionItem) {
@@ -58,6 +64,7 @@ public class OrchSessionItem {
         this.authTime = orchSessionItem.authTime;
         this.currentCredentialStrength = orchSessionItem.currentCredentialStrength;
         this.processingIdentityAttempts = orchSessionItem.processingIdentityAttempts;
+        this.clientSessions = orchSessionItem.clientSessions;
     }
 
     @DynamoDbPartitionKey
@@ -218,5 +225,22 @@ public class OrchSessionItem {
     public int incrementProcessingIdentityAttempts() {
         this.processingIdentityAttempts += 1;
         return processingIdentityAttempts;
+    }
+
+    public List<String> getClientSessions() {
+        return clientSessions;
+    }
+
+    public void setClientSessions(List<String> clientSessions) {
+        this.clientSessions = clientSessions;
+    }
+
+    public OrchSessionItem addClientSession(String clientSessionId) {
+        this.clientSessions.add(clientSessionId);
+        return this;
+    }
+
+    public void resetClientSessions() {
+        this.clientSessions = new ArrayList<>();
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchSessionServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.di.orchestration.shared.exceptions.OrchSessionException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -50,6 +51,7 @@ class OrchSessionServiceTest {
         var session = new OrchSessionItem(SESSION_ID);
         assertThat(session.getProcessingIdentityAttempts(), equalTo(0));
         assertThat(session.getIsNewAccount(), equalTo(OrchSessionItem.AccountState.UNKNOWN));
+        assertThat(session.getClientSessions(), equalTo(new ArrayList<>()));
     }
 
     @Test


### PR DESCRIPTION
### Wider context of change: 

- We're migrating this field to the orch session item, and therefore we need to add the attribute to the dynamo object

### What’s changed
- Adds Client Sessions to the OrchSessionItem

### Manual testing:
- N/A just adding new attribute to item
- Sonar is complaining about low coverage of unused methods

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
