### PR TITLE
Aut 4205/migrated user default method signin

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -178,16 +178,9 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                 LOG.info("Setting internal common subject identifier in user session");
 
                 authSession.setInternalCommonSubjectId(internalCommonSubjectId);
-                var isPhoneNumberVerified = userProfile.get().isPhoneNumberVerified();
                 var userCredentials =
                         authenticationService.getUserCredentialsFromEmail(emailAddress);
-                userMfaDetail =
-                        getUserMFADetail(
-                                userContext,
-                                userCredentials,
-                                userProfile.get().getPhoneNumber(),
-                                isPhoneNumberVerified,
-                                userProfile.get());
+                userMfaDetail = getUserMFADetail(userContext, userCredentials, userProfile.get());
                 auditContext = auditContext.withSubjectId(internalCommonSubjectId);
             } else {
                 authSession.setInternalCommonSubjectId(null);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -186,7 +186,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                                 userContext,
                                 userCredentials,
                                 userProfile.get().getPhoneNumber(),
-                                isPhoneNumberVerified);
+                                isPhoneNumberVerified,
+                                userProfile.get());
                 auditContext = auditContext.withSubjectId(internalCommonSubjectId);
             } else {
                 authSession.setInternalCommonSubjectId(null);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -298,13 +298,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         .withAccountState(AuthSessionItem.AccountState.EXISTING)
                         .withInternalCommonSubjectId(internalCommonSubjectIdentifier));
 
-        var userMfaDetail =
-                getUserMFADetail(
-                        userContext,
-                        userCredentials,
-                        userProfile.getPhoneNumber(),
-                        userProfile.isPhoneNumberVerified(),
-                        userProfile);
+        var userMfaDetail = getUserMFADetail(userContext, userCredentials, userProfile);
 
         boolean isPasswordChangeRequired = isPasswordResetRequired(request.getPassword());
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -303,7 +303,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         userContext,
                         userCredentials,
                         userProfile.getPhoneNumber(),
-                        userProfile.isPhoneNumberVerified());
+                        userProfile.isPhoneNumberVerified(),
+                        userProfile);
 
         boolean isPasswordChangeRequired = isPasswordResetRequired(request.getPassword());
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -329,8 +329,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         }
 
         String redactedPhoneNumber =
-                userProfile.isPhoneNumberVerified()
-                        ? redactPhoneNumber(userProfile.getPhoneNumber())
+                userMfaDetail.phoneNumber() != null && userMfaDetail.mfaMethodVerified()
+                        ? redactPhoneNumber(userMfaDetail.phoneNumber())
                         : null;
 
         boolean termsAndConditionsAccepted = isTermsAndConditionsAccepted(userContext, userProfile);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -285,8 +285,6 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                                             userContext,
                                             authenticationService.getUserCredentialsFromEmail(
                                                     resetPasswordRequest.getEmail()),
