### PR TITLE
ATO-1117: migrate email and phone number

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -346,18 +346,6 @@ public class IPVCallbackHandler
             auditService.submitAuditEvent(
                     IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED, clientId, user);
 
-            // TODO: ATO-1117: temporary logs to check values are as expected
-            LOG.info(
-                    "is email the same on authUserInfo as on session: {}",
-                    Objects.equals(session.getEmailAddress(), authUserInfo.getEmailAddress()));
-            if (userProfile.getPhoneNumber() != null) {
-                LOG.info(
-                        "is phone number the same on authUserInfo as on UserProfile: {}",
-                        Objects.equals(
-                                userProfile.getPhoneNumber(), authUserInfo.getPhoneNumber()));
-            }
-            //
-
             var tokenResponse =
                     segmentedFunctionCall(
                             "getIpvToken",

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -293,11 +293,11 @@ public class IPVCallbackHandler
                             sessionId,
                             clientId,
                             orchSession.getInternalCommonSubjectId(),
-                            session.getEmailAddress(),
+                            authUserInfo.getEmailAddress(),
                             ipAddress,
-                            Objects.isNull(userProfile.getPhoneNumber())
+                            Objects.isNull(authUserInfo.getPhoneNumber())
                                     ? AuditService.UNKNOWN
-                                    : userProfile.getPhoneNumber(),
+                                    : authUserInfo.getPhoneNumber(),
                             persistentId);
 
             if (errorObject.isPresent()) {
@@ -336,8 +336,11 @@ public class IPVCallbackHandler
                             .withGovukSigninJourneyId(clientSessionId)
                             .withSessionId(sessionId)
                             .withUserId(orchSession.getInternalCommonSubjectId())
-                            .withEmail(session.getEmailAddress())
-                            .withPhone(userProfile.getPhoneNumber())
+                            .withEmail(authUserInfo.getEmailAddress())
+                            .withPhone(
+                                    Objects.isNull(authUserInfo.getPhoneNumber())
+                                            ? AuditService.UNKNOWN
+                                            : authUserInfo.getPhoneNumber())
                             .withPersistentSessionId(persistentId);
 
             auditService.submitAuditEvent(
@@ -416,7 +419,6 @@ public class IPVCallbackHandler
                                 ipvCallbackHelper.generateReturnCodeAuthenticationResponse(
                                         authRequest,
                                         clientSessionId,
-                                        userProfile,
                                         session,
                                         sessionId,
                                         orchSession,
@@ -426,7 +428,8 @@ public class IPVCallbackHandler
                                         userIdentityUserInfo,
                                         ipAddress,
                                         persistentId,
-                                        clientId);
+                                        clientId,
+                                        authUserInfo.getEmailAddress());
                         return generateApiGatewayProxyResponse(
                                 302,
                                 "",

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -48,7 +48,6 @@ import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageServ
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
-import uk.gov.di.orchestration.shared.services.DynamoService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
 import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
@@ -87,7 +86,6 @@ public class IPVCallbackHandler
     private final SessionService sessionService;
     private final OrchSessionService orchSessionService;
     private final AuthenticationUserInfoStorageService authUserInfoStorageService;
-    private final DynamoService dynamoService;
     private final OrchClientSessionService orchClientSessionService;
     private final DynamoClientService dynamoClientService;
     private final AuditService auditService;
@@ -109,7 +107,6 @@ public class IPVCallbackHandler
             SessionService sessionService,
             OrchSessionService orchSessionService,
             AuthenticationUserInfoStorageService authUserInfoStorageService,
-            DynamoService dynamoService,
             OrchClientSessionService orchClientSessionService,
             DynamoClientService dynamoClientService,
             AuditService auditService,
@@ -124,7 +121,6 @@ public class IPVCallbackHandler
         this.sessionService = sessionService;
         this.orchSessionService = orchSessionService;
         this.authUserInfoStorageService = authUserInfoStorageService;
-        this.dynamoService = dynamoService;
         this.orchClientSessionService = orchClientSessionService;
         this.dynamoClientService = dynamoClientService;
         this.auditService = auditService;
@@ -148,7 +144,6 @@ public class IPVCallbackHandler
         this.orchSessionService = new OrchSessionService(configurationService);
         this.authUserInfoStorageService =
                 new AuthenticationUserInfoStorageService(configurationService);
-        this.dynamoService = new DynamoService(configurationService);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);
         this.auditService = new AuditService(configurationService);
@@ -175,7 +170,6 @@ public class IPVCallbackHandler
         this.orchSessionService = new OrchSessionService(configurationService);
         this.authUserInfoStorageService =
                 new AuthenticationUserInfoStorageService(configurationService);
-        this.dynamoService = new DynamoService(configurationService);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
         this.dynamoClientService = new DynamoClientService(configurationService);
         this.auditService = new AuditService(configurationService);
@@ -270,13 +264,6 @@ public class IPVCallbackHandler
                             () ->
                                     ipvAuthorisationService.validateResponse(
                                             input.getQueryStringParameters(), sessionId));
