### PR TITLE
Alert0010983: Add a separate alert threshold for the notifications DLQ

### DIFF
--- a/ci/terraform/oidc/alerts.tf
+++ b/ci/terraform/oidc/alerts.tf
@@ -6,12 +6,12 @@ resource "aws_cloudwatch_metric_alarm" "sqs_deadletter_cloudwatch_alarm" {
   namespace           = "AWS/SQS"
   period              = "300"
   statistic           = "Average"
-  threshold           = var.dlq_alarm_threshold
+  threshold           = var.notifications_dlq_alarm_threshold
 
   dimensions = {
     QueueName = aws_sqs_queue.email_dead_letter_queue.name
   }
-  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.email_dead_letter_queue.name}. ACCOUNT: ${local.aws_account_alias}. Runbook: https://govukverify.atlassian.net/wiki/spaces/LO/pages/4164649233/BAU+Daytime+Support+Hygiene+and+Optimisation+Rota#SUP-7%3A-Resolve-DLQ-messages"
+  alarm_description = "${var.notifications_dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.email_dead_letter_queue.name}. ACCOUNT: ${local.aws_account_alias}. Runbook: https://govukverify.atlassian.net/wiki/spaces/LO/pages/4164649233/BAU+Daytime+Support+Hygiene+and+Optimisation+Rota#SUP-7%3A-Resolve-DLQ-messages"
   alarm_actions     = [local.slack_event_sns_topic_arn]
 }
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -245,6 +245,12 @@ variable "dlq_alarm_threshold" {
   description = "The number of messages on a DLQ before a Cloudwatch alarm is generated"
 }
 
+variable "notifications_dlq_alarm_threshold" {
+  default     = 10
+  type        = number
+  description = "The number of messages on the notifications DLQ before a Cloudwatch alarm is generated"
+}
+
 variable "test_client_verify_email_otp" {
   type = string
 }


### PR DESCRIPTION
## What

Add a separate alert threshold for the notifications DLQ

There is no need to trigger an alert for each individual message on the DLQ.  Three attempts are made to send the message before it ends up on the queue.  Action should only be taken if there is another indication of an issue.

See https://govukverify.atlassian.net/wiki/spaces/LO/pages/4164649233/BAU+Daytime+Support+Hygiene+and+Optimisation+Rota#SUP-7%3A-Resolve-DLQ-messages

## How to review

1. Code Review
1. Deploy to a test environment.
1. Run a test and try to send messages to an invalid number at least 10 times.  You can do this by updating the number for your account in the database and trying to sign in.
1. Check that the alarm is triggered in cloudwatch.

## Checklist

- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] No changes required or changes have been made to stub-orchestration.


