### PR TITLE
ATO-1117: migrate LOCAL_ACCOUNT_ID

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -271,7 +271,6 @@ public class IPVCallbackHelper {
     public void queueSPOTRequest(
             LogIds logIds,
             String sectorIdentifier,
-            UserProfile userProfile,
             UserInfo authUserInfo,
             Subject pairwiseSubject,
             UserInfo userIdentityUserInfo,
@@ -296,7 +295,7 @@ public class IPVCallbackHelper {
         var spotRequest =
                 new SPOTRequest(
                         spotClaimsBuilder.build(),
-                        userProfile.getSubjectID(),
+                        authUserInfo.getStringClaim(AuthUserInfoClaims.LOCAL_ACCOUNT_ID.getValue()),
                         authUserInfo.getStringClaim(AuthUserInfoClaims.SALT.getValue()),
                         sectorIdentifier,
                         pairwiseSubject.getValue(),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -28,7 +28,6 @@ import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.api.CommonFrontend;
 import uk.gov.di.orchestration.shared.api.OrchFrontend;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
-import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
@@ -354,12 +353,6 @@ public class IPVCallbackHandler
                         Objects.equals(
                                 userProfile.getPhoneNumber(), authUserInfo.getPhoneNumber()));
             }
-            LOG.info(
-                    "is subjectId the same on authUserInfo as on UserProfile: {}",
-                    Objects.equals(
-                            userProfile.getSubjectID(),
-                            authUserInfo.getClaim(AuthUserInfoClaims.LOCAL_ACCOUNT_ID.getValue())));
-
             //
 
             var tokenResponse =

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -481,7 +481,6 @@ public class IPVCallbackHandler
                     logIds,
                     getSectorIdentifierForClient(
                             clientRegistry, configurationService.getInternalSectorURI()),
-                    userProfile,
                     authUserInfo,
                     rpPairwiseSubject,
                     userIdentityUserInfo,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -296,7 +296,6 @@ class IPVCallbackHelperTest {
         helper.queueSPOTRequest(
                 new LogIds(),
                 "sector-identifier",
-                userProfile,
                 authUserInfo,
                 SUBJECT,
                 p2VotUserIdentityUserInfo,
@@ -344,7 +343,6 @@ class IPVCallbackHelperTest {
                                 helper.queueSPOTRequest(
                                         new LogIds(),
                                         "sector-identifier",
-                                        userProfile,
                                         authUserInfo,
                                         SUBJECT,
                                         p2VotUserIdentityUserInfo,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -748,7 +748,6 @@ class IPVCallbackHandlerTest {
                 .queueSPOTRequest(
                         any(),
                         anyString(),
-                        eq(userProfile),
                         eq(authUserInfo),
                         eq(new Subject(TEST_RP_PAIRWISE_ID)),
                         any(UserInfo.class),


### PR DESCRIPTION
### Wider context of change
This is part of the session migration work. Here, we continue the migration of IPVCallbackHandler away from using UserProfile and to using AuthUserInfo instead. A lot has needed to happen before this PR can be raised, from destroying orch session on logout, to migrating the AuthUserInfo table itself to orch. There is still some uncertainty with rpPairwiseId, but I want to get some of this over the line.

### What’s changed
In a nutshell, move from using UserProfile to using AuthUserInfo. That required a lot of detangling, as a lot of properties on UserProfile are used. Here, we continue the migration and move LOCAL_ACCOUNT_ID over to using AuthUserInfo

### Manual testing
Deployed to dev and tested an identity reuse journey worked

Verified in logs that LOCAL_ACCOUNT_ID and UserProfile.getSubject() are in sync [here](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22is%20subjectId%20the%20same%20on%20authUserInfo%20as%20on%20UserProfile%3A*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1744671600&latest=1745362800&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&sid=1745332568.99629).

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required**
- [x] Changes have been made to the simulator or not required. **Not required**
- [x] Changes have been made to stubs or not required. **Not required**
- [x] Successfully deployed to authdev or not required. **Not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required**

### Related PRs
The original PR with all the change in one:
https://github.com/govuk-one-login/authentication-api/pull/5804
