### PR TITLE
ATO-1596: migrate ipv callback to get pairwise id from client session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -128,11 +128,13 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     public static final State RP_STATE = new State();
     public static final State ORCHESTRATION_STATE = new State();
     private static final Subject TEST_SUBJECT = new Subject();
-    private static final String TEST_INTERNAL_SECTOR_ID = "test.com";
+    private static final String TEST_INTERNAL_SECTOR_HOST = "test.account.gov.uk";
+    private static final String TEST_RP_SECTOR_HOST = "test.com";
 
     private static byte[] salt;
     private static String base64EncodedSalt;
     private static String internalCommonSubjectId;
+    private static String rpPairwiseId;
 
     @BeforeEach
     void setup() {
@@ -147,7 +149,10 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         salt = userStore.addSalt(TEST_EMAIL_ADDRESS);
         base64EncodedSalt = Base64.getEncoder().encodeToString(salt);
         internalCommonSubjectId =
-                calculatePairwiseIdentifier(TEST_SUBJECT.getValue(), TEST_INTERNAL_SECTOR_ID, salt);
+                calculatePairwiseIdentifier(
+                        TEST_SUBJECT.getValue(), TEST_INTERNAL_SECTOR_HOST, salt);
+        rpPairwiseId =
+                calculatePairwiseIdentifier(TEST_SUBJECT.getValue(), TEST_RP_SECTOR_HOST, salt);
 
         setupOrchSession(internalCommonSubjectId);
         setupAuthUserInfoTable(internalCommonSubjectId, salt);
@@ -174,11 +179,12 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
         redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
@@ -222,7 +228,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 TEST_SUBJECT.getValue(),
                                 salt,
                                 sectorId,
-                                internalCommonSubjectId,
+                                rpPairwiseId,
                                 new LogIds(
                                         SESSION_ID,
                                         PERSISTENT_SESSION_ID,
@@ -311,11 +317,12 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
         redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
@@ -348,7 +355,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                         + SerializationService.getInstance().writeValueAsString(base64EncodedSalt)
                         + ",\"in_rp_sector_id\":\"test.com\","
                         + "\"out_sub\":\""
-                        + internalCommonSubjectId
+                        + rpPairwiseId
                         + "\",\"log_ids\":{\"session_id\":\"some-session-id\""
                         + ",\"persistent_session_id\":\""
                         + PERSISTENT_SESSION_ID
@@ -376,11 +383,12 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
         redis.addClientSessionAndStateToRedis(ORCHESTRATION_STATE, CLIENT_SESSION_ID);
 
         var response =
@@ -430,11 +438,12 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
 
         var response =
                 makeRequest(
@@ -486,11 +495,12 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
         redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
@@ -583,11 +593,12 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
         redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
@@ -644,11 +655,12 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 clientCreationTime);
         orchClientSessionExtension.storeClientSession(
                 new OrchClientSessionItem(
-                        CLIENT_SESSION_ID,
-                        authRequestBuilder.build().toParameters(),
-                        clientCreationTime,
-                        List.of(VectorOfTrust.getDefaults()),
-                        CLIENT_NAME));
+                                CLIENT_SESSION_ID,
+                                authRequestBuilder.build().toParameters(),
+                                clientCreationTime,
+                                List.of(VectorOfTrust.getDefaults()),
+                                CLIENT_NAME)
+                        .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, sessionId);
         redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.UserInfoRequest;
@@ -35,7 +36,6 @@ import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
-import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.ConstructUriHelper;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
@@ -329,11 +329,9 @@ public class IPVCallbackHandler
             }
 
             var rpPairwiseSubject =
