### PR TITLE
AUT-1416: Return `mfaMethods` in `LoginHandler`

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
@@ -3,8 +3,11 @@ package uk.gov.di.authentication.frontendapi.entity;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.entity.UserMfaDetail;
+import uk.gov.di.authentication.frontendapi.entity.mfa.MfaMethodResponse;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.validation.Required;
+
+import java.util.List;
 
 public record LoginResponse(
         @SerializedName("redactedPhoneNumber") @Expose String redactedPhoneNumber,
@@ -13,6 +16,7 @@ public record LoginResponse(
                 boolean latestTermsAndConditionsAccepted,
         @SerializedName("mfaMethodType") @Expose @Required MFAMethodType mfaMethodType,
         @SerializedName("mfaMethodVerified") @Expose @Required boolean mfaMethodVerified,
+        @SerializedName("mfaMethods") @Expose @Required List<MfaMethodResponse> mfaMethodResponses,
         @SerializedName(value = "passwordChangeRequired") @Expose @Required
                 boolean passwordChangeRequired) {
 
@@ -20,6 +24,7 @@ public record LoginResponse(
             String redactedPhoneNumber,
             UserMfaDetail mfaDetail,
             boolean latestTermsAndConditionsAccepted,
+            List<MfaMethodResponse> mfaMethodResponses,
             boolean passwordChangeRequired) {
         this(
                 redactedPhoneNumber,
@@ -27,6 +32,7 @@ public record LoginResponse(
                 latestTermsAndConditionsAccepted,
                 mfaDetail.mfaMethodType(),
                 mfaDetail.mfaMethodVerified(),
+                mfaMethodResponses,
                 passwordChangeRequired);
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/mfa/AuthAppMfaMethodResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/mfa/AuthAppMfaMethodResponse.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.frontendapi.entity.mfa;
+
+import com.google.gson.annotations.Expose;
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public record AuthAppMfaMethodResponse(
+        @Expose @Required String id,
+        @Expose @Required MFAMethodType type,
+        @Expose @Required PriorityIdentifier priority)
+        implements MfaMethodResponse {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/mfa/MfaMethodResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/mfa/MfaMethodResponse.java
@@ -1,7 +1,11 @@
 package uk.gov.di.authentication.frontendapi.entity.mfa;
 
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+
+import static uk.gov.di.authentication.frontendapi.helpers.FrontendApiPhoneNumberHelper.redactPhoneNumber;
 
 public sealed interface MfaMethodResponse permits SmsMfaMethodResponse, AuthAppMfaMethodResponse {
     String id();
@@ -9,4 +13,37 @@ public sealed interface MfaMethodResponse permits SmsMfaMethodResponse, AuthAppM
     PriorityIdentifier priority();
 
     MFAMethodType type();
+
+    static Result<String, MfaMethodResponse> from(MFAMethod mfaMethod) {
+        String id = mfaMethod.getMfaIdentifier();
+        MFAMethodType type;
+        try {
+            type = MFAMethodType.valueOf(mfaMethod.getMfaMethodType());
+        } catch (NullPointerException | IllegalArgumentException e) {
+            return Result.failure("Unsupported MFA method type: " + mfaMethod.getMfaMethodType());
+        }
+
+        PriorityIdentifier priority;
+        try {
+            priority = PriorityIdentifier.valueOf(mfaMethod.getPriority());
+        } catch (NullPointerException | IllegalArgumentException e) {
+            return Result.failure("Unsupported PriorityIdentifier: " + mfaMethod.getPriority());
+        }
+
+        return switch (type) {
+            case SMS -> {
+                String phoneNumber = mfaMethod.getDestination();
+                yield Result.success(
+                        new SmsMfaMethodResponse(
+                                id,
+                                MFAMethodType.SMS,
+                                priority,
+                                phoneNumber != null ? redactPhoneNumber(phoneNumber) : null));
+            }
+            case AUTH_APP -> Result.success(
+                    new AuthAppMfaMethodResponse(id, MFAMethodType.AUTH_APP, priority));
+            default -> Result.failure(
+                    "Unsupported MFA method type: " + mfaMethod.getMfaMethodType());
+        };
+    }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/mfa/MfaMethodResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/mfa/MfaMethodResponse.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.frontendapi.entity.mfa;
+
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+
+public sealed interface MfaMethodResponse permits SmsMfaMethodResponse, AuthAppMfaMethodResponse {
+    String id();
+
+    PriorityIdentifier priority();
+
+    MFAMethodType type();
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/mfa/SmsMfaMethodResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/mfa/SmsMfaMethodResponse.java
@@ -1,0 +1,14 @@
+package uk.gov.di.authentication.frontendapi.entity.mfa;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public record SmsMfaMethodResponse(
+        @Expose @Required String id,
+        @Expose @Required MFAMethodType type,
+        @Expose @Required PriorityIdentifier priority,
+        @SerializedName("redactedPhoneNumber") @Expose String redactedPhoneNumber)
+        implements MfaMethodResponse {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/MfaMethodResponseConverterHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/MfaMethodResponseConverterHelper.java
@@ -1,0 +1,32 @@
+package uk.gov.di.authentication.frontendapi.helpers;
+
+import uk.gov.di.authentication.frontendapi.entity.mfa.MfaMethodResponse;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
+
+import java.util.List;
+
+import static java.lang.String.format;
+
+public class MfaMethodResponseConverterHelper {
+    private MfaMethodResponseConverterHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static Result<String, List<MfaMethodResponse>> convertMfaMethodsToMfaMethodResponse(
+            List<MFAMethod> mfaMethods) {
+        List<Result<String, MfaMethodResponse>> mfaMethodDataResults =
+                mfaMethods.stream()
+                        .map(
+                                mfaMethod -> {
+                                    var mfaMethodData = MfaMethodResponse.from(mfaMethod);
+                                    return mfaMethodData.mapFailure(
+                                            failure ->
+                                                    format(
+                                                            "Error converting mfa method to mfa method data: %s",
+                                                            mfaMethodData.getFailure()));
+                                })
+                        .toList();
+        return Result.sequenceSuccess(mfaMethodDataResults);
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/serialization/MfaMethodResponseAdapter.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/serialization/MfaMethodResponseAdapter.java
@@ -1,0 +1,37 @@
+package uk.gov.di.authentication.frontendapi.serialization;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import uk.gov.di.authentication.frontendapi.entity.mfa.AuthAppMfaMethodResponse;
+import uk.gov.di.authentication.frontendapi.entity.mfa.MfaMethodResponse;
+import uk.gov.di.authentication.frontendapi.entity.mfa.SmsMfaMethodResponse;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+
+import java.io.IOException;
+
+import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.AUTH_APP;
+
+public class MfaMethodResponseAdapter extends TypeAdapter<MfaMethodResponse> {
+    private final Gson gson = new Gson();
+
+    @Override
+    public void write(JsonWriter out, MfaMethodResponse value) throws IOException {
+        gson.toJson(value, value.getClass(), out);
+    }
+
+    @Override
+    public MfaMethodResponse read(JsonReader in) throws IOException {
+        JsonObject jsonObject = JsonParser.parseReader(in).getAsJsonObject();
+        String type = jsonObject.get("type").getAsString();
+        MFAMethodType mfaMethodType = MFAMethodType.valueOf(type);
+        return gson.fromJson(
+                jsonObject,
+                mfaMethodType == AUTH_APP
+                        ? AuthAppMfaMethodResponse.class
+                        : SmsMfaMethodResponse.class);
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/MfaMethodResponseConverterHelperTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/MfaMethodResponseConverterHelperTest.java
@@ -1,0 +1,110 @@
+package uk.gov.di.authentication.frontendapi.helpers;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.frontendapi.entity.mfa.AuthAppMfaMethodResponse;
+import uk.gov.di.authentication.frontendapi.entity.mfa.MfaMethodResponse;
+import uk.gov.di.authentication.frontendapi.entity.mfa.SmsMfaMethodResponse;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.frontendapi.helpers.FrontendApiPhoneNumberHelper.redactPhoneNumber;
+import static uk.gov.di.authentication.frontendapi.helpers.MfaMethodResponseConverterHelper.convertMfaMethodsToMfaMethodResponse;
+import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.BACKUP;
+import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
+
+class MfaMethodResponseConverterHelperTest {
+    private static final String PHONE_NUMBER = "+447900000000";
+    private static final String DEFAULT_SMS_MFA_IDENTIFIER = "f78f2603-bcc2-4602-9897-d9ea76a343c7";
+    private static final String DEFAULT_AUTH_APP_MFA_IDENTIFIER =
+            "3c7a7f92-006f-4ab8-b3ae-4ce1032df9dd";
+    private static final String BACKUP_AUTH_APP_MFA_IDENTIFIER =
+            "a1bbb03d-5f3e-4b3f-9439-46e648c3d892";
+    private static final String AUTH_APP_CREDENTIAL = "some-credential";
+    private static final String AUTH_APP_CREDENTIAL_2 = "another-credential";
+    private static final MFAMethod SMS_MFA_METHOD =
+            MFAMethod.smsMfaMethod(true, true, PHONE_NUMBER, DEFAULT, DEFAULT_SMS_MFA_IDENTIFIER);
+    private static final MfaMethodResponse SMS_MFA_METHOD_AS_MFA_METHOD_RESPONSE =
+            new SmsMfaMethodResponse(
+                    DEFAULT_SMS_MFA_IDENTIFIER,
+                    MFAMethodType.SMS,
+                    DEFAULT,
+                    redactPhoneNumber(PHONE_NUMBER));
+    private static final MFAMethod DEFAULT_AUTH_APP_MFA_METHOD =
+            MFAMethod.authAppMfaMethod(
+                    AUTH_APP_CREDENTIAL, true, true, DEFAULT, DEFAULT_AUTH_APP_MFA_IDENTIFIER);
+    private static final MfaMethodResponse DEFAULT_AUTH_APP_MFA_AS_MFA_METHOD_RESPONSE =
+            new AuthAppMfaMethodResponse(
+                    DEFAULT_AUTH_APP_MFA_IDENTIFIER, MFAMethodType.AUTH_APP, DEFAULT);
+    private static final MFAMethod BACKUP_AUTH_APP_MFA_METHOD =
+            MFAMethod.authAppMfaMethod(
+                    AUTH_APP_CREDENTIAL_2, true, true, BACKUP, BACKUP_AUTH_APP_MFA_IDENTIFIER);
+    private static final MfaMethodResponse BACKUP_AUTH_APP_MFA_AS_MFA_METHOD_RESPONSE =
+            new AuthAppMfaMethodResponse(
+                    BACKUP_AUTH_APP_MFA_IDENTIFIER, MFAMethodType.AUTH_APP, BACKUP);
+    private static final String INVALID_MFA_TYPE = "not a valid mfa type";
+
+    private static Stream<Arguments> convertableMethodsToExpectedMfaMethodResponses() {
+        return Stream.of(
+                Arguments.of(
+                        List.of(SMS_MFA_METHOD), List.of(SMS_MFA_METHOD_AS_MFA_METHOD_RESPONSE)),
+                Arguments.of(
+                        List.of(DEFAULT_AUTH_APP_MFA_METHOD),
+                        List.of(DEFAULT_AUTH_APP_MFA_AS_MFA_METHOD_RESPONSE)),
+                Arguments.of(
+                        List.of(SMS_MFA_METHOD, BACKUP_AUTH_APP_MFA_METHOD),
+                        List.of(
+                                SMS_MFA_METHOD_AS_MFA_METHOD_RESPONSE,
+                                BACKUP_AUTH_APP_MFA_AS_MFA_METHOD_RESPONSE)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("convertableMethodsToExpectedMfaMethodResponses")
+    void shouldSuccessfullyConvertMfaMethodsToResponses(
+            List<MFAMethod> mfaMethods, List<MfaMethodResponse> expectedResponses) {
+        var convertedResult = convertMfaMethodsToMfaMethodResponse(mfaMethods);
+
+        var expectedResult = Result.success(expectedResponses);
+
+        assertEquals(expectedResult, convertedResult);
+    }
+
+    private static Stream<List<MFAMethod>> methodsIncludingInvalidMfa() {
+        var invalidMfaMethodType = new MFAMethod(INVALID_MFA_TYPE, null, true, true, "updated-at");
+        var invalidMfaMethodPriority =
+                new MFAMethod()
+                        .withMfaMethodType(MFAMethodType.SMS.getValue())
+                        .withMethodVerified(true)
+                        .withEnabled(true)
+                        .withDestination("destination")
+                        .withPriority("invalid-priority")
+                        .withMfaIdentifier("id");
+        return Stream.of(
+                List.of(invalidMfaMethodType),
+                List.of(invalidMfaMethodType, SMS_MFA_METHOD),
+                List.of(SMS_MFA_METHOD, invalidMfaMethodType),
+                List.of(SMS_MFA_METHOD, BACKUP_AUTH_APP_MFA_METHOD, invalidMfaMethodType),
+                List.of(invalidMfaMethodPriority, SMS_MFA_METHOD));
+    }
+
+    @ParameterizedTest
+    @MethodSource("methodsIncludingInvalidMfa")
+    void shouldReturnAnErrorIfAnyMethodsFailToConvert(
+            List<MFAMethod> mfaMethodsIncludingUnconvertableMfaMethod) {
+        var convertedResult =
+                convertMfaMethodsToMfaMethodResponse(mfaMethodsIncludingUnconvertableMfaMethod);
+
+        assertTrue(
+                convertedResult
+                        .getFailure()
+                        .startsWith("Error converting mfa method to mfa method data"),
+                "Failure string should start with the expected prefix");
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -47,6 +47,7 @@ import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
@@ -122,6 +123,7 @@ class LoginHandlerReauthenticationRedisTest {
     private final CommonPasswordsService commonPasswordsService =
             mock(CommonPasswordsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
+    private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT_ID.getValue(), "test.account.gov.uk", SALT);
@@ -183,7 +185,8 @@ class LoginHandlerReauthenticationRedisTest {
                         cloudwatchMetricsService,
                         commonPasswordsService,
                         null,
-                        authSessionService);
+                        authSessionService,
+                        mfaMethodsService);
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -55,6 +55,7 @@ import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
@@ -167,6 +168,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
     private final AuthenticationAttemptsService authenticationAttemptsService =
             mock(AuthenticationAttemptsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
+    private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging = new CaptureLoggingExtension(LoginHandler.class);
@@ -210,7 +212,8 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                         cloudwatchMetricsService,
                         commonPasswordsService,
                         authenticationAttemptsService,
-                        authSessionService);
+                        authSessionService,
+                        mfaMethodsService);
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/serialization/MfaMethodResponseAdapterTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/serialization/MfaMethodResponseAdapterTest.java
@@ -1,0 +1,44 @@
+package uk.gov.di.authentication.frontendapi.serialization;
+
+import com.google.gson.stream.JsonReader;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.frontendapi.entity.mfa.AuthAppMfaMethodResponse;
+import uk.gov.di.authentication.frontendapi.entity.mfa.MfaMethodResponse;
+import uk.gov.di.authentication.frontendapi.entity.mfa.SmsMfaMethodResponse;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MfaMethodResponseAdapterTest {
+    @Test
+    void shouldThrowWithInvalidType() {
+        String json =
+                "{\"id\":\"sms-id\",\"type\":\"WHOKNOWS\",\"priority\":\"DEFAULT\",\"redactedPhoneNumber\":\"123\"}";
+        JsonReader reader = new JsonReader(new StringReader(json));
+        MfaMethodResponseAdapter adapter = new MfaMethodResponseAdapter();
+        assertThrows(IllegalArgumentException.class, () -> adapter.read(reader));
+    }
+
+    @Test
+    void shouldReadSmsMfaMethodResponse() throws IOException {
+        String json =
+                "{\"id\":\"sms-id\",\"type\":\"SMS\",\"priority\":\"DEFAULT\",\"redactedPhoneNumber\":\"123\"}";
+        JsonReader reader = new JsonReader(new StringReader(json));
+        MfaMethodResponseAdapter adapter = new MfaMethodResponseAdapter();
+        MfaMethodResponse mfaMethodResponse = adapter.read(reader);
+        assertEquals(SmsMfaMethodResponse.class, mfaMethodResponse.getClass());
+    }
+
+    @Test
+    void shouldReadAuthAppMfaMethodResponse() throws IOException {
+        String json =
+                "{\"id\":\"sms-id\",\"type\":\"AUTH_APP\",\"priority\":\"DEFAULT\",\"redactedPhoneNumber\":\"123\"}";
+        JsonReader reader = new JsonReader(new StringReader(json));
+        MfaMethodResponseAdapter adapter = new MfaMethodResponseAdapter();
+        MfaMethodResponse mfaMethodResponse = adapter.read(reader);
+        assertEquals(AuthAppMfaMethodResponse.class, mfaMethodResponse.getClass());
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -14,7 +14,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.frontendapi.entity.LoginRequest;
 import uk.gov.di.authentication.frontendapi.entity.LoginResponse;
+import uk.gov.di.authentication.frontendapi.entity.mfa.MfaMethodResponse;
 import uk.gov.di.authentication.frontendapi.lambda.LoginHandler;
+import uk.gov.di.authentication.frontendapi.serialization.MfaMethodResponseAdapter;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.JourneyType;
@@ -24,6 +26,7 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
@@ -73,6 +76,9 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             new ClientID(CLIENT_ID),
                             URI.create(REDIRECT_URI))
                     .nonce(new Nonce());
+    protected final Json objectMapper =
+            new SerializationService(
+                    Map.of(MfaMethodResponse.class, new MfaMethodResponseAdapter()));
 
     @BeforeEach
     void setup() {


### PR DESCRIPTION
## What

`LoginHandler` now returns an array of `MfaMethodResponse` as `mfaMethods`. This is a list of active MFA methods the user has set up, whether they have added a backup MFA or not.

This will be used by the frontend to show the user their options when choosing a different MFA method.


## How to review

1. Code review, commit-by-commit

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
