### PR TITLE
ATO 1619/Update JUnit to 5.12.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -199,6 +199,7 @@ subprojects {
 
         tests "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit}",
                 "org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit}",
+                "org.junit.platform:junit-platform-launcher",
                 "org.mockito:mockito-core:5.17.0",
                 "org.awaitility:awaitility:4.3.0",
                 "com.approvaltests:approvaltests:24.21.0",

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext {
         jetbrains_annotations: "26.0.2",
         nimbusds_oauth_version: "10.13.2",
         nimbusds_jwt_version: "10.2",
-        junit: "5.11.4",
+        junit: "5.12.2",
         xray: "2.18.2",
         pact: "4.6.17",
     ]


### PR DESCRIPTION
Context: Dependabot suggested update to dependencyVersions.junit from 5.11.4 to 5.12.2. Tests failed to build due to unaligned versions of the junit-platform-engine and junit-platform-launcher.
- add junit-platform-launcher to tests configuration to align with JUnit 5.12 requirements.
- update JUnit to 5.12.2

NB: I've closed the [original dependabot PR](https://github.com/govuk-one-login/authentication-api/pull/6336) because of problems rebasing.
