### PR TITLE
ATO-1588: Update frontend error redirect logging

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -251,15 +251,17 @@ public class DocAppCallbackHandler
                         clientId,
                         user);
             } else {
-                LOG.error(
-                        "Doc App TokenResponse was not successful: {}",
-                        tokenResponse.toErrorResponse().toJSONObject());
                 incrementDocAppCallbackErrorCounter(false, "UnsuccessfulTokenResponse");
                 auditService.submitAuditEvent(
                         DocAppAuditableEvent.DOC_APP_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                         clientId,
                         user);
-                return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
+                return RedirectService.redirectToFrontendErrorPage(
+                        authFrontend.errorURI(),
+                        new Error(
+                                String.format(
+                                        "Doc App TokenResponse was not successful: %s",
+                                        tokenResponse.toErrorResponse().toJSONObject())));
             }
 
             try {
@@ -339,16 +341,20 @@ public class DocAppCallbackHandler
                             DocAppAuditableEvent.DOC_APP_UNSUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED,
                             clientId,
                             user);
-                    LOG.warn("Doc App sendCriDataRequest was not successful: {}", e.getMessage());
-                    return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
+                    return RedirectService.redirectToFrontendErrorPage(
+                            authFrontend.errorURI(),
+                            new Error(
+                                    String.format(
+                                            "Doc App sendCriDataRequest was not successful: %s",
+                                            e.getMessage())));
                 }
             }
         } catch (DocAppCallbackException | NoSessionException | OrchAuthCodeException e) {
-            LOG.warn(e.getMessage());
-            return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
+            return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI(), e);
         } catch (ParseException e) {
-            LOG.info("Cannot retrieve auth request params from client session id");
-            return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
+            return RedirectService.redirectToFrontendErrorPage(
+                    authFrontend.errorURI(),
+                    new Error("Cannot retrieve auth request params from client session id"));
         }
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -369,12 +369,14 @@ public class IPVCallbackHandler
                                     ipvTokenService.getToken(
                                             input.getQueryStringParameters().get("code")));
             if (!tokenResponse.indicatesSuccess()) {
-                LOG.error(
-                        "IPV TokenResponse was not successful: {}",
-                        tokenResponse.toErrorResponse().toJSONObject());
                 auditService.submitAuditEvent(
                         IPVAuditableEvent.IPV_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED, clientId, user);
-                return RedirectService.redirectToFrontendErrorPage(frontend.errorURI());
+                return RedirectService.redirectToFrontendErrorPage(
+                        frontend.errorURI(),
+                        new Exception(
+                                String.format(
+                                        "IPV TokenResponse was not successful: %s",
+                                        tokenResponse.toErrorResponse().toJSONObject())));
             }
             auditService.submitAuditEvent(
                     IPVAuditableEvent.IPV_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED, clientId, user);
@@ -498,25 +500,27 @@ public class IPVCallbackHandler
             return generateApiGatewayProxyResponse(
                     302, "", Map.of(ResponseHeaders.LOCATION, redirectURI.toString()), null);
         } catch (NoSessionException e) {
-            LOG.warn(e.getMessage());
-            return RedirectService.redirectToFrontendErrorPage(frontend.errorIpvCallbackURI());
+            return RedirectService.redirectToFrontendErrorPage(frontend.errorIpvCallbackURI(), e);
         } catch (IpvCallbackException | UnsuccessfulCredentialResponseException e) {
-            LOG.warn(e.getMessage());
-            return RedirectService.redirectToFrontendErrorPage(frontend.errorURI());
+            return RedirectService.redirectToFrontendErrorPage(frontend.errorURI(), e);
         } catch (ParseException e) {
-            LOG.info("Cannot retrieve auth request params from client session id");
-            return RedirectService.redirectToFrontendErrorPage(frontend.errorURI());
+            return RedirectService.redirectToFrontendErrorPage(
+                    frontend.errorURI(),
+                    new Error("Cannot retrieve auth request params from client session id"));
         } catch (JsonException e) {
-            LOG.error("Unable to serialize SPOTRequest when placing on queue");
-            return RedirectService.redirectToFrontendErrorPage(frontend.errorURI());
+            return RedirectService.redirectToFrontendErrorPage(
+                    frontend.errorURI(),
+                    new Error("Unable to serialize SPOTRequest when placing on queue"));
         } catch (UserNotFoundException e) {
             LOG.error(e.getMessage());
             throw new RuntimeException(e);
         } catch (OrchAuthCodeException e) {
-            LOG.error(
-                    "Failed to generate and save authorisation code to orch auth code DynamoDB store. Error: {}",
-                    e.getMessage());
-            return RedirectService.redirectToFrontendErrorPage(frontend.errorURI());
+            return RedirectService.redirectToFrontendErrorPage(
+                    frontend.errorURI(),
+                    new Error(
+                            String.format(
+                                    "Failed to generate and save authorisation code to orch auth code DynamoDB store. Error: %s",
+                                    e.getMessage())));
         }
     }
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -79,6 +79,7 @@ import uk.gov.di.orchestration.shared.services.LogoutService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
+import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
@@ -118,7 +119,7 @@ import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.ADDRESS
 import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.CORE_IDENTITY_CLAIM;
 import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.CREDENTIAL_JWT_CLAIM;
 import static uk.gov.di.orchestration.sharedtest.helper.IdentityTestData.PASSPORT_CLAIM;