-                                            userProfile.getPhoneNumber(),
-                                            userProfile.isPhoneNumberVerified(),
                                             userProfile);
 
                             return new ResetPasswordRequestHandlerResponse(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -286,7 +286,8 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                                             authenticationService.getUserCredentialsFromEmail(
                                                     resetPasswordRequest.getEmail()),
                                             userProfile.getPhoneNumber(),
-                                            userProfile.isPhoneNumberVerified());
+                                            userProfile.isPhoneNumberVerified(),
+                                            userProfile);
 
                             return new ResetPasswordRequestHandlerResponse(
                                     userMfaDetail.mfaMethodType(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/CommonTestVariables.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/CommonTestVariables.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.frontendapi.helpers;
 
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 
 import java.util.Map;
@@ -37,4 +39,33 @@ public class CommonTestVariables {
                             PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, DI_PERSISTENT_SESSION_ID),
                     Map.entry(SESSION_ID_HEADER, SESSION_ID),
                     Map.entry(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID));
+
+    public static final MFAMethod DEFAULT_AUTH_APP_METHOD =
+            MFAMethod.authAppMfaMethod(
+                    "default-auth-app-secret",
+                    true,
+                    true,
+                    PriorityIdentifier.DEFAULT,
+                    "default-auth-app-identifier");
+    public static final MFAMethod BACKUP_AUTH_APP_METHOD =
+            MFAMethod.authAppMfaMethod(
+                    "backup-auth-app-secret",
+                    true,
+                    true,
+                    PriorityIdentifier.BACKUP,
+                    "backup-auth-app-identifier");
+    public static final MFAMethod DEFAULT_SMS_METHOD =
+            MFAMethod.smsMfaMethod(
+                    true,
+                    true,
+                    "+447900000100",
+                    PriorityIdentifier.DEFAULT,
+                    "default-sms-identifier");
+    public static final MFAMethod BACKUP_SMS_METHOD =
+            MFAMethod.smsMfaMethod(
+                    true,
+                    true,
+                    "+447900000000",
+                    PriorityIdentifier.BACKUP,
+                    "backup-sms-identifier");
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -30,6 +30,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -247,6 +248,83 @@ class ResetPasswordRequestHandlerTest {
 
             assertEquals(200, result.getStatusCode());
             var expectedBody = "{\"mfaMethodType\":\"SMS\",\"phoneNumberLastThree\":\"890\"}";
+            assertEquals(expectedBody, result.getBody());
+            verify(codeStorageService)
+                    .saveOtpCode(
+                            CommonTestVariables.EMAIL,
+                            TEST_SIX_DIGIT_CODE,
+                            CODE_EXPIRY_TIME,
+                            RESET_PASSWORD_WITH_CODE);
+            verify(authSessionService, atLeastOnce())
+                    .updateSession(
+                            argThat(
+                                    s ->
+                                            isAuthSessionWithCountAndResetState(
+                                                    s,
+                                                    1,
+                                                    AuthSessionItem.ResetPasswordState.ATTEMPTED)));
+        }
+
+        @Test
+        void shouldReturn200WithTheMigratedUsersMfaMethodAndSaveOtpCodeForAValidRequest() {
+            usingValidSession();
+            when(authenticationService.getUserProfileByEmailMaybe(CommonTestVariables.EMAIL))
+                    .thenReturn(Optional.of(migratedUserProfileWithoutPhoneNumber()));
+            when(authenticationService.getUserCredentialsFromEmail(CommonTestVariables.EMAIL))
+                    .thenReturn(
+                            new UserCredentials()
+                                    .withMfaMethods(
+                                            List.of(
+                                                    MFAMethod.
+                                                            smsMfaMethod(true,
+                                                                    true,
+                                                                    CommonTestVariables.UK_MOBILE_NUMBER,
+                                                                    PriorityIdentifier.DEFAULT, "1"))));
+
+
+            APIGatewayProxyResponseEvent result = handler.handleRequest(validEvent, context);
+
+            assertEquals(200, result.getStatusCode());
+            var expectedBody = "{\"mfaMethodType\":\"SMS\",\"phoneNumberLastThree\":\"890\"}";
+            assertEquals(expectedBody, result.getBody());
+            verify(codeStorageService)
+                    .saveOtpCode(
+                            CommonTestVariables.EMAIL,
+                            TEST_SIX_DIGIT_CODE,
+                            CODE_EXPIRY_TIME,
+                            RESET_PASSWORD_WITH_CODE);
+            verify(authSessionService, atLeastOnce())
+                    .updateSession(
+                            argThat(
+                                    s ->
+                                            isAuthSessionWithCountAndResetState(
+                                                    s,
+                                                    1,
+                                                    AuthSessionItem.ResetPasswordState.ATTEMPTED)));
+        }
+
+        @Test
+        void shouldReturn200WithTheMigratedUsersMfaMethodAndSaveEmailOtpCodeForAValidRequest() {
+            usingValidSession();
+            when(authenticationService.getUserProfileByEmailMaybe(CommonTestVariables.EMAIL))
+                    .thenReturn(Optional.of(migratedUserProfileWithoutPhoneNumber()));
+            when(authenticationService.getUserCredentialsFromEmail(CommonTestVariables.EMAIL))
+                    .thenReturn(
+                            new UserCredentials()
+                                    .withMfaMethods(
+                                            List.of(
+                                                    MFAMethod.
+                                                            authAppMfaMethod("cred",
+                                                                    true,
+                                                                    true,
+                                                                    PriorityIdentifier.DEFAULT,
+                                                                    "auth-app-id"))));
+
+
+            APIGatewayProxyResponseEvent result = handler.handleRequest(validEvent, context);
+
+            assertEquals(200, result.getStatusCode());
+            var expectedBody = "{\"mfaMethodType\":\"AUTH_APP\",\"phoneNumberLastThree\":null}";
             assertEquals(expectedBody, result.getBody());
             verify(codeStorageService)
                     .saveOtpCode(
@@ -607,6 +685,11 @@ class ResetPasswordRequestHandlerTest {
                 .thenReturn(Optional.of(authSession));
     }
 
+    private UserProfile migratedUserProfileWithoutPhoneNumber() {
+        return new UserProfile()
+                .withEmail(CommonTestVariables.EMAIL)
+                .withMfaMethodsMigrated(true);
+    }
     private UserProfile userProfileWithPhoneNumber() {
         return new UserProfile()
                 .withEmail(CommonTestVariables.EMAIL)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -275,12 +275,12 @@ class ResetPasswordRequestHandlerTest {
                             new UserCredentials()
                                     .withMfaMethods(
                                             List.of(
-                                                    MFAMethod.
-                                                            smsMfaMethod(true,
-                                                                    true,
-                                                                    CommonTestVariables.UK_MOBILE_NUMBER,
-                                                                    PriorityIdentifier.DEFAULT, "1"))));
-
+                                                    MFAMethod.smsMfaMethod(
+                                                            true,
+                                                            true,
+                                                            CommonTestVariables.UK_MOBILE_NUMBER,
+                                                            PriorityIdentifier.DEFAULT,
+                                                            "1"))));
 
             APIGatewayProxyResponseEvent result = handler.handleRequest(validEvent, context);
 
@@ -313,13 +313,12 @@ class ResetPasswordRequestHandlerTest {
                             new UserCredentials()
                                     .withMfaMethods(
                                             List.of(
-                                                    MFAMethod.
-                                                            authAppMfaMethod("cred",
-                                                                    true,
-                                                                    true,
-                                                                    PriorityIdentifier.DEFAULT,
-                                                                    "auth-app-id"))));
-
+                                                    MFAMethod.authAppMfaMethod(
+                                                            "cred",
+                                                            true,
+                                                            true,
+                                                            PriorityIdentifier.DEFAULT,
+                                                            "auth-app-id"))));
 
             APIGatewayProxyResponseEvent result = handler.handleRequest(validEvent, context);
 
@@ -686,10 +685,9 @@ class ResetPasswordRequestHandlerTest {
     }
 
     private UserProfile migratedUserProfileWithoutPhoneNumber() {
-        return new UserProfile()
-                .withEmail(CommonTestVariables.EMAIL)
-                .withMfaMethodsMigrated(true);
+        return new UserProfile().withEmail(CommonTestVariables.EMAIL).withMfaMethodsMigrated(true);
     }
