### PR TITLE
ATO-1621: set achieved credential strength on auth session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -300,11 +300,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             AuditContext auditContext,
             AuthSessionItem authSessionItem) {
 
-        authSessionService.updateSession(
-                authSessionItem
-                        .withAccountState(AuthSessionItem.AccountState.EXISTING)
-                        .withInternalCommonSubjectId(internalCommonSubjectIdentifier));
-
         var userMfaDetail = getUserMFADetail(userContext, userCredentials, userProfile);
 
         boolean isPasswordChangeRequired = isPasswordResetRequired(request.getPassword());
@@ -334,6 +329,11 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     clientService.isTestJourney(userContext.getClientId(), userProfile.getEmail()),
                     false);
         }
+
+        authSessionService.updateSession(
+                authSessionItem
+                        .withAccountState(AuthSessionItem.AccountState.EXISTING)
+                        .withInternalCommonSubjectId(internalCommonSubjectIdentifier));
 
         String redactedPhoneNumber =
                 userMfaDetail.phoneNumber() != null && userMfaDetail.mfaMethodVerified()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CountType;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -328,6 +329,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     "P0",
                     clientService.isTestJourney(userContext.getClientId(), userProfile.getEmail()),
                     false);
+            authSessionItem.setAchievedCredentialStrength(CredentialTrustLevel.LOW_LEVEL);
         }
 
         authSessionService.updateSession(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -50,6 +50,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
@@ -329,7 +330,13 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     "P0",
                     clientService.isTestJourney(userContext.getClientId(), userProfile.getEmail()),
                     false);
-            authSessionItem.setAchievedCredentialStrength(CredentialTrustLevel.LOW_LEVEL);
+
+            if (Objects.isNull(authSessionItem.getAchievedCredentialStrength())
+                    || !authSessionItem
+                            .getAchievedCredentialStrength()
+                            .isHigherThan(CredentialTrustLevel.LOW_LEVEL)) {
+                authSessionItem.setAchievedCredentialStrength(CredentialTrustLevel.LOW_LEVEL);
+            }
         }
 
         authSessionService.updateSession(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -55,6 +55,7 @@ import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder.getReauthFailureReasonFromCountTypes;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
+import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.NONE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
@@ -395,7 +396,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     MFAMethodType.SMS.getValue(),
                     false);
             authSessionService.updateSession(
-                    authSession.withVerifiedMfaMethodType(MFAMethodType.SMS));
+                    authSession
+                            .withVerifiedMfaMethodType(MFAMethodType.SMS)
+                            .withAchievedCredentialStrength(MEDIUM_LEVEL));
             clearAccountRecoveryBlockIfPresent(authSession, auditContext);
             cloudwatchMetricsService.incrementAuthenticationSuccess(
                     authSession.getIsNewAccount(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -417,7 +417,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         authSessionService.updateSession(
                 authSession
                         .withVerifiedMfaMethodType(codeRequest.getMfaMethodType())
-                        .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL));
+                        .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL)
+                        .withAchievedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL));
 
         var clientId = userContext.getClientId();
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -99,6 +99,7 @@ import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.V
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.VALID_HEADERS_WITHOUT_AUDIT_ENCODED;
 import static uk.gov.di.authentication.frontendapi.helpers.FrontendApiPhoneNumberHelper.redactPhoneNumber;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
+import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.AUTH_APP;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.SMS;
@@ -286,7 +287,8 @@ class LoginHandlerTest {
     }
 
     @Test
