### PR TITLE
ATO-1621: send achieved credential strength in userinfo

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/entity/AuthUserInfoClaims.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/entity/AuthUserInfoClaims.java
@@ -16,7 +16,8 @@ public enum AuthUserInfoClaims {
     VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type"),
     CURRENT_CREDENTIAL_STRENGTH("current_credential_strength"),
     NEW_ACCOUNT("new_account"),
-    UPLIFT_REQUIRED("uplift_required");
+    UPLIFT_REQUIRED("uplift_required"),
+    ACHIEVED_CREDENTIAL_STRENGTH("achieved_credential_strength");
 
     private final String value;
 

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -116,6 +116,17 @@ public class UserInfoService {
                     AuthUserInfoClaims.UPLIFT_REQUIRED.getValue(), authSession.getUpliftRequired());
             LOG.info("uplift_required value: {}", authSession.getUpliftRequired());
         }
+
+        if (accessTokenInfo
+                .getClaims()
+                .contains(AuthUserInfoClaims.ACHIEVED_CREDENTIAL_STRENGTH.getValue())) {
+            userInfo.setClaim(
+                    AuthUserInfoClaims.ACHIEVED_CREDENTIAL_STRENGTH.getValue(),
+                    authSession.getAchievedCredentialStrength());
+            LOG.info(
+                    "achieved_credential_strength value: {}",
+                    authSession.getAchievedCredentialStrength());
+        }
     }
 
     private static String bytesToBase64(ByteBuffer byteBuffer) {

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.external.entity.AuthUserInfoClaims.ACHIEVED_CREDENTIAL_STRENGTH;
 
 public class UserInfoServiceTest {
     private UserInfoService userInfoService;
@@ -54,6 +55,8 @@ public class UserInfoServiceTest {
     private static final MFAMethodType TEST_VERIFIED_MFA_METHOD_TYPE = MFAMethodType.EMAIL;
     private static final CredentialTrustLevel TEST_CURRENT_CREDENTIAL_STRENGTH =
             CredentialTrustLevel.MEDIUM_LEVEL;
+    private static final CredentialTrustLevel TEST_ACHIEVED_CREDENTIAL_STRENGTH =
+            CredentialTrustLevel.MEDIUM_LEVEL;
     private static final boolean TEST_UPLIFT_REQUIRED = true;
     private static final boolean TEST_IS_NEW_ACCOUNT = true;
     private static final long TEST_PASSWORD_RESET_TIME = 1710255380L;
@@ -71,6 +74,7 @@ public class UserInfoServiceTest {
             new AuthSessionItem()
                     .withVerifiedMfaMethodType(TEST_VERIFIED_MFA_METHOD_TYPE)
                     .withCurrentCredentialStrength(TEST_CURRENT_CREDENTIAL_STRENGTH)
+                    .withAchievedCredentialStrength(TEST_ACHIEVED_CREDENTIAL_STRENGTH)
                     .withUpliftRequired(TEST_UPLIFT_REQUIRED);
 
     @BeforeEach
@@ -99,7 +103,8 @@ public class UserInfoServiceTest {
             String expectedSalt,
             MFAMethodType expectedVerifiedMfaMethod,
             CredentialTrustLevel expectedCurrentCredentialStrength,
-            Boolean expectedUpliftRequired) {
+            Boolean expectedUpliftRequired,
+            CredentialTrustLevel expectedAchievedCredentialStrength) {
         UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore, authSession);
 
         assertEquals(TEST_INTERNAL_COMMON_SUBJECT_ID, actual.getSubject().getValue());
@@ -119,6 +124,9 @@ public class UserInfoServiceTest {
                 expectedCurrentCredentialStrength, actual.getClaim("current_credential_strength"));
         assertEquals(TEST_PASSWORD_RESET_TIME, actual.getClaim("password_reset_time"));
         assertEquals(expectedUpliftRequired, actual.getClaim("uplift_required"));
+        assertEquals(
+                expectedAchievedCredentialStrength,
+                actual.getClaim(ACHIEVED_CREDENTIAL_STRENGTH.getValue()));
     }
 
     private static Stream<Arguments> provideTestData() {
@@ -128,6 +136,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         TEST_SUBJECT.getValue(),
+                        null,
                         null,
                         null,
                         null,
@@ -149,6 +158,7 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         null,
+                        null,
                         null),
                 Arguments.of(
                         getMockAccessTokenStore(
@@ -163,7 +173,8 @@ public class UserInfoServiceTest {
                                         "salt",
                                         "verified_mfa_method_type",
                                         "current_credential_strength",
-                                        "uplift_required")),
+                                        "uplift_required",
+                                        "achieved_credential_strength")),
                         TEST_LEGACY_SUBJECT_ID,
                         TEST_PUBLIC_SUBJECT_ID,
                         TEST_SUBJECT.getValue(),
@@ -174,7 +185,8 @@ public class UserInfoServiceTest {
                         bytesToBase64(TEST_SALT),
                         TEST_VERIFIED_MFA_METHOD_TYPE,
                         TEST_CURRENT_CREDENTIAL_STRENGTH,
-                        TEST_UPLIFT_REQUIRED));
+                        TEST_UPLIFT_REQUIRED,
+                        TEST_ACHIEVED_CREDENTIAL_STRENGTH));
     }
 
     private static AccessTokenStore getMockAccessTokenStore(List<String> claims) {


### PR DESCRIPTION
### Wider context of change

We're migrating away from using Current Credential strength towards using Achieved credential strength. We send Orchestration the current credential strength value and we should send this new value to Orchestration in the userinfo response.

### What’s changed: 
- Optionally sends the achieved credential strength value if it is included in the claims from Orchestration 

### Manual testing: 
- Deploy to sandpit
- Run through a journey - shouldn't see anything massively different given Orchestration need to start requesting the claim
- No errors observed

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs: 
- Branches off of: https://github.com/govuk-one-login/authentication-api/pull/6438 so must be merged first
