### PR TITLE
ATO-1596: migrate authcode to get correct pairwise

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -300,7 +300,7 @@ public class AuthCodeHandler
                             isTestJourney,
                             isDocAppJourney);
 
-            var rpPairwiseId = AuditService.UNKNOWN;
+            String rpPairwiseId = AuditService.UNKNOWN;
             String internalCommonSubjectId;
             if (isDocAppJourney) {
                 LOG.info("Session not saved for DocCheckingAppUser");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -308,13 +308,9 @@ public class AuthCodeHandler
             } else {
                 authCodeResponseService.processVectorOfTrust(orchClientSession, dimensions);
                 internalCommonSubjectId = orchSession.getInternalCommonSubjectId();
-                rpPairwiseId = orchClientSession.getRpPairwiseId();
-                LOG.info(
-                        "is rpPairwiseId the same as pairwiseIdForClient: {}",
-                        Objects.equals(
-                                rpPairwiseId,
-                                orchClientSession.getCorrectPairwiseIdGivenSubjectType(
-                                        client.getSubjectType())));
+                rpPairwiseId =
+                        orchClientSession.getCorrectPairwiseIdGivenSubjectType(
+                                client.getSubjectType());
             }
 
             var metadataPairs = new ArrayList<AuditService.MetadataPair>();

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -308,7 +308,7 @@ class AuthCodeHandlerTest {
                 .thenReturn(authSuccessResponse);
         when(orchClientSession.getVtrList()).thenReturn(List.of(new VectorOfTrust(requestedLevel)));
         when(orchClientSession.getVtrLocsAsCommaSeparatedString()).thenReturn("P0");
-        when(orchClientSession.getRpPairwiseId())
+        when(orchClientSession.getCorrectPairwiseIdGivenSubjectType(anyString()))
                 .thenReturn(
                         ClientSubjectHelper.calculatePairwiseIdentifier(
                                 SUBJECT.getValue(), "rp-sector-uri", SALT));


### PR DESCRIPTION
### Wider context of change
Part of the rpPairwiseId migration work. There are currently no clients that have a "public" subjectType that also go to identity, so this is not a bug. However, it is fragile, as if that were turned on, this would be the wrong value. I also want to make orchClientSession.getRpPairwiseId() to be private if possible so no dev uses it accidentally.

The log being removed here showed these two values are always the same, see [logs here](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22is%20rpPairwiseId%20the%20same%20as%20pairwiseIdForClient*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1744239600&latest=1744758000&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&display.general.type=events&display.visualizations.charting.chart.stackMode=default&display.visualizations.charting.chart=column&sid=1744723048.265009).

### What’s changed
Swapped to using `getCorrectPairwiseIdGivenSubjectType()` instead of `getRpPairwiseId()`

### Note
**Unlike other handlers**, this handler is hit long after authenticationCallbackHandler, so this handler never hits the issue of orchClientSession getting read shortly after being written to. Hence, this is safe to merge now before the strongly consistent read work is complete.

### Manual testing
N/A

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing. **No change**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**