### PR TITLE
ATO-1514: remove old unused duplicated role

### DIFF
--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -23,37 +23,6 @@ module "ipv_processing_identity_role" {
   }
 }
 
-//ATO-1514: Duplicate role which is now unused and replaced by the one below
-// with write access. Will be removed in subsequent PR.
-module "ipv_processing_identity_role_with_orch_session_table_access" {
-  count = var.is_orch_stubbed ? 0 : 1
-
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "ipv-processing-identity-role-with-orch-session-access"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_user_read_access_policy.arn,
-    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.pepper_parameter_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn,
-    local.client_registry_encryption_policy_arn,
-    local.identity_credentials_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn,
-    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_decrypt_policy[0].arn,
-    aws_iam_policy.dynamo_orch_session_cross_account_read_and_delete_access_policy[0].arn,
-    aws_iam_policy.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy[0].arn,
-    aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_access_policy[0].arn,
-    aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn
-  ]
-}
-
 module "ipv_processing_identity_role_with_orch_session_table_read_write_delete_access" {
   count = var.is_orch_stubbed ? 0 : 1
 


### PR DESCRIPTION
### Wider context of change
Clean up for ATO-1514, where we migrated the processingIdentityAttempts to orch session. This required access to write to the orch session.

### What’s changed
Deleted the unused module

### Manual testing
n/a

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing. **deleting unused module**
- [x] Impact on orch and auth mutual dependencies has been checked. **yes**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **I haven't, but it's an unused module so I'm not worried**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**