### PR TITLE
ATO-1218: migrate ipv callback to read from the orch auth code store

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -29,7 +29,6 @@ import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthCodeResponseGenerationService;
-import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.AwsSqsClient;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -60,7 +59,6 @@ public class IPVCallbackHelper {
     protected final Json objectMapper;
     private final AuditService auditService;
     private final AuthCodeResponseGenerationService authCodeResponseService;
-    private final AuthorisationCodeService authorisationCodeService;
     private final OrchAuthCodeService orchAuthCodeService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final DynamoClientService dynamoClientService;
@@ -74,7 +72,6 @@ public class IPVCallbackHelper {
     public IPVCallbackHelper(ConfigurationService configurationService) {
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.authorisationCodeService = new AuthorisationCodeService(configurationService);
         this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);
         this.dynamoIdentityService = new DynamoIdentityService(configurationService);
@@ -96,9 +93,6 @@ public class IPVCallbackHelper {
             ConfigurationService configurationService, RedisConnectionService redis) {
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.authorisationCodeService =
-                new AuthorisationCodeService(
-                        configurationService, redis, SerializationService.getInstance());
         this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);
         this.dynamoIdentityService = new DynamoIdentityService(configurationService);
@@ -119,7 +113,6 @@ public class IPVCallbackHelper {
     public IPVCallbackHelper(
             AuditService auditService,
             AuthCodeResponseGenerationService authCodeResponseService,
-            AuthorisationCodeService authorisationCodeService,
             OrchAuthCodeService orchAuthCodeService,
             CloudwatchMetricsService cloudwatchMetricsService,
             DynamoClientService dynamoClientService,
@@ -132,7 +125,6 @@ public class IPVCallbackHelper {
             OrchSessionService orchSessionService) {
         this.auditService = auditService;
         this.authCodeResponseService = authCodeResponseService;
-        this.authorisationCodeService = authorisationCodeService;
         this.orchAuthCodeService = orchAuthCodeService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.dynamoClientService = dynamoClientService;

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -24,7 +24,6 @@ import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
-import uk.gov.di.orchestration.shared.exceptions.OrchAuthCodeException;
 import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
@@ -217,28 +216,11 @@ public class IPVCallbackHelper {
                                 clientSessionId, rpPairwiseSubject, userIdentityUserInfo));
 
         var authCode =
-                authorisationCodeService.generateAndSaveAuthorisationCode(
+                orchAuthCodeService.generateAndSaveAuthorisationCode(
                         clientId,
                         clientSessionId,
                         userProfile.getEmail(),
                         orchSession.getAuthTime());
-        /*
-            TODO: ATO-1218:
-             - Move the catch clause below to the bottom of the IPVCallbackHandler "handleRequest" method and return the result of redirectToFrontendErrorPage (similar to the other catch clauses).
-             - Update the log in the catch clause to be level 'error' and remove Redis references (as by this point the DynamoDB store will be the primary).
-        */
-        try {
-            orchAuthCodeService.generateAndSaveAuthorisationCode(
-                    authCode,
-                    clientId,
-                    clientSessionId,
-                    userProfile.getEmail(),
-                    orchSession.getAuthTime());
-        } catch (OrchAuthCodeException e) {
-            LOG.warn(
-                    "Failed to generate and save authorisation code to orch auth code DynamoDB store. NOTE: Redis is still the primary at present. Error: {}",
-                    e.getMessage());
-        }
 
         var authenticationResponse =
                 new AuthenticationSuccessResponse(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -33,6 +33,7 @@ import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
+import uk.gov.di.orchestration.shared.exceptions.OrchAuthCodeException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
@@ -553,6 +554,11 @@ public class IPVCallbackHandler
         } catch (UserNotFoundException e) {
             LOG.error(e.getMessage());
             throw new RuntimeException(e);
+        } catch (OrchAuthCodeException e) {
+            LOG.error(
+                    "Failed to generate and save authorisation code to orch auth code DynamoDB store. Error: {}",
+                    e.getMessage());
+            return RedirectService.redirectToFrontendErrorPage(frontend.errorURI());
         }
     }
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -41,7 +41,6 @@ import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthCodeResponseGenerationService;
-import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.AwsSqsClient;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
@@ -83,10 +82,6 @@ class IPVCallbackHelperTest {
     private final AuditService auditService = mock(AuditService.class);
     private final AuthCodeResponseGenerationService authCodeResponseService =
             mock(AuthCodeResponseGenerationService.class);
-
-    // TODO: ATO-1218: Remove the following mock for the auth code service.
-    private final AuthorisationCodeService authorisationCodeService =
-            mock(AuthorisationCodeService.class);
     private static final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
@@ -163,7 +158,6 @@ class IPVCallbackHelperTest {
                 new IPVCallbackHelper(
                         auditService,
                         authCodeResponseService,
-                        authorisationCodeService,
                         orchAuthCodeService,
                         cloudwatchMetricsService,
                         dynamoClientService,
@@ -316,7 +310,6 @@ class IPVCallbackHelperTest {
                 new IPVCallbackHelper(
                         auditService,
                         authCodeResponseService,
-                        authorisationCodeService,
                         orchAuthCodeService,
                         cloudwatchMetricsService,
                         dynamoClientService,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -67,7 +67,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -158,7 +157,6 @@ class IPVCallbackHelperTest {
 
     @BeforeEach
     void setUp() {
-        clearInvocations(authorisationCodeService);
         clearInvocations(orchAuthCodeService);
 
         helper =
@@ -187,12 +185,7 @@ class IPVCallbackHelperTest {
                         new AccountIntervention(
                                 new AccountInterventionState(false, true, false, false)));
 
-        // TODO: ATO-1218: Remove the following stub for the auth code service.
-        when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        anyString(), anyString(), anyString(), anyLong()))
-                .thenReturn(AUTH_CODE);
         when(orchAuthCodeService.generateAndSaveAuthorisationCode(
-                        any(AuthorizationCode.class),
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(TEST_EMAIL_ADDRESS),
@@ -489,16 +482,8 @@ class IPVCallbackHelperTest {
     }
 
     private void assertAuthorisationCodeGeneratedAndSaved() {
-        verify(authorisationCodeService, times(1))
-                .generateAndSaveAuthorisationCode(
-                        eq(CLIENT_ID.getValue()),
-                        eq(CLIENT_SESSION_ID),
-                        eq(TEST_EMAIL_ADDRESS),
-                        eq(AUTH_TIME));
-
         verify(orchAuthCodeService, times(1))
                 .generateAndSaveAuthorisationCode(
-                        any(AuthorizationCode.class),
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(TEST_EMAIL_ADDRESS),
@@ -506,11 +491,7 @@ class IPVCallbackHelperTest {
     }
 
     private void assertNoAuthorisationCodeGeneratedAndSaved() {
-        verify(authorisationCodeService, times(0))
-                .generateAndSaveAuthorisationCode(any(), any(), any(), any());
-
         verify(orchAuthCodeService, times(0))
-                .generateAndSaveAuthorisationCode(
-                        any(AuthorizationCode.class), any(), any(), any(), any());
+                .generateAndSaveAuthorisationCode(any(), any(), any(), any());
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
@@ -46,6 +46,16 @@ public class OrchAuthCodeService extends BaseDynamoService<OrchAuthCodeItem> {
         this.objectMapper = SerializationService.getInstance();
     }
 
+    // TODO: ATO-1205 (final PR): Remove this method once all other usages of the overloaded method
+    // have been addressed (see comment on the method below).
+    public AuthorizationCode generateAndSaveAuthorisationCode(
+            String clientId, String clientSessionId, String email, Long authTime) {
+        AuthorizationCode authorizationCode = new AuthorizationCode();
+
+        return generateAndSaveAuthorisationCode(
+                authorizationCode, clientId, clientSessionId, email, authTime);
+    }
+
     // TODO: ATO-1579: Move generation of the authorisation code back into this method (removing the
     // parameter).
     public AuthorizationCode generateAndSaveAuthorisationCode(


### PR DESCRIPTION
**MERGE NOTE: ATO-1205 (#6308) must be merged before this work as this Redis will still be the primary at that point and there is no fallback in place.**

### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Currently RP issued auth codes are stored in Redis. We are migrating away from Redis to DynamoDB. The auth code store is being migrated under the parent ticket.

In prior work, we are writing and reading to the new DynamoDB table (using the new orch auth code service) alongside the Redis calls.

Following consistency checks, added in #6287, we now wish to remove the Redis setter call from the handlers, so we're only writing to the DynamoDB.

This PR removes the Redis references in the ipv callback lambda.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Replace call to the `authorisationCodeService` with a call to the `orchAuthCodeService`
- Remove references to `authorisationCodeService`

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

WIP

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.
  - No additional permissions added, write access already granted under prior PRs.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required. **- N/A**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required. **- N/A**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required. **- N/A**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required. **- N/A**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required. **- N/A**

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Entity and service - #6220
- Update to use the same auth code for both stores to enable consistency checks - #6221
- DynamoDB write policy additions to lambdas - #6190
- Writing in lambdas - #6278, #6250, #6244, #6223
- Consistency checks - #6287
- Updating token endpoint to read from DynamoDB - #6308
