### PR TITLE
Bau: Return MFA Method from getMfaMethods, rather than response data object

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/MfaMethodResponseConverterHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/MfaMethodResponseConverterHelper.java
@@ -1,43 +1,30 @@
 package uk.gov.di.accountmanagement.helpers;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.response.MfaMethodResponse;
-import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 
 import java.util.List;
 
-public class MfaMethodResponseConverterHelper {
-    private static final Logger LOG = LogManager.getLogger(MfaMethodResponseConverterHelper.class);
+import static java.lang.String.format;
 
+public class MfaMethodResponseConverterHelper {
     private MfaMethodResponseConverterHelper() {
         throw new IllegalStateException("Utility class");
     }
 
-    public static Result<MfaRetrieveFailureReason, List<MfaMethodResponse>>
-            convertMfaMethodsToMfaMethodResponse(List<MFAMethod> mfaMethods) {
-        List<Result<MfaRetrieveFailureReason, MfaMethodResponse>> mfaMethodDataResults =
+    public static Result<String, List<MfaMethodResponse>> convertMfaMethodsToMfaMethodResponse(
+            List<MFAMethod> mfaMethods) {
+        List<Result<String, MfaMethodResponse>> mfaMethodDataResults =
                 mfaMethods.stream()
                         .map(
                                 mfaMethod -> {
                                     var mfaMethodData = MfaMethodResponse.from(mfaMethod);
-                                    if (mfaMethodData.isFailure()) {
-                                        LOG.error(
-                                                "Error converting mfa method with type {} to mfa method data: {}",
-                                                mfaMethod.getMfaMethodType(),
-                                                mfaMethodData.getFailure());
-                                        return Result
-                                                .<MfaRetrieveFailureReason, MfaMethodResponse>
-                                                        failure(
-                                                                MfaRetrieveFailureReason
-                                                                        .ERROR_CONVERTING_MFA_METHOD_TO_MFA_METHOD_DATA);
-                                    } else {
-                                        return Result
-                                                .<MfaRetrieveFailureReason, MfaMethodResponse>
-                                                        success(mfaMethodData.getSuccess());
-                                    }
+                                    return mfaMethodData.mapFailure(
+                                            failure ->
+                                                    format(
+                                                            "Error converting mfa method to mfa method data: %s",
+                                                            mfaMethodData.getFailure()));
                                 })
                         .toList();
         return Result.sequenceSuccess(mfaMethodDataResults);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/MfaMethodResponseConverterHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/MfaMethodResponseConverterHelper.java
@@ -1,0 +1,45 @@
+package uk.gov.di.accountmanagement.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
+import uk.gov.di.authentication.shared.entity.mfa.response.MfaMethodResponse;
+import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
+
+import java.util.List;
+
+public class MfaMethodResponseConverterHelper {
+    private static final Logger LOG = LogManager.getLogger(MfaMethodResponseConverterHelper.class);
+
+    private MfaMethodResponseConverterHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static Result<MfaRetrieveFailureReason, List<MfaMethodResponse>>
+            convertMfaMethodsToMfaMethodResponse(List<MFAMethod> mfaMethods) {
+        List<Result<MfaRetrieveFailureReason, MfaMethodResponse>> mfaMethodDataResults =
+                mfaMethods.stream()
+                        .map(
+                                mfaMethod -> {
+                                    var mfaMethodData = MfaMethodResponse.from(mfaMethod);
+                                    if (mfaMethodData.isFailure()) {
+                                        LOG.error(
+                                                "Error converting mfa method with type {} to mfa method data: {}",
+                                                mfaMethod.getMfaMethodType(),
+                                                mfaMethodData.getFailure());
+                                        return Result
+                                                .<MfaRetrieveFailureReason, MfaMethodResponse>
+                                                        failure(
+                                                                MfaRetrieveFailureReason
+                                                                        .ERROR_CONVERTING_MFA_METHOD_TO_MFA_METHOD_DATA);
+                                    } else {
+                                        return Result
+                                                .<MfaRetrieveFailureReason, MfaMethodResponse>
+                                                        success(mfaMethodData.getSuccess());
+                                    }
+                                })
+                        .toList();
+        return Result.sequenceSuccess(mfaMethodDataResults);
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
@@ -7,20 +7,16 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.accountmanagement.helpers.MfaMethodResponseConverterHelper;
 import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
-import uk.gov.di.authentication.shared.entity.mfa.response.MfaMethodResponse;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
-import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 
-import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
@@ -105,7 +101,9 @@ public class MFAMethodsRetrieveHandler
         var retrieveResult =
                 mfaMethodsService
                         .getMfaMethods(maybeUserProfile.get().getEmail())
-                        .flatMap(this::convertMfaMethodsToMfaMethodResponse);
+                        .flatMap(
+                                MfaMethodResponseConverterHelper
+                                        ::convertMfaMethodsToMfaMethodResponse);
 
         if (retrieveResult.isFailure()) {
             return switch (retrieveResult.getFailure()) {
@@ -127,32 +125,5 @@ public class MFAMethodsRetrieveHandler
         Map<String, String> headers = input.getHeaders();
         String sessionId = RequestHeaderHelper.getHeaderValueOrElse(headers, SESSION_ID_HEADER, "");
         attachSessionIdToLogs(sessionId);
-    }
-
-    private Result<MfaRetrieveFailureReason, List<MfaMethodResponse>>
-            convertMfaMethodsToMfaMethodResponse(List<MFAMethod> mfaMethods) {
-        List<Result<MfaRetrieveFailureReason, MfaMethodResponse>> mfaMethodDataResults =
-                mfaMethods.stream()
-                        .map(
-                                mfaMethod -> {
-                                    var mfaMethodData = MfaMethodResponse.from(mfaMethod);
-                                    if (mfaMethodData.isFailure()) {
-                                        LOG.error(
-                                                "Error converting mfa method with type {} to mfa method data: {}",
-                                                mfaMethod.getMfaMethodType(),
-                                                mfaMethodData.getFailure());
-                                        return Result
-                                                .<MfaRetrieveFailureReason, MfaMethodResponse>
-                                                        failure(
-                                                                MfaRetrieveFailureReason
-                                                                        .ERROR_CONVERTING_MFA_METHOD_TO_MFA_METHOD_DATA);
-                                    } else {
-                                        return Result
-                                                .<MfaRetrieveFailureReason, MfaMethodResponse>
-                                                        success(mfaMethodData.getSuccess());
-                                    }
-                                })
-                        .toList();
-        return Result.sequenceSuccess(mfaMethodDataResults);
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/MfaMethodResponseConverterHelperTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/MfaMethodResponseConverterHelperTest.java
@@ -1,0 +1,93 @@
+package uk.gov.di.accountmanagement.helpers;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
+import uk.gov.di.authentication.shared.entity.mfa.response.MfaMethodResponse;
+import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.accountmanagement.helpers.MfaMethodResponseConverterHelper.convertMfaMethodsToMfaMethodResponse;
+import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.BACKUP;
+import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
+
+class MfaMethodResponseConverterHelperTest {
+    private static final String PHONE_NUMBER = "+447900000000";
+    private static final String DEFAULT_SMS_MFA_IDENTIFIER = "f78f2603-bcc2-4602-9897-d9ea76a343c7";
+    private static final String DEFAULT_AUTH_APP_MFA_IDENTIFIER =
+            "3c7a7f92-006f-4ab8-b3ae-4ce1032df9dd";
+    private static final String BACKUP_AUTH_APP_MFA_IDENTIFIER =
+            "a1bbb03d-5f3e-4b3f-9439-46e648c3d892";
+    private static final String AUTH_APP_CREDENTIAL = "some-credential";
+    private static final String AUTH_APP_CREDENTIAL_2 = "another-credential";
+    private static final MFAMethod SMS_MFA_METHOD =
+            MFAMethod.smsMfaMethod(true, true, PHONE_NUMBER, DEFAULT, DEFAULT_SMS_MFA_IDENTIFIER);
+    private static final MfaMethodResponse SMS_MFA_METHOD_AS_MFA_METHOD_RESPONSE =
+            MfaMethodResponse.smsMethodData(
+                    DEFAULT_SMS_MFA_IDENTIFIER, DEFAULT, true, PHONE_NUMBER);
+    private static final MFAMethod DEFAULT_AUTH_APP_MFA_METHOD =
+            MFAMethod.authAppMfaMethod(
+                    AUTH_APP_CREDENTIAL, true, true, DEFAULT, DEFAULT_AUTH_APP_MFA_IDENTIFIER);
+    private static final MfaMethodResponse DEFAULT_AUTH_APP_MFA_AS_MFA_METHOD_RESPONSE =
+            MfaMethodResponse.authAppMfaData(
+                    DEFAULT_AUTH_APP_MFA_IDENTIFIER, DEFAULT, true, AUTH_APP_CREDENTIAL);
+    private static final MFAMethod BACKUP_AUTH_APP_MFA_METHOD =
+            MFAMethod.authAppMfaMethod(
+                    AUTH_APP_CREDENTIAL_2, true, true, BACKUP, BACKUP_AUTH_APP_MFA_IDENTIFIER);
+    private static final MfaMethodResponse BACKUP_AUTH_APP_MFA_AS_MFA_METHOD_RESPONSE =
+            MfaMethodResponse.authAppMfaData(
+                    BACKUP_AUTH_APP_MFA_IDENTIFIER, BACKUP, true, AUTH_APP_CREDENTIAL_2);
+
+    private static Stream<Arguments> convertableMethodsToExpectedMfaMethodResponses() {
+        return Stream.of(
+                Arguments.of(
+                        List.of(SMS_MFA_METHOD), List.of(SMS_MFA_METHOD_AS_MFA_METHOD_RESPONSE)),
+                Arguments.of(
+                        List.of(DEFAULT_AUTH_APP_MFA_METHOD),
+                        List.of(DEFAULT_AUTH_APP_MFA_AS_MFA_METHOD_RESPONSE)),
+                Arguments.of(
+                        List.of(SMS_MFA_METHOD, BACKUP_AUTH_APP_MFA_METHOD),
+                        List.of(
+                                SMS_MFA_METHOD_AS_MFA_METHOD_RESPONSE,
+                                BACKUP_AUTH_APP_MFA_AS_MFA_METHOD_RESPONSE)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("convertableMethodsToExpectedMfaMethodResponses")
+    void shouldSuccessfullyConvertMfaMethodsToReponses(
+            List<MFAMethod> mfaMethods, List<MfaMethodResponse> expectedResponses) {
+        var convertedResult = convertMfaMethodsToMfaMethodResponse(mfaMethods);
+
+        var expectedResult = Result.success(expectedResponses);
+
+        assertEquals(expectedResult, convertedResult);
+    }
+
+    private static Stream<List<MFAMethod>> methodsIncludingInvalidMfa() {
+        var invalidMfaMethod =
+                new MFAMethod("not a valid mfa type", null, true, true, "updated-at");
+        return Stream.of(
+                List.of(invalidMfaMethod),
+                List.of(invalidMfaMethod, SMS_MFA_METHOD),
+                List.of(SMS_MFA_METHOD, invalidMfaMethod),
+                List.of(SMS_MFA_METHOD, BACKUP_AUTH_APP_MFA_METHOD, invalidMfaMethod));
+    }
+
+    @ParameterizedTest
+    @MethodSource("methodsIncludingInvalidMfa")
+    void shouldReturnAnErrorIfAnyMethodsFailToConvert(
+            List<MFAMethod> mfaMethodsIncludingUncovertableMfaMethod) {
+        var convertedResult =
+                convertMfaMethodsToMfaMethodResponse(mfaMethodsIncludingUncovertableMfaMethod);
+
+        assertEquals(
+                Result.failure(
+                        MfaRetrieveFailureReason.ERROR_CONVERTING_MFA_METHOD_TO_MFA_METHOD_DATA),
+                convertedResult);
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
@@ -12,8 +12,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
-import uk.gov.di.authentication.shared.entity.mfa.response.MfaMethodResponse;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -72,11 +71,8 @@ class MFAMethodsRetrieveHandlerTest {
                 .thenReturn(Optional.of(userProfile));
 
         var method =
-                new MfaMethodResponse(
-                        MFA_IDENTIFIER,
-                        PriorityIdentifier.DEFAULT,
-                        true,
-                        new RequestSmsMfaDetail("+44123456789", "123456"));
+                MFAMethod.smsMfaMethod(
+                        true, true, "+44123456789", PriorityIdentifier.DEFAULT, MFA_IDENTIFIER);
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of(method)));
 
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
@@ -86,7 +82,7 @@ class MFAMethodsRetrieveHandlerTest {
         assertThat(result, hasStatus(200));
         var expectedBody =
                 format(
-                        "[{\"mfaIdentifier\":\"%s\",\"priorityIdentifier\":\"DEFAULT\",\"methodVerified\":true,\"method\":{\"mfaMethodType\":\"SMS\",\"phoneNumber\":\"+44123456789\",\"otp\":\"123456\"}}]",
+                        "[{\"mfaIdentifier\":\"%s\",\"priorityIdentifier\":\"DEFAULT\",\"methodVerified\":true,\"method\":{\"mfaMethodType\":\"SMS\",\"phoneNumber\":\"+44123456789\"}}]",
                         MFA_IDENTIFIER);
         assertEquals(expectedBody, result.getBody());
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
@@ -5,9 +5,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -24,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -119,35 +115,43 @@ class MFAMethodsRetrieveHandlerTest {
         assertThat(result, hasStatus(404));
     }
 
-    private static Stream<Arguments> mfaRetrieveFailureReasonsToExpectedErrors() {
-        return Stream.of(
-                Arguments.of(
-                        MfaRetrieveFailureReason.ERROR_CONVERTING_MFA_METHOD_TO_MFA_METHOD_DATA,
-                        500,
-                        ErrorResponse.ERROR_1064),
-                Arguments.of(
-                        MfaRetrieveFailureReason
-                                .UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP,
-                        500,
-                        ErrorResponse.ERROR_1078));
-    }
-
-    @ParameterizedTest
-    @MethodSource("mfaRetrieveFailureReasonsToExpectedErrors")
-    void shouldReturn500IfDynamoServiceReturnsError(
-            MfaRetrieveFailureReason error,
-            int expectedStatusCode,
-            ErrorResponse expectedErrorResponse) {
+    @Test
+    void shouldReturn500IfDynamoServiceReturnsError() {
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
+        var error =
+                MfaRetrieveFailureReason
+                        .UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP;
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.failure(error));
 
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
 
         var result = handler.handleRequest(event, context);
 
-        assertThat(result, hasStatus(expectedStatusCode));
-        assertThat(result, hasJsonBody(expectedErrorResponse));
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1078));
+    }
+
+    @Test
+    void shouldReturn500IfMfaMethodDoesNotHaveValidType() {
+        when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
+                .thenReturn(Optional.of(userProfile));
+        var mfaMethodWithInvalidType =
+                new MFAMethod(
+                        "not a valid type",
+                        "some-credential",
+                        true,
+                        true,
+                        "some-updated-timestamp");
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(mfaMethodWithInvalidType)));
+
+        var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1064));
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/MFAMethod.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/MFAMethod.java
@@ -9,7 +9,7 @@ import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import java.util.Objects;
 
 @DynamoDbBean
-public class MFAMethod {
+public class MFAMethod implements Comparable<MFAMethod> {
 
     public static final String ATTRIBUTE_MFA_METHOD_TYPE = "MfaMethodType";
     public static final String ATTRIBUTE_CREDENTIAL_VALUE = "CredentialValue";
@@ -206,5 +206,19 @@ public class MFAMethod {
     @Override
     public int hashCode() {
         return Objects.hash(mfaMethodType, credentialValue, methodVerified, enabled, updated);
+    }
+
+    @Override
+    public int compareTo(MFAMethod other) {
+        if (this.mfaIdentifier == null && other.mfaIdentifier == null) {
+            return 0;
+        }
+        if (this.mfaIdentifier == null) {
+            return -1;
+        }
+        if (other.mfaIdentifier == null) {
+            return 1;
+        }
+        return this.mfaIdentifier.compareTo(other.mfaIdentifier);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
@@ -40,16 +40,14 @@ public class MFAMethodsService {
         this.persistentService = new DynamoService(configurationService);
     }
 
-    public Result<MfaRetrieveFailureReason, List<MfaMethodResponse>> getMfaMethods(String email) {
+    public Result<MfaRetrieveFailureReason, List<MFAMethod>> getMfaMethods(String email) {
         var userProfile = persistentService.getUserProfileByEmail(email);
         var userCredentials = persistentService.getUserCredentialsFromEmail(email);
         if (Boolean.TRUE.equals(userProfile.getMfaMethodsMigrated())) {
-            return convertMfaMethodsToMfaMethodResponse(
-                    getMfaMethodsForMigratedUser(userCredentials));
+            return Result.success(getMfaMethodsForMigratedUser(userCredentials));
         } else {
             return getMfaMethodForNonMigratedUser(userProfile, userCredentials)
-                    .map(optional -> optional.map(List::of).orElseGet(List::of))
-                    .flatMap(this::convertMfaMethodsToMfaMethodResponse);
+                    .map(optional -> optional.map(List::of).orElseGet(List::of));
         }
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaRetrieveFailureReason.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaRetrieveFailureReason.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.shared.services.mfa;
 
 public enum MfaRetrieveFailureReason {
-    ERROR_CONVERTING_MFA_METHOD_TO_MFA_METHOD_DATA,
     UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP
 }


### PR DESCRIPTION
## What

We currently have two ways of representing an mfa method in the shared project:

* MFAMethod - which represents the item stored in the database; and
* MfaMethodResponse - which is a representation of the response we return for mfa methods in the method management api.

Originally this second object was introduced as a generic representation of the mfa method that could be used in both the account management api and the frontend api, but:

* we want to decouple these apis as much as possible; and
* there are slight differences in the data required by them (for example, the frontend api only ever returns a partially obscured phone number)

This PR, therefore, is the first step in moving the MfaMethodResponse from shared into the account management api. It focuses on the retrieve mfa methods functionality only, and ensures that in our shared MfaMethodsService, the retrieve method returns a list of MFAMethods, rather than a list of MfaMethodResponses, to make it as reusable as possible.

Note that this is the first step in the overall refactoring - the other methods in this shared service still use the MfaMethodResponse in their return types, so this PR alone does not enable us to move the MfaMethodResponse and associated records out of shared.

## How to review

1. Code Review
