### PR TITLE
ATO-1621: log achieved credential strength from userinfo response

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/CredentialTrustLevel.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/CredentialTrustLevel.java
@@ -34,4 +34,12 @@ public enum CredentialTrustLevel {
         }
         return b;
     }
+
+    public boolean isHigherThan(CredentialTrustLevel otherCredentialTrustLevel) {
+        return this.compareTo(otherCredentialTrustLevel) > 0;
+    }
+
+    public boolean isLowerThan(CredentialTrustLevel otherCredentialTrustLevel) {
+        return this.compareTo(otherCredentialTrustLevel) < 0;
+    }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/CredentialTrustLevelTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/CredentialTrustLevelTest.java
@@ -11,7 +11,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.orchestration.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.orchestration.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 
@@ -59,5 +61,25 @@ class CredentialTrustLevelTest {
                 Arguments.of(MEDIUM_LEVEL, MEDIUM_LEVEL, MEDIUM_LEVEL),
                 Arguments.of(MEDIUM_LEVEL, LOW_LEVEL, MEDIUM_LEVEL),
                 Arguments.of(LOW_LEVEL, MEDIUM_LEVEL, MEDIUM_LEVEL));
+    }
+
+    @Test
+    void mediumIsHigherThanLow() {
+        assertTrue(MEDIUM_LEVEL.isHigherThan(LOW_LEVEL));
+    }
+
+    @Test
+    void lowIsLowerThanMedium() {
+        assertTrue(LOW_LEVEL.isLowerThan(MEDIUM_LEVEL));
+    }
+
+    @Test
+    void mediumIsNotLowerThanLow() {
+        assertFalse(MEDIUM_LEVEL.isLowerThan(LOW_LEVEL));
+    }
+
+    @Test
+    void lowIsNotHigherThanMedium() {
+        assertFalse(LOW_LEVEL.isHigherThan(MEDIUM_LEVEL));
     }
 }


### PR DESCRIPTION
### Wider context of change:

We're requesting this value and now auth are sending it to us. We can now do some logging and check the value is as expected. 

### What’s changed: 
- Adds some logging to auth callback to check this value. This logging is wrapped in a wide catch so shouldn't create a problem.

### Manual testing: 
-  Deployed to dev
- Ran through a journey and checked logging was present 
- Inadvertently tested the case where the achieved credential strength was null because sandpit was not up to date with main 😄  - logging handled this gracefully as expected
- Also handled the comparison as expected

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
