### PR TITLE
ATO-1535: Turn on snapstart for spot response in int and prod

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -119,7 +119,7 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
     ]
-  SnapStartEnabled:
+  SnapStartEnabledSpotResponse:
     !Or [
       !Equals [dev, !Ref Environment],
       !Equals [build, !Ref Environment],
@@ -4226,7 +4226,7 @@ Resources:
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref SpotResponseQueueConsumePolicy
       SnapStart: !If
-        - SnapStartEnabled
+        - SnapStartEnabledSpotResponse
         - ApplyOn: PublishedVersions
         - !Ref AWS::NoValue
       Tags:

--- a/template.yaml
+++ b/template.yaml
@@ -124,6 +124,8 @@ Conditions:
       !Equals [dev, !Ref Environment],
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
+      !Equals [integration, !Ref Environment],
+      !Equals [production, !Ref Environment],
     ]
 
 Mappings:


### PR DESCRIPTION
### Wider context of change: 

We previously enabled SnapStart on the SpotResponse handler and we are now happy with the results and therefore will enable this in integration and production.


### What’s changed: 

- Enables SnapStart on SPOT response handler in integration and production envrionments

### Manual testing: 
- Reviewed the logs in staging before and after this feature was enabled and asserted a restore is much faster than a cold start

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
