### PR TITLE
AUT-4134: Add redis SSM policy

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -7,16 +7,20 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
+import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.entity.mfa.MfaMethodCreateOrUpdateRequest;
-import uk.gov.di.authentication.shared.entity.mfa.MfaMethodData;
+import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodCreateOrUpdateRequest;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.response.MfaMethodResponse;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaCreateFailureReason;
@@ -35,6 +39,7 @@ public class MFAMethodsCreateHandler
     private final Json objectMapper = SerializationService.getInstance();
 
     private final ConfigurationService configurationService;
+    private final CodeStorageService codeStorageService;
     private final MFAMethodsService mfaMethodsService;
     private final DynamoService dynamoService;
     private static final Logger LOG = LogManager.getLogger(MFAMethodsCreateHandler.class);
@@ -47,15 +52,19 @@ public class MFAMethodsCreateHandler
         this.configurationService = configurationService;
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
+        this.codeStorageService =
+                new CodeStorageService(new RedisConnectionService(configurationService));
     }
 
     public MFAMethodsCreateHandler(
             ConfigurationService configurationService,
             MFAMethodsService mfaMethodsService,
-            DynamoService dynamoService) {
+            DynamoService dynamoService,
+            CodeStorageService codeStorageService) {
         this.configurationService = configurationService;
         this.mfaMethodsService = mfaMethodsService;
         this.dynamoService = dynamoService;
+        this.codeStorageService = codeStorageService;
     }
 
     @Override
@@ -113,7 +122,19 @@ public class MFAMethodsCreateHandler
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1080);
             }
 
-            Result<MfaCreateFailureReason, MfaMethodData> addBackupMfaResult =
+            if (mfaMethodCreateRequest.mfaMethod().method()
+                    instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
+                boolean isValidOtpCode =
+                        codeStorageService.isValidOtpCode(
+                                userProfile.getEmail(),
+                                requestSmsMfaDetail.otp(),
+                                NotificationType.VERIFY_PHONE_NUMBER);
+                if (!isValidOtpCode) {
+                    return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1020);
+                }
+            }
+
+            Result<MfaCreateFailureReason, MfaMethodResponse> addBackupMfaResult =
                     mfaMethodsService.addBackupMfa(
                             userProfile.getEmail(), mfaMethodCreateRequest.mfaMethod());
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -11,15 +11,18 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import uk.gov.di.accountmanagement.entity.NotificationType;
+import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.entity.mfa.AuthAppMfaDetail;
 import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
-import uk.gov.di.authentication.shared.entity.mfa.MfaMethodCreateOrUpdateRequest;
-import uk.gov.di.authentication.shared.entity.mfa.MfaMethodData;
-import uk.gov.di.authentication.shared.entity.mfa.SmsMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodCreateOrUpdateRequest;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestAuthAppMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.response.MfaMethodResponse;
+import uk.gov.di.authentication.shared.entity.mfa.response.ResponseSmsMfaDetail;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -52,6 +55,8 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class MFAMethodsCreateHandlerTest {
+    public static final String TEST_OTP = "123456";
+
     @RegisterExtension
     private final CaptureLoggingExtension logging =
             new CaptureLoggingExtension(MFAMethodsCreateHandler.class);
@@ -66,6 +71,7 @@ class MFAMethodsCreateHandlerTest {
     private static final String TEST_PUBLIC_SUBJECT = new Subject().getValue();
     private static final ConfigurationService configurationService =
             mock(ConfigurationService.class);
+    private static final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private static final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private static final DynamoService dynamoService = mock(DynamoService.class);
     private static final byte[] TEST_SALT = SaltHelper.generateNewSalt();
@@ -82,7 +88,8 @@ class MFAMethodsCreateHandlerTest {
         reset(mfaMethodsService);
         when(configurationService.isMfaMethodManagementApiEnabled()).thenReturn(true);
         handler =
-                new MFAMethodsCreateHandler(configurationService, mfaMethodsService, dynamoService);
+                new MFAMethodsCreateHandler(
+                        configurationService, mfaMethodsService, dynamoService, codeStorageService);
         when(configurationService.getAwsRegion()).thenReturn("eu-west-2");
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
         when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(TEST_SALT);
@@ -115,7 +122,7 @@ class MFAMethodsCreateHandlerTest {
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.BACKUP,
-                        new SmsMfaDetail(TEST_PHONE_NUMBER),
+                        new RequestSmsMfaDetail(TEST_PHONE_NUMBER, TEST_OTP),
                         TEST_INTERNAL_SUBJECT);
 
         var result = handler.handleRequest(event, context);
@@ -130,16 +137,16 @@ class MFAMethodsCreateHandlerTest {
         when(mfaMethodsService.addBackupMfa(any(), any()))
                 .thenReturn(
                         Result.success(
-                                new MfaMethodData(
+                                new MfaMethodResponse(
                                         TEST_SMS_MFA_ID,
                                         PriorityIdentifier.BACKUP,
                                         true,
-                                        new SmsMfaDetail(TEST_PHONE_NUMBER))));
+                                        new ResponseSmsMfaDetail(TEST_PHONE_NUMBER))));
 
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.BACKUP,
-                        new SmsMfaDetail(TEST_PHONE_NUMBER),
+                        new RequestSmsMfaDetail(TEST_PHONE_NUMBER, TEST_OTP),
                         TEST_INTERNAL_SUBJECT);
 
         var result = handler.handleRequest(event, context);
@@ -150,7 +157,8 @@ class MFAMethodsCreateHandlerTest {
         verify(mfaMethodsService).addBackupMfa(eq(TEST_EMAIL), mfaMethodCaptor.capture());
         var capturedRequest = mfaMethodCaptor.getValue();
 
-        assertEquals(new SmsMfaDetail(TEST_PHONE_NUMBER), capturedRequest.method());
+        assertEquals(
+                new RequestSmsMfaDetail(TEST_PHONE_NUMBER, TEST_OTP), capturedRequest.method());
         assertEquals(PriorityIdentifier.BACKUP, capturedRequest.priorityIdentifier());
 
         assertThat(result, hasStatus(200));
@@ -178,16 +186,16 @@ class MFAMethodsCreateHandlerTest {
         when(mfaMethodsService.addBackupMfa(any(), any()))
                 .thenReturn(
                         Result.success(
-                                new MfaMethodData(
+                                new MfaMethodResponse(
                                         TEST_AUTH_APP_ID,
                                         PriorityIdentifier.BACKUP,
                                         true,
-                                        new AuthAppMfaDetail(TEST_CREDENTIAL))));
+                                        new RequestAuthAppMfaDetail(TEST_CREDENTIAL))));
 
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.BACKUP,
-                        new AuthAppMfaDetail(TEST_CREDENTIAL),
+                        new RequestAuthAppMfaDetail(TEST_CREDENTIAL),
                         TEST_INTERNAL_SUBJECT);
 
         var result = handler.handleRequest(event, context);
