### PR TITLE
ATO-1481: increase back channel logout DLQ retention period to 3 days

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -4362,7 +4362,7 @@ Resources:
       QueueName: !Sub ${Environment}-BackChannelLogoutDlq
       KmsMasterKeyId: !GetAtt BackChannelLogoutQueueEncryptionKey.Arn
       KmsDataKeyReusePeriodSeconds: 300
-      MessageRetentionPeriod: 21600
+      MessageRetentionPeriod: 259200
 
   BackChannelLogoutQueueEncryptionKey:
     Type: AWS::KMS::Key


### PR DESCRIPTION
### Wider context of change

Failed POST requests for the back channel logout get added to a DLQ. Current retention period for the DLQ is 6hrs. We want to increase it to 3 days. Minor issue of time spent in the queue before moving to the DLQ is included in the retention period (and the queue's retention period is 14 days) but we don't expect the message to stay in the queue for that long. It's also not a huge issue if we do miss the back channel logout due to logs and this being mostly for awareness than action.

### What’s changed

Retention period has changed from 6hrs to 3 days.

### Manual testing

N/A

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**