### PR TITLE
ATO-1128: duplicate role and add auth user info access

### DIFF
--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -49,6 +49,7 @@ orch_environment                                   = "build"
 orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:767397776536:key/b7cb6340-0d22-4b6a-8702-b5ec17d4f979"
 orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:767397776536:key/7a1d86fe-1ca0-499c-95e9-ee8593a850f9"
 orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:767397776536:key/e284a04a-bac2-42b0-b723-ef0d32722ad5"
+auth_user_info_table_encryption_key_arn            = "arn:aws:kms:eu-west-2:767397776536:key/827c3226-a50f-44a7-834a-e690b2483222"
 
 orch_storage_token_jwk_enabled              = true
 orch_openid_configuration_enabled           = true

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -730,6 +730,7 @@ data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_access_po
   }
 }
 
+// TODO: ATO-1128: delete this once no longer used
 data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_write_delete_access_policy_document" {
   count = var.is_orch_stubbed ? 0 : 1
 
@@ -779,7 +780,7 @@ data "aws_iam_policy_document" "dynamo_orch_session_cross_account_delete_access_
   }
 }
 
-
+// TODO: ATO-1128: delete this once no longer used
 data "aws_iam_policy_document" "dynamo_orch_client_session_cross_account_read_and_delete_access_policy_document" {
   count = var.is_orch_stubbed ? 0 : 1
   statement {
@@ -1189,6 +1190,7 @@ resource "aws_iam_policy" "dynamo_orch_session_cross_account_write_access_policy
   policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_write_access_policy_document[count.index].json
 }
 
+// TODO: ATO-1128: delete this once no longer used
 resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_write_delete_access_policy" {
   count = var.is_orch_stubbed ? 0 : 1
 
@@ -1209,7 +1211,7 @@ resource "aws_iam_policy" "dynamo_orch_session_cross_account_delete_access_polic
   policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_delete_access_policy_document[count.index].json
 }
 
-
+// TODO: ATO-1128: delete once no longer used
 resource "aws_iam_policy" "dynamo_orch_client_session_cross_account_read_and_delete_access_policy" {
   count = var.is_orch_stubbed ? 0 : 1
 

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -750,6 +750,37 @@ data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_write_del
   }
 }
 
+data "aws_iam_policy_document" "dynamo_orch_session_cross_account_read_write_delete_and_encryption_key_access_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  statement {
+    sid    = "AllowOrchSessionCrossAccountReadWriteDeleteAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem",
+    ]
+    resources = [
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Orch-Session",
+    ]
+  }
+
+  statement {
+    sid    = "AllowOrchSessionEncryptionKeyCrossAccountEncryptAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+    ]
+    resources = [
+      var.orch_session_table_encryption_key_arn,
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "dynamo_orch_session_cross_account_write_access_policy_document" {
   count = var.is_orch_stubbed ? 0 : 1
 
@@ -793,6 +824,34 @@ data "aws_iam_policy_document" "dynamo_orch_client_session_cross_account_read_an
     ]
     resources = [
       "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Client-Session",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_orch_client_session_cross_account_read_and_delete_and_encryption_key_access_policy_document" {
+  count = var.is_orch_stubbed ? 0 : 1
+  statement {
+    sid    = "AllowOrchClientSessionCrossAccountReadAndDeleteAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:DeleteItem",
+    ]
+    resources = [
+      "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-Client-Session",
+    ]
+  }
+
+
+  statement {
+    sid    = "AllowOrchClientSessionEncryptionKeyCrossAccountDecryptAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = [
+      var.orch_client_session_table_encryption_key_arn,
     ]
   }
 }
@@ -1201,6 +1260,16 @@ resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_write_delete_a
   policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_write_delete_access_policy_document[count.index].json
 }
 
+resource "aws_iam_policy" "dynamo_orch_session_cross_account_read_write_delete_and_encryption_key_access_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-session-cross-account-read-write-delete-and-encryption-key-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing read, write and delete, and encryption key permissions to the orch session table"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_session_cross_account_read_write_delete_and_encryption_key_access_policy_document[count.index].json
+}
+
 resource "aws_iam_policy" "dynamo_orch_session_cross_account_delete_access_policy" {
   count = var.is_orch_stubbed ? 0 : 1
 
@@ -1220,6 +1289,16 @@ resource "aws_iam_policy" "dynamo_orch_client_session_cross_account_read_and_del
   description = "IAM policy for managing read and delete permissions to the orch client session table"
 
   policy = data.aws_iam_policy_document.dynamo_orch_client_session_cross_account_read_and_delete_access_policy_document[count.index].json
+}
+
+resource "aws_iam_policy" "dynamo_orch_client_session_cross_account_read_and_delete_and_encryption_key_access_policy" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  name_prefix = "dynamo-orch-client-session-cross-account-read-and-delete-and-encryption-key-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing read and delete, and encryption key permissions to the orch client session table"
+
+  policy = data.aws_iam_policy_document.dynamo_orch_client_session_cross_account_read_and_delete_and_encryption_key_access_policy_document[count.index].json
 }
 
 resource "aws_iam_policy" "dynamo_orch_client_session_cross_account_read_access_policy" {

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -42,6 +42,7 @@ orch_environment                                   = "integration"
 orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:058264132019:key/1b5c001b-ed53-4a7b-bfbe-5d0f596110b5"
 orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:058264132019:key/fdf1686f-2d4d-4c7b-b3be-324b6ebba370"
 orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:058264132019:key/808a8c1e-82d8-487e-abb8-e13d6564b426"
+auth_user_info_table_encryption_key_arn            = "arn:aws:kms:eu-west-2:058264132019:key/abdc6b18-1ff5-48d8-acf2-c4caade743d0"
 
 orch_openid_configuration_enabled    = true
 orch_jwks_enabled                    = true

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -23,6 +23,37 @@ module "ipv_processing_identity_role" {
   }
 }
 