-import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
+import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withThrownMessageContaining;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVCallbackHandlerTest {
@@ -205,6 +206,10 @@ class IPVCallbackHandlerTest {
     @RegisterExtension
     private final CaptureLoggingExtension logging =
             new CaptureLoggingExtension(IPVCallbackHandler.class);
+
+    @RegisterExtension
+    private final CaptureLoggingExtension redirectLogging =
+            new CaptureLoggingExtension(RedirectService.class);
 
     private final Session session = new Session().setEmailAddress(TEST_EMAIL_ADDRESS);
 
@@ -1113,9 +1118,9 @@ class IPVCallbackHandlerTest {
 
         assertDoesRedirectToFrontendPage(response, FRONT_END_IPV_CALLBACK_ERROR_URI);
         assertThat(
-                logging.events(),
+                redirectLogging.events(),
                 hasItem(
-                        withMessageContaining(
+                        withThrownMessageContaining(
                                 "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: false")));
 
         verifyNoInteractions(ipvTokenService);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -336,14 +336,16 @@ public class AuthenticationCallbackHandler
                         clientId,
                         user);
             } else {
-                LOG.error(
-                        "Authentication TokenResponse was not successful: {}",
-                        tokenResponse.toErrorResponse().toJSONObject());
                 auditService.submitAuditEvent(
                         OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                         clientId,
                         user);
-                return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
+                return RedirectService.redirectToFrontendErrorPage(
+                        authFrontend.errorURI(),
+                        new Error(
+                                String.format(
+                                        "Authentication TokenResponse was not successful: %s",
+                                        tokenResponse.toErrorResponse().toJSONObject())));
             }
 
             try {
@@ -646,17 +648,14 @@ public class AuthenticationCallbackHandler
             } catch (UnsuccessfulCredentialResponseException e) {
                 auditService.submitAuditEvent(
                         AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED, clientId, user);
-                LOG.error(
-                        "Orchestration to Authentication userinfo request was not successful: {}",
-                        e.getMessage());
-                return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
+                return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI(), e);
             }
         } catch (AuthenticationCallbackException | OrchAuthCodeException e) {
-            LOG.warn(e.getMessage());
-            return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
+            return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI(), e);
         } catch (ParseException e) {
-            LOG.info("Cannot retrieve auth request params from client session id");
-            return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
+            return RedirectService.redirectToFrontendErrorPage(
+                    authFrontend.errorURI(),
+                    new Error("Cannot retrieve auth request params from client session id"));
         }
     }
 

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/logging/LogEventMatcher.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/logging/LogEventMatcher.java
@@ -45,6 +45,28 @@ public class LogEventMatcher {
         };
     }
 
