### PR TITLE
ATO-1515: Stop setting client session list on shared session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -945,7 +945,6 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         private void setupMaxAgeSession() throws Json.JsonException {
             var session = new Session();
-            session.addClientSession(CLIENT_SESSION_ID);
             redis.addSessionWithId(session, SESSION_ID);
             redis.addStateToRedis(
                     AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX,
@@ -968,7 +967,6 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                                     NowHelper.nowMinus(1, ChronoUnit.HOURS)
                                             .toInstant()
                                             .getEpochSecond());
-            PREVIOUS_CLIENT_SESSIONS.forEach(session::addClientSession);
             PREVIOUS_CLIENT_SESSIONS.forEach(orchSession::addClientSession);
             redis.addSessionWithId(session, PREVIOUS_SESSION_ID);
             redis.addStateToRedis(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1992,10 +1992,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         txmaAuditQueue.clear();
     }
 
-    private String givenAnExistingSessionWithClientSession(String clientSessionId)
-            throws Json.JsonException {
-        var sessionId = redis.createSession();
-        redis.addClientSessionIdToSession(clientSessionId, sessionId);
+    private String givenAnExistingSessionWithClientSession(String clientSessionId) {
+        var sessionId = IdGenerator.generate();
+        orchSessionExtension.addSession(new OrchSessionItem(sessionId));
+        orchSessionExtension.addClientSessionIdToSession(sessionId, clientSessionId);
         return sessionId;
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1329,44 +1329,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             assertTrue(newSession.isPresent());
             assertFalse(newSession.get().getAuthenticated());
             assertEquals(newSession.get().getSessionId(), newSessionId);
-        }
-
-        @Test
-        void shouldUpdateSharedSessionWhenMaxAgeExpired() throws Exception {
-            registerClient(
-                    CLIENT_ID, "test-client", singletonList("openid"), ClientType.WEB, false, true);
-            var previousClientSessionId = "a-previous-client-session";
-            var previousSessionId =
-                    givenAnExistingSessionWithClientSession(previousClientSessionId);
-            orchSessionExtension.addSession(
-                    new OrchSessionItem(previousSessionId)
-                            .withAuthenticated(true)
-                            .withAuthTime(NowHelper.now().toInstant().getEpochSecond() - 10));
-            handler = new AuthorisationHandler(configuration, redisConnectionService);
-            txmaAuditQueue.clear();
-
-            var previousSession = orchSessionExtension.getSession(previousSessionId);
-            assertTrue(previousSession.isPresent());
-            assertTrue(previousSession.get().getAuthenticated());
-            assertNull(previousSession.get().getPreviousSessionId());
-
-            var response =
-                    makeRequest(
-                            Optional.empty(),
-                            constructHeaders(
-                                    new HttpCookie[] {
-                                        buildSessionCookie(
-                                                previousSessionId, DUMMY_CLIENT_SESSION_ID),
-                                        new HttpCookie("bsid", BROWSER_SESSION_ID)
-                                    }),
-                            constructQueryStringParameters(
-                                    CLIENT_ID, null, "openid", "P2.Cl.Cm", 0L),
-                            Optional.of("GET"));
-            var newSessionId = getSessionId(response);
-            var newSession = redis.getSession(newSessionId);
-            assertNotNull(newSession);
-            assertEquals(1, newSession.getClientSessions().size());
-            assertFalse(newSession.getClientSessions().contains(previousClientSessionId));
+            assertEquals(1, newSession.get().getClientSessions().size());
         }
 
         @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -106,7 +106,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldRedirectToSpecifiedClientLogoutUriWhenThereIsNoActiveSession()
             throws Json.JsonException, ParseException {
         var signedJWT = setupClientAndSession(SESSION_ID, CLIENT_SESSION_ID);
-        redis.addClientSessionIdToSession("expired-client-session-id", SESSION_ID);
+        orchSessionExtension.addClientSessionIdToSession("expired-client-session-id", SESSION_ID);
         var response =
                 makeRequest(
                         Optional.empty(),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/AuthOrchSerializationServicesIntegrationTest.java
@@ -7,9 +7,8 @@ import uk.gov.di.authentication.shared.entity.Session;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class AuthOrchSerializationServicesIntegrationTest {
 
@@ -18,7 +17,6 @@ class AuthOrchSerializationServicesIntegrationTest {
     private static final Optional<String> REDIS_PASSWORD =
             Optional.ofNullable(System.getenv("REDIS_PASSWORD"));
     private static final String SESSION_ID = "session-id";
-    private static final String CLIENT_SESSION_ID = "client-session-id";
     private static final String EMAIL_ADDRESS = "example@example.com";
 
     private uk.gov.di.orchestration.shared.services.SessionService orchSessionService;
@@ -67,6 +65,7 @@ class AuthOrchSerializationServicesIntegrationTest {
     @Test
     void authCanUpdateSharedFieldInSessionCreatedByOrch() {
         var orchSession = orchSessionService.generateSession();
+        orchSession.setEmailAddress(EMAIL_ADDRESS);
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = authSessionService.getSession(SESSION_ID).get();
         authSession.setEmailAddress(EMAIL_ADDRESS);
@@ -91,13 +90,12 @@ class AuthOrchSerializationServicesIntegrationTest {
     }
 
     @Test
-    void authCanResetSharedFieldsWithoutOverridingUnsharedFields() {
+    void authAndOrchCanReadTheSessionWithoutError() {
         var orchSession = orchSessionService.generateSession();
-        orchSession.addClientSession(CLIENT_SESSION_ID);
         orchSessionService.storeOrUpdateSession(orchSession, SESSION_ID);
         var authSession = new Session();
         authSessionService.storeOrUpdateSession(authSession, SESSION_ID);
         orchSession = orchSessionService.getSession(SESSION_ID).get();
-        assertThat(orchSession.getClientSessions(), is(empty()));
+        assertNull(orchSession.getEmailAddress());
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -575,7 +575,6 @@ public class AuthorisationHandler
                 orchClientSession.withDocAppSubjectId(subjectId.getValue()));
         LOG.info("Subject saved to ClientSession for DocCheckingAppUser");
 
-        session.addClientSession(clientSessionId);
         orchSession.addClientSession(clientSessionId);
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         updateAttachedLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
@@ -743,7 +742,6 @@ public class AuthorisationHandler
         clientSessionService.storeClientSession(clientSessionId, clientSession);
         orchClientSessionService.storeClientSession(orchClientSession);
 
-        session.addClientSession(clientSessionId);
         orchSession.addClientSession(clientSessionId);
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         updateAttachedLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/entity/LogoutRequestTest.java
@@ -442,7 +442,7 @@ class LogoutRequestTest {
     }
 
     private Session generateSession() {
-        return new Session().addClientSession(CLIENT_SESSION_ID);
+        return new Session();
     }
 
     private void generateSessionFromCookie(Session session, OrchSessionItem orchSession) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -147,12 +147,13 @@ class AuthCodeHandlerTest {
     private static final Json objectMapper = SerializationService.getInstance();
     private AuthCodeHandler handler;
 
-    private final Session session = new Session().addClientSession(CLIENT_SESSION_ID);
+    private final Session session = new Session();
     private final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID)
                     .withAccountState(OrchSessionItem.AccountState.NEW)
                     .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID)
-                    .withAuthTime(12345L);
+                    .withAuthTime(12345L)
+                    .addClientSession(CLIENT_SESSION_ID);
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -1356,7 +1356,6 @@ class AuthenticationCallbackHandlerTest {
 
         private void withPreviousSharedSessionDueToMaxAge() {
             var previousSharedSession = new Session();
-            PREVIOUS_CLIENT_SESSIONS.forEach(previousSharedSession::addClientSession);
             previousSharedSession.setEmailAddress(TEST_EMAIL_ADDRESS);
             when(sessionService.getSession(PREVIOUS_SESSION_ID))
                     .thenReturn(Optional.of(previousSharedSession));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -285,7 +285,6 @@ class AuthenticationCallbackHandlerTest {
                         logoutService,
                         authFrontend,
                         noSessionOrchestrationService);
-        session.resetClientSessions();
         orchSession.resetClientSessions();
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -1382,7 +1382,7 @@ class AuthenticationCallbackHandlerTest {
         }
 
         private void withMaxAgeSharedSession() {
-            var session = new Session().addClientSession(CLIENT_SESSION_ID);
+            var session = new Session();
             when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
         }
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -136,7 +136,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -2005,15 +2004,6 @@ class AuthorisationHandlerTest {
         @AfterEach()
         void docAppTearDown() {
             docAppSubjectIdHelperMock.close();
-        }
-
-        @Test
-        void shouldCreateANewClientSessionAndAttachItToExistingSessionWhenRequestIsDocAppRequest()
-                throws JOSEException {
-            var sessionSpy = spy(session);
-            when(sessionService.getSession(any())).thenReturn(Optional.of(sessionSpy));
-            makeDocAppHandlerRequest();
-            verify(sessionSpy).addClientSession(CLIENT_SESSION_ID);
         }
 
         @Test

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchSessionExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/OrchSessionExtension.java
@@ -71,6 +71,14 @@ public class OrchSessionExtension extends DynamoExtension implements AfterEachCa
         orchSessionService.addSession(orchSession);
     }
 
+    public void addClientSessionIdToSession(String clientSessionId, String sessionId) {
+        orchSessionService.updateSession(
+                orchSessionService
+                        .getSession(sessionId)
+                        .orElse(new OrchSessionItem(sessionId))
+                        .addClientSession(clientSessionId));
+    }
+
     public OrchSessionItem addOrUpdateSessionId(
             Optional<String> previousSessionId, String newSessionId) {
         return orchSessionService.addOrUpdateSessionId(previousSessionId, newSessionId);

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -91,13 +91,6 @@ public class RedisExtension
         redis.saveWithExpiry("state:" + state.getValue(), clientSessionId, 3600);
     }
 
-    public void addClientSessionIdToSession(String clientSessionId, String sessionId)
-            throws Json.JsonException {
-        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.addClientSession(clientSessionId);
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
-    }
-
     public void addAuthRequestToSession(
             String clientSessionId,
             String sessionId,

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -109,7 +109,6 @@ public class RedisExtension
             LocalDateTime creationDate)
             throws Json.JsonException {
         Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.addClientSession(clientSessionId);
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
         redis.saveWithExpiry(
                 CLIENT_SESSION_PREFIX.concat(clientSessionId),

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -63,15 +63,6 @@ public class Session {
         initializeCodeRequestMap();
     }
 
-    public List<String> getClientSessions() {
-        return clientSessions;
-    }
-
-    public Session addClientSession(String clientSessionId) {
-        this.clientSessions.add(clientSessionId);
-        return this;
-    }
-
     public boolean validateSession(String emailAddress) {
         return this.emailAddress.equals(emailAddress);
     }
@@ -116,9 +107,5 @@ public class Session {
         for (CodeRequestType requestType : CodeRequestType.values()) {
             codeRequestCountMap.put(requestType, 0);
         }
-    }
-
-    public void resetClientSessions() {
-        this.clientSessions = new ArrayList<>();
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SessionService.java
@@ -37,7 +37,6 @@ public class SessionService {
     public Session copySessionForMaxAge(Session previousSession) {
         var copiedSession = new Session(previousSession);
         copiedSession.setAuthenticated(false).setCurrentCredentialStrength(null);
-        copiedSession.resetClientSessions();
         return copiedSession;
     }
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SessionServiceTest.java
@@ -24,7 +24,7 @@ class SessionServiceTest {
     void shouldPersistSessionToRedisWithExpiry() throws Json.JsonException {
         when(configuration.getSessionExpiry()).thenReturn(1234L);
 
-        var session = new Session().addClientSession("client-session-id");
+        var session = new Session();
 
         sessionService.storeOrUpdateSession(session, "session-id");
 
@@ -34,7 +34,7 @@ class SessionServiceTest {
 
     @Test
     void shouldUpdateSessionIdInRedisAndDeleteOldKey() {
-        var session = new Session().addClientSession("client-session-id");
+        var session = new Session();
 
         sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.updateWithNewSessionId(session, "session-id", "new-session-id");
@@ -46,7 +46,7 @@ class SessionServiceTest {
 
     @Test
     void shouldDeleteSessionIdFromRedis() {
-        var session = new Session().addClientSession("client-session-id");
+        var session = new Session();
 
         sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.deleteStoredSession("session-id");


### PR DESCRIPTION
### Wider context of change:

We previously swapped over to using the Client Session list from the Orch session instead of the shared session. This is the final PR in the migration removes setting the value on the shared session.

### What’s changed:
- Removes addClientSession call in authorisation.
- Removes resetClientSessions call in handling a max age session in authorise.
- Removes test usages of the methods 
- Removes methods from session class

### Manual testing: 
 Deploy to dev
- Run through a full journey + logout 
- Run through a max_age journey and logout

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