@@ -198,7 +206,7 @@ class MFAMethodsCreateHandlerTest {
         verify(mfaMethodsService).addBackupMfa(eq(TEST_EMAIL), mfaMethodCaptor.capture());
         var capturedRequest = mfaMethodCaptor.getValue();
 
-        assertEquals(new AuthAppMfaDetail(TEST_CREDENTIAL), capturedRequest.method());
+        assertEquals(new RequestAuthAppMfaDetail(TEST_CREDENTIAL), capturedRequest.method());
         assertEquals(PriorityIdentifier.BACKUP, capturedRequest.priorityIdentifier());
 
         assertThat(result, hasStatus(200));
@@ -228,7 +236,7 @@ class MFAMethodsCreateHandlerTest {
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.BACKUP,
-                        new AuthAppMfaDetail(TEST_CREDENTIAL),
+                        new RequestAuthAppMfaDetail(TEST_CREDENTIAL),
                         TEST_INTERNAL_SUBJECT);
 
         var result = handler.handleRequest(event, context);
@@ -260,7 +268,7 @@ class MFAMethodsCreateHandlerTest {
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.BACKUP,
-                        new AuthAppMfaDetail(TEST_CREDENTIAL),
+                        new RequestAuthAppMfaDetail(TEST_CREDENTIAL),
                         TEST_INTERNAL_SUBJECT);
 
         var result = handler.handleRequest(event, context);
@@ -274,7 +282,7 @@ class MFAMethodsCreateHandlerTest {
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.BACKUP,
-                        new SmsMfaDetail(TEST_PHONE_NUMBER),
+                        new RequestSmsMfaDetail(TEST_PHONE_NUMBER, TEST_OTP),
                         TEST_INTERNAL_SUBJECT);
         event.setBody("Invalid JSON");
 
@@ -289,7 +297,7 @@ class MFAMethodsCreateHandlerTest {
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.DEFAULT,
-                        new SmsMfaDetail(TEST_PHONE_NUMBER),
+                        new RequestSmsMfaDetail(TEST_PHONE_NUMBER, TEST_OTP),
                         TEST_INTERNAL_SUBJECT);
 
         var result = handler.handleRequest(event, context);
@@ -303,8 +311,11 @@ class MFAMethodsCreateHandlerTest {
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.BACKUP,
-                        new SmsMfaDetail(TEST_PHONE_NUMBER),
+                        new RequestSmsMfaDetail(TEST_PHONE_NUMBER, TEST_OTP),
                         TEST_INTERNAL_SUBJECT);
+        when(codeStorageService.isValidOtpCode(
+                        TEST_EMAIL, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER))
+                .thenReturn(true);
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
         when(mfaMethodsService.addBackupMfa(any(), any()))
@@ -319,11 +330,34 @@ class MFAMethodsCreateHandlerTest {
     }
 
     @Test
+    void shouldReturn400WhenOTPIsInvalid() {
+        var event =
+                generateApiGatewayEvent(
+                        PriorityIdentifier.BACKUP,
+                        new RequestSmsMfaDetail(TEST_PHONE_NUMBER, TEST_OTP),
+                        TEST_INTERNAL_SUBJECT);
+        when(codeStorageService.isValidOtpCode(
+                        TEST_EMAIL, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER))
+                .thenReturn(false);
+        when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
+                .thenReturn(Optional.of(userProfile));
+        when(mfaMethodsService.addBackupMfa(any(), any()))
+                .thenReturn(
+                        Result.failure(
+                                MfaCreateFailureReason.BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST));
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1020));
+    }
+
+    @Test
     void shouldReturn400WhenMfaMethodServiceReturnsSmsMfaAlreadyExistsError() {
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.BACKUP,
-                        new SmsMfaDetail(TEST_PHONE_NUMBER),
+                        new RequestSmsMfaDetail(TEST_PHONE_NUMBER, TEST_OTP),
                         TEST_INTERNAL_SUBJECT);
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
@@ -341,7 +375,7 @@ class MFAMethodsCreateHandlerTest {
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.BACKUP,
-                        new AuthAppMfaDetail(TEST_CREDENTIAL),
+                        new RequestAuthAppMfaDetail(TEST_CREDENTIAL),
                         TEST_INTERNAL_SUBJECT);
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
@@ -359,7 +393,7 @@ class MFAMethodsCreateHandlerTest {
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.BACKUP,
-                        new AuthAppMfaDetail(TEST_CREDENTIAL),
+                        new RequestAuthAppMfaDetail(TEST_CREDENTIAL),
                         TEST_INTERNAL_SUBJECT);
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
@@ -377,7 +411,7 @@ class MFAMethodsCreateHandlerTest {
         var event =
                 generateApiGatewayEvent(
                         PriorityIdentifier.BACKUP,
-                        new AuthAppMfaDetail(TEST_CREDENTIAL),
+                        new RequestAuthAppMfaDetail(TEST_CREDENTIAL),
                         "invalid");
 
         var result = handler.handleRequest(event, context);
@@ -390,18 +424,22 @@ class MFAMethodsCreateHandlerTest {
             PriorityIdentifier priorityIdentifier, MfaDetail mfaDetail, String principal) {
 
         String body =
-                mfaDetail instanceof SmsMfaDetail
+                mfaDetail instanceof RequestSmsMfaDetail
                         ? format(
                                 """
                                 { "mfaMethod": {
                                     "priorityIdentifier": "%s",
                                     "method": {
                                         "mfaMethodType": "SMS",
-                                        "phoneNumber": "%s" }
+                                        "phoneNumber": "%s",
+                                        "otp": "%s"
+                                    }
                                     }
                                 }
                                """,
-                                priorityIdentifier, ((SmsMfaDetail) mfaDetail).phoneNumber())
+                                priorityIdentifier,
+                                ((RequestSmsMfaDetail) mfaDetail).phoneNumber(),
+                                ((RequestSmsMfaDetail) mfaDetail).otp())
                         : format(
                                 """
                                 { "mfaMethod": {
@@ -412,7 +450,8 @@ class MFAMethodsCreateHandlerTest {
                                     }
                                 }
                                """,
-                                priorityIdentifier, ((AuthAppMfaDetail) mfaDetail).credential());
+                                priorityIdentifier,
+                                ((RequestAuthAppMfaDetail) mfaDetail).credential());
 
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
                 new APIGatewayProxyRequestEvent.ProxyRequestContext();

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -9,13 +9,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.accountmanagement.entity.NotificationType;
+import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.entity.mfa.MfaMethodCreateOrUpdateRequest;
-import uk.gov.di.authentication.shared.entity.mfa.MfaMethodData;
-import uk.gov.di.authentication.shared.entity.mfa.SmsMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodCreateOrUpdateRequest;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.response.MfaMethodResponse;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -43,6 +45,7 @@ class MFAMethodsPutHandlerTest {
 
     private static final ConfigurationService configurationService =
             mock(ConfigurationService.class);
+    private static final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private static final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private static final AuthenticationService authenticationService =
             mock(AuthenticationService.class);
@@ -57,6 +60,7 @@ class MFAMethodsPutHandlerTest {
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     TEST_PUBLIC_SUBJECT, "test.account.gov.uk", TEST_SALT);
     private static final String MFA_IDENTIFIER = "some-mfa-identifier";
+    public static final String TEST_OTP = "123456";
 
     private MFAMethodsPutHandler handler;
 
@@ -67,7 +71,10 @@ class MFAMethodsPutHandlerTest {
         when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(TEST_SALT);
         handler =
                 new MFAMethodsPutHandler(
-                        configurationService, mfaMethodsService, authenticationService);
+                        configurationService,
+                        mfaMethodsService,
+                        authenticationService,
+                        codeStorageService);
     }
 
     @Test
