### PR TITLE
AUT-4245: Only return AUTH_APP method when verified

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
@@ -189,6 +189,16 @@ class MFAMethodsServiceIntegrationTest {
 
         @ParameterizedTest
         @ValueSource(strings = {EMAIL, EXPLICITLY_NON_MIGRATED_USER_EMAIL})
+        void shouldReturnNoMethodsWhenAuthAppMethodNotVerified(String email) {
+            userStoreExtension.addAuthAppMethod(email, false, true, AUTH_APP_CREDENTIAL);
+
+            var result = mfaMethodsService.getMfaMethods(email).getSuccess();
+
+            assertEquals(List.of(), result);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {EMAIL, EXPLICITLY_NON_MIGRATED_USER_EMAIL})
         void shouldReturnNoMethodsWhenSmsMethodNotVerified(String email) {
             userStoreExtension.setPhoneNumberAndVerificationStatus(
                     email, PHONE_NUMBER, false, true);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
@@ -108,7 +108,7 @@ public class MFAMethodsService {
             getMfaMethodForNonMigratedUser(
                     UserProfile userProfile, UserCredentials userCredentials) {
         var enabledAuthAppMethod = getPrimaryMFAMethod(userCredentials);
-        if (enabledAuthAppMethod.isPresent()) {
+        if (enabledAuthAppMethod.filter(MFAMethod::isMethodVerified).isPresent()) {
             var method = enabledAuthAppMethod.get();
             String mfaIdentifier;
             if (Objects.nonNull(method.getMfaIdentifier())) {


### PR DESCRIPTION
## What

Following on from an investigation we have determined that we need to ensure only verified AUTH_APP MFA methods are returned. We had previously determined that we have no way to allow users to get into this state in our existing application (AUTH_APP records are only added after being verified).

However, an analysis of prod data with the MfaMethodAnalysisHandler shows we have some users in this state. Without this change those users could get locked out of their account.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
