### PR TITLE
ATO-1585: remove IPV key pair TF references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -362,7 +362,6 @@ task oidcTerraform (type: Terraform) {
         allprojects.findAll {it.name == "integration-tests"}.first().tasks.getByName("test") {
             environment "API_GATEWAY_ID", json.api_gateway_root_id.value
             environment "EXTERNAL_TOKEN_SIGNING_KEY_ALIAS", json.id_token_signing_key_alias.value
-            environment "IPV_TOKEN_SIGNING_KEY_ALIAS", json.ipv_token_auth_key_alias.value
             environment "OIDC_API_BASE_URL", json.base_url.value
             environment "API_KEY", json.frontend_api_key.value
             environment "FRONTEND_API_GATEWAY_ID", json.frontend_api_gateway_root_id.value

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -8,7 +8,6 @@ module "oidc_api_authentication_callback_role_1" {
     aws_iam_policy.storage_token_kms_signing_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.ipv_token_auth_kms_policy.arn,
     aws_iam_policy.ipv_public_encryption_key_parameter_policy.arn,
     aws_iam_policy.orch_to_auth_kms_policy.arn,
     module.oidc_txma_audit.access_policy_arn,

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -41,7 +41,6 @@ module "authentication_callback" {
     IPV_AUTHORISATION_CALLBACK_URI              = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_CLIENT_ID                 = var.ipv_authorisation_client_id
     IPV_AUTHORISATION_URI                       = var.ipv_authorisation_uri
-    IPV_TOKEN_SIGNING_KEY_ALIAS                 = local.ipv_token_auth_key_alias_name
     ORCH_CLIENT_ID                              = var.orch_client_id
     ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS        = local.orch_to_auth_signing_key_alias_name
     REDIS_KEY                                   = local.redis_key

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -13,7 +13,6 @@ module "ipv_callback_role" {
     aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.ipv_token_auth_kms_policy.arn,
     aws_iam_policy.spot_queue_encryption_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -49,7 +49,6 @@ module "ipv-callback" {
     IPV_AUTHORISATION_CLIENT_ID                 = var.ipv_authorisation_client_id
     IPV_AUTHORISATION_URI                       = var.ipv_authorisation_uri
     IPV_BACKEND_URI                             = var.ipv_backend_uri
-    IPV_TOKEN_SIGNING_KEY_ALIAS                 = local.ipv_token_auth_key_alias_name
     OIDC_API_BASE_URL                           = local.api_base_url
     REDIS_KEY                                   = local.redis_key
     SPOT_QUEUE_URL                              = aws_sqs_queue.spot_request_queue.id

--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -18,10 +18,6 @@ output "external_token_signing_key_alias" {
   value = local.id_token_signing_key_alias_name
 }
 
-output "ipv_token_auth_key_alias" {
-  value = local.ipv_token_auth_key_alias_name
-}
-
 output "frontend_api_key" {
   value     = aws_api_gateway_api_key.di_auth_frontend_api_key.value
   sensitive = true

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -39,7 +39,6 @@ locals {
   authentication_protected_subnet_ids         = data.terraform_remote_state.shared.outputs.authentication_protected_subnet_ids
   id_token_signing_key_alias_name             = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_name
   id_token_signing_key_arn                    = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
-  ipv_token_auth_key_alias_name               = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_alias_name
   ipv_token_auth_signing_key_arn              = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_arn
   orch_to_auth_signing_key_alias_name         = data.terraform_remote_state.shared.outputs.orch_to_auth_signing_key_alias_name
   orch_to_auth_signing_key_arn                = data.terraform_remote_state.shared.outputs.orch_to_auth_signing_key_arn


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Previously, orch was signing requests to IPV with a key that resides in the `gds-di-*` AWS accounts. The signing key resources have been moved to the `di-orchestration-*` AWS accounts (#6387) and publishing has been enabled on all environments (#6387, #6394, #6396, #6397) and we are now signing requests with this new key on all environments (#6405, #6412, #6414, #6415). We have also stopped publishing the old key on the IPV JWKS endpoint and cleaned up the infrastructure controlling deployment (#6425).

At this point, we are happy that things are working as expected on production.

We now need to remove the references to the old key pair before finally removing those resources.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Removed OIDC Terraform references for old IPV key

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Deployed to sandpit using the deploy shell script (deployed all with `./deploy-sandpit.sh -c -b`), no TF errors observed, ran through an identity journey successfully using the sandpit RP stub. 

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing. **- N/A**

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required. **- N/A**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required. **- N/A**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
--> 

- [ ] Changes have been made to stubs or not required. **- N/A**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required. **- N/A**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required. **- N/A**

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- #6387 - generate new signing key pair

- #6405 - sign on dev and build
- #6412
- #6414
- #6415

- #6425 - env var clean up