### PR TITLE
ATO-1622: add cache-control max age of 1 day on response

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -27,6 +27,7 @@ import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 import static com.nimbusds.langtag.LangTagUtils.parseLangTagList;
@@ -72,7 +73,8 @@ public class WellknownHandler
     public APIGatewayProxyResponseEvent wellknownRequestHandler(
             APIGatewayProxyRequestEvent input, Context context) {
         LOG.info("Wellknown request received");
-        return generateApiGatewayProxyResponse(200, providerMetadata);
+        return generateApiGatewayProxyResponse(
+                200, providerMetadata, Map.of("Cache-Control", "max-age=86400"), null);
     }
 
     private String constructProviderMetadata(ConfigurationService configService) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
@@ -47,6 +47,13 @@ class WellknownHandlerTest {
     }
 
     @Test
+    void shouldReturnCacheControlHeader() {
+        APIGatewayProxyResponseEvent result = getWellKnown();
+
+        assertThat(result.getHeaders().get("Cache-Control"), equalTo("max-age=86400"));
+    }
+
+    @Test
     void shouldContainAllOneLoginClaims() throws ParseException {
         APIGatewayProxyResponseEvent result = getWellKnown();
         var metadata = OIDCProviderMetadata.parse(result.getBody());


### PR DESCRIPTION
### Wider context of change
New requirement

### What’s changed
Adds cache control max age of 1 day to WellknownHandler response

### Manual testing
TBD

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.