+
     private UserProfile userProfileWithPhoneNumber() {
         return new UserProfile()
                 .withEmail(CommonTestVariables.EMAIL)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
@@ -41,7 +42,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.BACKUP_AUTH_APP_METHOD;
+import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.CLIENT_ID;
+import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.DEFAULT_AUTH_APP_METHOD;
+import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.DEFAULT_SMS_METHOD;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.EMAIL;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
@@ -95,6 +100,10 @@ class AuthAppCodeProcessorTest {
         this.mockAccountModifiersService = mock(DynamoAccountModifiersService.class);
         when(mockUserContext.getSession()).thenReturn(session);
         when(mockUserContext.getAuthSession()).thenReturn(authSession);
+        when(mockDynamoService.getUserProfileByEmail(EMAIL))
+                .thenReturn(new UserProfile().withMfaMethodsMigrated(false));
+        when(mockConfigurationService.getAuthAppCodeAllowedWindows()).thenReturn(9);
+        when(mockConfigurationService.getAuthAppCodeWindowLength()).thenReturn(30);
     }
 
     private static Stream<Arguments> validatorParams() {
@@ -127,6 +136,118 @@ class AuthAppCodeProcessorTest {
         assertEquals(Optional.empty(), authAppCodeProcessor.validateCode());
     }
 
+    private static Stream<Arguments> validatorParamsWithoutRegistrationJourney() {
+        return Stream.of(
+                Arguments.of(JourneyType.SIGN_IN, null, CodeRequestType.AUTH_APP_SIGN_IN),
+                Arguments.of(
+                        JourneyType.PASSWORD_RESET_MFA,
+                        null,
+                        CodeRequestType.PW_RESET_MFA_AUTH_APP),
+                Arguments.of(
+                        JourneyType.REAUTHENTICATION,
+                        null,
+                        CodeRequestType.AUTH_APP_REAUTHENTICATION));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validatorParamsWithoutRegistrationJourney")
+    void returnsNoErrorOnValidAuthCodeForMigratedUser(JourneyType journeyType) {
+        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
+                .thenReturn(false);
+
+        var userCredentials =
+                new UserCredentials()
+                        .withMfaMethods(List.of(DEFAULT_AUTH_APP_METHOD, BACKUP_SMS_METHOD));
+        when(mockDynamoService.getUserCredentialsFromEmail(EMAIL)).thenReturn(userCredentials);
+        when(mockDynamoService.getUserProfileByEmail(EMAIL))
+                .thenReturn(new UserProfile().withMfaMethodsMigrated(true));
+
+        var secretForMigratedAuthApp = DEFAULT_AUTH_APP_METHOD.getCredentialValue();
+
+        var authAppStub = new AuthAppStub();
+        var authCode =
+                authAppStub.getAuthAppOneTimeCode(
+                        secretForMigratedAuthApp, NowHelper.now().getTime());
+
+        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, authCode, journeyType);
+
+        this.authAppCodeProcessor =
+                new AuthAppCodeProcessor(
+                        mockUserContext,
+                        mockCodeStorageService,
+                        mockConfigurationService,
+                        mockDynamoService,
+                        MAX_RETRIES,
+                        codeRequest,
+                        mockAuditService,
+                        mockAccountModifiersService);
+
+        assertEquals(Optional.empty(), authAppCodeProcessor.validateCode());
+    }
+
+    @ParameterizedTest
+    @MethodSource("validatorParamsWithoutRegistrationJourney")
+    void returnsAnErrorIfDefaultMethodIsNotAuthAppForMigratedUser(JourneyType journeyType) {
+        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
+                .thenReturn(false);
+
+        var userCredentials =
+                new UserCredentials()
+                        .withMfaMethods(List.of(BACKUP_AUTH_APP_METHOD, DEFAULT_SMS_METHOD));
+        when(mockDynamoService.getUserCredentialsFromEmail(EMAIL)).thenReturn(userCredentials);
+        when(mockDynamoService.getUserProfileByEmail(EMAIL))
+                .thenReturn(new UserProfile().withMfaMethodsMigrated(true));
+
+        var secretForMigratedAuthApp = BACKUP_AUTH_APP_METHOD.getCredentialValue();
+
+        var authAppStub = new AuthAppStub();
+        var authCode =
+                authAppStub.getAuthAppOneTimeCode(
+                        secretForMigratedAuthApp, NowHelper.now().getTime());
+
+        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, authCode, journeyType);
+
+        this.authAppCodeProcessor =
+                new AuthAppCodeProcessor(
+                        mockUserContext,
+                        mockCodeStorageService,
+                        mockConfigurationService,
+                        mockDynamoService,
+                        MAX_RETRIES,
+                        codeRequest,
+                        mockAuditService,
+                        mockAccountModifiersService);
+
+        assertEquals(Optional.of(ErrorResponse.ERROR_1081), authAppCodeProcessor.validateCode());
+    }
+
+    @ParameterizedTest
+    @MethodSource("validatorParamsWithoutRegistrationJourney")
+    void returnsAnErrorIfThereIsNoDefaultMethodForMigratedUser(JourneyType journeyType) {
+        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
+                .thenReturn(false);
+
+        var userCredentials = new UserCredentials().withMfaMethods(List.of(BACKUP_AUTH_APP_METHOD));
+        when(mockDynamoService.getUserCredentialsFromEmail(EMAIL)).thenReturn(userCredentials);
+        when(mockDynamoService.getUserProfileByEmail(EMAIL))
+                .thenReturn(new UserProfile().withMfaMethodsMigrated(true));
+
+        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, "000000", journeyType);
+
+        this.authAppCodeProcessor =
+                new AuthAppCodeProcessor(
+                        mockUserContext,
+                        mockCodeStorageService,
+                        mockConfigurationService,
+                        mockDynamoService,
+                        MAX_RETRIES,
+                        codeRequest,
+                        mockAuditService,
+                        mockAccountModifiersService);
+
+        assertEquals(Optional.of(ErrorResponse.ERROR_1081), authAppCodeProcessor.validateCode());
+    }
+
     @ParameterizedTest
     @MethodSource("validatorParams")
     void returnsCorrectErrorWhenCodeBlockedForEmailAddress(
@@ -155,7 +276,7 @@ class AuthAppCodeProcessorTest {
         setUpNoAuthCodeForUser(
                 new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, "000000", journeyType));
 
-        assertEquals(Optional.of(ErrorResponse.ERROR_1043), authAppCodeProcessor.validateCode());
+        assertEquals(Optional.of(ErrorResponse.ERROR_1081), authAppCodeProcessor.validateCode());
     }
 
     @Test
