### PR TITLE
ATO-1514: remove processingIdentity attempts methods from shared session class

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -106,7 +106,6 @@ class AuthOrchSerializationServicesIntegrationTest {
     void authCanResetSharedFieldsWithoutOverridingUnsharedFields() {
         var orchSession = orchSessionService.generateSession();
         orchSession.addClientSession(CLIENT_SESSION_ID);
-        orchSession.incrementProcessingIdentityAttempts();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = new Session();
         authSessionService.storeOrUpdateSession(authSession, SESSION_ID);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 class AuthOrchSerializationServicesIntegrationTest {
@@ -89,18 +88,6 @@ class AuthOrchSerializationServicesIntegrationTest {
     }
 
     @Test
-    void orchCanReadUnsharedFieldAfterAuthUpdatesSession() {
-        var orchSession = orchSessionService.generateSession();
-        orchSession.incrementProcessingIdentityAttempts();
-        orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
-        var authSession = authSessionService.getSession(SESSION_ID).get();
-        authSession.addClientSession(CLIENT_SESSION_ID);
-        authSessionService.storeOrUpdateSession(authSession, SESSION_ID);
-        orchSession = orchSessionService.getSession(SESSION_ID).get();
-        assertThat(orchSession.getProcessingIdentityAttempts(), is(equalTo(1)));
-    }
-
-    @Test
     void authCanReadSessionAfterSessionIdIsUpdated() {
         var oldSessionId = SESSION_ID;
         var newSessionId = "new-session-id";
@@ -125,6 +112,5 @@ class AuthOrchSerializationServicesIntegrationTest {
         authSessionService.storeOrUpdateSession(authSession, SESSION_ID);
         orchSession = orchSessionService.getSession(SESSION_ID).get();
         assertThat(orchSession.getClientSessions(), is(empty()));
-        assertThat(orchSession.getProcessingIdentityAttempts(), is(equalTo(1)));
     }
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IdentityProgressFrontendHandlerTest.java
@@ -292,7 +292,6 @@ public class IdentityProgressFrontendHandlerTest {
                                         CLIENT_NAME,
                                         REDIRECT_URI,
                                         STATE))));
-        assertThat(session.getProcessingIdentityAttempts(), equalTo(0));
         assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(0));
         verify(cloudwatchMetricsService)
                 .incrementCounter(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -356,7 +356,6 @@ class ProcessingIdentityHandlerTest {
                         objectMapper.writeValueAsString(
                                 new ProcessingIdentityResponse(
                                         ProcessingIdentityStatus.NO_ENTRY))));
-        assertThat(session.getProcessingIdentityAttempts(), equalTo(0));
         assertThat(orchSession.getProcessingIdentityAttempts(), equalTo(0));
         verify(cloudwatchMetricsService)
                 .incrementCounter(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -2664,7 +2664,7 @@ class AuthorisationHandlerTest {
         void setup() {
             when(configService.supportMaxAgeEnabled()).thenReturn(true);
             when(configService.getSessionExpiry()).thenReturn(3600L);
-            session.incrementProcessingIdentityAttempts();
+            orchSession.incrementProcessingIdentityAttempts();
             withExistingSession(session);
             when(sessionService.copySessionForMaxAge(any(Session.class))).thenCallRealMethod();
         }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -2862,7 +2862,6 @@ class AuthorisationHandlerTest {
                         .storeOrUpdateSession(newSharedSesisonCaptor.capture(), anyString());
                 OrchSessionItem updatedPreviousSession = addSessionCaptor.getAllValues().get(0);
                 OrchSessionItem newOrchSession = addSessionCaptor.getAllValues().get(1);
-                Session newSharedSession = newSharedSesisonCaptor.getValue();
 
                 assertNotEquals(updatedPreviousSession.getSessionId(), orchSession.getSessionId());
                 assertNotEquals(
@@ -2875,7 +2874,6 @@ class AuthorisationHandlerTest {
                                 > timeNow + configService.getSessionExpiry() - 100);
                 assertTrue(updatedPreviousSession.getAuthenticated());
                 assertEquals(updatedPreviousSession.getAuthTime(), authTime);
-                assertEquals(0, newSharedSession.getProcessingIdentityAttempts());
 
                 verify(orchSessionService).deleteSession(orchSession.getSessionId());
 

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -100,13 +100,6 @@ public class RedisExtension
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
-    public void incrementInitialProcessingIdentityAttemptsInSession(String sessionId)
-            throws Json.JsonException {
-        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.incrementProcessingIdentityAttempts();
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
-    }
-
     public void addAuthRequestToSession(
             String clientSessionId,
             String sessionId,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -112,19 +112,6 @@ public class Session {
         return this;
     }
 
-    public int getProcessingIdentityAttempts() {
-        return processingIdentityAttempts;
-    }
-
-    public void resetProcessingIdentityAttempts() {
-        this.processingIdentityAttempts = 0;
-    }
-
-    public int incrementProcessingIdentityAttempts() {
-        this.processingIdentityAttempts += 1;
-        return processingIdentityAttempts;
-    }
-
     private void initializeCodeRequestMap() {
         for (CodeRequestType requestType : CodeRequestType.values()) {
             codeRequestCountMap.put(requestType, 0);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -63,7 +63,6 @@ public class SessionService {
     public Session updateWithNewSessionId(
             Session session, String oldSessionId, String newSessionId) {
         try {
-            session.resetProcessingIdentityAttempts();
             storeOrUpdateSession(session, oldSessionId, newSessionId);
             redisConnectionService.deleteValue(oldSessionId);
             return session;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -38,7 +38,6 @@ public class SessionService {
         var copiedSession = new Session(previousSession);
         copiedSession.setAuthenticated(false).setCurrentCredentialStrength(null);
         copiedSession.resetClientSessions();
-        copiedSession.resetProcessingIdentityAttempts();
         return copiedSession;
     }
 


### PR DESCRIPTION
### Wider context of change:
We are in the process of migrating this field from the shared redis session to the Orchestration only DynamoDB session. Now that we're reading the value in the processing identity handler from the new session store, we can remove other usages of methods which set this value. This removes usages of the reset method and any test usages of the increment methods

### What’s changed:
- Removes resetting the value in the authorise handler, given we're not reading it anymore in processing identity handler, we can remove resetting it here. 
- Removes test usages of the increment methods
- Removes the session class methods as they're now unused.

### Manual testing: 
- N/A just removes setting a now unread field

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