-                    ClientSubjectHelper.getSubject(
-                            userProfile,
-                            clientRegistry,
-                            dynamoService,
-                            configurationService.getInternalSectorURI());
+                    new Subject(
+                            orchClientSession.getCorrectPairwiseIdGivenSubjectType(
+                                    clientRegistry.getSubjectType()));
 
             var user =
                     TxmaAuditUser.user()

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -347,17 +347,6 @@ public class IPVCallbackHandler
 
             // TODO: ATO-1117: temporary logs to check values are as expected
             LOG.info(
-                    "is rpPairwiseId the same on clientSession as calculated: {}",
-                    Objects.equals(
-                            rpPairwiseSubject.getValue(), orchClientSession.getRpPairwiseId()));
-            LOG.info(
-                    "is correct pairwiseId for client the same on clientSession as calculated: {}",
-                    Objects.equals(
-                            rpPairwiseSubject.getValue(),
-                            orchClientSession.getCorrectPairwiseIdGivenSubjectType(
-                                    clientRegistry.getSubjectType())));
-
-            LOG.info(
                     "is email the same on authUserInfo as on session: {}",
                     Objects.equals(session.getEmailAddress(), authUserInfo.getEmailAddress()));
             if (userProfile.getPhoneNumber() != null) {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -170,8 +170,6 @@ class IPVCallbackHandlerTest {
     private static final URI IPV_URI = URI.create("http://ipv/");
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String CLIENT_NAME = "client-name";
-    private static final Subject PUBLIC_SUBJECT =
-            new Subject("TsEVC7vg0NPAmzB33vRUFztL2c0-fecKWKcc73fuDhc");
     private static final State STATE = new State();
     private static final List<VectorOfTrust> VTR_LIST =
             List.of(
@@ -232,7 +230,6 @@ class IPVCallbackHandlerTest {
                                     new VectorOfTrust(CredentialTrustLevel.LOW_LEVEL),
                                     new VectorOfTrust(CredentialTrustLevel.MEDIUM_LEVEL)),
                             CLIENT_NAME)
-                    .withPublicSubjectId(PUBLIC_SUBJECT.getValue())
                     .withRpPairwiseId(TEST_RP_PAIRWISE_ID);
     private final Json objectMapper = SerializationService.getInstance();
 
@@ -1262,7 +1259,6 @@ class IPVCallbackHandlerTest {
                 .withEmailVerified(true)
                 .withPhoneNumber(TEST_PHONE_NUMBER)
                 .withPhoneNumberVerified(true)
-                .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
                 .withSubjectID(TEST_SUBJECT.getValue());
     }
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -152,6 +152,9 @@ class IPVCallbackHandlerTest {
             URI.create("https://example.com/ipv-callback");
     private static final URI OIDC_BASE_URL = URI.create("https://base-url.com");
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
+    private static final String INTERNAL_SECTOR_HOST = "test.account.gov.uk";
+    private static final String RP_SECTOR_URI = "https://test.com";
+    private static final String RP_SECTOR_HOST = "test.com";
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final String COOKIE = "Cookie";
     private static final String SESSION_ID = "a-session-id";
@@ -193,7 +196,7 @@ class IPVCallbackHandlerTest {
     private static final Subject TEST_SUBJECT = new Subject();
     private static final String TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER =
             ClientSubjectHelper.calculatePairwiseIdentifier(
-                    TEST_SUBJECT.getValue(), "test.account.gov.uk", salt);
+                    TEST_SUBJECT.getValue(), INTERNAL_SECTOR_HOST, salt);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =
@@ -1276,7 +1279,7 @@ class IPVCallbackHandlerTest {
                 .withClientID(CLIENT_ID.getValue())
                 .withClientName("test-client")
                 .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
-                .withSectorIdentifierUri("https://test.com")
+                .withSectorIdentifierUri(RP_SECTOR_URI)
                 .withSubjectType("pairwise");
     }
 
@@ -1285,7 +1288,7 @@ class IPVCallbackHandlerTest {
                 .withClientID(CLIENT_ID.getValue())
                 .withClientName("test-client")
                 .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
-                .withSectorIdentifierUri("https://test.com")
+                .withSectorIdentifierUri(RP_SECTOR_URI)
                 .withSubjectType("pairwise")
                 .withClaims(List.of("https://vocab.account.gov.uk/v1/returnCode"));
     }


### PR DESCRIPTION
### Wider context of change
This is part of the rpPairwiseId migration work. 

### What’s changed
Swap to getting rpPairwiseId from the orchClientSession instead of calculating it.

### Manual testing
Deployed to dev and tested:
- a full identity reuse journey
- a silent login identity reuse journey

I have verified that rpPairwiseId's are in sync in the logs [here](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22is%20rpPairwiseId%20the%20same%20on%20clientSession%20as%20calculated%3A*%22%20AND%20loggerName%3D%22uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1744239600&latest=1744758000&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&display.general.type=events&display.visualizations.charting.chart.stackMode=default&display.visualizations.charting.chart=column&sid=1744727562.266316).

I've also verified that the method `getCorrectPairwiseIdForClient` is in sync in the logs [here](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22is%20correct%20pairwiseId%20for%20client%20the%20same%20on%20clientSession%20as%20calculated%3A*%22%20AND%20loggerName%3D%22uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1744239600&latest=1744758000&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&display.general.type=events&display.visualizations.charting.chart.stackMode=default&display.visualizations.charting.chart=column&sid=1744727482.266308)

### Checklist
- [x]  Lambdas have correct permissions for the resources they're accessing. **No change**
- [x] Impact on orch and auth mutual dependencies has been checked. **Not required**
- [x] Changes have been made to contract tests or not required. **Not required**
- [x] Changes have been made to the simulator or not required. **Not required**
- [x] Changes have been made to stubs or not required. **Not required**
- [x] Successfully deployed to authdev or not required. **Not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required**

### Related PRs
The original PR with all the change in one:
https://github.com/govuk-one-login/authentication-api/pull/5804