@@ -355,8 +476,6 @@ class AuthAppCodeProcessorTest {
     private void setUpValidAuthCode(CodeRequest codeRequest) {
         when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
-        when(mockConfigurationService.getAuthAppCodeAllowedWindows()).thenReturn(9);
-        when(mockConfigurationService.getAuthAppCodeWindowLength()).thenReturn(30);
 
         var mfaMethod =
                 new MFAMethod()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -28,7 +28,6 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.sharedtest.helper.AuthAppStub;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -339,7 +338,7 @@ class AuthAppCodeProcessorTest {
         when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
         when(mockDynamoService.getUserCredentialsFromEmail(EMAIL))
-                .thenReturn(mock(UserCredentials.class));
+                .thenReturn(new UserCredentials().withMfaMethods(List.of()));
 
         this.authAppCodeProcessor =
                 new AuthAppCodeProcessor(
@@ -359,14 +358,13 @@ class AuthAppCodeProcessorTest {
         when(mockConfigurationService.getAuthAppCodeAllowedWindows()).thenReturn(9);
         when(mockConfigurationService.getAuthAppCodeWindowLength()).thenReturn(30);
 
-        UserCredentials mockUserCredentials = mock(UserCredentials.class);
-        MFAMethod mockMfaMethod = mock(MFAMethod.class);
-        when(mockMfaMethod.getMfaMethodType()).thenReturn(MFAMethodType.AUTH_APP.getValue());
-        when(mockMfaMethod.getCredentialValue()).thenReturn(AUTH_APP_SECRET);
-        when(mockMfaMethod.isEnabled()).thenReturn(true);
-        List<MFAMethod> mockMfaMethodList = Collections.singletonList(mockMfaMethod);
-        when(mockUserCredentials.getMfaMethods()).thenReturn(mockMfaMethodList);
-        when(mockDynamoService.getUserCredentialsFromEmail(EMAIL)).thenReturn(mockUserCredentials);
+        var mfaMethod =
+                new MFAMethod()
+                        .withMfaMethodType(MFAMethodType.AUTH_APP.name())
+                        .withCredentialValue(AUTH_APP_SECRET)
+                        .withEnabled(true);
+        var userCredentials = new UserCredentials().withMfaMethods(List.of(mfaMethod));
+        when(mockDynamoService.getUserCredentialsFromEmail(EMAIL)).thenReturn(userCredentials);
 
         this.authAppCodeProcessor =
                 new AuthAppCodeProcessor(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
@@ -2,15 +2,20 @@ package uk.gov.di.authentication.api;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.entity.MfaRequest;
 import uk.gov.di.authentication.frontendapi.lambda.MfaHandler;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
 
 import java.util.List;
 import java.util.Map;
@@ -30,122 +35,307 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String USER_EMAIL = "test@email.com";
     private static final String USER_PASSWORD = "Password123!";
-    private static final String USER_PHONE_NUMBER = "+447712345432";
     private String SESSION_ID;
 
     @BeforeEach
-    void setup() throws Json.JsonException {
+    void setup() {
         handler = new MfaHandler(TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
         txmaAuditQueue.clear();
-        String subjectId = "new-subject";
-        SESSION_ID = redis.createSession();
-        authSessionStore.addSession(SESSION_ID);
-        authSessionStore.addEmailToSession(SESSION_ID, USER_EMAIL);
-        userStore.signUp(USER_EMAIL, USER_PASSWORD, new Subject(subjectId));
-        userStore.addVerifiedPhoneNumber(USER_EMAIL, USER_PHONE_NUMBER);
     }
 
-    @Test
-    void
-            shouldReturn204WithExistingRedisCachedCodeAndTriggerVerifyPhoneNotificationTypeWhenResendingVerifyPhoneCode() {
-        String mockPreviouslyIssuedPhoneCode =
-                redis.generateAndSavePhoneNumberCode(USER_EMAIL, 900L);
+    @Nested
+    class WhenAUsersMfaMethodsHaveNotBeenMigrated {
+        private static final String USER_PHONE_NUMBER = "+447712345432";
 
-        var response =
-                makeRequest(
-                        Optional.of(new MfaRequest(USER_EMAIL, true)),
-                        constructFrontendHeaders(SESSION_ID),
-                        Map.of());
+        @BeforeEach
+        void setup() throws Json.JsonException {
+            SESSION_ID = redis.createSession();
+            authSessionStore.addSession(SESSION_ID);
+            authSessionStore.addEmailToSession(SESSION_ID, USER_EMAIL);
+            userStore.signUp(USER_EMAIL, USER_PASSWORD, new Subject("new-subject"));
+            userStore.addVerifiedPhoneNumber(USER_EMAIL, USER_PHONE_NUMBER);
+        }
 
-        assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
+        @Test
+        void
+                shouldReturn204WithExistingRedisCachedCodeAndTriggerVerifyPhoneNotificationTypeWhenResendingVerifyPhoneCode() {
+            String previouslyIssuedPhoneCode =
+                    redis.generateAndSavePhoneNumberCode(USER_EMAIL, 900L);
 
+            var response =
+                    makeRequest(
+                            Optional.of(new MfaRequest(USER_EMAIL, true)),
+                            constructFrontendHeaders(SESSION_ID),
+                            Map.of());
+
+            assertThat(response, hasStatus(204));
+            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
+            assertNotificationsQueueHasMessageWithDestinationNotificationTypeAndCode(
+                    notificationsQueue,
+                    USER_PHONE_NUMBER,
+                    VERIFY_PHONE_NUMBER,
+                    previouslyIssuedPhoneCode);
+        }
+
+        @Test
+        void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenNotResendingVerifyPhoneCode() {
+            var response =
+                    makeRequest(
+                            Optional.of(new MfaRequest(USER_EMAIL, false)),
+                            constructFrontendHeaders(SESSION_ID),
+                            Map.of());
+
+            assertThat(response, hasStatus(204));
+            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
+
+            assertNotificationsQueueHasMessageWithDestinationAndNotificationType(
+                    notificationsQueue, USER_PHONE_NUMBER, MFA_SMS);
+        }
+
+        @Test
+        void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenResettingPassword() {
+            var response =
+                    makeRequest(
+                            Optional.of(
+                                    new MfaRequest(
+                                            USER_EMAIL, false, JourneyType.PASSWORD_RESET_MFA)),
+                            constructFrontendHeaders(SESSION_ID),
+                            Map.of());
+
+            assertThat(response, hasStatus(204));
+            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
+            assertNotificationsQueueHasMessageWithDestinationAndNotificationType(
+                    notificationsQueue, USER_PHONE_NUMBER, MFA_SMS);
+        }
+
+        @Test
+        void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenReauthenticating()
+                throws Json.JsonException {
+            var authenticatedSessionId = redis.createSession();
+            authSessionStore.addSession(authenticatedSessionId);
+            authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
+
+            var response =
+                    makeRequest(
+                            Optional.of(
+                                    new MfaRequest(
+                                            USER_EMAIL, false, JourneyType.REAUTHENTICATION)),
+                            constructFrontendHeaders(authenticatedSessionId),
+                            Map.of());
+
+            assertThat(response, hasStatus(204));
+            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
+            assertNotificationsQueueHasMessageWithDestinationAndNotificationType(
+                    notificationsQueue, USER_PHONE_NUMBER, MFA_SMS);
+        }
+
+        @Test
+        void shouldReturn400WhenInvalidMFAJourneyCombination() throws Json.JsonException {
+            var authenticatedSessionId = redis.createSession();
+            authSessionStore.addSession(authenticatedSessionId);
+
+            var response =
+                    makeRequest(
+                            Optional.of(
+                                    new MfaRequest(USER_EMAIL, false, JourneyType.PASSWORD_RESET)),
+                            constructFrontendHeaders(authenticatedSessionId),
+                            Map.of());
+
+            assertThat(response, hasStatus(400));
+            assertThat(response, hasJsonBody(ErrorResponse.ERROR_1002));
+
+            List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
+            assertThat(requests, hasSize(0));
+        }
+
+        @Test
+        void shouldReturn400WhenRequestingACodeForReauthenticationWhichBreachesTheMaxThreshold()
+                throws Json.JsonException {
+            var authenticatedSessionId = redis.createSession();
+            authSessionStore.addSession(authenticatedSessionId);
+
+            aUserHasEnteredAnOTPIncorrectlyTheMaximumAllowedTimes(authenticatedSessionId);
+
+            var response =
+                    makeRequest(
+                            Optional.of(
+                                    new MfaRequest(
+                                            USER_EMAIL, false, JourneyType.REAUTHENTICATION)),
+                            constructFrontendHeaders(authenticatedSessionId),
+                            Map.of());
+
+            assertThat(response, hasStatus(400));
+            assertThat(response, hasJsonBody(ErrorResponse.ERROR_1025));
+            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_INVALID_CODE_REQUEST));
+
+            List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
+            assertThat(requests, hasSize(0));
+        }
+    }
+
+    @Nested
+    class WhenAUsersMfaMethodsHaveBeenMigrated {
+        private static final String MIGRATED_PHONE_NUMBER_1 = "+447900000001";
+        private static final String MIGRATED_PHONE_NUMBER_2 = "+447900000002";
+        private static final MFAMethod DEFAULT_SMS_METHOD =
+                MFAMethod.smsMfaMethod(
+                        true,
+                        true,
+                        MIGRATED_PHONE_NUMBER_1,
+                        PriorityIdentifier.DEFAULT,
+                        "mfa-id-1");
+        private static final MFAMethod BACKUP_SMS_METHOD =
+                MFAMethod.smsMfaMethod(
+                        true, true, MIGRATED_PHONE_NUMBER_2, PriorityIdentifier.BACKUP, "mfa-id-1");
+
+        @BeforeEach
+        void setup() throws Json.JsonException {
+            SESSION_ID = redis.createSession();
+            authSessionStore.addSession(SESSION_ID);
+            authSessionStore.addEmailToSession(SESSION_ID, USER_EMAIL);
+            userStore.signUp(USER_EMAIL, USER_PASSWORD, new Subject("new-subject"));
+            userStore.setMfaMethodsMigrated(USER_EMAIL, true);
+
+            userStore.addMfaMethodSupportingMultiple(USER_EMAIL, DEFAULT_SMS_METHOD);
+            userStore.addMfaMethodSupportingMultiple(USER_EMAIL, BACKUP_SMS_METHOD);
+        }
+
+        @Test
+        void shouldReturn204AndSendCodeToCorrectNumberWhenUsersMfaMethodsHaveBeenMigrated() {
+            var response =
+                    makeRequest(
+                            Optional.of(new MfaRequest(USER_EMAIL, false)),
+                            constructFrontendHeaders(SESSION_ID),
+                            Map.of());
+
+            assertThat(response, hasStatus(204));
+            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
+            assertNotificationsQueueHasMessageWithDestinationAndNotificationType(
+                    notificationsQueue, MIGRATED_PHONE_NUMBER_1, MFA_SMS);
+        }
+
+        @Test
+        void
+                shouldReturn204WithExistingRedisCachedCodeAndTriggerVerifyPhoneNotificationTypeWhenResendingVerifyPhoneCode() {
+            String previouslyIssuedPhoneCode =
+                    redis.generateAndSavePhoneNumberCode(USER_EMAIL, 900L);
+
+            var response =
+                    makeRequest(
+                            Optional.of(new MfaRequest(USER_EMAIL, true)),
+                            constructFrontendHeaders(SESSION_ID),
+                            Map.of());
+
+            assertThat(response, hasStatus(204));
+            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
+            assertNotificationsQueueHasMessageWithDestinationNotificationTypeAndCode(
+                    notificationsQueue,
+                    MIGRATED_PHONE_NUMBER_1,
+                    VERIFY_PHONE_NUMBER,
+                    previouslyIssuedPhoneCode);
+        }
+
+        @Test
+        void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenResettingPassword() {
+            var response =
+                    makeRequest(
+                            Optional.of(
+                                    new MfaRequest(
+                                            USER_EMAIL, false, JourneyType.PASSWORD_RESET_MFA)),
+                            constructFrontendHeaders(SESSION_ID),
+                            Map.of());
+
+            assertThat(response, hasStatus(204));
+            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
+            assertNotificationsQueueHasMessageWithDestinationAndNotificationType(
+                    notificationsQueue, MIGRATED_PHONE_NUMBER_1, MFA_SMS);
+        }
+
+        @Test
+        void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenReauthenticating()
+                throws Json.JsonException {
+            var authenticatedSessionId = redis.createSession();
+            authSessionStore.addSession(authenticatedSessionId);
+            authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
+
+            var response =
+                    makeRequest(
+                            Optional.of(
+                                    new MfaRequest(
+                                            USER_EMAIL, false, JourneyType.REAUTHENTICATION)),
+                            constructFrontendHeaders(authenticatedSessionId),
+                            Map.of());
+
+            assertThat(response, hasStatus(204));
+            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
+            assertNotificationsQueueHasMessageWithDestinationAndNotificationType(
+                    notificationsQueue, MIGRATED_PHONE_NUMBER_1, MFA_SMS);
+        }
+
+        @Test
+        void shouldReturn400WhenInvalidMFAJourneyCombination() throws Json.JsonException {
+            var authenticatedSessionId = redis.createSession();
+            authSessionStore.addSession(authenticatedSessionId);
+
+            var response =
+                    makeRequest(
+                            Optional.of(
+                                    new MfaRequest(USER_EMAIL, false, JourneyType.PASSWORD_RESET)),
+                            constructFrontendHeaders(authenticatedSessionId),
+                            Map.of());
+
+            assertThat(response, hasStatus(400));
+            assertThat(response, hasJsonBody(ErrorResponse.ERROR_1002));
+
+            List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
+            assertThat(requests, hasSize(0));
+        }
+
+        @Test
+        void shouldReturn400WhenRequestingACodeForReauthenticationWhichBreachesTheMaxThreshold()
+                throws Json.JsonException {
+            var authenticatedSessionId = redis.createSession();
+            authSessionStore.addSession(authenticatedSessionId);
+
+            aUserHasEnteredAnOTPIncorrectlyTheMaximumAllowedTimes(authenticatedSessionId);
+
+            var response =
+                    makeRequest(
+                            Optional.of(
+                                    new MfaRequest(
+                                            USER_EMAIL, false, JourneyType.REAUTHENTICATION)),
+                            constructFrontendHeaders(authenticatedSessionId),
+                            Map.of());
+
+            assertThat(response, hasStatus(400));
+            assertThat(response, hasJsonBody(ErrorResponse.ERROR_1025));
+            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_INVALID_CODE_REQUEST));
+
+            List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
+            assertThat(requests, hasSize(0));
+        }
+    }
+
+    private static void assertNotificationsQueueHasMessageWithDestinationAndNotificationType(
+            SqsQueueExtension notificationsQueue,
+            String expectedDestination,
+            NotificationType expectedNotificationType) {
         List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
         assertThat(requests, hasSize(1));
-        assertThat(requests.get(0).getDestination(), equalTo(USER_PHONE_NUMBER));
-        assertThat(requests.get(0).getNotificationType(), equalTo(VERIFY_PHONE_NUMBER));
-        assertThat(requests.get(0).getCode(), equalTo(mockPreviouslyIssuedPhoneCode));
+        assertThat(requests.get(0).getDestination(), equalTo(expectedDestination));
+        assertThat(requests.get(0).getNotificationType(), equalTo(expectedNotificationType));
     }
 
-    @Test
-    void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenNotResendingVerifyPhoneCode() {
-        var response =
-                makeRequest(
-                        Optional.of(new MfaRequest(USER_EMAIL, false)),
-                        constructFrontendHeaders(SESSION_ID),
-                        Map.of());
-
-        assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
-
+    private static void assertNotificationsQueueHasMessageWithDestinationNotificationTypeAndCode(
+            SqsQueueExtension notificationsQueue,
+            String expectedDestination,
+            NotificationType expectedNotificationType,
+            String expectedCode) {
         List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
         assertThat(requests, hasSize(1));
-        assertThat(requests.get(0).getDestination(), equalTo(USER_PHONE_NUMBER));
-        assertThat(requests.get(0).getNotificationType(), equalTo(MFA_SMS));
-    }
-
-    @Test
-    void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenResettingPassword() {
-        var response =
-                makeRequest(
-                        Optional.of(
-                                new MfaRequest(USER_EMAIL, false, JourneyType.PASSWORD_RESET_MFA)),
-                        constructFrontendHeaders(SESSION_ID),
-                        Map.of());
-
-        assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
-
-        List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
-        assertThat(requests, hasSize(1));
-        assertThat(requests.get(0).getDestination(), equalTo(USER_PHONE_NUMBER));
-        assertThat(requests.get(0).getNotificationType(), equalTo(MFA_SMS));
-    }
-
-    @Test
-    void shouldReturn204AndTriggerMfaSmsNotificationTypeWhenReauthenticating()
-            throws Json.JsonException {
-        var authenticatedSessionId = redis.createSession();
-        authSessionStore.addSession(authenticatedSessionId);
-        authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
-
-        var response =
-                makeRequest(
-                        Optional.of(
-                                new MfaRequest(USER_EMAIL, false, JourneyType.REAUTHENTICATION)),
-                        constructFrontendHeaders(authenticatedSessionId),
-                        Map.of());
-
-        assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_CODE_SENT));
-
-        List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
-        assertThat(requests, hasSize(1));
-        assertThat(requests.get(0).getDestination(), equalTo(USER_PHONE_NUMBER));
-        assertThat(requests.get(0).getNotificationType(), equalTo(MFA_SMS));
-    }
-
-    @Test
-    void shouldReturn400WhenRequestingACodeForReauthenticationWhichBreachesTheMaxThreshold()
-            throws Json.JsonException {
-        var authenticatedSessionId = redis.createSession();
-        authSessionStore.addSession(authenticatedSessionId);
-
-        aUserHasEnteredAnOTPIncorrectlyTheMaximumAllowedTimes(authenticatedSessionId);
-
-        var response =
-                makeRequest(
-                        Optional.of(
-                                new MfaRequest(USER_EMAIL, false, JourneyType.REAUTHENTICATION)),
-                        constructFrontendHeaders(authenticatedSessionId),
-                        Map.of());
-
-        assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1025));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_MFA_INVALID_CODE_REQUEST));
-
-        List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
-        assertThat(requests, hasSize(0));
+        assertThat(requests.get(0).getDestination(), equalTo(expectedDestination));
+        assertThat(requests.get(0).getNotificationType(), equalTo(expectedNotificationType));
+        assertThat(requests.get(0).getCode(), equalTo(expectedCode));
     }
 
     private static void aUserHasEnteredAnOTPIncorrectlyTheMaximumAllowedTimes(
@@ -154,23 +344,5 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             authSessionStore.incrementSessionCodeRequestCount(
                     authenticatedSessionId, MFA_SMS, JourneyType.REAUTHENTICATION);
         }
