### PR TITLE
ATO-1621: Swap to using achieved credential strength when making uplift decisions

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -198,7 +198,7 @@ public class StartHandler
             var upliftRequired =
                     startService.isUpliftRequired(
                             requestedCredentialTrustLevel,
-                            startRequest.currentCredentialStrength());
+                            authSession.getAchievedCredentialStrength());
 
             authSessionService.addSession(authSession.withUpliftRequired(upliftRequired));
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -175,7 +175,7 @@ public class StartService {
         if (Objects.isNull(currentCredentialStrength)) {
             return false;
         }
-        return currentCredentialStrength.compareTo(requestedCredentialStrength) < 0;
+        return currentCredentialStrength.isLowerThan(requestedCredentialStrength);
     }
 
     public ClientRegistry getClient(String clientId) throws ClientNotFoundException {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -102,6 +102,14 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
                         .withInternalCommonSubjectId(internalCommonSubjectIdl));
     }
 
+    public void addAchievedCredentialTrustToSession(
+            String sessionId, CredentialTrustLevel credentialStrength) {
+        updateSession(
+                getSession(sessionId)
+                        .orElseThrow()
+                        .withAchievedCredentialStrength(credentialStrength));
+    }
+
     public AuthSessionItem getUpdatedPreviousSessionOrCreateNew(
             Optional<String> previousSessionId,
             String sessionId,


### PR DESCRIPTION
### Wider context of change: 

We are now confident that this value is set appropriately for all journey types and reflects when a user achieves the requested level of credential trust. We can now swap to using this value and ignoring the value of CurrentCredentialStrength, which is reliant on Orchestration to send in the JAR.

### What’s changed: 
- We've swapped where we derive the current level of credential trust a user has achieved from the something Orch sends 
us to something we now derive from the session. 
- This means the logic is no longer reliant on something Orchestration attach in the JAR

### Manual testing:
- Deployed to dev 
- Run acceptance tests against it - all passed bar one - this was related to MFA MM and is under development
- Run through an uplift journeys - low then medium -> Prompted for MFA code

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
