### PR TITLE
ATO-1218: remove Redis auth code setter in auth callback

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -584,29 +584,11 @@ public class AuthenticationCallbackHandler
                 }
 
                 var authCode =
-                        authorisationCodeService.generateAndSaveAuthorisationCode(
+                        orchAuthCodeService.generateAndSaveAuthorisationCode(
                                 clientId,
                                 clientSessionId,
                                 userInfo.getEmailAddress(),
                                 orchSession.getAuthTime());
-
-                /*
-                    TODO: ATO-1218:
-                     - Move the catch clause below to the bottom of this method and return the result of redirectToFrontendErrorPage (similar to the other catch clauses).
-                     - Update the log in the catch clause to be level 'error' and remove Redis references (as by this point the DynamoDB store will be the primary).
-                */
-                try {
-                    orchAuthCodeService.generateAndSaveAuthorisationCode(
-                            authCode,
-                            clientId,
-                            clientSessionId,
-                            userInfo.getEmailAddress(),
-                            orchSession.getAuthTime());
-                } catch (OrchAuthCodeException e) {
-                    LOG.warn(
-                            "Failed to generate and save authorisation code to orch auth code DynamoDB store. NOTE: Redis is still the primary at present. Error: {}",
-                            e.getMessage());
-                }
 
                 var authenticationResponse =
                         new AuthenticationSuccessResponse(
@@ -680,7 +662,7 @@ public class AuthenticationCallbackHandler
                         e.getMessage());
                 return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
             }
-        } catch (AuthenticationCallbackException e) {
+        } catch (AuthenticationCallbackException | OrchAuthCodeException e) {
             LOG.warn(e.getMessage());
             return RedirectService.redirectToFrontendErrorPage(authFrontend.errorURI());
         } catch (ParseException e) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -55,7 +55,6 @@ import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
-import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
@@ -69,7 +68,6 @@ import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
-import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.shared.services.TokenService;
 
@@ -117,7 +115,6 @@ public class AuthenticationCallbackHandler
     private final AuditService auditService;
     private final AuthenticationUserInfoStorageService userInfoStorageService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
-    private final AuthorisationCodeService authorisationCodeService;
     private final OrchAuthCodeService orchAuthCodeService;
     private final ClientService clientService;
     private final InitiateIPVAuthorisationService initiateIPVAuthorisationService;
@@ -146,7 +143,6 @@ public class AuthenticationCallbackHandler
         this.userInfoStorageService =
                 new AuthenticationUserInfoStorageService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.authorisationCodeService = new AuthorisationCodeService(configurationService);
         this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.clientService = new DynamoClientService(configurationService);
 
@@ -190,11 +186,6 @@ public class AuthenticationCallbackHandler
         this.userInfoStorageService =
                 new AuthenticationUserInfoStorageService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.authorisationCodeService =
-                new AuthorisationCodeService(
-                        configurationService,
-                        redisConnectionService,
-                        SerializationService.getInstance());
         this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.clientService = new DynamoClientService(configurationService);
         this.initiateIPVAuthorisationService =
@@ -231,7 +222,6 @@ public class AuthenticationCallbackHandler
             AuditService auditService,
             AuthenticationUserInfoStorageService dynamoAuthUserInfoService,
             CloudwatchMetricsService cloudwatchMetricsService,
-            AuthorisationCodeService authorisationCodeService,
             OrchAuthCodeService orchAuthCodeService,
             ClientService clientService,
             InitiateIPVAuthorisationService initiateIPVAuthorisationService,
@@ -249,7 +239,6 @@ public class AuthenticationCallbackHandler
         this.auditService = auditService;
         this.userInfoStorageService = dynamoAuthUserInfoService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
-        this.authorisationCodeService = authorisationCodeService;
         this.orchAuthCodeService = orchAuthCodeService;
         this.clientService = clientService;
         this.initiateIPVAuthorisationService = initiateIPVAuthorisationService;

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -65,7 +65,6 @@ import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseE
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
-import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.ClientService;
 import uk.gov.di.orchestration.shared.services.ClientSessionService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
@@ -136,10 +135,6 @@ class AuthenticationCallbackHandlerTest {
             mock(AuthenticationUserInfoStorageService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
-
-    // TODO: ATO-1218: Remove the following mock for the auth code service.
-    private static final AuthorisationCodeService authorisationCodeService =
-            mock(AuthorisationCodeService.class);
     private static final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
     private static final InitiateIPVAuthorisationService initiateIPVAuthorisationService =
             mock(InitiateIPVAuthorisationService.class);
@@ -277,7 +272,6 @@ class AuthenticationCallbackHandlerTest {
                         auditService,
                         userInfoStorageService,
                         cloudwatchMetricsService,
-                        authorisationCodeService,
                         orchAuthCodeService,
                         clientService,
                         initiateIPVAuthorisationService,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
@@ -46,6 +46,16 @@ public class OrchAuthCodeService extends BaseDynamoService<OrchAuthCodeItem> {
         this.objectMapper = SerializationService.getInstance();
     }
 
+    // TODO: ATO-1205 (final PR): Remove this method once all other usages of the overloaded method
+    // have been addressed (see comment on the method below).
+    public AuthorizationCode generateAndSaveAuthorisationCode(
+            String clientId, String clientSessionId, String email, Long authTime) {
+        AuthorizationCode authorizationCode = new AuthorizationCode();
+
+        return generateAndSaveAuthorisationCode(
+                authorizationCode, clientId, clientSessionId, email, authTime);
+    }
+
     // TODO: ATO-1579: Move generation of the authorisation code back into this method (removing the
     // parameter).
     public AuthorizationCode generateAndSaveAuthorisationCode(


### PR DESCRIPTION
~**MERGE NOTE: ATO-1205 (#6308) must be merged before this work as this Redis will still be the primary at that point and there is no fallback in place.**~ - merged

### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Currently RP issued auth codes are stored in Redis. We are migrating away from Redis to DynamoDB. The auth code store is being migrated under the parent ticket.

In prior work, we are writing and reading to the new DynamoDB table (using the new orch auth code service) alongside the Redis calls.

Following consistency checks, added in #6287, we now wish to remove the Redis setter call from the handlers, so we're only writing to the DynamoDB.

This PR removes the Redis references in the auth callback lambda.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Replace call to the `authorisationCodeService` with a call to the `orchAuthCodeService`
- Remove references to `authorisationCodeService`

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to Orch dev, ran through an auth only journey on sandpit. Observed a request being made to the `orchestration-redirect` endpoint (for this Auth Callback lambda). This returned 302 and continued on to the callback, redirecting successfully.

Reviewed the `dev-Orch-Auth-Code` DynamoDB table - the expected item and attribute values were found: auth code, exchange data, IsUsed=false, and a 5 minute TTL (expected value based on config).

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.
  - No additional permissions added, write access already granted under prior PRs.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required. **- N/A**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required. **- N/A**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required. **- N/A**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required. **- N/A**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required. **- N/A**

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Entity and service - #6220
- Update to use the same auth code for both stores to enable consistency checks - #6221
- DynamoDB write policy additions to lambdas - #6190
- Writing in lambdas - #6278, #6250, #6244, #6223
- Consistency checks - #6287
- Updating token endpoint to read from DynamoDB - #6308
