### PR TITLE
BAU: Add logging of NumberParseException type

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
@@ -17,7 +17,9 @@ public class PhoneNumberHelper {
             var parsedPhoneNumber = phoneUtil.parse(phoneNumber, "GB");
             return phoneUtil.format(parsedPhoneNumber, PhoneNumberUtil.PhoneNumberFormat.E164);
         } catch (NumberParseException e) {
-            LOG.warn("Error when trying to parse phone number");
+            LOG.warn(
+                    "Error when trying to parse phone number for formatPhoneNumber: {}",
+                    e.getErrorType());
             throw new RuntimeException(e);
         }
     }
@@ -27,7 +29,8 @@ public class PhoneNumberHelper {
             return Integer.toString(
                     PhoneNumberUtil.getInstance().parse(phoneNumber, "GB").getCountryCode());
         } catch (NumberParseException e) {
-            LOG.warn("Error when trying to parse phone number");
+            LOG.warn(
+                    "Error when trying to parse phone number for getCountry: {}", e.getErrorType());
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
We currently do not log why a number was failed to be parsed, which restricts our ability to debug live issues.