### PR TITLE
ATO-1128: add cross account read access for authUserInfo table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -570,6 +570,25 @@ Resources:
             Condition:
               ArnLike:
                 kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+          - Sid: AllowAuthUserInfoKeyCrossAccountEncryptActions
+            Effect: Allow
+            Principal:
+              AWS: !Sub
+                - arn:aws:iam::${AuthAccountId}:root
+                - AuthAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      authAccountId,
+                    ]
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: "*"
 
   AuthUserInfoTable:
     Type: AWS::DynamoDB::Table
@@ -580,6 +599,25 @@ Resources:
           AttributeType: S
         - AttributeName: ClientSessionId
           AttributeType: S
+      ResourcePolicy:
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Sid: AllowAuthUserInfoTableCrossAccountReadAccess
+              Effect: Allow
+              Action:
+                - dynamodb:DescribeTable
+                - dynamodb:Get*
+              Resource: "*"
+              Principal:
+                AWS: !Sub
+                  - arn:aws:iam::${AuthAccountId}:root
+                  - AuthAccountId:
+                      !FindInMap [
+                        EnvironmentConfiguration,
+                        !Ref Environment,
+                        authAccountId,
+                      ]
       KeySchema:
         - AttributeName: InternalCommonSubjectId
           KeyType: HASH


### PR DESCRIPTION
### Wider context of change
Part of email migration work.

### What’s changed
Adds
- cross account encrypt access to the authUserInfo table encryption key
- cross account read access to the authUserInfo table

### Manual testing
N/A

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