@@ -75,15 +82,15 @@ class MFAMethodsPutHandlerTest {
         var phoneNumber = "123456789";
         var updateRequest =
                 MfaMethodCreateOrUpdateRequest.from(
-                        PriorityIdentifier.DEFAULT, new SmsMfaDetail(phoneNumber));
+                        PriorityIdentifier.DEFAULT, new RequestSmsMfaDetail(phoneNumber, TEST_OTP));
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
-        var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber));
+        var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber, TEST_OTP));
 
         when(authenticationService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
 
         var updatedMfaMethod =
-                MfaMethodData.smsMethodData(
+                MfaMethodResponse.smsMethodData(
                         MFA_IDENTIFIER, PriorityIdentifier.DEFAULT, true, phoneNumber);
         when(mfaMethodsService.updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest))
                 .thenReturn(Result.success(List.of(updatedMfaMethod)));
@@ -158,14 +165,17 @@ class MFAMethodsPutHandlerTest {
             Optional<ErrorResponse> maybeErrorResponse) {
         when(authenticationService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
+        when(codeStorageService.isValidOtpCode(
+                        EMAIL, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER))
+                .thenReturn(true);
 
         var phoneNumber = "123456789";
         var updateRequest =
                 MfaMethodCreateOrUpdateRequest.from(
-                        PriorityIdentifier.DEFAULT, new SmsMfaDetail(phoneNumber));
+                        PriorityIdentifier.DEFAULT, new RequestSmsMfaDetail(phoneNumber, TEST_OTP));
 
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
-        var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber));
+        var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber, TEST_OTP));
         when(mfaMethodsService.updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest))
                 .thenReturn(Result.failure(failureReason));
         var result = handler.handleRequest(eventWithUpdateRequest, context);
@@ -257,6 +267,24 @@ class MFAMethodsPutHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1056));
     }
 
+    @Test
+    void shouldReturnClientErrorWhenOTPInvalid() {
+        when(authenticationService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
+                .thenReturn(Optional.of(userProfile));
+        when(codeStorageService.isValidOtpCode(
+                        EMAIL, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER))
+                .thenReturn(false);
+
+        var phoneNumber = "123456789";
+
+        var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
+        var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber, TEST_OTP));
+        var result = handler.handleRequest(eventWithUpdateRequest, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1020));
+    }
+
     private static APIGatewayProxyRequestEvent generateApiGatewayEvent(String principal) {
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
                 new APIGatewayProxyRequestEvent.ProxyRequestContext();
@@ -275,7 +303,7 @@ class MFAMethodsPutHandlerTest {
                 .withRequestContext(proxyRequestContext);
     }
 
-    private String updateSmsRequest(String phoneNumber) {
+    private String updateSmsRequest(String phoneNumber, String otp) {
         return format(
                 """
         {
@@ -283,11 +311,12 @@ class MFAMethodsPutHandlerTest {
             "priorityIdentifier": "DEFAULT",
             "method": {
                 "mfaMethodType": "SMS",
-                "phoneNumber": "%s"
+                "phoneNumber": "%s",
+                "otp": "%s"
             }
           }
         }
         """,
-                phoneNumber);
+                phoneNumber, otp);
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
@@ -12,8 +12,8 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.entity.mfa.MfaMethodData;
-import uk.gov.di.authentication.shared.entity.mfa.SmsMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.response.MfaMethodResponse;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -72,11 +72,11 @@ class MFAMethodsRetrieveHandlerTest {
                 .thenReturn(Optional.of(userProfile));
 
         var method =
-                new MfaMethodData(
+                new MfaMethodResponse(
                         MFA_IDENTIFIER,
                         PriorityIdentifier.DEFAULT,
                         true,
-                        new SmsMfaDetail("+44123456789"));
+                        new RequestSmsMfaDetail("+44123456789", "123456"));
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of(method)));
 
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
@@ -86,7 +86,7 @@ class MFAMethodsRetrieveHandlerTest {
         assertThat(result, hasStatus(200));
         var expectedBody =
                 format(
-                        "[{\"mfaIdentifier\":\"%s\",\"priorityIdentifier\":\"DEFAULT\",\"methodVerified\":true,\"method\":{\"mfaMethodType\":\"SMS\",\"phoneNumber\":\"+44123456789\"}}]",
+                        "[{\"mfaIdentifier\":\"%s\",\"priorityIdentifier\":\"DEFAULT\",\"methodVerified\":true,\"method\":{\"mfaMethodType\":\"SMS\",\"phoneNumber\":\"+44123456789\",\"otp\":\"123456\"}}]",
                         MFA_IDENTIFIER);
         assertEquals(expectedBody, result.getBody());
     }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
@@ -140,6 +140,7 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             shouldReturn200AndSwitchMfaMethodPrioritiesWhenAUserSwitchesTheirBackupMethodWithTheirDefault() {
         userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, defaultPrioritySms);
         userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, backupPrioritySms);
