### PR TITLE
ATO-1616: Emit metric for auth query param size

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -984,8 +984,16 @@ public class AuthorisationHandler
                         .endpointURI(URI.create(redirectURI))
                         .requestObject(encryptedJWT)
                         .build();
-        redirectURI = authorizationRequest.toURI().toString();
+        try {
+            cloudwatchMetricsService.putEmbeddedValue(
+                    "AuthRedirectQueryParamSize",
+                    authorizationRequest.toQueryString().length(),
+                    Map.of("clientId", client.getClientID()));
+        } catch (Exception e) {
+            LOG.warn("Error recording query params length, continuing: ", e);
+        }
 
+        redirectURI = authorizationRequest.toURI().toString();
         return generateApiGatewayProxyResponse(
                 302,
                 "",

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -360,6 +360,11 @@ class AuthorisationHandlerTest {
                             BASE_AUDIT_USER.withSessionId(NEW_SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME),
                             pair("new_authentication_required", false));
+            verify(cloudwatchMetricsService)
+                    .putEmbeddedValue(
+                            "AuthRedirectQueryParamSize",
+                            48,
+                            Map.of("clientId", CLIENT_ID.getValue()));
         }
 
         @Test
@@ -395,6 +400,11 @@ class AuthorisationHandlerTest {
                     ClaimsSetRequest.parse(captor.getValue().getStringClaim("claim"));
             assertEquals(
                     expectedClaimSetRequest.toJSONObject(), actualClaimSetRequest.toJSONObject());
+            verify(cloudwatchMetricsService)
+                    .putEmbeddedValue(
+                            "AuthRedirectQueryParamSize",
+                            1003,
+                            Map.of("clientId", CLIENT_ID.getValue()));
         }
 
         @Test
@@ -625,6 +635,11 @@ class AuthorisationHandlerTest {
                             BASE_AUDIT_USER.withSessionId(NEW_SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME),
                             pair("new_authentication_required", false));
+            verify(cloudwatchMetricsService)
+                    .putEmbeddedValue(
+                            "AuthRedirectQueryParamSize",
+                            48,
+                            Map.of("clientId", CLIENT_ID.getValue()));
         }
 
         @Test
@@ -691,6 +706,11 @@ class AuthorisationHandlerTest {
                             BASE_AUDIT_USER.withSessionId(NEW_SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME),
                             pair("new_authentication_required", false));
+            verify(cloudwatchMetricsService)
+                    .putEmbeddedValue(
+                            "AuthRedirectQueryParamSize",
+                            61,
+                            Map.of("clientId", CLIENT_ID.getValue()));
         }
 
         @ParameterizedTest
@@ -762,6 +782,11 @@ class AuthorisationHandlerTest {
                             BASE_AUDIT_USER.withSessionId(NEW_SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME),
                             pair("new_authentication_required", false));
+            verify(cloudwatchMetricsService)
+                    .putEmbeddedValue(
+                            "AuthRedirectQueryParamSize",
+                            48,
+                            Map.of("clientId", CLIENT_ID.getValue()));
         }
 
         @Test
@@ -808,6 +833,11 @@ class AuthorisationHandlerTest {
                             BASE_AUDIT_USER.withSessionId(NEW_SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME),
                             pair("new_authentication_required", false));
+            verify(cloudwatchMetricsService)
+                    .putEmbeddedValue(
+                            "AuthRedirectQueryParamSize",
+                            48,
+                            Map.of("clientId", CLIENT_ID.getValue()));
         }
 
         @Test
@@ -851,6 +881,11 @@ class AuthorisationHandlerTest {
                             BASE_AUDIT_USER.withSessionId(NEW_SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME),
                             pair("new_authentication_required", false));
+            verify(cloudwatchMetricsService)
+                    .putEmbeddedValue(
+                            "AuthRedirectQueryParamSize",
+                            48,
+                            Map.of("clientId", CLIENT_ID.getValue()));
         }
 
         @Test
@@ -1072,6 +1107,11 @@ class AuthorisationHandlerTest {
                             BASE_AUDIT_USER.withSessionId(NEW_SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME),
                             pair("new_authentication_required", false));
+            verify(cloudwatchMetricsService)
+                    .putEmbeddedValue(
+                            "AuthRedirectQueryParamSize",
+                            48,
+                            Map.of("clientId", CLIENT_ID.getValue()));
         }
 
         @Test
@@ -1122,6 +1162,11 @@ class AuthorisationHandlerTest {
                             BASE_AUDIT_USER.withSessionId(NEW_SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME),
                             pair("new_authentication_required", false));
+            verify(cloudwatchMetricsService)
+                    .putEmbeddedValue(
+                            "AuthRedirectQueryParamSize",
+                            48,
+                            Map.of("clientId", CLIENT_ID.getValue()));
         }
 
         @Test
@@ -1205,6 +1250,11 @@ class AuthorisationHandlerTest {
                             BASE_AUDIT_USER.withSessionId(NEW_SESSION_ID),
                             pair("client-name", RP_CLIENT_NAME),
                             pair("new_authentication_required", false));
+            verify(cloudwatchMetricsService)
+                    .putEmbeddedValue(
+                            "AuthRedirectQueryParamSize",
+                            48,
+                            Map.of("clientId", CLIENT_ID.getValue()));
         }
 
         @Test


### PR DESCRIPTION
### Wider context of change

Previously we had an incident where a new field was included in the JAR sent from orch to auth, which caused the query parameters of the redirect to auth to exceed the limit of our WAF. We did increase the query params limit in the WAF, however we will be adding new claims to this JAR and need a way of telling how close we are to the limit.

### What’s changed

This PR adds a new metric called "AuthRedirectQueryParamSize", which is the length of all query parameters in the redirect to auth. Tests have also been updated to assert on this metric being set.

### Manual testing

Deployed to sandpit. Saw new metric in CloudWatch after being redirected to the login page.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
