### PR TITLE
Aut 4234/migrate users before put

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/MfaMethodsMigrationHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/MfaMethodsMigrationHelper.java
@@ -1,0 +1,47 @@
+package uk.gov.di.accountmanagement.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
+import uk.gov.di.authentication.shared.services.mfa.MfaMigrationFailureReason;
+
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
+
+public class MfaMethodsMigrationHelper {
+    private MfaMethodsMigrationHelper() {}
+
+    public static Optional<APIGatewayProxyResponseEvent> migrateMfaCredentialsForUserIfRequired(
+            UserProfile userProfile,
+            MFAMethodsService mfaMethodsService,
+            Logger loggerForCallingHandler) {
+        if (!userProfile.getMfaMethodsMigrated()) {
+            Optional<MfaMigrationFailureReason> maybeMfaMigrationFailureReason =
+                    mfaMethodsService.migrateMfaCredentialsForUser(userProfile.getEmail());
+
+            if (maybeMfaMigrationFailureReason.isPresent()) {
+                MfaMigrationFailureReason mfaMigrationFailureReason =
+                        maybeMfaMigrationFailureReason.get();
+
+                loggerForCallingHandler.warn(
+                        "Failed to migrate user's MFA credentials due to {}",
+                        mfaMigrationFailureReason);
+
+                return switch (mfaMigrationFailureReason) {
+                    case NO_USER_FOUND_FOR_EMAIL -> Optional.of(
+                            generateApiGatewayProxyErrorResponse(404, ErrorResponse.ERROR_1056));
+                    case UNEXPECTED_ERROR_RETRIEVING_METHODS -> Optional.of(
+                            generateApiGatewayProxyErrorResponse(500, ErrorResponse.ERROR_1064));
+                    case ALREADY_MIGRATED -> Optional.empty();
+                };
+            } else {
+                loggerForCallingHandler.info("MFA Methods migrated for user");
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -189,7 +189,7 @@ public class MFAMethodsCreateHandler
 
                 return switch (mfaMigrationFailureReason) {
                     case NO_USER_FOUND_FOR_EMAIL -> Optional.of(
-                            generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1056));
+                            generateApiGatewayProxyErrorResponse(404, ErrorResponse.ERROR_1056));
                     case UNEXPECTED_ERROR_RETRIEVING_METHODS -> Optional.of(
                             generateApiGatewayProxyErrorResponse(500, ErrorResponse.ERROR_1064));
                     case ALREADY_MIGRATED -> Optional.empty();

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/MfaMethodsMigrationHelperTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/MfaMethodsMigrationHelperTest.java
@@ -1,0 +1,130 @@
+package uk.gov.di.accountmanagement.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
+import uk.gov.di.authentication.shared.services.mfa.MfaMigrationFailureReason;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.services.mfa.MfaMigrationFailureReason.ALREADY_MIGRATED;
+import static uk.gov.di.authentication.shared.services.mfa.MfaMigrationFailureReason.NO_USER_FOUND_FOR_EMAIL;
+import static uk.gov.di.authentication.shared.services.mfa.MfaMigrationFailureReason.UNEXPECTED_ERROR_RETRIEVING_METHODS;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
+
+class MfaMethodsMigrationHelperTest {
+    private static final String EMAIL = "email@example.com";
+    private static MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(MfaMethodsMigrationHelper.class);
+
+    private final Logger logger = LogManager.getLogger(MfaMethodsMigrationHelper.class);
+
+    private static final String MIGRATION_SUCCESS_LOG = "MFA Methods migrated for user";
+
+    @Test
+    void shouldReturnAnEmptyAndLogWhenUserNotMigratedAndMigrationReturnsNoError() {
+        var userProfile = new UserProfile().withMfaMethodsMigrated(false).withEmail(EMAIL);
+
+        when(mfaMethodsService.migrateMfaCredentialsForUser(EMAIL)).thenReturn(Optional.empty());
+
+        var result =
+                MfaMethodsMigrationHelper.migrateMfaCredentialsForUserIfRequired(
+                        userProfile, mfaMethodsService, logger);
+
+        assertEquals(Optional.empty(), result);
+
+        assertThat(logging.events(), hasItem(withMessageContaining(MIGRATION_SUCCESS_LOG)));
+    }
+
+    @Test
+    void shouldReturnAnEmptyAndNotLogSuccesWhenUserAlreadyMigrated() {
+        var userProfile = new UserProfile().withMfaMethodsMigrated(true).withEmail(EMAIL);
+
+        var result =
+                MfaMethodsMigrationHelper.migrateMfaCredentialsForUserIfRequired(
+                        userProfile, mfaMethodsService, logger);
+
+        assertEquals(Optional.empty(), result);
+
+        assertThat(logging.events(), not(hasItem(withMessageContaining(MIGRATION_SUCCESS_LOG))));
+    }
+
+    private static Stream<Arguments> fatalMigrationErrorsToHttpStatusAndError() {
+        return Stream.of(
+                Arguments.of(NO_USER_FOUND_FOR_EMAIL, 404, ErrorResponse.ERROR_1056),
+                Arguments.of(UNEXPECTED_ERROR_RETRIEVING_METHODS, 500, ErrorResponse.ERROR_1064));
+    }
+
+    @ParameterizedTest
+    @MethodSource("fatalMigrationErrorsToHttpStatusAndError")
+    void shouldReturnAppropriateApiProxyResponseWhenMigrationReturnsError(
+            MfaMigrationFailureReason migrationFailureReason,
+            int expectedHttpStatus,
+            ErrorResponse expectedErrorResponse) {
+        var userProfile = new UserProfile().withMfaMethodsMigrated(false).withEmail(EMAIL);
+
+        when(mfaMethodsService.migrateMfaCredentialsForUser(EMAIL))
+                .thenReturn(Optional.of(migrationFailureReason));
+
+        var maybeErrorResponse =
+                MfaMethodsMigrationHelper.migrateMfaCredentialsForUserIfRequired(
+                        userProfile, mfaMethodsService, logger);
+
+        assertTrue(maybeErrorResponse.isPresent());
+        assertEquals(expectedHttpStatus, maybeErrorResponse.get().getStatusCode());
+        assertThat(maybeErrorResponse.get(), hasJsonBody(expectedErrorResponse));
+
+        assertThat(logging.events(), not(hasItem(withMessageContaining(MIGRATION_SUCCESS_LOG))));
+
+        assertThat(
+                logging.events(),
+                hasItem(
+                        withMessageContaining(
+                                format(
+                                        "Failed to migrate user's MFA credentials due to %s",
+                                        migrationFailureReason))));
+    }
+
+    @Test
+    void shouldNotReturnFailureIfMigrationFailsDueToMethodsAlreadyMigrated() {
+        var userProfile = new UserProfile().withEmail(EMAIL).withMfaMethodsMigrated(false);
+
+        when(mfaMethodsService.migrateMfaCredentialsForUser(EMAIL))
+                .thenReturn(Optional.of(ALREADY_MIGRATED));
+
+        var maybeErrorResponse =
+                MfaMethodsMigrationHelper.migrateMfaCredentialsForUserIfRequired(
+                        userProfile, mfaMethodsService, logger);
+
+        assertEquals(Optional.empty(), maybeErrorResponse);
+
+        assertThat(logging.events(), not(hasItem(withMessageContaining(MIGRATION_SUCCESS_LOG))));
+
+        assertThat(
+                logging.events(),
+                hasItem(
+                        withMessageContaining(
+                                "Failed to migrate user's MFA credentials due to ALREADY_MIGRATED")));
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -103,7 +103,7 @@ class MFAMethodsCreateHandlerTest {
                 Arguments.of(
                         MfaMigrationFailureReason.NO_USER_FOUND_FOR_EMAIL,
                         ErrorResponse.ERROR_1056,
-                        400),
+                        404),
                 Arguments.of(
                         MfaMigrationFailureReason.UNEXPECTED_ERROR_RETRIEVING_METHODS,
                         ErrorResponse.ERROR_1064,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -23,6 +23,7 @@ import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
+import uk.gov.di.authentication.shared.services.mfa.MfaMigrationFailureReason;
 import uk.gov.di.authentication.shared.services.mfa.MfaUpdateFailureReason;
 
 import java.util.HashMap;
@@ -57,7 +58,10 @@ class MFAMethodsPutHandlerTest {
     private static final byte[] TEST_SALT = SaltHelper.generateNewSalt();
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final UserProfile userProfile =
-            new UserProfile().withSubjectID(TEST_PUBLIC_SUBJECT).withEmail(EMAIL);
+            new UserProfile()
+                    .withSubjectID(TEST_PUBLIC_SUBJECT)
+                    .withEmail(EMAIL)
+                    .withMfaMethodsMigrated(true);
     private static final String TEST_INTERNAL_SUBJECT =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     TEST_PUBLIC_SUBJECT, "test.account.gov.uk", TEST_SALT);
@@ -87,6 +91,9 @@ class MFAMethodsPutHandlerTest {
                         PriorityIdentifier.DEFAULT, new RequestSmsMfaDetail(phoneNumber, TEST_OTP));
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
         var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber, TEST_OTP));
+        when(codeStorageService.isValidOtpCode(
+                        EMAIL, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER))
+                .thenReturn(true);
 
         when(authenticationService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
@@ -117,6 +124,122 @@ class MFAMethodsPutHandlerTest {
         var expectedResponseParsedToString =
                 JsonParser.parseString(expectedResponse).getAsJsonArray().toString();
         assertEquals(expectedResponseParsedToString, result.getBody());
+    }
+
+    @Test
+    void shouldReturn200WithUpdatedMethodWhenFeatureFlagEnabledAndUserMigrationSuccessful() {
+        var nonMigratedEmail = "non-migrated-email@example.com";
+        var nonMigratedUser =
+                new UserProfile()
+                        .withMfaMethodsMigrated(false)
+                        .withEmail(nonMigratedEmail)
+                        .withSubjectID(TEST_PUBLIC_SUBJECT);
+        when(authenticationService.getOrGenerateSalt(nonMigratedUser)).thenReturn(TEST_SALT);
+        var phoneNumber = "123456789";
+        var updateRequest =
+                MfaMethodCreateOrUpdateRequest.from(
+                        PriorityIdentifier.DEFAULT, new RequestSmsMfaDetail(phoneNumber, TEST_OTP));
+        var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
+        var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber, TEST_OTP));
+        when(codeStorageService.isValidOtpCode(
+                        nonMigratedEmail, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER))
+                .thenReturn(true);
+
+        when(authenticationService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
+                .thenReturn(Optional.of(nonMigratedUser));
+
+        var updatedMfaMethod =
+                MFAMethod.smsMfaMethod(
+                        true, true, phoneNumber, PriorityIdentifier.DEFAULT, MFA_IDENTIFIER);
+        when(mfaMethodsService.updateMfaMethod(nonMigratedEmail, MFA_IDENTIFIER, updateRequest))
+                .thenReturn(Result.success(List.of(updatedMfaMethod)));
+        when(mfaMethodsService.migrateMfaCredentialsForUser(nonMigratedEmail))
+                .thenReturn(Optional.empty());
+
+        var result = handler.handleRequest(eventWithUpdateRequest, context);
+
+        assertEquals(200, result.getStatusCode());
+        var expectedResponse =
+                format(
+                        """
+                [{
+                  "mfaIdentifier": "%s",
+                  "priorityIdentifier": "DEFAULT",
+                  "methodVerified": true,
+                  "method": {
+                    "mfaMethodType": "SMS",
+                    "phoneNumber": "%s"
+                  }
+                }]
+                """,
+                        MFA_IDENTIFIER, phoneNumber);
+        var expectedResponseParsedToString =
+                JsonParser.parseString(expectedResponse).getAsJsonArray().toString();
+        assertEquals(expectedResponseParsedToString, result.getBody());
+    }
+
+    private static Stream<Arguments> migrationFailureReasonsToExpectedStatusCodes() {
+        return Stream.of(
+                Arguments.of(MfaMigrationFailureReason.UNEXPECTED_ERROR_RETRIEVING_METHODS, 500),
+                Arguments.of(MfaMigrationFailureReason.NO_USER_FOUND_FOR_EMAIL, 404),
+                Arguments.of(MfaMigrationFailureReason.ALREADY_MIGRATED, 200));
+    }
+
+    @ParameterizedTest
+    @MethodSource("migrationFailureReasonsToExpectedStatusCodes")
+    void shouldReturnAppropriateResponseWhenUserMigrationNotSuccessful(
+            MfaMigrationFailureReason migrationFailureReason, int expectedStatusCode) {
+        var nonMigratedEmail = "non-migrated-email@example.com";
+        var nonMigratedUser =
+                new UserProfile()
+                        .withMfaMethodsMigrated(false)
+                        .withEmail(nonMigratedEmail)
+                        .withSubjectID(TEST_PUBLIC_SUBJECT);
+        when(authenticationService.getOrGenerateSalt(nonMigratedUser)).thenReturn(TEST_SALT);
+        var phoneNumber = "123456789";
+        var updateRequest =
+                MfaMethodCreateOrUpdateRequest.from(
+                        PriorityIdentifier.DEFAULT, new RequestSmsMfaDetail(phoneNumber, TEST_OTP));
+        var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
+        var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber, TEST_OTP));
+        when(codeStorageService.isValidOtpCode(
+                        nonMigratedEmail, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER))
+                .thenReturn(true);
+
+        when(authenticationService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
+                .thenReturn(Optional.of(nonMigratedUser));
+
+        var updatedMfaMethod =
+                MFAMethod.smsMfaMethod(
+                        true, true, phoneNumber, PriorityIdentifier.DEFAULT, MFA_IDENTIFIER);
+        when(mfaMethodsService.updateMfaMethod(nonMigratedEmail, MFA_IDENTIFIER, updateRequest))
+                .thenReturn(Result.success(List.of(updatedMfaMethod)));
+        when(mfaMethodsService.migrateMfaCredentialsForUser(nonMigratedEmail))
+                .thenReturn(Optional.of(migrationFailureReason));
+
+        var result = handler.handleRequest(eventWithUpdateRequest, context);
+
+        assertEquals(expectedStatusCode, result.getStatusCode());
+
+        if (expectedStatusCode == 200) {
+            var expectedResponseIfSuccess =
+                    format(
+                            """
+                    [{
+                      "mfaIdentifier": "%s",
+                      "priorityIdentifier": "DEFAULT",
+                      "methodVerified": true,
+                      "method": {
+                        "mfaMethodType": "SMS",
+                        "phoneNumber": "%s"
+                      }
+                    }]
+                    """,
+                            MFA_IDENTIFIER, phoneNumber);
+            var expectedResponseParsedToString =
+                    JsonParser.parseString(expectedResponseIfSuccess).getAsJsonArray().toString();
+            assertEquals(expectedResponseParsedToString, result.getBody());
+        }
     }
 
     private static Stream<Arguments> updateFailureReasonsToExpectedResponses() {


### PR DESCRIPTION
We have four new endpoints in the the account management api for managing mfa methods, which map to the basic CRUD operations.

Whether or not these work on non migrated users differs by endpoint. A non-migrated user is a user who can only have at most one mfa method, and where that method is stored - user credentials table or user profile table - varies on what type of MFA method that is.

* CREATE migrates[1] users before acting on them
* GET works on migrated and non migrated users
* DELETE will return a failed http status if attempting to act on a non migrated user. (This makes sense since you can't delete if you only have a default method, which is what non-migrated users have)

[1] By migration, we mean that we move any sms mfa methods into the user credentials table, remove traces of it from the user profile table, and for either an sms or an auth app method we ensure that it contains the new fields that the method management api needs for it (an mfa identifier and a Priority Identifier that says whether it's the default or the backup mfa method).

This PR clarifies the behaviour for a PUT request, since currently there is no migration, and no guard against it acting on a non-migrated user - but if it did act on an unmigrated user it might have unintended consequences. Here we migrate users on requests to the PUT endpoint, to ensure that they are in a consistent state before we do any updates. 

This reuses some existing functionality from the CREATE endpoint, moving it to a shared place so it can be reused.

## How to review

* Code review