### PR TITLE
ATO-1585: remove permissions for old orch to IPV key pair from auth

### DIFF
--- a/ci/terraform/oidc/kms-policies.tf
+++ b/ci/terraform/oidc/kms-policies.tf
@@ -64,31 +64,6 @@ resource "aws_iam_policy" "orch_to_auth_kms_policy" {
   policy = data.aws_iam_policy_document.orch_to_auth_kms_policy_document.json
 }
 
-### IPV Token signing key access
-
-data "aws_iam_policy_document" "ipv_token_auth_kms_policy_document" {
-  statement {
-    sid    = "AllowAccessToKmsSigningKey"
-    effect = "Allow"
-
-    actions = [
-      "kms:Sign",
-      "kms:GetPublicKey",
-    ]
-    resources = [
-      local.ipv_token_auth_signing_key_arn
-    ]
-  }
-}
-
-resource "aws_iam_policy" "ipv_token_auth_kms_policy" {
-  name_prefix = "kms-ipv-token-auth-policy"
-  path        = "/${var.environment}/ipv-token/"
-  description = "IAM policy for managing IPV authentication token KMS key access"
-
-  policy = data.aws_iam_policy_document.ipv_token_auth_kms_policy_document.json
-}
-
 ### Doc App signing key access
 
 data "aws_iam_policy_document" "doc_app_auth_kms_policy_document" {

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -39,7 +39,6 @@ locals {
   authentication_protected_subnet_ids         = data.terraform_remote_state.shared.outputs.authentication_protected_subnet_ids
   id_token_signing_key_alias_name             = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_name
   id_token_signing_key_arn                    = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
-  ipv_token_auth_signing_key_arn              = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_arn
   orch_to_auth_signing_key_alias_name         = data.terraform_remote_state.shared.outputs.orch_to_auth_signing_key_alias_name
   orch_to_auth_signing_key_arn                = data.terraform_remote_state.shared.outputs.orch_to_auth_signing_key_arn
   doc_app_auth_key_alias_name                 = data.terraform_remote_state.shared.outputs.doc_app_auth_signing_key_alias_name


### PR DESCRIPTION
**MERGE NOTE: Dependent on #6451 being merged**

### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Previously, orch was signing requests to IPV with a key that resides in the `gds-di-*` AWS accounts. The signing key resources have been moved to the `di-orchestration-*` AWS accounts (#6387) and publishing has been enabled on all environments (#6387, #6394, #6396, #6397) and we are now signing requests with this new key on all environments (#6405, #6412, #6414, #6415). We have also stopped publishing the old key on the IPV JWKS endpoint and cleaned up the infrastructure controlling deployment (#6425).

At this point, we are happy that things are working as expected on production.

We now need to remove the old key pair resources.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Removed Terraform key resources and access policies

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing. **- N/A**

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required. **- N/A**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required. **- N/A**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
--> 

- [ ] Changes have been made to stubs or not required. **- N/A**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required. **- N/A**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required. **- N/A**

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- #6387 - generate new signing key pair

- #6405 - sign on dev and build
- #6412
- #6414
- #6415

- #6425 - env var clean up
- #6451 - remove references to old key pair resources