### PR TITLE
AUT-4196: Give dynamo user roles access to the user-credentials customer managed encryption key

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
       "kms:CreateGrant",
       "kms:DescribeKey",
     ]
-    resources = [local.user_profile_kms_key_arn]
+    resources = [local.user_profile_kms_key_arn, local.user_credentials_kms_key_arn]
   }
 }
 
@@ -117,7 +117,7 @@ data "aws_iam_policy_document" "dynamo_user_read_policy_document" {
       "kms:CreateGrant",
       "kms:DescribeKey",
     ]
-    resources = [local.user_profile_kms_key_arn]
+    resources = [local.user_profile_kms_key_arn, local.user_credentials_kms_key_arn]
   }
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -68,6 +68,7 @@ locals {
   pending_email_check_queue_id                = data.terraform_remote_state.shared.outputs.pending_email_check_queue_id
   pending_email_check_queue_access_policy_arn = data.terraform_remote_state.shared.outputs.pending_email_check_queue_access_policy_arn
   user_profile_kms_key_arn                    = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
+  user_credentials_kms_key_arn                = data.terraform_remote_state.shared.outputs.user_credentials_kms_key_arn
   authentication_attempt_kms_key_arn          = data.terraform_remote_state.shared.outputs.authentication_attempt_kms_key_arn
   auth_session_table_encryption_key_arn       = data.terraform_remote_state.shared.outputs.auth_session_table_encryption_key_arn
   email_check_results_encryption_policy_arn   = data.terraform_remote_state.shared.outputs.email_check_results_encryption_policy_arn


### PR DESCRIPTION
## What

Give dynamo user roles access to the user-credentials customer managed encryption key

- When encryption of the user-credentials table is switched to the CMK the lambdas accessing the table will have rights they need to access it.
- The required lambdas will first be given the rights they need before switching over encryption to the CMK.
- Changing the role causes an update in place rather than a destroy and recreate, so this is a zero downtime operation

## How to review

1. Code review
2. Apply to a dev environment to observe terraform plan

