### PR TITLE
ATO-1218: remove Redis auth code setter in auth code handler

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -30,7 +30,6 @@ import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
-import uk.gov.di.orchestration.shared.exceptions.OrchAuthCodeException;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
@@ -267,6 +266,7 @@ public class AuthCodeHandler
                             clientSessionId,
                             session,
                             orchSession);
+
             authenticationResponse =
                     orchestrationAuthorizationService.generateSuccessfulAuthResponse(
                             authenticationRequest, authCode, redirectUri, state);
@@ -482,27 +482,10 @@ public class AuthCodeHandler
             orchSession.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
         }
 
-        var authCode =
-                authorisationCodeService.generateAndSaveAuthorisationCode(
-                        clientID.getValue(),
-                        clientSessionId,
-                        emailOptional.orElse(null),
-                        orchSession.getAuthTime());
-
-        // TODO: ATO-1218: Remove the try-catch block below
-        try {
-            orchAuthCodeService.generateAndSaveAuthorisationCode(
-                    authCode,
-                    clientID.getValue(),
-                    clientSessionId,
-                    emailOptional.orElse(null),
-                    orchSession.getAuthTime());
-        } catch (OrchAuthCodeException e) {
-            LOG.warn(
-                    "Failed to generate and save authorisation code to orch auth code DynamoDB store. NOTE: Redis is still the primary at present. Error: {}",
-                    e.getMessage());
-        }
-
-        return authCode;
+        return orchAuthCodeService.generateAndSaveAuthorisationCode(
+                clientID.getValue(),
+                clientSessionId,
+                emailOptional.orElse(null),
+                orchSession.getAuthTime());
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -30,6 +30,7 @@ import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
+import uk.gov.di.orchestration.shared.exceptions.OrchAuthCodeException;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
@@ -272,6 +273,11 @@ public class AuthCodeHandler
             return processUserNotFoundException(authenticationRequest);
         } catch (ParseException e) {
             return processParseException(e);
+        } catch (OrchAuthCodeException e) {
+            LOG.error(
+                    "Failed to generate and save authorisation code to orch auth code DynamoDB store. Error: {}",
+                    e.getMessage());
+            return generateApiGatewayProxyResponse(500, "Internal server error");
         }
 
         LOG.info("Successfully processed request");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -36,7 +36,6 @@ import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthCodeResponseGenerationService;
 import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
-import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
@@ -80,7 +79,6 @@ public class AuthCodeHandler
     private final OrchSessionService orchSessionService;
     private final AuthenticationUserInfoStorageService authUserInfoStorageService;
     private final AuthCodeResponseGenerationService authCodeResponseService;
-    private final AuthorisationCodeService authorisationCodeService;
     private final OrchAuthCodeService orchAuthCodeService;
     private final OrchestrationAuthorizationService orchestrationAuthorizationService;
     private final OrchClientSessionService orchClientSessionService;
@@ -95,7 +93,6 @@ public class AuthCodeHandler
             OrchSessionService orchSessionService,
             AuthenticationUserInfoStorageService authUserInfoStorageService,
             AuthCodeResponseGenerationService authCodeResponseService,
-            AuthorisationCodeService authorisationCodeService,
             OrchAuthCodeService orchAuthCodeService,
             OrchestrationAuthorizationService orchestrationAuthorizationService,
             OrchClientSessionService orchClientSessionService,
@@ -108,7 +105,6 @@ public class AuthCodeHandler
         this.orchSessionService = orchSessionService;
         this.authUserInfoStorageService = authUserInfoStorageService;
         this.authCodeResponseService = authCodeResponseService;
-        this.authorisationCodeService = authorisationCodeService;
         this.orchAuthCodeService = orchAuthCodeService;
         this.orchestrationAuthorizationService = orchestrationAuthorizationService;
         this.orchClientSessionService = orchClientSessionService;
@@ -123,7 +119,6 @@ public class AuthCodeHandler
         sessionService = new SessionService(configurationService);
         orchSessionService = new OrchSessionService(configurationService);
         authUserInfoStorageService = new AuthenticationUserInfoStorageService(configurationService);
-        authorisationCodeService = new AuthorisationCodeService(configurationService);
         orchAuthCodeService = new OrchAuthCodeService(configurationService);
         orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(configurationService);
