### PR TITLE
BAU: Move cannot create default MFA rule

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -108,9 +108,9 @@ public class MFAMethodsCreateHandler
 
             LOG.info("Update MFA POST called with: {}", mfaMethodCreateRequest);
 
-            if (mfaMethodCreateRequest.mfaMethod().priorityIdentifier() == PriorityIdentifier.DEFAULT) {
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.ERROR_1080);
+            if (mfaMethodCreateRequest.mfaMethod().priorityIdentifier()
+                    == PriorityIdentifier.DEFAULT) {
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1080);
             }
 
             Result<MfaCreateFailureReason, MfaMethodData> addBackupMfaResult =

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MfaMethodCreateOrUpdateRequest;
@@ -107,14 +108,17 @@ public class MFAMethodsCreateHandler
 
             LOG.info("Update MFA POST called with: {}", mfaMethodCreateRequest);
 
+            if (mfaMethodCreateRequest.mfaMethod().priorityIdentifier() == PriorityIdentifier.DEFAULT) {
+                return generateApiGatewayProxyErrorResponse(
+                        400, ErrorResponse.ERROR_1080);
+            }
+
             Result<MfaCreateFailureReason, MfaMethodData> addBackupMfaResult =
                     mfaMethodsService.addBackupMfa(
                             userProfile.getEmail(), mfaMethodCreateRequest.mfaMethod());
 
             if (addBackupMfaResult.isFailure()) {
                 return switch (addBackupMfaResult.getFailure()) {
-                    case INVALID_PRIORITY_IDENTIFIER -> generateApiGatewayProxyErrorResponse(
-                            400, ErrorResponse.ERROR_1001);
                     case BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST -> generateApiGatewayProxyErrorResponse(
                             400, ErrorResponse.ERROR_1068);
                     case PHONE_NUMBER_ALREADY_EXISTS -> generateApiGatewayProxyErrorResponse(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -285,6 +285,20 @@ class MFAMethodsCreateHandlerTest {
     }
 
     @Test
+    void shouldReturn400WhenRequestToCreateNewDefault() {
+        var event =
+                generateApiGatewayEvent(
+                        PriorityIdentifier.DEFAULT,
+                        new SmsMfaDetail(TEST_PHONE_NUMBER),
+                        TEST_INTERNAL_SUBJECT);
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1080));
+    }
+
+    @Test
     void shouldReturn400WhenMfaMethodServiceReturnsBackupAndDefaultExistError() {
         var event =
                 generateApiGatewayEvent(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
@@ -523,24 +523,6 @@ class MFAMethodsServiceIntegrationTest {
         }
 
         @Test
-        void shouldErrorWhenPriorityIdentifierIsDefault() {
-            userStoreExtension.addAuthAppMethod(
-                    MFAMethodsServiceIntegrationTest.EMAIL, true, true, AUTH_APP_CREDENTIAL);
-            SmsMfaDetail smsMfaDetail = new SmsMfaDetail(PHONE_NUMBER);
-
-            MfaMethodCreateOrUpdateRequest request =
-                    new MfaMethodCreateOrUpdateRequest(
-                            new MfaMethodCreateOrUpdateRequest.MfaMethod(
-                                    PriorityIdentifier.DEFAULT, smsMfaDetail));
-
-            var result =
-                    mfaMethodsService.addBackupMfa(
-                            MFAMethodsServiceIntegrationTest.EMAIL, request.mfaMethod());
-
-            assertEquals(MfaCreateFailureReason.INVALID_PRIORITY_IDENTIFIER, result.getFailure());
-        }
-
-        @Test
         void shouldReturnAtMaximumMfaErrorWhenAddingBackupWithTwoExistingMfaMethods() {
             userStoreExtension.addMfaMethodSupportingMultiple(EMAIL, defaultPriorityAuthApp);
             userStoreExtension.addMfaMethodSupportingMultiple(EMAIL, backupPrioritySms);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -90,7 +90,8 @@ public enum ErrorResponse {
     ERROR_1076(1076, "Cannot update a backup sms mfa method's auth app credential"),
     ERROR_1077(1076, "Attempted to update a backup mfa method without a default present"),
     ERROR_1078(1078, "Unexpected error creating mfa identifier for auth app mfa method"),
-    ERROR_1079(1079, "Invalid principal in request");
+    ERROR_1079(1079, "Invalid principal in request"),
+    ERROR_1080(1080, "Default method already exists, new one cannot be created.");
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
@@ -157,10 +157,6 @@ public class MFAMethodsService {
 
     public Result<MfaCreateFailureReason, MfaMethodData> addBackupMfa(
             String email, MfaMethodCreateOrUpdateRequest.MfaMethod mfaMethod) {
-        if (mfaMethod.priorityIdentifier() == PriorityIdentifier.DEFAULT) {
-            return Result.failure(MfaCreateFailureReason.INVALID_PRIORITY_IDENTIFIER);
-        }
-
         UserCredentials userCredentials = persistentService.getUserCredentialsFromEmail(email);
         Result<MfaRetrieveFailureReason, List<MfaMethodData>> mfaMethodsResult =
                 getMfaMethodsForMigratedUser(userCredentials);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaCreateFailureReason.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaCreateFailureReason.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.shared.services.mfa;
 
 public enum MfaCreateFailureReason {
-    INVALID_PRIORITY_IDENTIFIER,
     BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST,
     PHONE_NUMBER_ALREADY_EXISTS,
     AUTH_APP_EXISTS,


### PR DESCRIPTION
## What

The rule that you cannot create a new DEFAULT MFA Method is only true in account-management api.  The MFAMethodsService can be used to create a new DEFAULT method, for example during sign-up.

Moving this check into the MFAMethodsCreateHandler enforces the rule for updates to existing Users who must already have a DEFAULT method.


<!-- Describe what you have changed and why -->

## How to review

1. Code Review
2. Deploy to a dev environment and use the http file to try to create a DEFAULT method.

<!-- Describe the steps required to review this PR.
For example:


1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