+    public static Matcher<LogEvent> withThrownMessageContaining(String... values) {
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            protected boolean matchesSafely(LogEvent item) {
+                if (item.getThrown() == null) {
+                    return false;
+                }
+                var message = item.getThrown().getMessage();
+                return Arrays.stream(values).anyMatch(message::contains);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(
+                        "a log event with throwable message containing ["
+                                + Arrays.asList(values)
+                                + "]");
+            }
+        };
+    }
+
     public static Matcher<LogEvent> withMessage(String value) {
         return new TypeSafeMatcher<>() {
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/RedirectService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/RedirectService.java
@@ -13,9 +13,12 @@ import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.ge
 public class RedirectService {
     private static final Logger LOG = LogManager.getLogger(RedirectService.class);
 
-    public static APIGatewayProxyResponseEvent redirectToFrontendErrorPage(URI errorPageUri) {
+    public static APIGatewayProxyResponseEvent redirectToFrontendErrorPage(
+            URI errorPageUri, Throwable error) {
         var errorPageUriStr = errorPageUri.toString();
-        LOG.info("Redirecting to frontend error page: {}", errorPageUriStr);
+        LOG.atError()
+                .withThrowable(error)
+                .log("Redirecting to frontend error page: {}", errorPageUriStr);
         return generateApiGatewayProxyResponse(
                 302, "", Map.of(ResponseHeaders.LOCATION, errorPageUriStr), null);
     }

--- a/template.yaml
+++ b/template.yaml
@@ -1554,6 +1554,75 @@ Resources:
             ]
           ApiId:
             !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+
+  DocAppCallbackFunctionErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterName: !Sub ${Environment}-doc-app-callback-request-errors
+      FilterPattern: '{($.level = "ERROR")}'
+      LogGroupName: !Ref DocAppCallbackFunctionLogGroup
+      MetricTransformations:
+        - MetricName: !Sub ${Environment}-doc-app-callback-count
+          MetricNamespace: LambdaErrorsNamespace
+          MetricValue: 1
+
+  DocAppCallbackFunctionErrorCloudwatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref SlackEvents
+      AlarmDescription: !Sub "20 or more errors have occurred in the ${Environment} doc app callback lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
+      AlarmName: !Sub ${Environment}-doc-app-callback-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: !Sub ${Environment}-doc-app-callback-count
+      Namespace: LambdaErrorsNamespace
+      Period: 3600
+      Statistic: Sum
+      Threshold: 20
+
+  DocAppCallbackFunctionErrorRateCloudwatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${Environment}-doc-app-callback-error-rate-alarm
+      AlarmDescription: !Sub "Lambda error rate of 10 has been reached in the ${Environment} doc app callback lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref SlackEvents
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Threshold: 10
+      Metrics:
+        - Id: e1
+          ReturnData: true
+          Expression: m2/m1*100
+          Label: Error Rate
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Invocations
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub ${Environment}-DocAppCallbackFunction
+            Period: 60
+            Stat: Sum
+            Unit: Count
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Errors
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub ${Environment}-DocAppCallbackFunction
+            Period: 60
+            Stat: Sum
+            Unit: Count
+
   #endregion
 
   #region Token Lambda

--- a/template.yaml
+++ b/template.yaml
@@ -2268,7 +2268,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SlackEvents
-      AlarmDescription: !Sub "15 or more errors have occurred in the ${Environment} authentication callback lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
+      AlarmDescription: !Sub "20 or more errors have occurred in the ${Environment} authentication callback lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/JoD2FwE"
       AlarmName: !Sub ${Environment}-authentication-callback-alarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
@@ -2276,7 +2276,7 @@ Resources:
       Namespace: LambdaErrorsNamespace
       Period: 3600
       Statistic: Sum
-      Threshold: 15
+      Threshold: 20
 
   AuthenticationCallbackFunctionErrorRateCloudwatchAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
### Wider context of change

We don't always log at error level when we redirect to the frontend error page. This PR moves the error logging into the method itself, so we're consistently logging when a user sees an error.
This PR also increased the threshold for auth callback logging alarms, as we've added additional error logs in this lambda, and adds doc app callback error alarms. I've check the logs and this level should be above the baseline but low enough to spot any issues.

How the new logs look in cloudwatch: 
![image](https://github.com/user-attachments/assets/8f4d78bb-2fc3-4844-90aa-76c1aca87731)


### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
