### PR TITLE
AUT-4133: create SSM parameter for frontend session redis cache

### DIFF
--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -93,7 +93,7 @@ resource "aws_elasticache_replication_group" "frontend_sessions_store" {
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true
-  auth_token                 = random_password.redis_password.result
+  auth_token                 = random_password.frontend_redis_password.result
   apply_immediately          = true
 
   subnet_group_name = aws_elasticache_subnet_group.frontend_redis_session_store.name

--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -65,6 +65,16 @@ resource "aws_elasticache_subnet_group" "frontend_redis_session_store" {
 }
 
 
+resource "random_password" "frontend_redis_password" {
+  length = 32
+
+  override_special = "!&#$^<>-"
+  min_lower        = 3
+  min_numeric      = 3
+  min_special      = 3
+  min_upper        = 3
+}
+
 resource "aws_elasticache_replication_group" "frontend_sessions_store" {
   automatic_failover_enabled  = true
   preferred_cache_cluster_azs = data.aws_availability_zones.available.names
@@ -93,7 +103,7 @@ resource "aws_elasticache_replication_group" "frontend_sessions_store" {
 
   lifecycle {
     ignore_changes = [
-      engine_version
+      engine_version, auth_token
     ]
   }
 }

--- a/ci/terraform/shared/ssm.tf
+++ b/ci/terraform/shared/ssm.tf
@@ -244,7 +244,7 @@ resource "aws_ssm_parameter" "frontend_redis_password" {
   name   = "${var.environment}-${local.frontend_redis_key}-redis-password"
   type   = "SecureString"
   key_id = aws_kms_alias.frontend_parameter_store_key_alias.id
-  value  = random_password.redis_password.result
+  value  = random_password.frontend_redis_password.result
   lifecycle {
     ignore_changes = [value]
   }

--- a/ci/terraform/shared/ssm.tf
+++ b/ci/terraform/shared/ssm.tf
@@ -174,3 +174,123 @@ resource "aws_iam_role_policy_attachment" "lambda_iam_role_pepper_parameters" {
   policy_arn = aws_iam_policy.pepper_parameter_policy.arn
   role       = aws_iam_role.lambda_iam_role.name
 }
+
+### Frontend cache redis SSM
+locals {
+  frontend_redis_key = "frontend-cache"
+}
+
+data "aws_iam_policy_document" "frontend_key_policy" {
+  policy_id = "key-policy-frontend-ssm"
+  statement {
+    sid = "Enable IAM User Permissions for root user"
+    actions = [
+      "kms:*",
+    ]
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        format(
+          "arn:%s:iam::%s:root",
+          data.aws_partition.current.partition,
+          data.aws_caller_identity.current.account_id
+        )
+      ]
+    }
+    resources = ["*"]
+  }
+}
+
+resource "aws_kms_key" "frontend_parameter_store_key" {
+  description             = "KMS key for account management frontend parameter store"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.frontend_key_policy.json
+
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  key_usage                = "ENCRYPT_DECRYPT"
+}
+
+resource "aws_kms_alias" "frontend_parameter_store_key_alias" {
+  name          = "alias/${var.environment}-frontend-cache-parameter-store-encryption-key"
+  target_key_id = aws_kms_key.frontend_parameter_store_key.id
+}
+
+resource "aws_ssm_parameter" "frontend_redis_master_host" {
+  name   = "${var.environment}-${local.frontend_redis_key}-redis-master-host"
+  type   = "SecureString"
+  key_id = aws_kms_alias.frontend_parameter_store_key_alias.id
+  value  = aws_elasticache_replication_group.frontend_sessions_store.primary_endpoint_address
+}
+
+resource "aws_ssm_parameter" "frontend_redis_replica_host" {
+  name   = "${var.environment}-${local.frontend_redis_key}-redis-replica-host"
+  type   = "SecureString"
+  key_id = aws_kms_alias.frontend_parameter_store_key_alias.id
+  value  = aws_elasticache_replication_group.frontend_sessions_store.reader_endpoint_address
+}
+
+resource "aws_ssm_parameter" "frontend_redis_tls" {
+  name   = "${var.environment}-${local.frontend_redis_key}-redis-tls"
+  type   = "SecureString"
+  key_id = aws_kms_alias.frontend_parameter_store_key_alias.id
+  value  = "true"
+}
+
+
+
+resource "aws_ssm_parameter" "frontend_redis_password" {
+  name   = "${var.environment}-${local.frontend_redis_key}-redis-password"
+  type   = "SecureString"
+  key_id = aws_kms_alias.frontend_parameter_store_key_alias.id
+  value  = random_password.redis_password.result
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+resource "aws_ssm_parameter" "frontend_redis_port" {
+  name   = "${var.environment}-${local.frontend_redis_key}-redis-port"
+  type   = "SecureString"
+  key_id = aws_kms_alias.frontend_parameter_store_key_alias.id
+  value  = aws_elasticache_replication_group.frontend_sessions_store.port
+}
+
+data "aws_iam_policy_document" "frontend_redis_parameter_policy" {
+  statement {
+    sid    = "AllowGetParameters"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      aws_ssm_parameter.redis_master_host.arn,
+      aws_ssm_parameter.redis_replica_host.arn,
+      aws_ssm_parameter.redis_tls.arn,
+      aws_ssm_parameter.redis_password.arn,
+      aws_ssm_parameter.redis_port.arn,
+    ]
+  }
+  statement {
+    sid    = "AllowDecryptOfParameters"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+    ]
+
+    resources = [
+      aws_kms_alias.frontend_parameter_store_key_alias.arn,
+      aws_kms_key.frontend_parameter_store_key.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "frontend_parameter_policy" {
+  policy      = data.aws_iam_policy_document.frontend_redis_parameter_policy.json
+  path        = "/${var.environment}/redis/${local.frontend_redis_key}/"
+  name_prefix = "parameter-store-policy"
+}


### PR DESCRIPTION
## What

AUT-4133: create SSM parameter for frontend session Redis cache output 

## How to review

1. deploy to dev and monitor the deployment , there should be no change in redis front end 