+        var otp = redis.generateAndSavePhoneNumberCode(TEST_EMAIL, 9000);
 
         var backupMfaIdentifier = backupPrioritySms.getMfaIdentifier();
         var updateRequest =
@@ -150,12 +151,13 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                                     "priorityIdentifier": "DEFAULT",
                                     "method": {
                                         "mfaMethodType": "SMS",
-                                        "phoneNumber": "%s"
+                                        "phoneNumber": "%s",
+                                        "otp": "%s"
                                     }
                                   }
                                 }
                                 """,
-                        backupPrioritySms.getDestination());
+                        backupPrioritySms.getDestination(), otp);
 
         var response =
                 makeRequest(
@@ -223,6 +225,8 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
     void shouldReturn200AndMfaMethodDataWhenSmsUserUpdatesTheirPhoneNumber() {
         userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, defaultPrioritySms);
         userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, backupPrioritySms);
+        var otp = redis.generateAndSavePhoneNumberCode(TEST_EMAIL, 9000);
+
         var mfaIdentifier = defaultPrioritySms.getMfaIdentifier();
         var updatedPhoneNumber = "111222333";
         var updateRequest =
@@ -233,12 +237,13 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                                     "priorityIdentifier": "DEFAULT",
                                     "method": {
                                         "mfaMethodType": "SMS",
-                                        "phoneNumber": "%s"
+                                        "phoneNumber": "%s",
+                                        "otp": "%s"
                                     }
                                   }
                                 }
                                 """,
-                        updatedPhoneNumber);
+                        updatedPhoneNumber, otp);
 
         var response =
                 makeRequest(
@@ -378,21 +383,9 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
     void duplicateUpdatesShouldBeIdempotentForUpdateToBackupMethod() {
         userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, defaultPriorityAuthApp);
         userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, backupPrioritySms);
+
         var mfaIdentifierOfBackup = backupPrioritySms.getMfaIdentifier();
-        var updateRequest =
-                format(
-                        """
-                                {
-                                  "mfaMethod": {
-                                    "priorityIdentifier": "DEFAULT",
-                                    "method": {
-                                        "mfaMethodType": "SMS",
-                                        "phoneNumber": "%s"
-                                    }
-                                  }
-                                }
-                                """,
-                        backupPrioritySms.getDestination());
+        var updateRequest = buildUpdateRequestWithOtp();
 
         var requestPathParams =
                 Map.ofEntries(
@@ -422,6 +415,7 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                 backupPrioritySms, retrievedDefaultAfterFirstRequest, DEFAULT);
 
         for (int i = 0; i < 5; i++) {
+            updateRequest = buildUpdateRequestWithOtp();
             var response =
                     makeRequest(
                             Optional.of(updateRequest),
@@ -443,6 +437,24 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             assertEquals(retrievedBackupAfterFirstRequest, retrievedBackup);
             assertEquals(retrievedDefaultAfterFirstRequest, retrievedDefault);
         }
+    }
+
+    private static String buildUpdateRequestWithOtp() {
+        var otp = redis.generateAndSavePhoneNumberCode(TEST_EMAIL, 9000);
+        return format(
+                """
+                        {
+                          "mfaMethod": {
+                            "priorityIdentifier": "DEFAULT",
+                            "method": {
+                                "mfaMethodType": "SMS",
+                                "phoneNumber": "%s",
+                                "otp": "%s"
+                            }
+                          }
+                        }
+                        """,
+                backupPrioritySms.getDestination(), otp);
     }
 
     @Test