+// ATO-1128: this is a duplicate of the below module, ipv_processing_identity_role_with_orch_session_table_read_write_delete_access
+// we have to create a temporary module in order to swap to using it safely
+module "ipv_processing_identity_role_with_orch_cross_account_access" {
+  count = var.is_orch_stubbed ? 0 : 1
+
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-processing-identity-role-with-orch-session-combined-access"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.pepper_parameter_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn,
+    local.account_modifiers_encryption_policy_arn,
+    local.client_registry_encryption_policy_arn,
+    local.identity_credentials_encryption_policy_arn,
+    local.user_credentials_encryption_policy_arn,
+    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_encrypt_decrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_read_write_delete_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn
+  ]
+}
+
 module "ipv_processing_identity_role_with_orch_session_table_read_write_delete_access" {
   count = var.is_orch_stubbed ? 0 : 1
 

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -46,10 +46,8 @@ module "ipv_processing_identity_role_with_orch_cross_account_access" {
     local.client_registry_encryption_policy_arn,
     local.identity_credentials_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
-    aws_iam_policy.dynamo_orch_session_encryption_key_cross_account_encrypt_decrypt_policy[0].arn,
-    aws_iam_policy.dynamo_orch_session_cross_account_read_write_delete_access_policy[0].arn,
-    aws_iam_policy.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy[0].arn,
-    aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_session_cross_account_read_write_delete_and_encryption_key_access_policy[0].arn,
+    aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_and_encryption_key_access_policy[0].arn,
     aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn
   ]
 }

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -48,7 +48,8 @@ module "ipv_processing_identity_role_with_orch_cross_account_access" {
     local.user_credentials_encryption_policy_arn,
     aws_iam_policy.dynamo_orch_session_cross_account_read_write_delete_and_encryption_key_access_policy[0].arn,
     aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_and_encryption_key_access_policy[0].arn,
-    aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn
+    aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn,
+    aws_iam_policy.dynamo_auth_user_info_cross_account_read_and_encryption_key_access_policy[0].arn
   ]
 }
 

--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -53,6 +53,7 @@ orch_environment                                   = "production"
 orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:533266965190:key/7ad27a55-9d21-47f2-be03-b61f2c9a8ce6"
 orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:533266965190:key/9b57120e-3bcd-4fce-ada8-89ea9d1412d6"
 orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:533266965190:key/b2979629-c62f-458d-992b-ac4239c2cf81"
+auth_user_info_table_encryption_key_arn            = "arn:aws:kms:eu-west-2:533266965190:key/095dd840-d73b-48a4-87a3-ca0d4d47c2e2"
 
 orch_openid_configuration_enabled    = true
 orch_jwks_enabled                    = true

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -77,6 +77,7 @@ orch_environment                                   = "dev"
 orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:816047645251:key/645669ba-b288-4b63-bfe1-9d8bde9956ec"
 orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:816047645251:key/4cd7c551-128f-4579-99c2-a7f1bff64fb7"
 orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:816047645251:key/590f841e-3eec-45f1-a9bc-4b32b2edece4"
+auth_user_info_table_encryption_key_arn            = "arn:aws:kms:eu-west-2:816047645251:key/26760f54-3d69-4483-a47c-65877c1fb78e"
 
 cmk_for_back_channel_logout_enabled = true
 use_strongly_consistent_reads       = true

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -29,6 +29,7 @@ orch_environment                                   = "staging"
 orch_session_table_encryption_key_arn              = "arn:aws:kms:eu-west-2:590183975515:key/156f87e0-001a-4ae8-a6c1-23f8f68b6e84"
 orch_client_session_table_encryption_key_arn       = "arn:aws:kms:eu-west-2:590183975515:key/b94d81a1-a41f-4e61-859c-87dcacb32e51"
 orch_identity_credentials_table_encryption_key_arn = "arn:aws:kms:eu-west-2:590183975515:key/d0bdb864-8478-4411-a44a-a4232fc97cf3"
+auth_user_info_table_encryption_key_arn            = "arn:aws:kms:eu-west-2:590183975515:key/e0e84378-2220-499d-bc5d-03f9068d5ae2"
 cmk_for_back_channel_logout_enabled                = true
 
 contra_state_bucket = "di-auth-staging-tfstate"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -674,6 +674,11 @@ variable "orch_identity_credentials_table_encryption_key_arn" {
   default = ""
 }
 
+variable "auth_user_info_table_encryption_key_arn" {
+  type    = string
+  default = ""
+}
+
 variable "cmk_for_back_channel_logout_enabled" {
   default     = false
   type        = bool


### PR DESCRIPTION
### Wider context of change
Part of email migration. This is the second step in adding cross account access: defining the new role that this lambda will use. We need to define it in a separate PR, as there will be temporary downtime if we overwrite a policy.

### What’s changed
Defines a new policy for adding access to read AuthUserInfo table on orch accounts. In order to do this, I've also created combo policies for other orch tables, so the action access and key access are in one policy, as we were reaching the limit of 20 policies.

### Manual testing
N/A. I will manually test once we swap over to the new one that it deploys ok, and a full identity journey still works.

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs
PR to add the resource policy onto the AuthUserInfo table, allowing this cross-account access:
https://github.com/govuk-one-login/authentication-api/pull/6413
