### PR TITLE
ATO-1117: migrate salt

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -226,7 +226,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                         VTM.getValue(),
                                         "/trustmark"),
                                 TEST_SUBJECT.getValue(),
-                                salt,
+                                base64EncodedSalt,
                                 sectorId,
                                 rpPairwiseId,
                                 new LogIds(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/SpotQueueAssertionHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/SpotQueueAssertionHelper.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.testsupport.helpers;
 import uk.gov.di.authentication.ipv.entity.SPOTRequest;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -13,7 +12,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.testsupport.matchers.SpotRequestMatcher.hasAccountId;
 import static uk.gov.di.authentication.testsupport.matchers.SpotRequestMatcher.hasSub;
 
@@ -39,10 +38,9 @@ public class SpotQueueAssertionHelper {
 
         var expectedSpotRequest = expectedRequests.stream().findFirst().orElseThrow();
 
-        assertTrue(
-                Arrays.equals(
-                        actualRequests.stream().findFirst().orElseThrow().getSalt(),
-                        expectedSpotRequest.getSalt()));
+        assertEquals(
+                actualRequests.stream().findFirst().orElseThrow().getSalt(),
+                expectedSpotRequest.getSalt());
 
         assertThat(
                 expectedSpotRequest.getLogIds().getSessionId(),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
@@ -1,9 +1,7 @@
 package uk.gov.di.authentication.ipv.entity;
 
 import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
-import uk.gov.di.orchestration.shared.serialization.Base64ByteArrayAdapter;
 
 import java.util.Map;
 
@@ -19,8 +17,7 @@ public class SPOTRequest {
 
     @SerializedName(value = "in_salt")
     @Expose
-    @JsonAdapter(Base64ByteArrayAdapter.class)
-    private byte[] salt;
+    private String salt;
 
     @SerializedName(value = "in_rp_sector_id")
     @Expose
@@ -41,7 +38,7 @@ public class SPOTRequest {
     public SPOTRequest(
             Map<String, Object> spotClaims,
             String localAccountId,
-            byte[] salt,
+            String salt,
             String rpSectorId,
             String sub,
             LogIds logIds,
@@ -65,7 +62,7 @@ public class SPOTRequest {
         return localAccountId;
     }
 
-    public byte[] getSalt() {
+    public String getSalt() {
         return salt;
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.ipv.entity.SPOTClaims;
 import uk.gov.di.authentication.ipv.entity.SPOTRequest;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
+import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.IdentityClaims;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -271,6 +272,7 @@ public class IPVCallbackHelper {
             LogIds logIds,
             String sectorIdentifier,
             UserProfile userProfile,
+            UserInfo authUserInfo,
             Subject pairwiseSubject,
             UserInfo userIdentityUserInfo,
             String clientId)
@@ -295,7 +297,7 @@ public class IPVCallbackHelper {
                 new SPOTRequest(
                         spotClaimsBuilder.build(),
                         userProfile.getSubjectID(),
-                        dynamoService.getOrGenerateSalt(userProfile),
+                        authUserInfo.getStringClaim(AuthUserInfoClaims.SALT.getValue()),
                         sectorIdentifier,
                         pairwiseSubject.getValue(),
                         logIds,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -60,8 +60,6 @@ import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 
-import java.nio.ByteBuffer;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -355,18 +353,6 @@ public class IPVCallbackHandler
                         "is phone number the same on authUserInfo as on UserProfile: {}",
                         Objects.equals(
                                 userProfile.getPhoneNumber(), authUserInfo.getPhoneNumber()));
-            }
-            var saltFromAuthUserInfo = authUserInfo.getStringClaim("salt");
-            if (saltFromAuthUserInfo != null && !saltFromAuthUserInfo.isBlank()) {
-                var saltDecoded = Base64.getDecoder().decode(saltFromAuthUserInfo);
-                var saltBuffer = ByteBuffer.wrap(saltDecoded).asReadOnlyBuffer();
-                LOG.info(
-                        "is salt the same on authUserInfo as on UserProfile: {}",
-                        Objects.equals(userProfile.getSalt(), saltBuffer));
-            } else {
-                LOG.info(
-                        "salt on authUserInfo is null or blank. Is salt on UserProfile defined: {}",
-                        userProfile.getSalt() != null);
             }
             LOG.info(
                     "is subjectId the same on authUserInfo as on UserProfile: {}",

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -496,6 +496,7 @@ public class IPVCallbackHandler
                     getSectorIdentifierForClient(
                             clientRegistry, configurationService.getInternalSectorURI()),
                     userProfile,
+                    authUserInfo,
                     rpPairwiseSubject,
                     userIdentityUserInfo,
                     clientId);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/entity/SPOTRequestTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/entity/SPOTRequestTest.java
@@ -35,7 +35,7 @@ class SPOTRequestTest {
                 spotRequest.getSpotClaims().get(IdentityClaims.CREDENTIAL_JWT.getValue()));
         assertEquals("P2", spotRequest.getSpotClaims().get("vot"));
         assertEquals("/trustmark", spotRequest.getSpotClaims().get("vtm"));
-        assertEquals(saltString, Base64.getEncoder().encodeToString(spotRequest.getSalt()));
+        assertEquals(saltString, spotRequest.getSalt());
         assertEquals("<id>", spotRequest.getLocalAccountId());
         assertEquals("<subject identifier>", spotRequest.getSub());
         assertEquals("<id>", spotRequest.getLogIds().getSessionId());

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -53,6 +53,8 @@ import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -98,6 +100,7 @@ class IPVCallbackHelperTest {
     private static final String SESSION_ID = "a-session-id";
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
+    private static final String TEST_PHONE_NUMBER = "012345678902";
     private static final Subject PUBLIC_SUBJECT =
             new Subject("TsEVC7vg0NPAmzB33vRUFztL2c0-fecKWKcc73fuDhc");
     private static final Subject SUBJECT = new Subject("subject-id");
@@ -105,6 +108,9 @@ class IPVCallbackHelperTest {
     private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
     private static final String TEST_INTERNAL_COMMON_SUBJECT_ID_WITH_INTERVENTION =
             "internal-common-subject-id-with-intervention";
+    private static final byte[] salt =
+            "Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw=".getBytes(StandardCharsets.UTF_8);
+    private static final String BASE_64_ENCODED_SALT = Base64.getEncoder().encodeToString(salt);
     private static final List<VectorOfTrust> VTR_LIST_P1_AND_P2 =
             List.of(
                     VectorOfTrust.of(CredentialTrustLevel.MEDIUM_LEVEL, LevelOfConfidence.NONE),
@@ -121,6 +127,8 @@ class IPVCallbackHelperTest {
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final Long AUTH_TIME = 1234L;
     private static final UserProfile userProfile = generateUserProfile();
+    private static final UserInfo authUserInfo = generateAuthUserInfo();
+
     private static final UserInfo p0VotUserIdentityUserInfo =
             new UserInfo(
                     new JSONObject(
@@ -454,10 +462,28 @@ class IPVCallbackHelperTest {
         return new UserProfile()
                 .withEmail(TEST_EMAIL_ADDRESS)
                 .withEmailVerified(true)
-                .withPhoneNumber("012345678902")
+                .withPhoneNumber(TEST_PHONE_NUMBER)
                 .withPhoneNumberVerified(true)
                 .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
                 .withSubjectID(SUBJECT.getValue());
+    }
+
+    private static UserInfo generateAuthUserInfo() {
+        return new UserInfo(
+                new JSONObject(
+                        Map.of(
+                                "sub",
+                                TEST_INTERNAL_COMMON_SUBJECT_ID,
+                                "client_session_id",
+                                CLIENT_SESSION_ID,
+                                "email",
+                                TEST_EMAIL_ADDRESS,
+                                "phone_number",
+                                TEST_PHONE_NUMBER,
+                                "salt",
+                                BASE_64_ENCODED_SALT,
+                                "local_account_id",
+                                SUBJECT.getValue())));
     }
 
     public static AuthenticationRequest generateAuthRequest(OIDCClaimsRequest oidcClaimsRequest) {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -749,6 +749,7 @@ class IPVCallbackHandlerTest {
                         any(),
                         anyString(),
                         eq(userProfile),
+                        eq(authUserInfo),
                         eq(new Subject(TEST_RP_PAIRWISE_ID)),
                         any(UserInfo.class),
                         eq(CLIENT_ID.getValue()));


### PR DESCRIPTION
### Wider context of change
This is part of the session migration work. Here, we begin the migration of IPVCallbackHandler away from using UserProfile and to using AuthUserInfo instead. A lot has needed to happen before this PR can be raised, from destroying orch session on logout, to migrating the AuthUserInfo table itself to orch. There is still some uncertainty with rpPairwiseId, but I want to get some of this over the line.

### What’s changed
In a nutshell, move from using UserProfile to using AuthUserInfo. That required a lot of detangling, as a lot of properties on UserProfile are used. Here, we just migrate salt.

### Manual testing
Deployed to dev and tested an identity reuse journey worked

Verified values are in sync in logs [here](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22is%20salt%20the%20same%20on%20authUserInfo%20as%20on%20UserProfile%3A*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1744671600&latest=1745362800&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&display.general.type=events&display.visualizations.charting.chart.stackMode=default&display.visualizations.charting.chart=column&sid=1745314437.90429).

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required**
- [x] Changes have been made to the simulator or not required. **Not required**
- [x] Changes have been made to stubs or not required. **Not required**
- [x] Successfully deployed to authdev or not required. **Not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required**

### Related PRs
PR to add a test which verifies my approach with salt:
https://github.com/govuk-one-login/authentication-api/pull/6165

The original PR with all the change in one:
https://github.com/govuk-one-login/authentication-api/pull/5804
