### PR TITLE
Introduce remote JWKS service

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/JwksServiceFailureReason.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/JwksServiceFailureReason.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+public enum JwksServiceFailureReason {
+    IO_FAILURE,
+    INTERRUPTED_FAILURE,
+    PARSE_FAILURE,
+    NO_MATCHING_KEY
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/RemoteJwksService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/RemoteJwksService.java
@@ -1,0 +1,87 @@
+package uk.gov.di.authentication.frontendapi.services;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyType;
+import uk.gov.di.authentication.frontendapi.entity.JwksServiceFailureReason;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.text.ParseException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+public class RemoteJwksService {
+    private static RemoteJwksService remoteJwksService;
+    private final HttpClient httpClient;
+    private final ConfigurationService configurationService;
+    private final String jwksUrl;
+
+    public RemoteJwksService(
+            ConfigurationService configurationService, String jwksUrl, HttpClient httpClient) {
+        this.configurationService = configurationService;
+        this.jwksUrl = jwksUrl;
+        this.httpClient = httpClient;
+    }
+
+    public static RemoteJwksService getInstance(
+            ConfigurationService configurationService, String jwksUrl) {
+        if (remoteJwksService == null) {
+            remoteJwksService =
+                    new RemoteJwksService(
+                            configurationService, jwksUrl, HttpClient.newHttpClient());
+        }
+        return remoteJwksService;
+    }
+
+    private Result<JwksServiceFailureReason, List<JWK>> getJwksResult() {
+        var request =
+                HttpRequest.newBuilder(URI.create(jwksUrl))
+                        .GET()
+                        .timeout(
+                                Duration.ofMillis(
+                                        configurationService.getRemoteJwksServiceCallTimeout()))
+                        .build();
+
+        HttpResponse<String> response;
+        String jwksJson;
+        try {
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            jwksJson = response.body();
+        } catch (IOException ioException) {
+            return Result.failure(JwksServiceFailureReason.IO_FAILURE);
+        } catch (InterruptedException interruptedException) {
+            return Result.failure(JwksServiceFailureReason.INTERRUPTED_FAILURE);
+        }
+
+        JWKSet jwks;
+        try {
+            jwks = JWKSet.parse(jwksJson);
+        } catch (ParseException parseException) {
+            return Result.failure(JwksServiceFailureReason.PARSE_FAILURE);
+        }
+        return Result.success(jwks.getKeys());
+    }
+
+    public Result<JwksServiceFailureReason, JWK> getJwkByKeyType(KeyType keyType) {
+        Result<JwksServiceFailureReason, List<JWK>> jwksResult = getJwksResult();
+
+        return jwksResult.flatMap(
+                jwks -> {
+                    Optional<JWK> key =
+                            jwks.stream()
+                                    .filter(jwk -> jwk.getKeyType().equals(keyType))
+                                    .findFirst();
+
+                    return key.<Result<JwksServiceFailureReason, JWK>>map(Result::success)
+                            .orElseGet(
+                                    () -> Result.failure(JwksServiceFailureReason.NO_MATCHING_KEY));
+                });
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/RemoteJwksServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/RemoteJwksServiceTest.java
@@ -1,0 +1,55 @@
+package uk.gov.di.authentication.frontendapi.services;
+
+import com.nimbusds.jose.jwk.KeyType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import uk.gov.di.authentication.frontendapi.entity.JwksServiceFailureReason;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RemoteJwksServiceTest {
+    private RemoteJwksService remoteJwksService;
+    private static final ConfigurationService configurationService =
+            mock(ConfigurationService.class);
+    private static final HttpClient httpClient = mock(HttpClient.class);
+
+    private static final String TEST_JWKS_URL = "https://test-jwks.url";
+
+    @BeforeAll
+    static void setUp() {
+        when(configurationService.getRemoteJwksServiceCallTimeout()).thenReturn(1000L);
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        Mockito.reset(httpClient);
+        remoteJwksService = new RemoteJwksService(configurationService, TEST_JWKS_URL, httpClient);
+    }
+
+    @Test
+    void shouldReturnIOFailureError() throws IOException, InterruptedException {
+        when(httpClient.send(any(), any())).thenThrow(new IOException());
+
+        var result = remoteJwksService.getJwkByKeyType(KeyType.EC);
+
+        assertEquals(JwksServiceFailureReason.IO_FAILURE, result.getFailure());
+    }
+
+    @Test
+    void shouldReturnInterruptedFailureError() throws IOException, InterruptedException {
+        when(httpClient.send(any(), any())).thenThrow(new InterruptedException());
+
+        var result = remoteJwksService.getJwkByKeyType(KeyType.EC);
+
+        assertEquals(JwksServiceFailureReason.INTERRUPTED_FAILURE, result.getFailure());
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/RemoteJwksServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/RemoteJwksServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.frontendapi.services;
 
+import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,8 +11,10 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.io.IOException;
 import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -21,8 +24,30 @@ class RemoteJwksServiceTest {
     private static final ConfigurationService configurationService =
             mock(ConfigurationService.class);
     private static final HttpClient httpClient = mock(HttpClient.class);
-
     private static final String TEST_JWKS_URL = "https://test-jwks.url";
+    private static final String TEST_VALID_JWKS =
+            """
+                    {
+                      "keys": [
+                        {
+                          "kty": "RSA",
+                          "e": "AQAB",
+                          "use": "enc",
+                          "alg": "RS256",
+                          "n": "modulus",
+                          "kid": "key1rsa"
+                        },
+                        {
+                          "kty": "EC",
+                          "use": "sig",
+                          "crv": "P-256",
+                          "x": "UPvU5NPmELrWiWSMVfDD7G8u3EJYryqPIZ46W9MAlRc",
+                          "y": "r77F2-KPhpvTIGEWgt5SmavSvBUHCqWUxD6RG_FJHVk",
+                          "alg": "ES256",
+                          "kid": "key2ec"
+                        }
+                      ]
+                    }""";
 
     @BeforeAll
     static void setUp() {
@@ -36,8 +61,10 @@ class RemoteJwksServiceTest {
     }
 
     @Test
-    void shouldReturnIOFailureError() throws IOException, InterruptedException {
-        when(httpClient.send(any(), any())).thenThrow(new IOException());
+    void shouldReturnIOFailureErrorAfterExceedingMaxRetries()
+            throws IOException, InterruptedException {
+        when(httpClient.send(any(), any()))
+                .thenThrow(new IOException(), new IOException(), new IOException());
 
         var result = remoteJwksService.getJwkByKeyType(KeyType.EC);
 
@@ -45,11 +72,30 @@ class RemoteJwksServiceTest {
     }
 
     @Test
-    void shouldReturnInterruptedFailureError() throws IOException, InterruptedException {
-        when(httpClient.send(any(), any())).thenThrow(new InterruptedException());
+    void shouldReturnInterruptedFailureErrorAfterExceedingMaxRetries()
+            throws IOException, InterruptedException {
+        when(httpClient.send(any(), any()))
+                .thenThrow(
+                        new InterruptedException(),
+                        new InterruptedException(),
+                        new InterruptedException());
 
         var result = remoteJwksService.getJwkByKeyType(KeyType.EC);
 
         assertEquals(JwksServiceFailureReason.INTERRUPTED_FAILURE, result.getFailure());
+    }
+
+    @Test
+    void shouldReturnSuccessfulResponseAfterRetryingBelowMaxAttempts()
+            throws IOException, InterruptedException {
+        var httpResponse = mock(HttpResponse.class);
+        when(httpClient.send(any(), any()))
+                .thenThrow(new InterruptedException(), new IOException())
+                .thenReturn(httpResponse);
+        when(httpResponse.body()).thenReturn(TEST_VALID_JWKS);
+
+        var result = remoteJwksService.getJwkByKeyType(KeyType.EC);
+
+        assertInstanceOf(JWK.class, result.getSuccess());
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/RemoteJwksServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/RemoteJwksServiceIntegrationTest.java
@@ -1,0 +1,117 @@
+package uk.gov.di.authentication.services;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.frontendapi.entity.JwksServiceFailureReason;
+import uk.gov.di.authentication.frontendapi.services.RemoteJwksService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.net.http.HttpClient;
+import java.util.stream.Stream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class RemoteJwksServiceIntegrationTest {
+    private static WireMockServer wireMockServer;
+    private static RemoteJwksService remoteJwksService;
+    private static final ConfigurationService configurationService = new ConfigurationService();
+
+    @BeforeAll
+    static void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+        int port = wireMockServer.port();
+        String testUrl = String.format("http://localhost:%d/.well-known/jwks.json", port);
+        configureFor("localhost", wireMockServer.port());
+
+        HttpClient httpClient = HttpClient.newHttpClient();
+        remoteJwksService = new RemoteJwksService(configurationService, testUrl, httpClient);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    static Stream<Arguments> keyTypes() {
+        return Stream.of(Arguments.of(KeyType.RSA, "key1rsa"), Arguments.of(KeyType.EC, "key2ec"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("keyTypes")
+    void shouldGetKeys(KeyType kty, String expectedKeyId) {
+        String jwksResponse =
+                """
+                        {
+                          "keys": [
+                            {
+                              "kty": "RSA",
+                              "e": "AQAB",
+                              "use": "enc",
+                              "alg": "RS256",
+                              "n": "modulus",
+                              "kid": "key1rsa"
+                            },
+                            {
+                              "kty": "EC",
+                              "use": "sig",
+                              "crv": "P-256",
+                              "x": "UPvU5NPmELrWiWSMVfDD7G8u3EJYryqPIZ46W9MAlRc",
+                              "y": "r77F2-KPhpvTIGEWgt5SmavSvBUHCqWUxD6RG_FJHVk",
+                              "alg": "ES256",
+                              "kid": "key2ec"
+                            }
+                          ]
+                        }""";
+
+        wireMockServer.stubFor(
+                get(urlPathMatching("/.well-known/jwks.json"))
+                        .willReturn(
+                                aResponse()
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBody(jwksResponse)));
+
+        JWK jwk = remoteJwksService.getJwkByKeyType(kty).getSuccess();
+        assertNotNull(jwk);
+        assertEquals(kty, jwk.getKeyType());
+        assertEquals(expectedKeyId, jwk.getKeyID());
+    }
+
+    @Test
+    void shouldReturnParseFailureError() {
+        String jwksResponse =
+                """
+                        {
+                          "invalid": [
+                            {
+                              "invalid": "invalid",
+                            },
+                          ]
+                        }""";
+
+        wireMockServer.stubFor(
+                get(urlPathMatching("/.well-known/jwks.json"))
+                        .willReturn(
+                                aResponse()
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBody(jwksResponse)));
+
+        var result = remoteJwksService.getJwkByKeyType(KeyType.EC);
+        assertEquals(JwksServiceFailureReason.PARSE_FAILURE, result.getFailure());
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -702,4 +702,9 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .getOrDefault("USE_STRONGLY_CONSISTENT_READS", FEATURE_SWITCH_OFF)
                 .equals(FEATURE_SWITCH_ON);
     }
+
+    public long getRemoteJwksServiceCallTimeout() {
+        return Long.parseLong(
+                System.getenv().getOrDefault("REMOTE_JWKS_SERVICE_CALL_TIMEOUT", "3000"));
+    }
 }


### PR DESCRIPTION
## What

- This service is to get JWKSets from well known endpoints
- - The initial use case is for getting IPV's well known JWKS, but the intention is for this service
    to be re-usable
- - This will be implemented in a separate PR in the MFA reset handlers to encrypt and validate JWTs
- In subsequent PRs, key caching and rotation handling will be implemented.


## How to review

1. Code Review
