### PR TITLE
ATO-1515: remove auth setter for client session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -180,20 +180,9 @@ public class StartHandler
                             sessionId,
                             startRequest.currentCredentialStrength());
 
-            var isUserProfileEmpty = startService.isUserProfileEmpty(authSession);
-
             isUserAuthenticatedWithValidProfile =
-                    startRequest.authenticated() && !isUserProfileEmpty;
+                    startRequest.authenticated() && !startService.isUserProfileEmpty(authSession);
 
-            if (startRequest.authenticated() && isUserProfileEmpty) {
-                session =
-                        startService.createNewSessionWithExistingIdAndClientSession(
-                                sessionId,
-                                getHeaderValueFromHeaders(
-                                        input.getHeaders(),
-                                        CLIENT_SESSION_ID_HEADER,
-                                        configurationService.getHeadersCaseInsensitive()));
-            }
             var upliftRequired =
                     startService.isUpliftRequired(
                             clientSession, startRequest.currentCredentialStrength());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -56,15 +56,6 @@ public class StartService {
         this.sessionService = sessionService;
     }
 
-    public Session createNewSessionWithExistingIdAndClientSession(
-            String sessionId, String clientSessionId) {
-        LOG.info("Creating new session with existing sessionID");
-        Session session = new Session();
-        session.addClientSession(clientSessionId);
-        sessionService.storeOrUpdateSession(session, sessionId);
-        return session;
-    }
-
     public UserContext buildUserContext(
             Session session, ClientSession clientSession, AuthSessionItem authSession) {
         var builder =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -308,7 +308,7 @@ class StartHandlerTest {
     }
 
     @Test
-    void shouldCreateNewSessionAndConsiderUserNotAuthenticatedWhenUserProfileNotPresent()
+    void shouldConsiderUserNotAuthenticatedWhenUserProfileNotPresent()
             throws ParseException, Json.JsonException {
         withNoUserProfilePresent();
         var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
@@ -323,8 +323,6 @@ class StartHandlerTest {
         handler.handleRequest(event, context);
 
         verify(startService)
-                .createNewSessionWithExistingIdAndClientSession(SESSION_ID, CLIENT_SESSION_ID);
-        verify(startService)
                 .buildUserStartInfo(
                         any(),
                         any(),
@@ -337,7 +335,7 @@ class StartHandlerTest {
     }
 
     @Test
-    void retainsExistingSessionAndConsidersUserAuthenticatedWhenUserProfilePresent()
+    void considersUserAuthenticatedWhenUserProfilePresent()
             throws ParseException, Json.JsonException {
         withUserProfilePresent();
         var userStartInfo = new UserStartInfo(false, false, true, null, null, null, false);
@@ -351,8 +349,6 @@ class StartHandlerTest {
 
         handler.handleRequest(event, context);
 
-        verify(startService, never())
-                .createNewSessionWithExistingIdAndClientSession(SESSION_ID, CLIENT_SESSION_ID);
         verify(startService)
                 .buildUserStartInfo(
                         any(),
@@ -552,9 +548,6 @@ class StartHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
-        when(startService.createNewSessionWithExistingIdAndClientSession(
-                        SESSION_ID, CLIENT_SESSION_ID))
-                .thenReturn(session);
         when(authSessionService.getUpdatedPreviousSessionOrCreateNew(any(), any(), any()))
                 .thenReturn(new AuthSessionItem().withSessionId(SESSION_ID));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -58,7 +58,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 
@@ -98,20 +97,6 @@ class StartServiceTest {
     @BeforeEach
     void setup() {
         startService = new StartService(dynamoClientService, dynamoService, sessionService);
-    }
-
-    @Test
-    void shouldOverwriteSessionWithNewSessionUsingExistingSessionAndClientSessionIds() {
-        var currentClientSessionId = "some-client-session-id";
-        SESSION.addClientSession("previous-session-client-session-id");
-
-        var session =
-                startService.createNewSessionWithExistingIdAndClientSession(
-                        SESSION_ID, currentClientSessionId);
-
-        assertTrue(session.getClientSessions().contains("some-client-session-id"));
-        assertFalse(session.getClientSessions().contains("previous-session-client-session-id"));
-        verify(sessionService).storeOrUpdateSession(session, SESSION_ID);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -305,7 +305,6 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var userEmail = "joe.bloggs+3@digital.cabinet-office.gov.uk";
         var sessionId = redis.createSession();
         authSessionExtension.addSession(sessionId);
-        redis.addClientSessionIdToSession(CLIENT_SESSION_ID, sessionId);
         registerWebClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR());
 
         var response =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -7,8 +7,8 @@ import uk.gov.di.authentication.shared.entity.Session;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 class AuthOrchSerializationServicesIntegrationTest {
@@ -18,8 +18,8 @@ class AuthOrchSerializationServicesIntegrationTest {
     private static final Optional<String> REDIS_PASSWORD =
             Optional.ofNullable(System.getenv("REDIS_PASSWORD"));
     private static final String SESSION_ID = "session-id";
-    private static final String BROWSER_SESSION_ID = "browser-session-id";
     private static final String CLIENT_SESSION_ID = "client-session-id";
+    private static final String EMAIL_ADDRESS = "example@example.com";
 
     private uk.gov.di.orchestration.shared.services.SessionService orchSessionService;
     private uk.gov.di.authentication.shared.services.SessionService authSessionService;
@@ -48,20 +48,20 @@ class AuthOrchSerializationServicesIntegrationTest {
     @Test
     void authCanReadFromSessionCreatedByOrch() {
         var orchSession = orchSessionService.generateSession();
-        orchSession.addClientSession(CLIENT_SESSION_ID);
+        orchSession.setEmailAddress(EMAIL_ADDRESS);
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
-        assertThat(authSession.getClientSessions(), contains(CLIENT_SESSION_ID));
+        assertThat(authSession.getEmailAddress(), equalTo(EMAIL_ADDRESS));
     }
 
     @Test
     void orchCanReadFromSessionCreatedByAuth() {
         var sessionId = "some-existing-session-id";
         var authSession = new Session();
-        authSession.addClientSession(CLIENT_SESSION_ID);
+        authSession.setEmailAddress(EMAIL_ADDRESS);
         authSessionService.storeOrUpdateSession(authSession, sessionId);
         var orchSession = orchSessionService.getSession(sessionId).get();
-        assertThat(orchSession.getClientSessions(), contains(CLIENT_SESSION_ID));
+        assertThat(orchSession.getEmailAddress(), equalTo(EMAIL_ADDRESS));
     }
 
     @Test
@@ -69,22 +69,10 @@ class AuthOrchSerializationServicesIntegrationTest {
         var orchSession = orchSessionService.generateSession();
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
-        authSession.addClientSession(CLIENT_SESSION_ID);
+        authSession.setEmailAddress(EMAIL_ADDRESS);
         authSessionService.storeOrUpdateSession(authSession, SESSION_ID);
         orchSession = orchSessionService.getSession(SESSION_ID).get();
-        assertThat(orchSession.getClientSessions(), contains(CLIENT_SESSION_ID));
-    }
-
-    @Test
-    void orchCanUpdateSharedFieldInSessionCreatedByAuth() {
-        var sessionId = "some-existing-session-id";
-        var authSession = new Session();
-        authSessionService.storeOrUpdateSession(authSession, sessionId);
-        var orchSession = orchSessionService.getSession(sessionId).get();
-        orchSession.addClientSession(CLIENT_SESSION_ID);
-        orchSessionService.storeOrUpdateSession(orchSession, sessionId);
-        authSession = authSessionService.getSession(sessionId).get();
-        assertThat(authSession.getClientSessions(), contains(CLIENT_SESSION_ID));
+        assertThat(orchSession.getEmailAddress(), equalTo(EMAIL_ADDRESS));
     }
 
     @Test
@@ -94,12 +82,12 @@ class AuthOrchSerializationServicesIntegrationTest {
         var orchSession = orchSessionService.generateSession();
         orchSessionService.storeOrUpdateSession(orchSession, oldSessionId);
         var authSession = authSessionService.getSession(oldSessionId).get();
-        authSession.addClientSession(CLIENT_SESSION_ID);
+        authSession.setEmailAddress(EMAIL_ADDRESS);
         authSessionService.storeOrUpdateSession(authSession, oldSessionId);
         orchSession = orchSessionService.getSession(oldSessionId).get();
         orchSessionService.updateWithNewSessionId(orchSession, oldSessionId, newSessionId);
         authSessionService.getSession(newSessionId).get();
-        assertThat(authSession.getClientSessions(), contains(CLIENT_SESSION_ID));
+        assertThat(authSession.getEmailAddress(), equalTo(EMAIL_ADDRESS));
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -71,13 +71,6 @@ public class RedisExtension
         redis.saveWithExpiry("state:" + state.getValue(), clientSessionId, 3600);
     }
 
-    public void addClientSessionIdToSession(String clientSessionId, String sessionId)
-            throws Json.JsonException {
-        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.addClientSession(clientSessionId);
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
-    }
-
     public void incrementPasswordCount(String email) {
         codeStorageService.increaseIncorrectPasswordCount(email);
     }
@@ -88,26 +81,6 @@ public class RedisExtension
 
     public void incrementEmailCount(String email) {
         codeStorageService.increaseIncorrectEmailCount(email);
-    }
-
-    public void addAuthRequestToSession(
-            String clientSessionId,
-            String sessionId,
-            Map<String, List<String>> authRequest,
-            String clientName)
-            throws Json.JsonException {
-        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.addClientSession(clientSessionId);
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
-        redis.saveWithExpiry(
-                CLIENT_SESSION_PREFIX.concat(clientSessionId),
-                objectMapper.writeValueAsString(
-                        new ClientSession(
-                                authRequest,
-                                LocalDateTime.now(),
-                                VectorOfTrust.getDefaults(),
-                                clientName)),
-                3600);
     }
 
     public void setSessionCredentialTrustLevel(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -49,15 +49,6 @@ public class Session {
         initializeCodeRequestMap();
     }
 
-    public List<String> getClientSessions() {
-        return clientSessions;
-    }
-
-    public Session addClientSession(String clientSessionId) {
-        this.clientSessions.add(clientSessionId);
-        return this;
-    }
-
     public String getEmailAddress() {
         return emailAddress;
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
@@ -33,7 +33,7 @@ class SessionServiceTest {
     void shouldPersistSessionToRedisWithExpiry() throws Json.JsonException {
         when(configuration.getSessionExpiry()).thenReturn(1234L);
 
-        var session = new Session().addClientSession("client-session-id");
+        var session = new Session().setEmailAddress("example@example.com");
 
         sessionService.storeOrUpdateSession(session, SESSION_ID);
 
@@ -138,7 +138,7 @@ class SessionServiceTest {
 
     @Test
     void shouldDeleteSessionIdFromRedis() {
-        var session = new Session().addClientSession("client-session-id");
+        var session = new Session().setEmailAddress("example@example.com");
 
         sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.deleteSessionFromRedis(SESSION_ID);
@@ -147,7 +147,7 @@ class SessionServiceTest {
     }
 
     private String generateSearlizedSession() throws Json.JsonException {
-        var session = new Session().addClientSession("client-session-id");
+        var session = new Session().setEmailAddress("example@example.com");
 
         return objectMapper.writeValueAsString(session);
     }


### PR DESCRIPTION
### Wider context of change:
We're migrating the Client Session list away from the redis session in Orchestration. Authentication should not be concerned with the Client Session and therefore we will not be adding this field to new Auth dynamo session. Here we're removing some previous behaviour in the start handler that _reset_ the shared session and added the current client session back to it. This behaviour is also becoming increasingly redundant as we move away from the shared session.

### What’s changed
- Removes the method `createNewSessionWithExistingIdAndClientSession` which previously handled resetting the shared session when there was no user profile present.
- Removes the methods for client session on the auth session class

### Manual testing: 
- Repeated the steps outlined in commit: https://github.com/govuk-one-login/authentication-api/commit/3a3752321071e6398b6ea7031bb58486d66b5016 to ensure we still retain the desired behaviour
- Deploy to sandpit 
   -  Run through a journey from the RP stub  in one tab 
   - Delete my user entries in the relevant tables 
   - Try and run through a journey in a separate tab
   - Get redirected to the start page with no silent login

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