-    }
-
-    @Test
-    void shouldReturn400WhenInvalidMFAJourneyCombination() throws Json.JsonException {
-        var authenticatedSessionId = redis.createSession();
-        authSessionStore.addSession(authenticatedSessionId);
-
-        var response =
-                makeRequest(
-                        Optional.of(new MfaRequest(USER_EMAIL, false, JourneyType.PASSWORD_RESET)),
-                        constructFrontendHeaders(authenticatedSessionId),
-                        Map.of());
-
-        assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1002));
-
-        List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
-        assertThat(requests, hasSize(0));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
+import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 
 public class MfaHelper {
     private static final Logger LOG = LogManager.getLogger(MfaHelper.class);
@@ -39,6 +40,13 @@ public class MfaHelper {
         return Optional.ofNullable(userCredentials.getMfaMethods())
                 .flatMap(
                         mfaMethods -> mfaMethods.stream().filter(MFAMethod::isEnabled).findFirst());
+    }
+
+    public static Optional<MFAMethod> getDefaultMfaMethodForMigratedUser(
+            UserCredentials userCredentials) {
+        return userCredentials.getMfaMethods().stream()
+                .filter(mfaMethod -> DEFAULT.name().equals(mfaMethod.getPriority()))
+                .findFirst();
     }
 
     public static UserMfaDetail getUserMFADetail(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -91,7 +91,8 @@ public enum ErrorResponse {
     ERROR_1077(1076, "Attempted to update a backup mfa method without a default present"),
     ERROR_1078(1078, "Unexpected error creating mfa identifier for auth app mfa method"),
     ERROR_1079(1079, "Invalid principal in request"),
-    ERROR_1080(1080, "Default method already exists, new one cannot be created.");
+    ERROR_1080(1080, "Default method already exists, new one cannot be created."),
+    ERROR_1081(1081, "Attempting to validate auth app code for user without auth app method");
 
     private int code;
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/conditions/MfaHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/conditions/MfaHelperTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -48,6 +49,7 @@ import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMe
 class MfaHelperTest {
     private static final UserCredentials userCredentials = mock(UserCredentials.class);
     private static final String PHONE_NUMBER = "+44123456789";
+    private static final UserProfile userProfile = mock(UserProfile.class);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging = new CaptureLoggingExtension(MfaHelper.class);
@@ -65,8 +67,10 @@ class MfaHelperTest {
         void isMfaRequiredShouldReflectLevelOfTrustRequested(
                 CredentialTrustLevel trustLevel, boolean expectedMfaRequired) {
             var userContext = userContextWithLevelOfTrustRequested(trustLevel);
+            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
-            var result = getUserMFADetail(userContext, userCredentials, PHONE_NUMBER, true);
+            var result =
+                    getUserMFADetail(userContext, userCredentials, PHONE_NUMBER, true, userProfile);
 
             assertEquals(expectedMfaRequired, result.isMfaRequired());
         }
@@ -75,6 +79,7 @@ class MfaHelperTest {
         void shouldReturnAVerifiedSmsMethodWhenNoAuthAppExists() {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
+            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
             var isPhoneNumberVerified = true;
 
@@ -82,7 +87,11 @@ class MfaHelperTest {
 
             var result =
                     getUserMFADetail(
-                            userContext, userCredentials, PHONE_NUMBER, isPhoneNumberVerified);
+                            userContext,
+                            userCredentials,
+                            PHONE_NUMBER,
+                            isPhoneNumberVerified,
+                            userProfile);
             var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -96,6 +105,7 @@ class MfaHelperTest {
         void shouldReturnAVerifiedSmsMethodWhenAuthAppExistsButIsNotEnabled() {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
+            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
             var isPhoneNumberVerified = true;
             var isAuthAppEnabled = false;
@@ -105,7 +115,11 @@ class MfaHelperTest {
 
             var result =
                     getUserMFADetail(
-                            userContext, userCredentials, PHONE_NUMBER, isPhoneNumberVerified);
+                            userContext,
+                            userCredentials,
+                            PHONE_NUMBER,
+                            isPhoneNumberVerified,
+                            userProfile);
             var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -115,6 +129,7 @@ class MfaHelperTest {
         void shouldReturnMethodTypeOfNoneWhenSmsMethodNotVerified() {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
+            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
             var isPhoneNumberVerified = false;
 
@@ -122,7 +137,11 @@ class MfaHelperTest {
 
             var result =
                     getUserMFADetail(
-                            userContext, userCredentials, PHONE_NUMBER, isPhoneNumberVerified);
+                            userContext,
+                            userCredentials,
+                            PHONE_NUMBER,
+                            isPhoneNumberVerified,
+                            userProfile);
             var expectedResult = new UserMfaDetail(true, false, NONE, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -139,6 +158,7 @@ class MfaHelperTest {
                         boolean isPhoneNumberVerified) {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
+            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
             var isAuthAppVerified = true;
 
@@ -147,7 +167,11 @@ class MfaHelperTest {
 
             var result =
                     getUserMFADetail(
-                            userContext, userCredentials, PHONE_NUMBER, isPhoneNumberVerified);
+                            userContext,
+                            userCredentials,
+                            PHONE_NUMBER,
+                            isPhoneNumberVerified,
+                            userProfile);
             var expectedResult =
                     new UserMfaDetail(true, true, MFAMethodType.AUTH_APP, PHONE_NUMBER);
 
@@ -164,6 +188,7 @@ class MfaHelperTest {
         void shouldReturnVerifiedSMSMethodWhenAuthAppExistsButIsNotVerified() {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
+            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
             var isPhoneNumberVerified = true;
 
@@ -172,7 +197,11 @@ class MfaHelperTest {
 
             var result =
                     getUserMFADetail(
-                            userContext, userCredentials, PHONE_NUMBER, isPhoneNumberVerified);
+                            userContext,
+                            userCredentials,
+                            PHONE_NUMBER,
+                            isPhoneNumberVerified,
+                            userProfile);
             var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -182,6 +211,7 @@ class MfaHelperTest {
         void shouldReturnUnVerifiedAuthMethodWhenPhoneNumberIsNotVerified() {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
+            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
             var isAuthAppVerified = false;
             var isPhoneNumberVerified = false;
@@ -191,7 +221,11 @@ class MfaHelperTest {
 
             var result =
                     getUserMFADetail(
-                            userContext, userCredentials, PHONE_NUMBER, isPhoneNumberVerified);
+                            userContext,
+                            userCredentials,
+                            PHONE_NUMBER,
+                            isPhoneNumberVerified,
+                            userProfile);
             var expectedResult = new UserMfaDetail(true, false, AUTH_APP, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -201,6 +235,44 @@ class MfaHelperTest {
                     hasItem(
                             withMessageContaining(
                                     "Unverified auth app mfa method present and no verified phone number")));
+        }
+
+        @Test
+        void shouldReturnRelevantMethodForAMigratedUser() {
+            var userContext =
+                    userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
+            when(userProfile.getMfaMethodsMigrated()).thenReturn(true);
+
+            var phoneNumberOfMigratedMethod = "+447900000000";
+
+            var isPhoneNumberVerified = false;
+
+            when(userCredentials.getMfaMethods())
+                    .thenReturn(
+                            List.of(
+                                    MFAMethod.smsMfaMethod(
+                                            true,
+                                            true,
+                                            phoneNumberOfMigratedMethod,
+                                            PriorityIdentifier.DEFAULT,
+                                            "some-mfa-identifier"),
+                                    MFAMethod.authAppMfaMethod(
+                                            "some-credential",
+                                            true,
+                                            true,
+                                            PriorityIdentifier.BACKUP,
+                                            "auth-app-mfa-id")));
+
+            var result =
+                    getUserMFADetail(
+                            userContext,
+                            userCredentials,
+                            PHONE_NUMBER,
+                            isPhoneNumberVerified,
+                            userProfile);
+            var expectedResult = new UserMfaDetail(true, true, SMS, phoneNumberOfMigratedMethod);
+
+            assertEquals(expectedResult, result);
         }
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/conditions/MfaHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/conditions/MfaHelperTest.java
@@ -67,10 +67,9 @@ class MfaHelperTest {
         void isMfaRequiredShouldReflectLevelOfTrustRequested(
                 CredentialTrustLevel trustLevel, boolean expectedMfaRequired) {
             var userContext = userContextWithLevelOfTrustRequested(trustLevel);
-            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
+            setupUserProfile(userProfile, PHONE_NUMBER, true, false);
 
-            var result =
-                    getUserMFADetail(userContext, userCredentials, PHONE_NUMBER, true, userProfile);
+            var result = getUserMFADetail(userContext, userCredentials, userProfile);
 
             assertEquals(expectedMfaRequired, result.isMfaRequired());
         }
@@ -79,19 +78,13 @@ class MfaHelperTest {
         void shouldReturnAVerifiedSmsMethodWhenNoAuthAppExists() {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
-            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
             var isPhoneNumberVerified = true;
+            setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
 
             when(userCredentials.getMfaMethods()).thenReturn(List.of());
 
-            var result =
-                    getUserMFADetail(
-                            userContext,
-                            userCredentials,
-                            PHONE_NUMBER,
-                            isPhoneNumberVerified,
-                            userProfile);
+            var result = getUserMFADetail(userContext, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -105,21 +98,15 @@ class MfaHelperTest {
         void shouldReturnAVerifiedSmsMethodWhenAuthAppExistsButIsNotEnabled() {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
-            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
             var isPhoneNumberVerified = true;
             var isAuthAppEnabled = false;
+            setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
 
             var authApp = authAppMfaMethod(true, isAuthAppEnabled);
             when(userCredentials.getMfaMethods()).thenReturn(List.of(authApp));
 
-            var result =
-                    getUserMFADetail(
-                            userContext,
-                            userCredentials,
-                            PHONE_NUMBER,
-                            isPhoneNumberVerified,
-                            userProfile);
+            var result = getUserMFADetail(userContext, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -129,19 +116,13 @@ class MfaHelperTest {
         void shouldReturnMethodTypeOfNoneWhenSmsMethodNotVerified() {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
-            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
             var isPhoneNumberVerified = false;
+            setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
 
             when(userCredentials.getMfaMethods()).thenReturn(List.of());
 
-            var result =
-                    getUserMFADetail(
-                            userContext,
-                            userCredentials,
-                            PHONE_NUMBER,
-                            isPhoneNumberVerified,
-                            userProfile);
+            var result = getUserMFADetail(userContext, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, false, NONE, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -158,20 +139,14 @@ class MfaHelperTest {
                         boolean isPhoneNumberVerified) {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
-            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
+            setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
 
             var isAuthAppVerified = true;
 
             when(userCredentials.getMfaMethods())
                     .thenReturn(List.of(authAppMfaMethod(isAuthAppVerified, true)));
 
-            var result =
-                    getUserMFADetail(
-                            userContext,
-                            userCredentials,
-                            PHONE_NUMBER,
-                            isPhoneNumberVerified,
-                            userProfile);
+            var result = getUserMFADetail(userContext, userCredentials, userProfile);
             var expectedResult =
                     new UserMfaDetail(true, true, MFAMethodType.AUTH_APP, PHONE_NUMBER);
 
@@ -188,20 +163,14 @@ class MfaHelperTest {
         void shouldReturnVerifiedSMSMethodWhenAuthAppExistsButIsNotVerified() {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
-            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
             var isPhoneNumberVerified = true;
+            setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
 
             when(userCredentials.getMfaMethods())
                     .thenReturn(List.of(authAppMfaMethod(false, true)));
 
-            var result =
-                    getUserMFADetail(
-                            userContext,
-                            userCredentials,
-                            PHONE_NUMBER,
-                            isPhoneNumberVerified,
-                            userProfile);
+            var result = getUserMFADetail(userContext, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -211,21 +180,15 @@ class MfaHelperTest {
         void shouldReturnUnVerifiedAuthMethodWhenPhoneNumberIsNotVerified() {
             var userContext =
                     userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
-            when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
 
             var isAuthAppVerified = false;
             var isPhoneNumberVerified = false;
+            setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
 
             when(userCredentials.getMfaMethods())
                     .thenReturn(List.of(authAppMfaMethod(isAuthAppVerified, true)));
 
-            var result =
-                    getUserMFADetail(
-                            userContext,
-                            userCredentials,
-                            PHONE_NUMBER,
-                            isPhoneNumberVerified,
-                            userProfile);
+            var result = getUserMFADetail(userContext, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, false, AUTH_APP, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -244,32 +207,29 @@ class MfaHelperTest {
             when(userProfile.getMfaMethodsMigrated()).thenReturn(true);
 
             var phoneNumberOfMigratedMethod = "+447900000000";
+            var isPhoneNumberVerifiedOnUserProfile = false;
+            setupUserProfile(userProfile, null, isPhoneNumberVerifiedOnUserProfile, true);
 
-            var isPhoneNumberVerified = false;
+            var defaultSmsMethod =
+                    MFAMethod.smsMfaMethod(
+                            true,
+                            true,
+                            phoneNumberOfMigratedMethod,
+                            PriorityIdentifier.DEFAULT,
+                            "some-mfa-identifier");
+
+            var backupAuthAppMethod =
+                    MFAMethod.authAppMfaMethod(
+                            "some-credential",
+                            true,
+                            true,
+                            PriorityIdentifier.BACKUP,
+                            "auth-app-mfa-id");
 
             when(userCredentials.getMfaMethods())
-                    .thenReturn(
-                            List.of(
-                                    MFAMethod.smsMfaMethod(
-                                            true,
-                                            true,
-                                            phoneNumberOfMigratedMethod,
-                                            PriorityIdentifier.DEFAULT,
-                                            "some-mfa-identifier"),
-                                    MFAMethod.authAppMfaMethod(
-                                            "some-credential",
-                                            true,
-                                            true,
-                                            PriorityIdentifier.BACKUP,
-                                            "auth-app-mfa-id")));
+                    .thenReturn(List.of(defaultSmsMethod, backupAuthAppMethod));
 
-            var result =
-                    getUserMFADetail(
-                            userContext,
-                            userCredentials,
-                            PHONE_NUMBER,
-                            isPhoneNumberVerified,
-                            userProfile);
+            var result = getUserMFADetail(userContext, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, true, SMS, phoneNumberOfMigratedMethod);
 
             assertEquals(expectedResult, result);
@@ -384,5 +344,15 @@ class MfaHelperTest {
                 isAuthAppVerified,
                 enabled,
                 NowHelper.nowMinus(50, ChronoUnit.DAYS).toString());
+    }
+
+    private static void setupUserProfile(
+            UserProfile userProfile,
+            String phoneNumber,
+            boolean isPhoneNumberVerified,
+            boolean areMfaMethodsMigrated) {
+        when(userProfile.getPhoneNumber()).thenReturn(phoneNumber);
+        when(userProfile.isPhoneNumberVerified()).thenReturn(isPhoneNumberVerified);
+        when(userProfile.getMfaMethodsMigrated()).thenReturn(areMfaMethodsMigrated);
     }
 }


### PR DESCRIPTION
Allow a user with migrated mfa methods (i.e. methods stored under the new structure in user credentials, supporting multiple methods for a user) to sign in with their default method, by returning the correct method in all the places we respond from the frontend api with this information. No change for non-migrated users.

How to review:
1. Code review