### PR TITLE
AUT-4213: Give cross account access to dev dynamo DB table

### DIFF
--- a/ci/terraform/interventions-api-stub/authdev1.tfvars
+++ b/ci/terraform/interventions-api-stub/authdev1.tfvars
@@ -1,2 +1,5 @@
 shared_state_bucket = "di-auth-development-tfstate"
 vpc_environment     = "dev"
+
+# Account IDs
+auth_new_account_id = "975050272416"

--- a/ci/terraform/interventions-api-stub/authdev2.tfvars
+++ b/ci/terraform/interventions-api-stub/authdev2.tfvars
@@ -1,2 +1,5 @@
 shared_state_bucket = "di-auth-development-tfstate"
 vpc_environment     = "dev"
+
+# Account IDs
+auth_new_account_id = "975050272416"

--- a/ci/terraform/interventions-api-stub/build.tfvars
+++ b/ci/terraform/interventions-api-stub/build.tfvars
@@ -8,3 +8,6 @@ logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_c
 
 # Scaling
 lambda_min_concurrency = 1
+
+# Account IDs
+auth_new_account_id = "058264536367"

--- a/ci/terraform/interventions-api-stub/dev.tfvars
+++ b/ci/terraform/interventions-api-stub/dev.tfvars
@@ -2,3 +2,6 @@ shared_state_bucket = "di-auth-development-tfstate"
 
 # VPC
 orchestration_vpc_endpoint_id = "vpce-0028f62dad635589a"
+
+# Account IDs
+auth_new_account_id = "975050272416"

--- a/ci/terraform/interventions-api-stub/dynamodb.tf
+++ b/ci/terraform/interventions-api-stub/dynamodb.tf
@@ -47,3 +47,38 @@ resource "aws_iam_policy" "stub_interventions_dynamo_read_access" {
 
   policy = data.aws_iam_policy_document.stub_interventions_dynamo_read_access.json
 }
+
+## DynamoDB Resource Policies
+## These policies are used to allow cross-account access to the DynamoDB tables
+
+locals {
+  restricted_environments = ["production", "integration", "staging"]
+  create_resource         = !contains(local.restricted_environments, var.environment)
+}
+resource "aws_dynamodb_resource_policy" "stub_account_interventions_table" {
+  count        = local.create_resource ? 1 : 0
+  resource_arn = aws_dynamodb_table.stub_account_interventions_table.arn
+  policy       = data.aws_iam_policy_document.cross_account_table_resource_policy_document[0].json
+}
+
+data "aws_iam_policy_document" "cross_account_table_resource_policy_document" {
+  count = local.create_resource ? 1 : 0
+  statement {
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:BatchWriteItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    effect = "Allow"
+    principals {
+      identifiers = [var.auth_new_account_id]
+      type        = "AWS"
+    }
+    resources = ["*"]
+  }
+}

--- a/ci/terraform/interventions-api-stub/variables.tf
+++ b/ci/terraform/interventions-api-stub/variables.tf
@@ -88,3 +88,9 @@ variable "vpc_environment" {
   type        = string
   default     = null
 }
+
+variable "auth_new_account_id" {
+  type        = string
+  description = "Account id of the auth new AWS account"
+  default     = ""
+}

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -792,12 +792,6 @@ resource "aws_dynamodb_resource_policy" "user_credentials_table" {
   policy       = data.aws_iam_policy_document.auth_cross_account_table_resource_policy_document[0].json
 }
 
-resource "aws_dynamodb_resource_policy" "doc_app_credential_table" {
-  count        = local.allow_cross_account_access ? 1 : 0
-  resource_arn = aws_dynamodb_table.doc_app_credential_table.arn
-  policy       = data.aws_iam_policy_document.auth_cross_account_table_resource_policy_document[0].json
-}
-
 resource "aws_dynamodb_resource_policy" "common_passwords_table" {
   count        = local.allow_cross_account_access ? 1 : 0
   resource_arn = aws_dynamodb_table.common_passwords_table.arn

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -848,8 +848,8 @@ resource "aws_dynamodb_resource_policy" "id_reverification_state" {
 
 
 locals {
-  allowed_environments       = ["dev", "authdev1", "authdev2", "sandpit"]
-  allow_cross_account_access = contains(local.allowed_environments, var.environment)
+  allowed_env                = ["dev", "authdev1", "authdev2", "sandpit"]
+  allow_cross_account_access = contains(local.allowed_env, var.environment)
 }
 
 

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -854,6 +854,8 @@ locals {
 
 
 data "aws_iam_policy_document" "auth_cross_account_table_resource_policy_document" {
+  #checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints
+  #checkov:skip=CKV_AWS_356:Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions
   count = local.allow_cross_account_access ? 1 : 0
   statement {
     actions = [

--- a/ci/terraform/ticf-cri-stub/authdev1.tfvars
+++ b/ci/terraform/ticf-cri-stub/authdev1.tfvars
@@ -1,2 +1,5 @@
 shared_state_bucket = "di-auth-development-tfstate"
 vpc_environment     = "dev"
+
+# Account IDs
+auth_new_account_id = "975050272416"

--- a/ci/terraform/ticf-cri-stub/authdev2.tfvars
+++ b/ci/terraform/ticf-cri-stub/authdev2.tfvars
@@ -1,2 +1,5 @@
 shared_state_bucket = "di-auth-development-tfstate"
 vpc_environment     = "dev"
+
+# Account IDs
+auth_new_account_id = "975050272416"

--- a/ci/terraform/ticf-cri-stub/build.tfvars
+++ b/ci/terraform/ticf-cri-stub/build.tfvars
@@ -5,3 +5,6 @@ logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_c
 
 # Sizing
 lambda_min_concurrency = 1
+
+# Account IDs
+auth_new_account_id = "058264536367"

--- a/ci/terraform/ticf-cri-stub/dev.tfvars
+++ b/ci/terraform/ticf-cri-stub/dev.tfvars
@@ -2,3 +2,6 @@ shared_state_bucket = "di-auth-development-tfstate"
 
 # Sizing
 lambda_min_concurrency = 1
+
+# Account IDs
+auth_new_account_id = "975050272416"

--- a/ci/terraform/ticf-cri-stub/variables.tf
+++ b/ci/terraform/ticf-cri-stub/variables.tf
@@ -82,3 +82,9 @@ variable "vpc_environment" {
   type        = string
   default     = null
 }
+
+variable "auth_new_account_id" {
+  type        = string
+  description = "Account id of the auth new AWS account"
+  default     = ""
+}


### PR DESCRIPTION
## What

[AUT-4213]

PR to add policy to dynamo DB for cross account table access

## How to review

1. Code Review
2. Deploy to Dev env and verify the Dynamo DB tables permission to all table in Dev environment

3. Deploy Account invention stub  &  TICF stub in authdevs 

./deploy-authdevs.sh -i -p   ( deploy the account interventions API stub)   verify the Dynamo DB tables permission for stub table 
./deploy-authdevs.sh --ticf-stub -p   ( deploy the TICF CRI stub) verify the Dynamo DB tables permission for ticf stub table 


[AUT-4213]: https://govukverify.atlassian.net/browse/AUT-4213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