### PR TITLE
ATO-1535: Enable snapstart on spot response in some envs

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -119,6 +119,12 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
     ]
+  SnapStartEnabled:
+    !Or [
+      !Equals [dev, !Ref Environment],
+      !Equals [build, !Ref Environment],
+      !Equals [staging, !Ref Environment],
+    ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -4148,6 +4154,10 @@ Resources:
         - !Ref OrchIdentityCredentialsTableDeleteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref SpotResponseQueueConsumePolicy
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 


### PR DESCRIPTION
### Wider context of change:

SpotResponseFunction is one of our few lambdas which doesn't use redis and therefore is a good candidate for testing out snapstart. We'd like to sequentially enable this per environment to test out the effect of cold starts vs restores on this function. Looking in our logs we can see the average [INIT_DURATION for the SPOT response handler is approx ~3.5 seconds.](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?q=search%20index%3D%22gds_di_production%22%20%22*Init%20Duration*%22%20%20di_account_name_enriched%3D%22di-orchestration-production%22%20log_group%3D%22%2Faws%2Flambda%2Fproduction-spot-response-lambda%22%20%20%7C%20rex%20field%3D_raw%20%22Init%20Duration%3A%20(%3F%3CcoldStart%3E.*%3F)%20ms%22%20%7C%20stats%20avg(coldStart)&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-30d%40d&latest=now&display.page.search.tab=events&display.general.type=statistics&display.visualizations.charting.chart=line&sid=1745406578.126094) 

### What’s changed: 
- Enables Snap start in environments up to staging for the SPOT response handler

### Manual testing: 
- Deployed to dev and compared INIT_DURATION before deployment and RESTORE_DURATION after running through some identity journeys:
- Without Snapstart:
```
REPORT RequestId: 29f35b35-4567-5998-bd58-3bb783a26daa	Duration: 1372.13 ms	Billed Duration: 1373 ms	Memory Size: 1536 MB	Max Memory Used: 284 MB	Init Duration: 3289.12 ms	
```
- With SnapStart:
```
 REPORT RequestId: 14d1ecbf-82db-5707-9eaf-8c3d4843a1ff	Duration: 2206.35 ms	Billed Duration: 2410 ms	Memory Size: 1536 MB	Max Memory Used: 282 MB	Restore Duration: 1203.81 ms	Billed Restore Duration: 203 ms
```

So Snapstart is saving approx ~2 seconds

Also observed INIT logs on deployment (where Snapstart initialises the execution environment when a new alias is deployed and caches this) 

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

