### PR TITLE
ATO-1621: Add AchievedCredentialStrength to Auth session

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -32,6 +32,8 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_CODE_REQUEST_COUNT_MAP = "CodeRequestCountMap";
     public static final String ATTRIBUTE_PRESERVED_REAUTH_COUNTS_FOR_AUDIT_MAP =
             "PreservedReauthCountsForAuditMap";
+    public static final String ATTRIBUTE_ACHIEVED_CREDENTIAL_STRENGTH =
+            "AchievedCredentialStrength";
 
     public enum AccountState {
         NEW,
@@ -65,6 +67,7 @@ public class AuthSessionItem {
     private Map<CodeRequestType, Integer> codeRequestCountMap;
     private int passwordResetCount;
     private Map<CountType, Integer> preservedReauthCountsForAuditMap;
+    private CredentialTrustLevel achievedCredentialStrength;
 
     public AuthSessionItem() {
         this.codeRequestCountMap = new HashMap<>();
@@ -304,6 +307,20 @@ public class AuthSessionItem {
     public AuthSessionItem withPreservedReauthCountsForAuditMap(
             Map<CountType, Integer> preservedReauthCountsForAuditMap) {
         this.preservedReauthCountsForAuditMap = preservedReauthCountsForAuditMap;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_ACHIEVED_CREDENTIAL_STRENGTH)
+    public CredentialTrustLevel getAchievedCredentialStrength() {
+        return this.achievedCredentialStrength;
+    }
+
+    public void setAchievedCredentialStrength(CredentialTrustLevel credentialStrength) {
+        this.achievedCredentialStrength = credentialStrength;
+    }
+
+    public AuthSessionItem withAchievedCredentialStrength(CredentialTrustLevel credentialStrength) {
+        this.achievedCredentialStrength = credentialStrength;
         return this;
     }
 


### PR DESCRIPTION
### Wider context of change: 

We're planning to migrate away from using CurrentCredentialStrength on the Auth session in favour of a new field. We're doing this in this manner to allow us to be able to set this value in additional places before we swap over. This will allow us to check the value is what we expect before we swap over any usages. The plan is for this to be a value auth derive itself instead of partially requiring Orchestration (as it currently does).
 
### What’s changed: 
 - Adds a new attribute to the Auth session `AchievedCredentialStrength`

### Manual testing: 
- N/A just adding a new unused attribute to the session

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