-    void shouldSetAchievedCredentialTrustLowWhenMfaNotRequired() throws Json.JsonException {
+    void shouldSetAchievedCredentialTrustLowWhenMfaNotRequiredAndNoPreviousValue()
+            throws Json.JsonException {
         // Arrange
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
@@ -301,6 +303,123 @@ class LoginHandlerTest {
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
         usingValidAuthSession();
+
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+
+        // Act
+        var result = handler.handleRequest(event, context);
+
+        // Assert
+        assertThat(result, hasStatus(200));
+
+        LoginResponse response = objectMapper.readValue(result.getBody(), LoginResponse.class);
+
+        assertThat(
+                response.redactedPhoneNumber(),
+                equalTo(redactPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER)));
+        assertThat(response.latestTermsAndConditionsAccepted(), equalTo(true));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.AUTH_LOG_IN_SUCCESS,
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
+                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()));
+
+        verify(cloudwatchMetricsService)
+                .incrementAuthenticationSuccess(
+                        AuthSessionItem.AccountState.EXISTING,
+                        CLIENT_ID.getValue(),
+                        CLIENT_NAME,
+                        "P0",
+                        false,
+                        false);
+
+        verify(authSessionService)
+                .updateSession(
+                        argThat(
+                                as ->
+                                        as.getAchievedCredentialStrength() == LOW_LEVEL
+                                                && as.getIsNewAccount()
+                                                        == AuthSessionItem.AccountState.EXISTING));
+        verifyInternalCommonSubjectIdentifierSaved();
+    }
+
+    @Test
+    void shouldRetainPreviouslyMediumCredentialTrustWhenOnLowLevelJourney()
+            throws Json.JsonException {
+        // Arrange
+        UserProfile userProfile = generateUserProfile(null);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+        when(clientSession.getAuthRequestParams())
+                .thenReturn(generateAuthRequest(LOW_LEVEL).toParameters());
+        var vot =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArrayOf("P0.Cl")));
+        when(clientSession.getEffectiveVectorOfTrust()).thenReturn(vot);
+
+        usingValidSession();
+        usingApplicableUserCredentialsWithLogin(SMS, true);
+        usingValidAuthSessionWithAchievedCredentialStrength(MEDIUM_LEVEL);
+
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+
+        // Act
+        var result = handler.handleRequest(event, context);
+
+        // Assert
+        assertThat(result, hasStatus(200));
+
+        LoginResponse response = objectMapper.readValue(result.getBody(), LoginResponse.class);
+
+        assertThat(
+                response.redactedPhoneNumber(),
+                equalTo(redactPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER)));
+        assertThat(response.latestTermsAndConditionsAccepted(), equalTo(true));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.AUTH_LOG_IN_SUCCESS,
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
+                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()));
+
+        verify(cloudwatchMetricsService)
+                .incrementAuthenticationSuccess(
+                        AuthSessionItem.AccountState.EXISTING,
+                        CLIENT_ID.getValue(),
+                        CLIENT_NAME,
+                        "P0",
+                        false,
+                        false);
+
+        verify(authSessionService)
+                .updateSession(
+                        argThat(
+                                as ->
+                                        as.getAchievedCredentialStrength() == MEDIUM_LEVEL
+                                                && as.getIsNewAccount()
+                                                        == AuthSessionItem.AccountState.EXISTING));
+        verifyInternalCommonSubjectIdentifierSaved();
+    }
+
+    @Test
+    void shouldRetainLowCredentialTrustLevelWhenPreviouslyObtained() throws Json.JsonException {
+        // Arrange
+        UserProfile userProfile = generateUserProfile(null);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+        when(clientSession.getAuthRequestParams())
+                .thenReturn(generateAuthRequest(LOW_LEVEL).toParameters());
+        var vot =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArrayOf("P0.Cl")));
+        when(clientSession.getEffectiveVectorOfTrust()).thenReturn(vot);
+
+        usingValidSession();
+        usingApplicableUserCredentialsWithLogin(SMS, true);
+        usingValidAuthSessionWithAchievedCredentialStrength(LOW_LEVEL);
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
 
@@ -1165,14 +1284,20 @@ class LoginHandlerTest {
                 .thenReturn(Optional.of(session));
     }
 
-    private void usingValidAuthSession() {
+    private void usingValidAuthSessionWithAchievedCredentialStrength(
+            CredentialTrustLevel credentialTrustLevel) {
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(
                         Optional.of(
                                 new AuthSessionItem()
                                         .withSessionId(SESSION_ID)
                                         .withEmailAddress(EMAIL)
-                                        .withAccountState(AuthSessionItem.AccountState.UNKNOWN)));
+                                        .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
+                                        .withAchievedCredentialStrength(credentialTrustLevel)));
+    }
+
+    private void usingValidAuthSession() {
+        usingValidAuthSessionWithAchievedCredentialStrength(null);
     }
 
     private void usingInvalidAuthSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -74,6 +74,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -102,6 +103,7 @@ import static uk.gov.di.authentication.shared.entity.CountType.ENTER_AUTH_APP_CO
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_SMS_CODE;
+import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
@@ -227,7 +229,7 @@ class VerifyMfaCodeHandlerTest {
     }
 
     private static Stream<CredentialTrustLevel> credentialTrustLevels() {
-        return Stream.of(CredentialTrustLevel.LOW_LEVEL, CredentialTrustLevel.MEDIUM_LEVEL);
+        return Stream.of(CredentialTrustLevel.LOW_LEVEL, MEDIUM_LEVEL);
     }
 
     @ParameterizedTest
