### PR TITLE
ATO-1422: Pass exact value for LevelOfConfidence to auth frontend

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1685,13 +1685,13 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static Stream<Arguments> vtrParams() {
         return Stream.of(
-                Arguments.of(jsonArrayOf("Cl"), LOW_LEVEL, LevelOfConfidence.NONE),
+                Arguments.of(jsonArrayOf("Cl"), LOW_LEVEL, null),
                 Arguments.of(jsonArrayOf("Cl.Cm.P2"), MEDIUM_LEVEL, LevelOfConfidence.MEDIUM_LEVEL),
                 Arguments.of(
                         jsonArrayOf("Cl.Cm.PCL200", "Cl.Cm.P2"),
                         MEDIUM_LEVEL,
                         LevelOfConfidence.HMRC200),
-                Arguments.of(null, MEDIUM_LEVEL, LevelOfConfidence.NONE));
+                Arguments.of(null, MEDIUM_LEVEL, null));
     }
 
     @ParameterizedTest
@@ -1715,25 +1715,28 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         queryParams,
                         Optional.of("GET"));
         assertThat(response, hasStatus(302));
-        assertResponseJarHasClaimsWithValues(
-                response,
-                Map.of(
-                        "confidence",
-                        expectedCredentialStrength.getValue(),
-                        "requested_credential_strength",
-                        expectedCredentialStrength.getValue(),
-                        "requested_level_of_confidence",
-                        expectedLevelOfConfidence.getValue(),
-                        "_ga",
-                        "12345",
-                        "cookie_consent",
-                        "approve",
-                        "client_id",
-                        configuration.getOrchestrationClientId(),
-                        "scope",
-                        "openid",
-                        "redirect_uri",
-                        configuration.getOrchestrationRedirectURI()));
+        var expectedClaims =
+                new HashMap<String, Object>(
+                        Map.of(
+                                "confidence",
+                                expectedCredentialStrength.getValue(),
+                                "requested_credential_strength",
+                                expectedCredentialStrength.getValue(),
+                                "_ga",
+                                "12345",
+                                "cookie_consent",
+                                "approve",
+                                "client_id",
+                                configuration.getOrchestrationClientId(),
+                                "scope",
+                                "openid",
+                                "redirect_uri",
+                                configuration.getOrchestrationRedirectURI()));
+        if (expectedLevelOfConfidence != null) {
+            expectedClaims.put(
+                    "requested_level_of_confidence", expectedLevelOfConfidence.getValue());
+        }
+        assertResponseJarHasClaimsWithValues(response, expectedClaims);
         assertResponseJarHasClaims(response, List.of("state"));
     }
 
@@ -1768,25 +1771,28 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         requestParams,
                         Optional.of("GET"));
         assertThat(response, hasStatus(302));
-        assertResponseJarHasClaimsWithValues(
-                response,
-                Map.of(
-                        "confidence",
-                        expectedCredentialStrength.getValue(),
-                        "requested_credential_strength",
-                        expectedCredentialStrength.getValue(),
-                        "requested_level_of_confidence",
-                        expectedLevelOfConfidence.getValue(),
-                        "_ga",
-                        "12345",
-                        "cookie_consent",
-                        "approve",
-                        "client_id",
-                        configuration.getOrchestrationClientId(),
-                        "scope",
-                        "openid",
-                        "redirect_uri",
-                        configuration.getOrchestrationRedirectURI()));
+        var expectedClaims =
+                new HashMap<String, Object>(
+                        Map.of(
+                                "confidence",
+                                expectedCredentialStrength.getValue(),
+                                "requested_credential_strength",
+                                expectedCredentialStrength.getValue(),
+                                "_ga",
+                                "12345",
+                                "cookie_consent",
+                                "approve",
+                                "client_id",
+                                configuration.getOrchestrationClientId(),
+                                "scope",
+                                "openid",
+                                "redirect_uri",
+                                configuration.getOrchestrationRedirectURI()));
+        if (expectedLevelOfConfidence != null) {
+            expectedClaims.put(
+                    "requested_level_of_confidence", expectedLevelOfConfidence.getValue());
+        }
+        assertResponseJarHasClaimsWithValues(response, expectedClaims);
         assertResponseJarHasClaims(response, List.of("state"));
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -49,7 +49,6 @@ import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
-import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -931,6 +930,7 @@ public class AuthorisationHandler
                 Optional.ofNullable(authenticationRequest.getCustomParameter("_ga"))
                         .map(List::stream)
                         .flatMap(Stream::findFirst);
+        var levelOfConfidenceOpt = Optional.ofNullable(requestedVtr.getLevelOfConfidence());
         var claimsBuilder =
                 new JWTClaimsSet.Builder()
                         .issuer(configurationService.getOrchestrationClientId())
@@ -954,11 +954,6 @@ public class AuthorisationHandler
                         .claim(
                                 "requested_credential_strength",
                                 requestedVtr.getCredentialTrustLevel().getValue())
-                        .claim(
-                                "requested_level_of_confidence",
-                                requestedVtr.containsLevelOfConfidence()
-                                        ? requestedVtr.getLevelOfConfidence().getValue()
-                                        : LevelOfConfidence.NONE.getValue())
                         .claim("state", state.getValue())
                         .claim("client_id", configurationService.getOrchestrationClientId())
                         .claim("redirect_uri", configurationService.getOrchestrationRedirectURI())
@@ -975,6 +970,10 @@ public class AuthorisationHandler
         gaOpt.ifPresent(ga -> claimsBuilder.claim("_ga", ga));
         cookieConsentOpt.ifPresent(
                 cookieConsent -> claimsBuilder.claim("cookie_consent", cookieConsent));
+        levelOfConfidenceOpt.ifPresent(
+                levelOfConfidence ->
+                        claimsBuilder.claim(
+                                "requested_level_of_confidence", levelOfConfidence.getValue()));
 
         var claimsSetRequest =
                 constructAdditionalAuthenticationClaims(client, authenticationRequest);


### PR DESCRIPTION
### Wider context of change

We have started to send fields to the frontend to replace the need for the client session. We have been sending the level of confidence of the requested VTR, but were mapping a `null` level of confidence to `NONE`. I don't think it makes much of a difference at the moment, however it makes sense to send the exact value of this field, to differentiate an RP sending us a request with no LOC, from an RP sending us a request with a P0 LOC.

### What’s changed

This PR makes the claim `requested_level_of_confidence` an optional claim. The tests have also been updated to reflect this

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.