--- a/ci/terraform/account-management/mfa-methods-create.tf
+++ b/ci/terraform/account-management/mfa-methods-create.tf
@@ -7,6 +7,7 @@ module "account_management_api_mfa_methods_create_role" {
   policies_to_attach = [
     aws_iam_policy.dynamo_am_user_read_access_policy.arn,
     aws_iam_policy.dynamo_am_user_write_access_policy.arn,
+    aws_iam_policy.parameter_policy.arn
   ]
   extra_tags = {
     Service = "mfa-methods-create"

--- a/ci/terraform/account-management/mfa-methods-update.tf
+++ b/ci/terraform/account-management/mfa-methods-update.tf
@@ -7,6 +7,7 @@ module "account_management_api_mfa_methods_update_role" {
   policies_to_attach = [
     aws_iam_policy.dynamo_am_user_read_access_policy.arn,
     aws_iam_policy.dynamo_am_user_write_access_policy.arn,
+    aws_iam_policy.parameter_policy.arn
   ]
   extra_tags = {
     Service = "mfa-methods-update"

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/request/MfaDetailDeserializer.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/request/MfaDetailDeserializer.java
@@ -1,14 +1,12 @@
-package uk.gov.di.authentication.shared.serialization;
+package uk.gov.di.authentication.shared.entity.mfa.request;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import uk.gov.di.authentication.shared.entity.mfa.AuthAppMfaDetail;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
-import uk.gov.di.authentication.shared.entity.mfa.SmsMfaDetail;
 
 import java.lang.reflect.Type;
 
@@ -21,10 +19,11 @@ public class MfaDetailDeserializer implements JsonDeserializer<MfaDetail> {
 
         if (MFAMethodType.SMS.getValue().equalsIgnoreCase(type)) {
             String phoneNumber = jsonObject.get("phoneNumber").getAsString();
-            return new SmsMfaDetail(phoneNumber);
+            String otp = jsonObject.get("otp").getAsString();
+            return new RequestSmsMfaDetail(phoneNumber, otp);
         } else if (MFAMethodType.AUTH_APP.getValue().equalsIgnoreCase(type)) {
             String credential = jsonObject.get("credential").getAsString();
-            return new AuthAppMfaDetail(credential);
+            return new RequestAuthAppMfaDetail(credential);
         } else {
             throw new JsonParseException("Unknown mfa detail type: " + type);
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/request/MfaMethodCreateOrUpdateRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/request/MfaMethodCreateOrUpdateRequest.java
@@ -1,10 +1,10 @@
-package uk.gov.di.authentication.shared.entity.mfa;
+package uk.gov.di.authentication.shared.entity.mfa.request;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
-import uk.gov.di.authentication.shared.serialization.MfaDetailDeserializer;
+import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
 
 public record MfaMethodCreateOrUpdateRequest(
         @Expose @SerializedName("mfaMethod") MfaMethod mfaMethod) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/request/RequestAuthAppMfaDetail.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/request/RequestAuthAppMfaDetail.java
@@ -1,0 +1,17 @@
+package uk.gov.di.authentication.shared.entity.mfa.request;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public record RequestAuthAppMfaDetail(
+        @Expose @Required @SerializedName("mfaMethodType") MFAMethodType mfaMethodType,
+        @Expose @Required @SerializedName("credential") String credential)
+        implements MfaDetail {
+
+    public RequestAuthAppMfaDetail(String credential) {
+        this(MFAMethodType.AUTH_APP, credential);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/request/RequestSmsMfaDetail.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/request/RequestSmsMfaDetail.java
@@ -1,0 +1,18 @@
+package uk.gov.di.authentication.shared.entity.mfa.request;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public record RequestSmsMfaDetail(
+        @Expose @Required @SerializedName("mfaMethodType") MFAMethodType mfaMethodType,
+        @Expose @Required @SerializedName("phoneNumber") String phoneNumber,
+        @Expose @Required @SerializedName("otp") String otp)
+        implements MfaDetail {
+
+    public RequestSmsMfaDetail(String phoneNumber, String otp) {
+        this(MFAMethodType.SMS, phoneNumber, otp);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/response/MfaMethodResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/response/MfaMethodResponse.java
@@ -1,19 +1,22 @@
-package uk.gov.di.authentication.shared.entity.mfa;
+package uk.gov.di.authentication.shared.entity.mfa.response;
 
 import com.google.gson.annotations.Expose;
 import org.jetbrains.annotations.NotNull;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
 import uk.gov.di.authentication.shared.validation.Required;
 
-public record MfaMethodData(
+public record MfaMethodResponse(
         @Expose String mfaIdentifier,
         @Expose @Required PriorityIdentifier priorityIdentifier,
         @Expose @Required boolean methodVerified,
         @Expose @Required MfaDetail method)
-        implements Comparable<MfaMethodData> {
+        implements Comparable<MfaMethodResponse> {
 
-    public static Result<String, MfaMethodData> from(MFAMethod mfaMethod) {
+    public static Result<String, MfaMethodResponse> from(MFAMethod mfaMethod) {
         if (mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())) {
             return Result.success(
                     smsMethodData(
@@ -33,29 +36,32 @@ public record MfaMethodData(
         }
     }
 
-    public static MfaMethodData smsMethodData(
+    public static MfaMethodResponse smsMethodData(
             String mfaIdentifier,
             PriorityIdentifier priorityIdentifier,
             boolean methodVerified,
             String phoneNumber) {
-        return new MfaMethodData(
-                mfaIdentifier, priorityIdentifier, methodVerified, new SmsMfaDetail(phoneNumber));
+        return new MfaMethodResponse(
+                mfaIdentifier,
+                priorityIdentifier,
+                methodVerified,
+                new ResponseSmsMfaDetail(phoneNumber));
     }
 
-    public static MfaMethodData authAppMfaData(
+    public static MfaMethodResponse authAppMfaData(
             String mfaIdentifier,
             PriorityIdentifier priorityIdentifier,
             boolean methodVerified,
             String credential) {
-        return new MfaMethodData(
+        return new MfaMethodResponse(
                 mfaIdentifier,
                 priorityIdentifier,
                 methodVerified,
-                new AuthAppMfaDetail(credential));
+                new ResponseAuthAppMfaDetail(credential));
     }
 
     @Override
-    public int compareTo(@NotNull MfaMethodData other) {
+    public int compareTo(@NotNull MfaMethodResponse other) {
         return this.mfaIdentifier.compareTo(other.mfaIdentifier);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/response/ResponseAuthAppMfaDetail.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/response/ResponseAuthAppMfaDetail.java
@@ -1,15 +1,17 @@
-package uk.gov.di.authentication.shared.entity.mfa;
+package uk.gov.di.authentication.shared.entity.mfa.response;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
 import uk.gov.di.authentication.shared.validation.Required;
 
-public record AuthAppMfaDetail(
+public record ResponseAuthAppMfaDetail(
         @Expose @Required @SerializedName("mfaMethodType") MFAMethodType mfaMethodType,
         @Expose @Required @SerializedName("credential") String credential)
         implements MfaDetail {
 
-    public AuthAppMfaDetail(String credential) {
+    public ResponseAuthAppMfaDetail(String credential) {
         this(MFAMethodType.AUTH_APP, credential);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/response/ResponseSmsMfaDetail.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/response/ResponseSmsMfaDetail.java
@@ -1,15 +1,17 @@
-package uk.gov.di.authentication.shared.entity.mfa;
+package uk.gov.di.authentication.shared.entity.mfa.response;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
 import uk.gov.di.authentication.shared.validation.Required;
 
-public record SmsMfaDetail(
+public record ResponseSmsMfaDetail(
         @Expose @Required @SerializedName("mfaMethodType") MFAMethodType mfaMethodType,
         @Expose @Required @SerializedName("phoneNumber") String phoneNumber)
         implements MfaDetail {
 
-    public SmsMfaDetail(String phoneNumber) {
+    public ResponseSmsMfaDetail(String phoneNumber) {
         this(MFAMethodType.SMS, phoneNumber);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
@@ -6,13 +6,15 @@ import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.entity.mfa.AuthAppMfaDetail;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
-import uk.gov.di.authentication.shared.entity.mfa.MfaMethodCreateOrUpdateRequest;
-import uk.gov.di.authentication.shared.entity.mfa.MfaMethodData;
-import uk.gov.di.authentication.shared.entity.mfa.SmsMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodCreateOrUpdateRequest;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestAuthAppMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.response.MfaMethodResponse;
+import uk.gov.di.authentication.shared.entity.mfa.response.ResponseAuthAppMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.response.ResponseSmsMfaDetail;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -36,7 +38,7 @@ public class MFAMethodsService {
         this.persistentService = new DynamoService(configurationService);
     }
 
-    public Result<MfaRetrieveFailureReason, List<MfaMethodData>> getMfaMethods(String email) {
+    public Result<MfaRetrieveFailureReason, List<MfaMethodResponse>> getMfaMethods(String email) {
         var userProfile = persistentService.getUserProfileByEmail(email);
         var userCredentials = persistentService.getUserCredentialsFromEmail(email);
         if (Boolean.TRUE.equals(userProfile.getMfaMethodsMigrated())) {
@@ -47,28 +49,29 @@ public class MFAMethodsService {
         }
     }
 
-    private Result<MfaRetrieveFailureReason, List<MfaMethodData>> getMfaMethodsForMigratedUser(
+    private Result<MfaRetrieveFailureReason, List<MfaMethodResponse>> getMfaMethodsForMigratedUser(
             UserCredentials userCredentials) {
-        List<Result<MfaRetrieveFailureReason, MfaMethodData>> mfaMethodDataResults =
+        List<Result<MfaRetrieveFailureReason, MfaMethodResponse>> mfaMethodDataResults =
                 Optional.ofNullable(userCredentials.getMfaMethods())
                         .orElse(new ArrayList<>())
                         .stream()
                         .map(
                                 mfaMethod -> {
-                                    var mfaMethodData = MfaMethodData.from(mfaMethod);
+                                    var mfaMethodData = MfaMethodResponse.from(mfaMethod);
                                     if (mfaMethodData.isFailure()) {
                                         LOG.error(
                                                 "Error converting mfa method with type {} to mfa method data: {}",
                                                 mfaMethod.getMfaMethodType(),
                                                 mfaMethodData.getFailure());
                                         return Result
-                                                .<MfaRetrieveFailureReason, MfaMethodData>failure(
-                                                        MfaRetrieveFailureReason
-                                                                .ERROR_CONVERTING_MFA_METHOD_TO_MFA_METHOD_DATA);
+                                                .<MfaRetrieveFailureReason, MfaMethodResponse>
+                                                        failure(
+                                                                MfaRetrieveFailureReason
+                                                                        .ERROR_CONVERTING_MFA_METHOD_TO_MFA_METHOD_DATA);
                                     } else {
                                         return Result
-                                                .<MfaRetrieveFailureReason, MfaMethodData>success(
-                                                        mfaMethodData.getSuccess());
+                                                .<MfaRetrieveFailureReason, MfaMethodResponse>
+                                                        success(mfaMethodData.getSuccess());
                                     }
                                 })
                         .toList();
@@ -104,7 +107,7 @@ public class MFAMethodsService {
         return Result.success(mfaIdentifier);
     }
 
-    private Result<MfaRetrieveFailureReason, Optional<MfaMethodData>>
+    private Result<MfaRetrieveFailureReason, Optional<MfaMethodResponse>>
             getMfaMethodForNonMigratedUser(
                     UserProfile userProfile, UserCredentials userCredentials) {
         var enabledAuthAppMethod = getPrimaryMFAMethod(userCredentials);
@@ -129,7 +132,7 @@ public class MFAMethodsService {
             }
             return Result.success(
                     Optional.of(
-                            MfaMethodData.authAppMfaData(
+                            MfaMethodResponse.authAppMfaData(
                                     mfaIdentifier,
                                     PriorityIdentifier.DEFAULT,
                                     method.isMethodVerified(),
@@ -145,7 +148,7 @@ public class MFAMethodsService {
             }
             return Result.success(
                     Optional.of(
-                            MfaMethodData.smsMethodData(
+                            MfaMethodResponse.smsMethodData(
                                     mfaIdentifier,
                                     PriorityIdentifier.DEFAULT,
                                     true,
@@ -155,10 +158,10 @@ public class MFAMethodsService {
         }
     }
 
-    public Result<MfaCreateFailureReason, MfaMethodData> addBackupMfa(
+    public Result<MfaCreateFailureReason, MfaMethodResponse> addBackupMfa(
             String email, MfaMethodCreateOrUpdateRequest.MfaMethod mfaMethod) {
         UserCredentials userCredentials = persistentService.getUserCredentialsFromEmail(email);
-        Result<MfaRetrieveFailureReason, List<MfaMethodData>> mfaMethodsResult =
+        Result<MfaRetrieveFailureReason, List<MfaMethodResponse>> mfaMethodsResult =
                 getMfaMethodsForMigratedUser(userCredentials);
         if (mfaMethodsResult.isFailure()) {
             return Result.failure(MfaCreateFailureReason.ERROR_RETRIEVING_MFA_METHODS);
@@ -170,14 +173,18 @@ public class MFAMethodsService {
             return Result.failure(MfaCreateFailureReason.BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST);
         }
 
-        if (mfaMethod.method() instanceof SmsMfaDetail smsMfaDetail) {
+        if (mfaMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
 
             boolean phoneNumberExists =
                     mfaMethods.stream()
-                            .map(MfaMethodData::method)
-                            .filter(SmsMfaDetail.class::isInstance)
-                            .map(SmsMfaDetail.class::cast)
-                            .anyMatch(mfa -> mfa.phoneNumber().equals(smsMfaDetail.phoneNumber()));
+                            .map(MfaMethodResponse::method)
+                            .filter(ResponseSmsMfaDetail.class::isInstance)
+                            .map(ResponseSmsMfaDetail.class::cast)
+                            .anyMatch(
+                                    mfa ->
+                                            mfa.phoneNumber()
+                                                    .equalsIgnoreCase(
+                                                            requestSmsMfaDetail.phoneNumber()));
 
             if (phoneNumberExists) {
                 return Result.failure(MfaCreateFailureReason.PHONE_NUMBER_ALREADY_EXISTS);
@@ -189,21 +196,21 @@ public class MFAMethodsService {
                     MFAMethod.smsMfaMethod(
                             true,
                             true,
-                            smsMfaDetail.phoneNumber(),
+                            requestSmsMfaDetail.phoneNumber(),
                             mfaMethod.priorityIdentifier(),
                             uuid));
             return Result.success(
-                    MfaMethodData.smsMethodData(
+                    MfaMethodResponse.smsMethodData(
                             uuid,
                             mfaMethod.priorityIdentifier(),
                             true,
-                            smsMfaDetail.phoneNumber()));
+                            requestSmsMfaDetail.phoneNumber()));
         } else {
             boolean authAppExists = // TODO: Should this logic change to only look for "enabled"
                     // auth apps?
                     mfaMethods.stream()
-                            .map(MfaMethodData::method)
-                            .filter(AuthAppMfaDetail.class::isInstance)
+                            .map(MfaMethodResponse::method)
+                            .filter(ResponseAuthAppMfaDetail.class::isInstance)
                             .anyMatch(mfa -> true);
 
             if (authAppExists) {
@@ -214,21 +221,21 @@ public class MFAMethodsService {
             persistentService.addMFAMethodSupportingMultiple(
                     email,
                     MFAMethod.authAppMfaMethod(
-                            ((AuthAppMfaDetail) mfaMethod.method()).credential(),
+                            ((RequestAuthAppMfaDetail) mfaMethod.method()).credential(),
                             true,
                             true,
                             mfaMethod.priorityIdentifier(),
                             uuid));
             return Result.success(
-                    MfaMethodData.authAppMfaData(
+                    MfaMethodResponse.authAppMfaData(
                             uuid,
                             mfaMethod.priorityIdentifier(),
                             true,
-                            ((AuthAppMfaDetail) mfaMethod.method()).credential()));
+                            ((RequestAuthAppMfaDetail) mfaMethod.method()).credential()));
         }
     }
 
-    public Result<MfaUpdateFailureReason, List<MfaMethodData>> updateMfaMethod(
+    public Result<MfaUpdateFailureReason, List<MfaMethodResponse>> updateMfaMethod(
             String email, String mfaIdentifier, MfaMethodCreateOrUpdateRequest request) {
         var mfaMethods = persistentService.getUserCredentialsFromEmail(email).getMfaMethods();
 
@@ -242,8 +249,10 @@ public class MFAMethodsService {
                         method -> {
                             if (updateRequestChangesMethodType(
                                     method.getMfaMethodType(), request.mfaMethod().method())) {
-                                return Result.<MfaUpdateFailureReason, List<MfaMethodData>>failure(
-                                        MfaUpdateFailureReason.CANNOT_CHANGE_TYPE_OF_MFA_METHOD);
+                                return Result
+                                        .<MfaUpdateFailureReason, List<MfaMethodResponse>>failure(
+                                                MfaUpdateFailureReason
+                                                        .CANNOT_CHANGE_TYPE_OF_MFA_METHOD);
                             } else {
                                 return switch (PriorityIdentifier.valueOf(method.getPriority())) {
                                     case DEFAULT -> handleDefaultMethodUpdate(
@@ -260,12 +269,12 @@ public class MFAMethodsService {
                 .orElse(Result.failure(MfaUpdateFailureReason.UNKOWN_MFA_IDENTIFIER));
     }
 
-    private Result<MfaUpdateFailureReason, List<MfaMethodData>> handleBackupMethodUpdate(
+    private Result<MfaUpdateFailureReason, List<MfaMethodResponse>> handleBackupMethodUpdate(
             MFAMethod backupMethod,
             MfaMethodCreateOrUpdateRequest.MfaMethod updatedMethod,
             String email,
             List<MFAMethod> allMethods) {
-        if (updatedMethod.method() instanceof SmsMfaDetail updatedSmsDetail) {
+        if (updatedMethod.method() instanceof RequestSmsMfaDetail updatedSmsDetail) {
             var changesPhoneNumber =
                     !updatedSmsDetail.phoneNumber().equals(backupMethod.getDestination());
             if (changesPhoneNumber) {
@@ -273,7 +282,7 @@ public class MFAMethodsService {
                         MfaUpdateFailureReason.ATTEMPT_TO_UPDATE_BACKUP_METHOD_PHONE_NUMBER);
             }
         } else {
-            var authAppDetail = (AuthAppMfaDetail) updatedMethod.method();
+            var authAppDetail = (RequestAuthAppMfaDetail) updatedMethod.method();
             var changesAuthAppCredential =
                     !authAppDetail.credential().equals(backupMethod.getCredentialValue());
             if (changesAuthAppCredential) {
@@ -307,14 +316,14 @@ public class MFAMethodsService {
         return updateMfaResultToMfaMethodData(databaseUpdateResult);
     }
 
-    private Result<MfaUpdateFailureReason, List<MfaMethodData>> updateMfaResultToMfaMethodData(
+    private Result<MfaUpdateFailureReason, List<MfaMethodResponse>> updateMfaResultToMfaMethodData(
             Result<String, List<MFAMethod>> updateResult) {
-        Result<String, List<MfaMethodData>> returnedMfaMethods =
+        Result<String, List<MfaMethodResponse>> returnedMfaMethods =
                 updateResult.flatMap(
                         mfaMethods ->
                                 Result.sequenceSuccess(
                                                 mfaMethods.stream()
-                                                        .map(MfaMethodData::from)
+                                                        .map(MfaMethodResponse::from)
                                                         .toList())
                                         .map(list -> list.stream().sorted().toList()));
 
@@ -325,7 +334,7 @@ public class MFAMethodsService {
                 });
     }
 
-    private Result<MfaUpdateFailureReason, List<MfaMethodData>> handleDefaultMethodUpdate(
+    private Result<MfaUpdateFailureReason, List<MfaMethodResponse>> handleDefaultMethodUpdate(
             MFAMethod defaultMethod,
             MfaMethodCreateOrUpdateRequest.MfaMethod updatedMethod,
             String email,
@@ -338,7 +347,7 @@ public class MFAMethodsService {
 
         Result<String, List<MFAMethod>> databaseUpdateResult;
 
-        if (updatedMethod.method() instanceof SmsMfaDetail updatedSmsDetail) {
+        if (updatedMethod.method() instanceof RequestSmsMfaDetail updatedSmsDetail) {
             var isExistingDefaultPhoneNumber =
                     updatedSmsDetail.phoneNumber().equals(defaultMethod.getDestination());
             var otherMethods =
@@ -366,7 +375,7 @@ public class MFAMethodsService {
                                 email, updatedSmsDetail.phoneNumber(), mfaIdentifier);
             }
         } else {
-            var authAppDetail = (AuthAppMfaDetail) updatedMethod.method();
+            var authAppDetail = (RequestAuthAppMfaDetail) updatedMethod.method();
             if (authAppDetail.credential().equals(defaultMethod.getCredentialValue())) {
                 return Result.failure(
                         MfaUpdateFailureReason.REQUEST_TO_UPDATE_MFA_METHOD_WITH_NO_CHANGE);
@@ -382,7 +391,7 @@ public class MFAMethodsService {
 
     private boolean updateRequestChangesMethodType(
             String methodTypeFromExisting, MfaDetail updatedMethodDetail) {
-        return updatedMethodDetail instanceof AuthAppMfaDetail
+        return updatedMethodDetail instanceof RequestAuthAppMfaDetail
                 ? !MFAMethodType.AUTH_APP.name().equals(methodTypeFromExisting)
                 : !MFAMethodType.SMS.name().equals(methodTypeFromExisting);
     }
@@ -428,19 +437,21 @@ public class MFAMethodsService {
             mfaIdentifier = nonMigratedMfaMethod.mfaIdentifier();
         }
 
-        return nonMigratedMfaMethod.method() instanceof AuthAppMfaDetail
+        return nonMigratedMfaMethod.method() instanceof ResponseAuthAppMfaDetail
                 ? migrateAuthAppToNewFormat(
-                        email, (AuthAppMfaDetail) nonMigratedMfaMethod.method(), mfaIdentifier)
+                        email,
+                        (ResponseAuthAppMfaDetail) nonMigratedMfaMethod.method(),
+                        mfaIdentifier)
                 : migrateSmsToNewFormat(
-                        email, (SmsMfaDetail) nonMigratedMfaMethod.method(), mfaIdentifier);
+                        email, (ResponseSmsMfaDetail) nonMigratedMfaMethod.method(), mfaIdentifier);
     }
 
     private Optional<MfaMigrationFailureReason> migrateAuthAppToNewFormat(
-            String email, AuthAppMfaDetail authAppMfaDetail, String identifier) {
+            String email, ResponseAuthAppMfaDetail requestAuthAppMfaDetail, String identifier) {
         persistentService.overwriteMfaMethodToCredentialsAndDeleteProfilePhoneNumberForUser(
                 email,
                 MFAMethod.authAppMfaMethod(
-                        authAppMfaDetail.credential(),
+                        requestAuthAppMfaDetail.credential(),
                         true,
                         true,
                         PriorityIdentifier.DEFAULT,
@@ -449,13 +460,13 @@ public class MFAMethodsService {
     }
 
     private Optional<MfaMigrationFailureReason> migrateSmsToNewFormat(
-            String email, SmsMfaDetail smsMfaDetail, String identifier) {
+            String email, ResponseSmsMfaDetail requestSmsMfaDetail, String identifier) {
         persistentService.overwriteMfaMethodToCredentialsAndDeleteProfilePhoneNumberForUser(
                 email,
                 MFAMethod.smsMfaMethod(
                         true,
                         true,
-                        smsMfaDetail.phoneNumber(),
+                        requestSmsMfaDetail.phoneNumber(),
                         PriorityIdentifier.DEFAULT,
                         identifier));
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/serialization/MfaDetailDeserializerTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/serialization/MfaDetailDeserializerTest.java
@@ -3,27 +3,29 @@ package uk.gov.di.authentication.shared.serialization;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.shared.entity.mfa.AuthAppMfaDetail;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
-import uk.gov.di.authentication.shared.entity.mfa.SmsMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.request.MfaDetailDeserializer;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestAuthAppMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-public class MfaDetailDeserializerTest {
+class MfaDetailDeserializerTest {
 
     @Test
     void shouldDeserializeSmsMfaDetail() {
-        String json = "{\"mfaMethodType\": \"SMS\", \"phoneNumber\": \"+447700900123\"}";
+        String json =
+                "{\"mfaMethodType\": \"SMS\", \"phoneNumber\": \"+447700900123\", \"otp\":\"123456\"}";
         Gson gson =
                 new GsonBuilder()
                         .registerTypeAdapter(MfaDetail.class, new MfaDetailDeserializer())
                         .create();
         MfaDetail mfaDetail = gson.fromJson(json, MfaDetail.class);
-        assertInstanceOf(SmsMfaDetail.class, mfaDetail);
-        assertEquals(MFAMethodType.SMS, ((SmsMfaDetail) mfaDetail).mfaMethodType());
-        assertEquals("+447700900123", ((SmsMfaDetail) mfaDetail).phoneNumber());
+        assertInstanceOf(RequestSmsMfaDetail.class, mfaDetail);
+        assertEquals(MFAMethodType.SMS, ((RequestSmsMfaDetail) mfaDetail).mfaMethodType());
+        assertEquals("+447700900123", ((RequestSmsMfaDetail) mfaDetail).phoneNumber());
     }
 
     @Test
@@ -34,8 +36,8 @@ public class MfaDetailDeserializerTest {
                         .registerTypeAdapter(MfaDetail.class, new MfaDetailDeserializer())
                         .create();
         MfaDetail mfaDetail = gson.fromJson(json, MfaDetail.class);
-        assertInstanceOf(AuthAppMfaDetail.class, mfaDetail);
-        assertEquals(MFAMethodType.AUTH_APP, ((AuthAppMfaDetail) mfaDetail).mfaMethodType());
-        assertEquals("123456", ((AuthAppMfaDetail) mfaDetail).credential());
+        assertInstanceOf(RequestAuthAppMfaDetail.class, mfaDetail);
+        assertEquals(MFAMethodType.AUTH_APP, ((RequestAuthAppMfaDetail) mfaDetail).mfaMethodType());
+        assertEquals("123456", ((RequestAuthAppMfaDetail) mfaDetail).credential());
     }
 }


### PR DESCRIPTION
# What

Reinstates changes made in this [pull request](https://github.com/govuk-one-login/authentication-api/pull/6349) that implements OTP verification to the MFA methods put and create handlers. This pull request also adds permissions to get parameters from SSM.