@@ -250,9 +252,8 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
-        assertThat(
-                authSession.getCurrentCredentialStrength(),
-                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(authSession.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
+        assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -334,9 +335,8 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
-        assertThat(
-                authSession.getCurrentCredentialStrength(),
-                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(authSession.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
+        assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -378,9 +378,8 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
-        assertThat(
-                authSession.getCurrentCredentialStrength(),
-                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(authSession.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
+        assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(phoneNumberCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -422,9 +421,7 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
-        assertThat(
-                authSession.getCurrentCredentialStrength(),
-                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(authSession.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -472,9 +469,8 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
-        assertThat(
-                authSession.getCurrentCredentialStrength(),
-                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        assertThat(authSession.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
+        assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -829,7 +825,7 @@ class VerifyMfaCodeHandlerTest {
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.of(ErrorResponse.ERROR_1041));
-        session.setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
+        session.setCurrentCredentialStrength(MEDIUM_LEVEL);
         if (!CodeRequestType.isValidCodeRequestType(MFAMethodType.AUTH_APP, journeyType)) {
             return;
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
@@ -27,4 +27,12 @@ public enum CredentialTrustLevel {
     public static CredentialTrustLevel getDefault() {
         return MEDIUM_LEVEL;
     }
+
+    public boolean isHigherThan(CredentialTrustLevel otherCredentialTrustLevel) {
+        return this.compareTo(otherCredentialTrustLevel) > 0;
+    }
+
+    public boolean isLowerThan(CredentialTrustLevel otherCredentialTrustLevel) {
+        return this.compareTo(otherCredentialTrustLevel) < 0;
+    }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
@@ -10,7 +10,9 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 
@@ -43,5 +45,25 @@ class CredentialTrustLevelTest {
 
     private static Stream<String> invalidCredentialTrustLevelValues() {
         return Stream.of("Cm", "Cm.Cl", "Cl.Cm.Cl.Cm", "P2.Cl.Cm");
+    }
+
+    @Test
+    void mediumIsHigherThanLow() {
+        assertTrue(MEDIUM_LEVEL.isHigherThan(LOW_LEVEL));
+    }
+
+    @Test
+    void lowIsLowerThanMedium() {
+        assertTrue(LOW_LEVEL.isLowerThan(MEDIUM_LEVEL));
+    }
+
+    @Test
+    void mediumIsNotLowerThanLow() {
+        assertFalse(MEDIUM_LEVEL.isLowerThan(LOW_LEVEL));
+    }
+
+    @Test
+    void lowIsNotHigherThanMedium() {
+        assertFalse(LOW_LEVEL.isHigherThan(MEDIUM_LEVEL));
     }
 }


### PR DESCRIPTION
### Wider context of change: 

As we're in the process of migrating from using CurrentCredentialStrength to Achieved Credential strength, we need to set this value in all places where we're certain a user has achieved a level of credential trust. This means we'll set it in some places where we previously set CurrentCredentialStrength and some new places.

### What’s changed: 
- Sets Achieved Credential Strength to low in Login Handler when MFA is not required and user has not previously achieved a higher level of strength (**NEW**)
- Sets Achieved Credential Strength  to medium in VerifyMfaCode in the same place Current Credential Strength is set
- Sets Archived Credential Strength to medium in VerifyCode Handler when on a SMS MFA journey (**NEW**)

### Manual testing: 

- Deployed to sandpit and test the following:
- [x] A low confidence journey - check session has low
- [x] Uplift Auth App  - Check session has medium
- [x] Uplift SMS - Check session has medium
- [x] Medium followed by low - session should retain medium
- [x] A medium sign up with SMS - Check session has medium 
- [x] A medium sign up with Auth APP - Check session has medium 
- [x] A medium sign in with SMS -  Check session has medium 
- [x] A medium sign in with Auth App -  Check session has medium 

- [X] Deploy to auth dev and let the acceptance tests run against it. Review the sessions generated by the test run and confirm all complete journeys have an associated achievedCredentialStrength value:
 -  Saw a couple of failures related which look related to the MFA method management 
- Have reviewed the test output logs and sessions from when the test run happened. Correlated the sessions with each test scenario and looks like any scenarios with no `AchievedCredentialStrength` value are incomplete journeys:
 > - Lockouts 
 > - Partial sign ins
> - Partial sign ups 
> - Failed MFA resets
 
Happy to talk through my working on this

- Auth devs should review this one to make sure it's correct

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs: 
- Branches off of https://github.com/govuk-one-login/authentication-api/pull/6437, so must be merged first