### PR TITLE
ATO-1128: migrate away from using user profile

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -37,6 +37,7 @@ import uk.gov.di.orchestration.shared.state.UserContext;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.orchestration.shared.helpers.AuditHelper.attachTxmaAuditFieldFromHeaders;
@@ -156,10 +157,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             userContext.getSessionId(),
                             client.getClientID(),
                             AuditService.UNKNOWN,
-                            userContext
-                                    .getUserProfile()
-                                    .map(UserProfile::getEmail)
-                                    .orElse(AuditService.UNKNOWN),
+                            Optional.ofNullable(request.getEmail()).orElse(AuditService.UNKNOWN),
                             IpAddressHelper.extractIpAddress(input),
                             AuditService.UNKNOWN,
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -15,7 +15,6 @@ import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
-import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.lambda.BaseFrontendHandler;
@@ -122,7 +121,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
         LOG.info("ProcessingIdentity request received");
         attachTxmaAuditFieldFromHeaders(input.getHeaders());
         try {
-            UserProfile userProfile = userContext.getUserProfile().orElseThrow();
             ClientRegistry client = userContext.getClient().orElseThrow();
 
             int processingAttempts =
@@ -191,9 +189,8 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
             LOG.error("Unable to generate ProcessingIdentityResponse");
             throw new RuntimeException();
         } catch (NoSuchElementException e) {
-            LOG.warn(
-                    "Issue retrieving UserProfile or ClientRegistry from UserContext. UserProfile is present: {}, ClientRegistry is present: {}",
-                    userContext.getUserProfile().isPresent(),
+            LOG.error(
+                    "Issue retrieving ClientRegistry from UserContext. ClientRegistry is present: {}",
                     userContext.getClient().isPresent());
             throw new RuntimeException();
         }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -125,12 +125,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
         try {
             UserProfile userProfile = userContext.getUserProfile().orElseThrow();
             ClientRegistry client = userContext.getClient().orElseThrow();
-            var rpPairwiseSubject =
-                    ClientSubjectHelper.getSubject(
-                            userProfile,
-                            client,
-                            authenticationService,
-                            configurationService.getInternalSectorURI());
             var internalPairwiseSubjectId =
                     ClientSubjectHelper.calculatePairwiseIdentifier(
                             userProfile.getSubjectID(),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -131,22 +131,6 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             URI.create(configurationService.getInternalSectorURI()),
                             authenticationService.getOrGenerateSalt(userProfile));
 
-            // TODO: ATO-1128: temp logs to verify values are in sync:
-            try {
-                LOG.info(
-                        "is internalCommonSubjectId in sync {}",
-                        Objects.equals(
-                                userContext.getOrchSession().getInternalCommonSubjectId(),
-                                internalPairwiseSubjectId));
-
-                LOG.info(
-                        "is email in sync {}",
-                        Objects.equals(request.getEmail(), userProfile.getEmail()));
-            } catch (Exception e) {
-                LOG.info("temp logs failed, message: {}", e.getMessage());
-            }
-            //
-
             int processingAttempts =
                     userContext.getOrchSession().incrementProcessingIdentityAttempts();
             LOG.info(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -24,9 +24,7 @@ import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.Session;
-import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AccountInterventionService;
 import uk.gov.di.orchestration.shared.services.AuditService;
@@ -44,9 +42,7 @@ import uk.gov.di.orchestration.shared.services.SessionService;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,10 +73,6 @@ class ProcessingIdentityHandlerTest {
     private static final String EMAIL_ADDRESS = "test@test.com";
     private static final String CLIENT_ID = "test-client-id";
     private static final String CLIENT_NAME = "test-client-name";
-    private static final String PHONE_NUMBER = "01234567890";
-    private static final Date CREATED_DATE_TIME = NowHelper.nowMinus(30, ChronoUnit.SECONDS);
-    private static final Date UPDATED_DATE_TIME = NowHelper.now();
-    private static final String PUBLIC_SUBJECT_ID = new Subject("public-subject-id-2").getValue();
     private static final String SUBJECT_ID = new Subject("subject-id-3").getValue();
     private static final ByteBuffer SALT =
             ByteBuffer.wrap("a-test-salt".getBytes(StandardCharsets.UTF_8));
@@ -118,12 +110,8 @@ class ProcessingIdentityHandlerTest {
 
     @BeforeEach
     void setup() {
-        var userProfile = generateUserProfile();
         when(dynamoClientService.getClient(CLIENT_ID))
                 .thenReturn(Optional.of(generateClientRegistry()));
-        when(dynamoService.getUserProfileFromEmail(EMAIL_ADDRESS))
-                .thenReturn(Optional.of(userProfile));
-        when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(SALT.array());
         when(configurationService.getEnvironment()).thenReturn(ENVIRONMENT);
         when(configurationService.getInternalSectorURI()).thenReturn(INTERNAL_SECTOR_URI);
         Map<String, String> headers = new HashMap<>();
@@ -399,18 +387,5 @@ class ProcessingIdentityHandlerTest {
                 .withScopes(singletonList("openid"))
                 .withCookieConsentShared(true)
                 .withSubjectType("pairwise");
-    }
-
-    private UserProfile generateUserProfile() {
-        return new UserProfile()
-                .withEmail(EMAIL_ADDRESS)
-                .withEmailVerified(true)
-                .withPhoneNumber(PHONE_NUMBER)
-                .withPhoneNumberVerified(true)
-                .withPublicSubjectID(PUBLIC_SUBJECT_ID)
-                .withSubjectID(SUBJECT_ID)
-                .withSalt(SALT)
-                .withCreated(CREATED_DATE_TIME.toString())
-                .withUpdated(UPDATED_DATE_TIME.toString());
     }
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -110,7 +110,8 @@ class ProcessingIdentityHandlerTest {
     private final OrchClientSessionService orchClientSessionService =
             mock(OrchClientSessionService.class);
     private final Session session = new Session();
-    private final OrchSessionItem orchSession = new OrchSessionItem(SESSION_ID);
+    private final OrchSessionItem orchSession =
+            new OrchSessionItem(SESSION_ID).withInternalCommonSubjectId(PAIRWISE_SUBJECT);
     private final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
     protected final Json objectMapper = SerializationService.getInstance();
     private ProcessingIdentityHandler handler;
@@ -259,7 +260,7 @@ class ProcessingIdentityHandlerTest {
         verify(logoutService)
                 .handleAccountInterventionLogout(
                         new DestroySessionsRequest(SESSION_ID, List.of()),
-                        null,
+                        PAIRWISE_SUBJECT,
                         event,
                         CLIENT_ID,
                         intervention);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/lambda/BaseFrontendHandler.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/lambda/BaseFrontendHandler.java
@@ -187,19 +187,14 @@ public abstract class BaseFrontendHandler<T>
         session.map(Session::getEmailAddress)
                 .map(authenticationService::getUserProfileFromEmail)
                 .ifPresentOrElse(
-                        userProfile ->
-                                userContextBuilder
-                                        .withUserProfile(userProfile)
-                                        .withUserAuthenticated(true),
+                        userContextBuilder::withUserProfile,
                         () -> {
                             if (request instanceof BaseFrontendRequest baseFrontendRequest)
-                                userContextBuilder
-                                        .withUserProfile(
-                                                authenticationService.getUserProfileFromEmail(
-                                                        baseFrontendRequest
-                                                                .getEmail()
-                                                                .toLowerCase(Locale.ROOT)))
-                                        .withUserAuthenticated(false);
+                                userContextBuilder.withUserProfile(
+                                        authenticationService.getUserProfileFromEmail(
+                                                baseFrontendRequest
+                                                        .getEmail()
+                                                        .toLowerCase(Locale.ROOT)));
                         });
 
         userContextBuilder.withUserLanguage(matchSupportedLanguage(userLanguage));

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/lambda/BaseFrontendHandler.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/lambda/BaseFrontendHandler.java
@@ -154,6 +154,12 @@ public abstract class BaseFrontendHandler<T>
                 PERSISTENT_SESSION_ID,
                 PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
+        if (orchSession.get().getInternalCommonSubjectId() == null
+                || orchSession.get().getInternalCommonSubjectId().isBlank()) {
+            LOG.warn("Orch session has no internalCommonSubjectId");
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
+        }
+
         Optional<String> userLanguage =
                 getUserLanguageFromRequestHeaders(input.getHeaders(), configurationService);
         final T request;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/lambda/BaseFrontendHandler.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/lambda/BaseFrontendHandler.java
@@ -7,7 +7,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
-import uk.gov.di.orchestration.shared.entity.BaseFrontendRequest;
 import uk.gov.di.orchestration.shared.entity.ErrorResponse;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
@@ -28,7 +27,6 @@ import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
 import uk.gov.di.orchestration.shared.state.UserContext;
 
-import java.util.Locale;
 import java.util.Optional;
 
 import static uk.gov.di.orchestration.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
@@ -183,19 +181,6 @@ public abstract class BaseFrontendHandler<T>
         clientID.ifPresent(c -> userContextBuilder.withClient(clientService.getClient(c)));
 
         orchClientSession.ifPresent(userContextBuilder::withOrchClientSession);
-
-        session.map(Session::getEmailAddress)
-                .map(authenticationService::getUserProfileFromEmail)
-                .ifPresentOrElse(
-                        userContextBuilder::withUserProfile,
-                        () -> {
-                            if (request instanceof BaseFrontendRequest baseFrontendRequest)
-                                userContextBuilder.withUserProfile(
-                                        authenticationService.getUserProfileFromEmail(
-                                                baseFrontendRequest
-                                                        .getEmail()
-                                                        .toLowerCase(Locale.ROOT)));
-                        });
 
         userContextBuilder.withUserLanguage(matchSupportedLanguage(userLanguage));
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/UserContext.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/UserContext.java
@@ -15,7 +15,6 @@ public class UserContext {
     private final String sessionId;
     private final Optional<UserProfile> userProfile;
     private final Optional<UserCredentials> userCredentials;
-    private final boolean userAuthenticated;
     private final Optional<ClientRegistry> client;
     private final OrchClientSessionItem orchClientSession;
     private final SupportedLanguage userLanguage;
@@ -27,7 +26,6 @@ public class UserContext {
             String sessionId,
             Optional<UserProfile> userProfile,
             Optional<UserCredentials> userCredentials,
-            boolean userAuthenticated,
             Optional<ClientRegistry> client,
             OrchClientSessionItem orchClientSession,
             SupportedLanguage userLanguage,
@@ -37,7 +35,6 @@ public class UserContext {
         this.sessionId = sessionId;
         this.userProfile = userProfile;
         this.userCredentials = userCredentials;
-        this.userAuthenticated = userAuthenticated;
         this.client = client;
         this.orchClientSession = orchClientSession;
         this.userLanguage = userLanguage;
@@ -59,10 +56,6 @@ public class UserContext {
 
     public Optional<UserCredentials> getUserCredentials() {
         return userCredentials;
-    }
-
-    public boolean isUserAuthenticated() {
-        return userAuthenticated;
     }
 
     public Optional<ClientRegistry> getClient() {
@@ -102,7 +95,6 @@ public class UserContext {
         private String sessionId;
         private Optional<UserProfile> userProfile = Optional.empty();
         private Optional<UserCredentials> userCredentials = Optional.empty();
-        private boolean userAuthenticated = false;
         private Optional<ClientRegistry> client = Optional.empty();
         private OrchClientSessionItem orchClientSession;
         private SupportedLanguage userLanguage;
@@ -129,11 +121,6 @@ public class UserContext {
 
         public Builder withUserCredentials(Optional<UserCredentials> userCredentials) {
             this.userCredentials = userCredentials;
-            return this;
-        }
-
-        public Builder withUserAuthenticated(boolean userAuthenticated) {
-            this.userAuthenticated = userAuthenticated;
             return this;
         }
 
@@ -172,7 +159,6 @@ public class UserContext {
                     sessionId,
                     userProfile,
                     userCredentials,
-                    userAuthenticated,
                     client,
                     orchClientSession,
                     userLanguage,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/UserContext.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/state/UserContext.java
@@ -5,7 +5,6 @@ import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.UserCredentials;
-import uk.gov.di.orchestration.shared.entity.UserProfile;
 import uk.gov.di.orchestration.shared.helpers.LocaleHelper.SupportedLanguage;
 
 import java.util.Optional;
@@ -13,7 +12,6 @@ import java.util.Optional;
 public class UserContext {
     private final Session session;
     private final String sessionId;
-    private final Optional<UserProfile> userProfile;
     private final Optional<UserCredentials> userCredentials;
     private final Optional<ClientRegistry> client;
     private final OrchClientSessionItem orchClientSession;
@@ -24,7 +22,6 @@ public class UserContext {
     protected UserContext(
             Session session,
             String sessionId,
-            Optional<UserProfile> userProfile,
             Optional<UserCredentials> userCredentials,
             Optional<ClientRegistry> client,
             OrchClientSessionItem orchClientSession,
@@ -33,7 +30,6 @@ public class UserContext {
             OrchSessionItem orchSession) {
         this.session = session;
         this.sessionId = sessionId;
-        this.userProfile = userProfile;
         this.userCredentials = userCredentials;
         this.client = client;
         this.orchClientSession = orchClientSession;
@@ -48,10 +44,6 @@ public class UserContext {
 
     public String getSessionId() {
         return sessionId;
-    }
-
-    public Optional<UserProfile> getUserProfile() {
-        return userProfile;
     }
 
     public Optional<UserCredentials> getUserCredentials() {
@@ -93,7 +85,6 @@ public class UserContext {
     public static class Builder {
         private final Session session;
         private String sessionId;
-        private Optional<UserProfile> userProfile = Optional.empty();
         private Optional<UserCredentials> userCredentials = Optional.empty();
         private Optional<ClientRegistry> client = Optional.empty();
         private OrchClientSessionItem orchClientSession;
@@ -107,15 +98,6 @@ public class UserContext {
 
         public Builder withSessionId(String sessionId) {
             this.sessionId = sessionId;
-            return this;
-        }
-
-        public Builder withUserProfile(UserProfile userProfile) {
-            return withUserProfile(Optional.of(userProfile));
-        }
-
-        public Builder withUserProfile(Optional<UserProfile> userProfile) {
-            this.userProfile = userProfile;
             return this;
         }
 
@@ -157,7 +139,6 @@ public class UserContext {
             return new UserContext(
                     session,
                     sessionId,
-                    userProfile,
                     userCredentials,
                     client,
                     orchClientSession,


### PR DESCRIPTION
### Wider context of change
Final migration in the email migration work. Migrates ProcessingIdentityHandler.

### What’s changed
- Swaps getting email from the session to the request. 
- Swaps getting internalCommonSubjectId from calculating via UserProfile to getting from the orchSession.
- Removes the now unused UserProfile from the handler

### Manual testing
TBD: Deploy to dev and test

[Logs to verify email is in sync](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22is%20email%20in%20sync*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1745920800&latest=1746021600&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&display.general.type=events&sid=1746018261.60231)
[Logs to verify internalCommonSubjectId is in sync](https://gds.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22gds_di_production%22%20message%3D%22is%20internalCommonSubjectId%20in%20sync*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1745920800&latest=1746021600&display.page.search.tab=events&display.page.search.patterns.sensitivity=0.866&display.general.type=events&sid=1746018227.60200)

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing. **No new resources accessed**
- [x] Impact on orch and auth mutual dependencies has been checked. **Yes**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