-            var userProfile =
-                    dynamoService
-                            .getUserProfileByEmailMaybe(session.getEmailAddress())
-                            .orElseThrow(
-                                    () ->
-                                            new IpvCallbackException(
-                                                    "Email from session does not have a user profile"));
 
             UserInfo authUserInfo =
                     getAuthUserInfo(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -449,7 +449,6 @@ class IPVCallbackHelperTest {
         helper.generateReturnCodeAuthenticationResponse(
                 generateAuthRequest(new OIDCClaimsRequest()),
                 CLIENT_SESSION_ID,
-                userProfile,
                 new Session(),
                 SESSION_ID,
                 orchSession,
@@ -459,7 +458,8 @@ class IPVCallbackHelperTest {
                 new UserInfo(new Subject()),
                 "127.0.0.1",
                 "a-persistent-session-id",
-                CLIENT_ID.getValue());
+                CLIENT_ID.getValue(),
+                TEST_EMAIL_ADDRESS);
 
         assertAuthorisationCodeGeneratedAndSaved();
     }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelperTest.java
@@ -34,7 +34,6 @@ import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
-import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.UserNotFoundException;
 import uk.gov.di.orchestration.shared.serialization.Json;
@@ -103,8 +102,6 @@ class IPVCallbackHelperTest {
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String TEST_PHONE_NUMBER = "012345678902";
-    private static final Subject PUBLIC_SUBJECT =
-            new Subject("TsEVC7vg0NPAmzB33vRUFztL2c0-fecKWKcc73fuDhc");
     private static final Subject SUBJECT = new Subject("subject-id");
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
@@ -128,7 +125,6 @@ class IPVCallbackHelperTest {
     private static final State RP_STATE = new State();
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final Long AUTH_TIME = 1234L;
-    private static final UserProfile userProfile = generateUserProfile();
     private static final UserInfo authUserInfo = generateAuthUserInfo();
 
     private static final UserInfo p0VotUserIdentityUserInfo =
@@ -462,16 +458,6 @@ class IPVCallbackHelperTest {
                 TEST_EMAIL_ADDRESS);
 
         assertAuthorisationCodeGeneratedAndSaved();
-    }
-
-    private static UserProfile generateUserProfile() {
-        return new UserProfile()
-                .withEmail(TEST_EMAIL_ADDRESS)
-                .withEmailVerified(true)
-                .withPhoneNumber(TEST_PHONE_NUMBER)
-                .withPhoneNumberVerified(true)
-                .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
-                .withSubjectID(SUBJECT.getValue());
     }
 
     private static UserInfo generateAuthUserInfo() {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -424,8 +424,8 @@ class IPVCallbackHandlerTest {
                         any(),
                         any(),
                         any(),
-                        any(),
                         anyString(),
+                        any(),
                         any(),
                         any(),
                         any(),
@@ -519,8 +519,8 @@ class IPVCallbackHandlerTest {
                             any(),
                             any(),
                             any(),
-                            any(),
                             anyString(),
+                            any(),
                             any(),
                             any(),
                             any(),
@@ -639,8 +639,8 @@ class IPVCallbackHandlerTest {
                         any(),
                         any(),
                         any(),
-                        any(),
                         anyString(),
+                        any(),
                         any(),
                         any(),
                         any(),
@@ -660,7 +660,6 @@ class IPVCallbackHandlerTest {
                 .generateReturnCodeAuthenticationResponse(
                         any(),
                         eq(CLIENT_SESSION_ID),
-                        eq(userProfile),
                         eq(session),
                         eq(SESSION_ID),
                         any(OrchSessionItem.class),
@@ -670,7 +669,8 @@ class IPVCallbackHandlerTest {
                         eq(userIdentityUserInfo),
                         anyString(),
                         eq(PERSISTENT_SESSION_ID),
-                        eq(CLIENT_ID.getValue()));
+                        eq(CLIENT_ID.getValue()),
+                        eq(TEST_EMAIL_ADDRESS));
     }
 
     @Test

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -816,7 +816,7 @@ class IPVCallbackHandlerTest {
     }
 
     @Test
-    void shouldRedirectToFrontendErrorPageWhenUserProfileNotFound() throws ParseException {
+    void shouldRedirectToFrontendErrorPageWhenAuthUserInfoNotFound() throws ParseException {
         usingValidSession();
         usingValidClientSession();
         Map<String, String> responseHeaders = new HashMap<>();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -304,7 +304,6 @@ class IPVCallbackHandlerTest {
                         sessionService,
                         orchSessionService,
                         authUserInfoStorageService,
-                        dynamoService,
                         orchClientSessionService,
                         dynamoClientService,
                         auditService,


### PR DESCRIPTION
### Wider context of change
This is part of the session migration work. Here, we continue the migration of IPVCallbackHandler away from using UserProfile and to using AuthUserInfo instead. A lot has needed to happen before this PR can be raised, from destroying orch session on logout, to migrating the AuthUserInfo table itself to orch. There is still some uncertainty with rpPairwiseId, but I want to get some of this over the line.

### What’s changed
In a nutshell, move from using UserProfile to using AuthUserInfo. That required a lot of detangling, as a lot of properties on UserProfile are used. Here, we continue the migration and move email and phone number over to using AuthUserInfo.

This is the final property that needs migrating in IPVCallbackHandler, so we also do some cleanup to remove UserProfile.

### Manual testing
Deployed to dev and tested an identity reuse journey worked.

Verified in logs that email and session.getEmail() are in sync [here](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22is%20email%20the%20same%20on%20authUserInfo%20as%20on%20session%3A*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1744671600&latest=1745362800&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&sid=1745338059.102406).

Verified in logs that phone number and UserProfile.getPhoneNumber() and in sync [here](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22is%20phone%20number%20the%20same%20on%20authUserInfo%20as%20on%20UserProfile%3A*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1744671600&latest=1745362800&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&sid=1745338097.102433).

### Checklist
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required. **Not required**
- [x] Changes have been made to the simulator or not required. **Not required**
- [x] Changes have been made to stubs or not required. **Not required**
- [x] Successfully deployed to authdev or not required. **Not required**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **Not required**

### Related PRs
The original PR with all the change in one:
https://github.com/govuk-one-login/authentication-api/pull/5804
