### PR TITLE
ATO-1570: remove email from auth shared session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -131,7 +131,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
             var userProfile = authenticationService.getUserProfileByEmailMaybe(emailAddress);
             var userExists = userProfile.isPresent();
-            userContext.getSession().setEmailAddress(emailAddress);
             userContext.getAuthSession().setEmailAddress(emailAddress);
 
             var session = userContext.getSession();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -169,8 +169,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
 
             LOG.info("Setting internal common subject identifier in user session");
             sessionService.storeOrUpdateSession(
-                    userContext.getSession().setEmailAddress(request.getEmail()),
-                    userContext.getAuthSession().getSessionId());
+                    userContext.getSession(), userContext.getAuthSession().getSessionId());
 
             authSessionService.updateSession(
                     authSessionItem

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -171,9 +171,6 @@ class SignUpHandlerTest {
 
         verify(authenticationService)
                 .signUp(eq(EMAIL), eq(PASSWORD), any(Subject.class), any(TermsAndConditions.class));
-        verify(sessionService)
-                .storeOrUpdateSession(
-                        argThat(s -> s.getEmailAddress().equals(EMAIL)), eq(SESSION_ID));
 
         assertThat(result, hasStatus(200));
         verify(authenticationService)
@@ -218,9 +215,6 @@ class SignUpHandlerTest {
 
         verify(authenticationService)
                 .signUp(eq(EMAIL), eq(PASSWORD), any(Subject.class), any(TermsAndConditions.class));
-        verify(sessionService)
-                .storeOrUpdateSession(
-                        argThat(s -> s.getEmailAddress().equals(EMAIL)), eq(SESSION_ID));
 
         assertThat(result, hasStatus(200));
         verify(authSessionService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -70,7 +70,7 @@ class StartServiceTest {
     private static final ClientID CLIENT_ID = new ClientID("client-id");
     private static final String CLIENT_NAME = "test-client";
     private static final String SESSION_ID = "a-session-id";
-    private static final Session SESSION = new Session().setEmailAddress(EMAIL);
+    private static final Session SESSION = new Session();
     private static final AuthSessionItem AUTH_SESSION =
             new AuthSessionItem().withEmailAddress(EMAIL).withSessionId(SESSION_ID);
     private static final Scope SCOPES =
@@ -408,7 +408,6 @@ class StartServiceTest {
                         Optional.of(userProfile),
                         Optional.of(userCredentials),
                         false);
-        userContext.getSession().setEmailAddress(EMAIL);
 
         var upliftRequired =
                 startService.isUpliftRequired(userContext.getClientSession(), credentialTrustLevel);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -49,11 +49,6 @@ public class Session {
         initializeCodeRequestMap();
     }
 
-    public Session setEmailAddress(String emailAddress) {
-        this.emailAddress = emailAddress;
-        return this;
-    }
-
     public Session setCurrentCredentialStrength(CredentialTrustLevel currentCredentialStrength) {
         this.currentCredentialStrength = currentCredentialStrength;
         return this;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -49,10 +49,6 @@ public class Session {
         initializeCodeRequestMap();
     }
 
-    public String getEmailAddress() {
-        return emailAddress;
-    }
-
     public Session setEmailAddress(String emailAddress) {
         this.emailAddress = emailAddress;
         return this;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -29,7 +29,6 @@ import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
@@ -225,11 +224,6 @@ public abstract class BaseFrontendHandler<T>
         clientID.ifPresent(c -> userContextBuilder.withClient(clientService.getClient(c)));
 
         clientSession.ifPresent(userContextBuilder::withClientSession);
-
-        LOG.info(
-                "Auth session email migration check {}",
-                Objects.equals(
-                        session.get().getEmailAddress(), authSession.get().getEmailAddress()));
 
         authSession
                 .map(AuthSessionItem::getEmailAddress)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
@@ -33,7 +33,7 @@ class SessionServiceTest {
     void shouldPersistSessionToRedisWithExpiry() throws Json.JsonException {
         when(configuration.getSessionExpiry()).thenReturn(1234L);
 
-        var session = new Session().setEmailAddress("example@example.com");
+        var session = new Session();
 
         sessionService.storeOrUpdateSession(session, SESSION_ID);
 
@@ -138,7 +138,7 @@ class SessionServiceTest {
 
     @Test
     void shouldDeleteSessionIdFromRedis() {
-        var session = new Session().setEmailAddress("example@example.com");
+        var session = new Session();
 
         sessionService.storeOrUpdateSession(session, "session-id");
         sessionService.deleteSessionFromRedis(SESSION_ID);
@@ -147,7 +147,7 @@ class SessionServiceTest {
     }
 
     private String generateSearlizedSession() throws Json.JsonException {
-        var session = new Session().setEmailAddress("example@example.com");
+        var session = new Session();
 
         return objectMapper.writeValueAsString(session);
     }


### PR DESCRIPTION
### Wider context of change
Final PR on auth's side for email migration

### What’s changed
- deletes session.getEmailAddress and remaining test uses
- deletes session.setEmailAddress and remaining uses (no live uses of getEmailAddress anymore, so no need to keep it consistent).

### Manual testing
N/A

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing. **No change**

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked. **Orch don't use email on shared session anymore**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required. **N/A**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required. **N/A**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required. **N/A**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required. **N/A**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**