@@ -142,7 +137,6 @@ public class AuthCodeHandler
         sessionService = new SessionService(configurationService, redis);
         orchSessionService = new OrchSessionService(configurationService);
         authUserInfoStorageService = new AuthenticationUserInfoStorageService(configurationService);
-        authorisationCodeService = new AuthorisationCodeService(configurationService);
         orchAuthCodeService = new OrchAuthCodeService(configurationService);
         orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(configurationService);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -285,16 +285,7 @@ class AuthCodeHandlerTest {
         when(orchestrationAuthorizationService.isClientRedirectUriValid(
                         (ClientRegistry) any(), eq(REDIRECT_URI)))
                 .thenReturn(true);
-
-        // TODO: ATO-1218: Remove the following stub for the auth code service.
-        when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        eq(CLIENT_ID.getValue()),
-                        eq(CLIENT_SESSION_ID),
-                        eq(EMAIL),
-                        any(Long.class)))
-                .thenReturn(authorizationCode);
         when(orchAuthCodeService.generateAndSaveAuthorisationCode(
-                        any(AuthorizationCode.class),
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(EMAIL),
@@ -352,12 +343,7 @@ class AuthCodeHandlerTest {
                         pair("authCode", authorizationCode),
                         pair("nonce", NONCE.getValue()));
 
-        verify(authorisationCodeService, times(1))
-                .generateAndSaveAuthorisationCode(
-                        eq(CLIENT_ID.getValue()),
-                        eq(CLIENT_SESSION_ID),
-                        eq(EMAIL),
-                        any(Long.class));
+        assertAuthorisationCodeGeneratedAndSaved(EMAIL);
 
         var dimensions =
                 Map.of(
@@ -411,17 +397,8 @@ class AuthCodeHandlerTest {
         when(orchestrationAuthorizationService.isClientRedirectUriValid(
                         (ClientRegistry) any(), eq(REDIRECT_URI)))
                 .thenReturn(true);
-
-        // TODO: ATO-1218: Remove the following stub for the auth code service.
-        when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        eq(CLIENT_ID.getValue()), eq(CLIENT_SESSION_ID), eq(null), any(Long.class)))
-                .thenReturn(authorizationCode);
         when(orchAuthCodeService.generateAndSaveAuthorisationCode(
-                        any(AuthorizationCode.class),
-                        eq(CLIENT_ID.getValue()),
-                        eq(CLIENT_SESSION_ID),
-                        eq(null),
-                        any(Long.class)))
+                        eq(CLIENT_ID.getValue()), eq(CLIENT_SESSION_ID), eq(null), any(Long.class)))
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(
                         eq(orchSession),
@@ -482,9 +459,8 @@ class AuthCodeHandlerTest {
                         pair("rpPairwiseId", AuditService.UNKNOWN),
                         pair("authCode", authorizationCode),
                         pair("nonce", NONCE.getValue()));
-        verify(authorisationCodeService, times(1))
-                .generateAndSaveAuthorisationCode(
-                        eq(CLIENT_ID.getValue()), eq(CLIENT_SESSION_ID), eq(null), any(Long.class));
+
+        assertAuthorisationCodeGeneratedAndSaved(null);
 
         var expectedDimensions =
                 Map.of(
@@ -753,20 +729,8 @@ class AuthCodeHandlerTest {
         when(orchestrationAuthorizationService.isClientRedirectUriValid(
                         (ClientRegistry) any(), eq(REDIRECT_URI)))
                 .thenReturn(true);
-
-        // TODO: ATO-1218: Remove the following stub for the auth code service.
-        when(authorisationCodeService.generateAndSaveAuthorisationCode(
-                        eq(CLIENT_ID.getValue()),
-                        eq(CLIENT_SESSION_ID),
-                        eq(EMAIL),
-                        any(Long.class)))
-                .thenReturn(authorizationCode);
         when(orchAuthCodeService.generateAndSaveAuthorisationCode(
-                        any(AuthorizationCode.class),
-                        eq(CLIENT_ID.getValue()),
-                        eq(CLIENT_SESSION_ID),
-                        eq(EMAIL),
-                        any(Long.class)))
+                        eq(CLIENT_ID.getValue()), eq(CLIENT_SESSION_ID), eq(EMAIL), anyLong()))
                 .thenReturn(authorizationCode);
         when(authCodeResponseService.getDimensions(
                         eq(orchSession),
@@ -899,16 +863,8 @@ class AuthCodeHandlerTest {
     }
 
     private void assertAuthorisationCodeGeneratedAndSaved(String expectedEmail) {
-        verify(authorisationCodeService, times(1))
-                .generateAndSaveAuthorisationCode(
-                        eq(CLIENT_ID.getValue()),
-                        eq(CLIENT_SESSION_ID),
-                        eq(expectedEmail),
-                        anyLong());
-
         verify(orchAuthCodeService, times(1))
                 .generateAndSaveAuthorisationCode(
-                        any(AuthorizationCode.class),
                         eq(CLIENT_ID.getValue()),
                         eq(CLIENT_SESSION_ID),
                         eq(expectedEmail),
@@ -916,15 +872,7 @@ class AuthCodeHandlerTest {
     }
 
     private void assertNoAuthorisationCodeGeneratedAndSaved() {
-        verify(authorisationCodeService, times(0))
-                .generateAndSaveAuthorisationCode(anyString(), anyString(), anyString(), anyLong());
-
         verify(orchAuthCodeService, times(0))
-                .generateAndSaveAuthorisationCode(
-                        any(AuthorizationCode.class),
-                        anyString(),
-                        anyString(),
-                        anyString(),
-                        anyLong());
+                .generateAndSaveAuthorisationCode(anyString(), anyString(), anyString(), anyLong());
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -49,7 +49,6 @@ import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthCodeResponseGenerationService;
 import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
-import uk.gov.di.orchestration.shared.services.AuthorisationCodeService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
@@ -109,8 +108,7 @@ class AuthCodeHandlerTest {
     private final AuthCodeResponseGenerationService authCodeResponseService =
             mock(AuthCodeResponseGenerationService.class);
     private final AuditService auditService = mock(AuditService.class);
-    private final AuthorisationCodeService authorisationCodeService =
-            mock(AuthorisationCodeService.class);
+
     private final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
     private final OrchClientSessionItem orchClientSession = mock(OrchClientSessionItem.class);
     private final OrchClientSessionService orchClientSessionService =
@@ -182,7 +180,6 @@ class AuthCodeHandlerTest {
                         orchSessionService,
                         authUserInfoService,
                         authCodeResponseService,
-                        authorisationCodeService,
                         orchAuthCodeService,
                         orchestrationAuthorizationService,
                         orchClientSessionService,


### PR DESCRIPTION
~**MERGE NOTE: ATO-1205 (#6308) must be merged before this work as this Redis will still be the primary at that point and there is no fallback in place.**~ - merged

### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Currently RP issued auth codes are stored in Redis. We are migrating away from Redis to DynamoDB. The auth code store is being migrated under the parent ticket.

In prior work, we are writing and reading to the new DynamoDB table (using the new orch auth code service) alongside the Redis calls.

Following consistency checks, added in #6287, we now wish to remove the Redis setter call from the handlers, so we're only writing to the DynamoDB.

This PR removes the Redis references in the auth code lambda.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Replace call to the `authorisationCodeService` with a call to the `orchAuthCodeService`
- Remove references to `authorisationCodeService`

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to Orch dev, ran through an identity journey (sandpit RP stub, selected "P2" level of confidence, clicked continue, signed in, clicked continue on the IPV stub form using the default values, redirected to user info screen).

Redirected successfully to the user information screen. The AuthCodeFunction lambda logs showed a call being made to the new orch auth code service.

Reviewed the dev-Orch-Auth-Code DynamoDB table - the expected item and attribute values were found: auth code, exchange data, IsUsed=false, and a 5 minute TTL (expected value based on config).

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.
  - No additional permissions added, write access already granted under prior PRs.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required. **- N/A**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required. **- N/A**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required. **- N/A**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required. **- N/A**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required. **- N/A**

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Entity and service - #6220
- Update to use the same auth code for both stores to enable consistency checks - #6221
- DynamoDB write policy additions to lambdas - #6190
- Writing in lambdas - #6278, #6250, #6244, #6223
- Consistency checks - #6287
- Updating token endpoint to read from DynamoDB - #6308
