### PR TITLE
ATO-1125: remove email from orch shared session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -959,7 +959,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         private void setupPreviousSessions(String internalCommonSubjectId)
                 throws Json.JsonException {
-            var session = new Session().setEmailAddress(TEST_EMAIL_ADDRESS);
+            var session = new Session();
             var orchSession =
                     new OrchSessionItem(PREVIOUS_SESSION_ID)
                             .withInternalCommonSubjectId(internalCommonSubjectId)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -186,7 +186,6 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 CLIENT_NAME)
                         .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
-        redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
         var response =
                 makeRequest(
@@ -324,7 +323,6 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 CLIENT_NAME)
                         .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
-        redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
         makeRequest(
                 Optional.empty(),
@@ -502,7 +500,6 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 CLIENT_NAME)
                         .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
-        redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
         var response =
                 makeRequest(
@@ -600,7 +597,6 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 CLIENT_NAME)
                         .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
-        redis.addEmailToSession(SESSION_ID, TEST_EMAIL_ADDRESS);
 
         var response =
                 makeRequest(
@@ -662,7 +658,6 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 CLIENT_NAME)
                         .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, sessionId);
-        redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
 
         var response =
                 makeRequest(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -206,7 +206,7 @@ class IPVCallbackHandlerTest {
     private final CaptureLoggingExtension redirectLogging =
             new CaptureLoggingExtension(RedirectService.class);
 
-    private final Session session = new Session().setEmailAddress(TEST_EMAIL_ADDRESS);
+    private final Session session = new Session();
 
     private final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -155,10 +155,7 @@ class AuthenticationCallbackHandlerTest {
     private static final String SESSION_ID = "a-session-id";
 
     private static final Session session =
-            new Session()
-                    .setAuthenticated(false)
-                    .setCurrentCredentialStrength(null)
-                    .setEmailAddress(TEST_EMAIL_ADDRESS);
+            new Session().setAuthenticated(false).setCurrentCredentialStrength(null);
     public static final OrchSessionItem orchSession =
             new OrchSessionItem(SESSION_ID)
                     .withAuthenticated(false)
@@ -1355,7 +1352,6 @@ class AuthenticationCallbackHandlerTest {
 
         private void withPreviousSharedSessionDueToMaxAge() {
             var previousSharedSession = new Session();
-            previousSharedSession.setEmailAddress(TEST_EMAIL_ADDRESS);
             when(sessionService.getSession(PREVIOUS_SESSION_ID))
                     .thenReturn(Optional.of(previousSharedSession));
         }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -75,7 +75,6 @@ class LogoutHandlerTest {
     private SignedJWT signedIDToken;
     private String idTokenHint;
     private static final Subject SUBJECT = new Subject();
-    private static final String EMAIL = "joe.bloggs@test.com";
     private Session session;
     private OrchSessionItem orchSession;
 
@@ -126,7 +125,7 @@ class LogoutHandlerTest {
 
     @Test
     void shouldDestroySessionAndLogoutWhenSessionIsAvailable() {
-        session = generateSession().setEmailAddress(EMAIL);
+        session = generateSession();
         APIGatewayProxyRequestEvent event =
                 generateRequestEvent(
                         Map.of(
@@ -192,7 +191,7 @@ class LogoutHandlerTest {
 
     @Test
     void shouldNotThrowWhenTryingToDeleteClientSessionWhichHasExpired() {
-        session = generateSession().setEmailAddress(EMAIL);
+        session = generateSession();
         APIGatewayProxyRequestEvent event =
                 generateRequestEvent(
                         Map.of(

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/RedisExtension.java
@@ -22,7 +22,6 @@ import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static uk.gov.di.orchestration.shared.services.ClientSessionService.CLIENT_SESSION_PREFIX;
 
@@ -41,13 +40,12 @@ public class RedisExtension
     }
 
     public String createSession(String sessionId) throws Json.JsonException {
-        return createSession(sessionId, false, Optional.empty());
+        return createSession(sessionId, false);
     }
 
-    private String createSession(String sessionId, boolean isAuthenticated, Optional<String> email)
+    private String createSession(String sessionId, boolean isAuthenticated)
             throws Json.JsonException {
         Session session = new Session().setAuthenticated(isAuthenticated);
-        email.ifPresent(session::setEmailAddress);
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
         return sessionId;
     }
@@ -62,7 +60,7 @@ public class RedisExtension
     }
 
     public String createSession(boolean isAuthenticated) throws Json.JsonException {
-        return createSession(IdGenerator.generate(), isAuthenticated, Optional.empty());
+        return createSession(IdGenerator.generate(), isAuthenticated);
     }
 
     public void addDocAppSubjectIdToClientSession(Subject subject, String clientSessionId)
@@ -132,12 +130,6 @@ public class RedisExtension
                 CLIENT_SESSION_PREFIX.concat(clientSessionId),
                 objectMapper.writeValueAsString(clientSession),
                 3600);
-    }
-
-    public void addEmailToSession(String sessionId, String emailAddress) throws Json.JsonException {
-        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
-        session.setEmailAddress(emailAddress);
-        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 
     public void setSessionCredentialTrustLevel(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -67,10 +67,6 @@ public class Session {
         return this.emailAddress.equals(emailAddress);
     }
 
-    public String getEmailAddress() {
-        return emailAddress;
-    }
-
     public Session setEmailAddress(String emailAddress) {
         this.emailAddress = emailAddress;
         return this;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -67,11 +67,6 @@ public class Session {
         return this.emailAddress.equals(emailAddress);
     }
 
-    public Session setEmailAddress(String emailAddress) {
-        this.emailAddress = emailAddress;
-        return this;
-    }
-
     public CredentialTrustLevel getCurrentCredentialStrength() {
         return currentCredentialStrength;
     }


### PR DESCRIPTION
### Wider context of change
Final PR on orch's side for email migration

### What’s changed
- deletes session.getEmailAddress and remaining test uses
- deletes session.setEmailAddress and remaining tests uses (Auth aren't reliant on orch setting email)

### Manual testing
N/A

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing. **No change**

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked. **Auth don't rely on Orch setting email**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required. **N/A**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required. **N/A**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required. **N/A**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required. **N/A**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**