### PR TITLE
ATO-1596: migrate in tests and add comment to not use methods directly

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchClientSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/OrchClientSessionServiceIntegrationTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.services;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.SubjectType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -72,7 +73,9 @@ class OrchClientSessionServiceIntegrationTest {
         assertThat(session.get().getIdTokenHint(), equalTo(idTokenHint));
         assertThat(session.get().getCreationDate(), equalTo(creationDate));
         assertThat(session.get().getVtrList(), equalTo(VTR_LIST));
-        assertThat(session.get().getRpPairwiseId(), equalTo(rpPairwiseId));
+        assertThat(
+                session.get().getCorrectPairwiseIdGivenSubjectType(SubjectType.PAIRWISE.toString()),
+                equalTo(rpPairwiseId));
         assertThat(session.get().getDocAppSubjectId(), equalTo(docAppSubjectId.getValue()));
         assertThat(session.get().getClientName(), equalTo(clientName));
         // Default expiry is 1 hour (3600 seconds)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -22,6 +22,7 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCError;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import com.nimbusds.openid.connect.sdk.SubjectType;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -1538,10 +1539,15 @@ class AuthenticationCallbackHandlerTest {
         verify(orchClientSessionService, times(1))
                 .updateStoredClientSession(orchClientSessionCaptor.capture());
         assertEquals(
-                RP_PAIRWISE_ID.getValue(), orchClientSessionCaptor.getValue().getRpPairwiseId());
+                RP_PAIRWISE_ID.getValue(),
+                orchClientSessionCaptor
+                        .getValue()
+                        .getCorrectPairwiseIdGivenSubjectType(SubjectType.PAIRWISE.toString()));
         assertEquals(
                 PUBLIC_SUBJECT_ID.getValue(),
-                orchClientSessionCaptor.getValue().getPublicSubjectId());
+                orchClientSessionCaptor
+                        .getValue()
+                        .getCorrectPairwiseIdGivenSubjectType(SubjectType.PUBLIC.toString()));
     }
 
     private void clientSessionWithCredentialTrustValue(CredentialTrustLevel credentialTrustLevel) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
@@ -136,6 +136,8 @@ public class OrchClientSessionItem {
 
     @DynamoDbAttribute(ATTRIBUTE_RP_PAIRWISE_ID)
     public String getRpPairwiseId() {
+        // This is public because the DynamoDbMapper requires it to be for serialisation.
+        // Do not use it directly - use getCorrectPairwiseIdGivenSubjectType instead.
         return rpPairwiseId;
     }
 
@@ -150,6 +152,8 @@ public class OrchClientSessionItem {
 
     @DynamoDbAttribute(ATTRIBUTE_PUBLIC_SUBJECT_ID)
     public String getPublicSubjectId() {
+        // This is public because the DynamoDbMapper requires it to be for serialisation.
+        // Do not use it directly - use getCorrectPairwiseIdGivenSubjectType instead.
         return publicSubjectId;
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/ClientSessionMigrationUtils.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/ClientSessionMigrationUtils.java
@@ -1,6 +1,7 @@
 package uk.gov.di.orchestration.shared.utils;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.SubjectType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.ClientSession;
@@ -66,7 +67,8 @@ public class ClientSessionMigrationUtils {
                 && areFieldsEqual(
                         "rpPairwiseId",
                         clientSession.getRpPairwiseId(),
-                        orchClientSession.getRpPairwiseId());
+                        orchClientSession.getCorrectPairwiseIdGivenSubjectType(
+                                SubjectType.PAIRWISE.toString()));
     }
 
     private static <T> boolean areFieldsEqual(


### PR DESCRIPTION
### Wider context of change
Part of the rpPairwiseId migration. This was an offshoot of ATO-1117, the email migration. RpPairwiseId got complex enough that it deserved it's own ticket and PRs.

### What’s changed
- Replaced the remaining uses of `getRpPairwiseId` and `getPublicSubjectId` on the orchClientSession with `getCorrectPairwiseIdGivenSubjectType`. These were in tests and a temporary log helper.
- Add a comment to the `getRpPairwiseId` and `getPublicSubjectId` methods to not use them directly. If we still want to access each individual one, this should be done  by passing in the necessary subjectType into `getCorrectPairwiseIdGivenSubjectType` (eg to get exactly rpPairwiseId, can get it via `getCorrectPairwiseIdGivenSubjectType("pairwise")`, as I have done in the first commit on this PR). 

### Manual testing
tbd: depoy the dev. I am 99% confident making the methods private won't affect the interaction with dynamoDb, but I want to be safe, not sorry.

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing. **No new data accessed**
- [x] Impact on orch and auth mutual dependencies has been checked. **No changed**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required.  **N/A**
- [x] Changes have been made to stubs or not required.  **N/A**
- [x] Successfully deployed to authdev or not required.  **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required.  **N/A**
