### PR TITLE
Aut 4159/use ipv jwks endpoint

### DIFF
--- a/ci/terraform/oidc/mfa-reset-authorize.tf
+++ b/ci/terraform/oidc/mfa-reset-authorize.tf
@@ -46,6 +46,8 @@ module "mfa_reset_authorize" {
     EVCS_AUDIENCE                                 = var.evcs_audience
     AUTH_ISSUER_CLAIM_FOR_EVCS                    = var.auth_issuer_claim_for_evcs
     USE_STRONGLY_CONSISTENT_READS                 = var.use_strongly_consistent_reads
+    IPV_JWKS_URL                                  = var.ipv_jwks_url
+    IPV_AUTH_PUBLIC_ENCRYPTION_KEY_ID             = var.ipv_auth_public_encryption_key_id
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetAuthorizeHandler::handleRequest"

--- a/ci/terraform/oidc/mfa-reset-authorize.tf
+++ b/ci/terraform/oidc/mfa-reset-authorize.tf
@@ -48,6 +48,7 @@ module "mfa_reset_authorize" {
     USE_STRONGLY_CONSISTENT_READS                 = var.use_strongly_consistent_reads
     IPV_JWKS_URL                                  = var.ipv_jwks_url
     IPV_AUTH_PUBLIC_ENCRYPTION_KEY_ID             = var.ipv_auth_public_encryption_key_id
+    IPV_JWKS_CALL_ENABLED                         = var.ipv_jwks_call_enabled
   }
 
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetAuthorizeHandler::handleRequest"

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -160,3 +160,6 @@ performance_tuning = {
 lambda_max_concurrency        = 10
 lambda_min_concurrency        = 3
 use_strongly_consistent_reads = true
+
+ipv_jwks_call_enabled = true
+ipv_jwks_url          = "https://api.identity.staging.account.gov.uk/.well-known/jwks.json"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -746,3 +746,8 @@ variable "ipv_auth_public_encryption_key_id" {
   default     = ""
   description = "Key ID for to encrypt JWT to send to IPV"
 }
+
+variable "ipv_jwks_call_enabled" {
+  type    = bool
+  default = false
+}

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -734,3 +734,15 @@ variable "frontend_api_fms_tag_value" {
   description = "Tag value to be used for FMS WAF association for frontend API"
   type        = string
 }
+
+variable "ipv_jwks_url" {
+  type        = string
+  default     = ""
+  description = "Endpoint to get the IPV JWKS to encrypt and verify JWTs in the MFA reset journey"
+}
+
+variable "ipv_auth_public_encryption_key_id" {
+  type        = string
+  default     = ""
+  description = "Key ID for to encrypt JWT to send to IPV"
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
@@ -76,18 +76,10 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
 
     public MfaResetAuthorizeHandler(ConfigurationService configurationService) {
         super(MfaResetRequest.class, configurationService);
-        RedisConnectionService redisConnectionService =
-                new RedisConnectionService(configurationService);
-        KmsConnectionService kmsConnectionService = new KmsConnectionService(configurationService);
-        JwtService jwtService = new JwtService(kmsConnectionService);
-        TokenService tokenService =
-                new TokenService(
-                        configurationService, redisConnectionService, kmsConnectionService);
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.ipvReverificationService =
-                new IPVReverificationService(configurationService, jwtService, tokenService);
         this.idReverificationStateService = new IDReverificationStateService(configurationService);
+        this.ipvReverificationService = new IPVReverificationService(configurationService);
     }
 
     public MfaResetAuthorizeHandler(RedisConnectionService redisConnectionService) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
@@ -34,6 +34,8 @@ import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.TokenService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.net.MalformedURLException;
+
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_REVERIFY_AUTHORISATION_REQUESTED;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1060;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -82,7 +84,8 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
         this.ipvReverificationService = new IPVReverificationService(configurationService);
     }
 
-    public MfaResetAuthorizeHandler(RedisConnectionService redisConnectionService) {
+    public MfaResetAuthorizeHandler(RedisConnectionService redisConnectionService)
+            throws MalformedURLException {
         super(MfaResetRequest.class, ConfigurationService.getInstance(), redisConnectionService);
         KmsConnectionService kmsConnectionService = new KmsConnectionService(configurationService);
         JwtService jwtService = new JwtService(kmsConnectionService);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationServiceTest.java
@@ -40,6 +40,7 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.TokenService;
 import uk.gov.di.authentication.sharedtest.helper.TestClockHelper;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.KeyPair;
@@ -101,6 +102,8 @@ class IPVReverificationServiceTest {
     private SignedJWT testSignedJwt;
     private EncryptedJWT testEncryptedJwt;
     MockedStatic<IdGenerator> mockIdGen;
+
+    IPVReverificationServiceTest() throws MalformedURLException {}
 
     @BeforeEach
     void testSetup() throws URISyntaxException, ParseException, JOSEException {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
@@ -4,7 +4,10 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.matching.ContainsPattern;
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.crypto.RSADecrypter;
+import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -13,6 +16,9 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+import net.minidev.json.parser.ParseException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,19 +44,27 @@ import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
 import java.time.LocalDateTime;
+import java.util.AbstractMap;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -58,6 +72,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -72,6 +87,8 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
     public static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final ClientID CLIENT_ID = new ClientID("test-client");
     private static final String CLIENT_NAME = "some-client-name";
+    private static final String testRsaKeyId = "test-key-rsa";
+    private static RSAKey rsaKey;
 
     private static WireMockServer wireMockServer;
 
@@ -114,6 +131,10 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
                 any(urlPathMatching("/.*"))
                         .willReturn(aResponse().proxiedFrom("http://localhost:45678")));
         environment.set("LOCALSTACK_ENDPOINT", "http://localhost:" + wireMockServer.port());
+        environment.set("IPV_AUTH_PUBLIC_ENCRYPTION_KEY_ID", testRsaKeyId);
+        environment.set(
+                "IPV_JWKS_URL",
+                "http://localhost:" + wireMockServer.port() + "/.well-known/jwks.json");
     }
 
     @AfterAll
@@ -155,7 +176,24 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
     }
 
     @BeforeEach
-    void setup() throws Json.JsonException {
+    void setup() throws Json.JsonException, MalformedURLException, NoSuchAlgorithmException {
+        rsaKey =
+                new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                        .privateKey(
+                                (RSAPrivateKey)
+                                        keyPair.getPrivate()) // Include private key if needed
+                        .keyID("dynamic-test-key") // Set a key ID
+                        .build();
+
+        JWKSet jwkSet = new JWKSet(singletonList(rsaKey));
+
+        wireMockServer.stubFor(
+                get(urlPathMatching("/.well-known/jwks.json"))
+                        .willReturn(
+                                aResponse()
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBody(jwkSet.toString())));
+
         handler = new MfaResetAuthorizeHandler(redisConnectionService);
 
         var internalCommonSubjectId =
@@ -239,8 +277,14 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
 
         assertThat(response, hasStatus(200));
 
+        checkJwksRetrievedFromWellKnownEndpoint();
         checkCorrectKeysUsedViaIntegrationWithKms();
         checkTxmaEventPublishedViaIntegrationWithSQS();
+        checkThatJwtCanBeDecryptedWithMatchingPrivateKey(response.getBody());
+    }
+
+    private static void checkJwksRetrievedFromWellKnownEndpoint() {
+        wireMockServer.verify(1, getRequestedFor(urlPathMatching("/.well-known/jwks.json")));
     }
 
     private static void checkCorrectKeysUsedViaIntegrationWithKms() {
@@ -255,5 +299,41 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
 
     private static void checkTxmaEventPublishedViaIntegrationWithSQS() {
         assertEquals(1, txmaAuditQueue.getRawMessages().size());
+    }
+
+    private static void checkThatJwtCanBeDecryptedWithMatchingPrivateKey(String body) {
+        try {
+            JSONParser parser = new JSONParser(JSONParser.MODE_PERMISSIVE);
+            JSONObject json = (JSONObject) parser.parse(body);
+            String authorizeUrl = (String) json.get("authorize_url");
+
+            String queryString = authorizeUrl.substring(authorizeUrl.indexOf("?") + 1);
+
+            Map<String, String> queryParams =
+                    Arrays.stream(queryString.split("&"))
+                            .map(MfaResetAuthorizeHandlerIntegrationTest::splitQueryParameter)
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            String jwt = queryParams.get("request");
+
+            EncryptedJWT encryptedJWT = EncryptedJWT.parse(jwt);
+
+            RSADecrypter decrypter = new RSADecrypter(rsaKey.toPrivateKey());
+
+            assertDoesNotThrow(
+                    () -> {
+                        encryptedJWT.decrypt(decrypter);
+                    });
+
+        } catch (JOSEException | ParseException | java.text.ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Map.Entry<String, String> splitQueryParameter(String param) {
+        String[] parts = param.split("=", 2);
+        String key = parts[0];
+        String value = (parts.length > 1) ? parts[1] : "";
+        return new AbstractMap.SimpleImmutableEntry<>(key, value);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -713,4 +713,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
             throw new MalformedURLException(e.getMessage());
         }
     }
+
+    public boolean isIpvJwksCallEnabled() {
+        return System.getenv()
+                .getOrDefault("IPV_JWKS_CALL_ENABLED", String.valueOf(false))
+                .equals(FEATURE_SWITCH_ON);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -15,7 +15,9 @@ import uk.gov.di.authentication.shared.configuration.BaseLambdaConfiguration;
 import uk.gov.di.authentication.shared.entity.DeliveryReceiptsNotificationType;
 import uk.gov.di.authentication.shared.exceptions.MissingEnvVariableException;
 
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
@@ -701,5 +703,14 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv()
                 .getOrDefault("USE_STRONGLY_CONSISTENT_READS", FEATURE_SWITCH_OFF)
                 .equals(FEATURE_SWITCH_ON);
+    }
+
+    public URL getIpvJwksUrl() throws MalformedURLException {
+        try {
+            return new URL(System.getenv().getOrDefault("IPV_JWKS_URL", ""));
+        } catch (MalformedURLException e) {
+            LOG.error("Invalid JWKS URL: {}", e.getMessage());
+            throw new MalformedURLException(e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## What

Makes the IPV reverification service call the IPV JWKS endpoint to get their public encryption key. This is then used to encrypt the JWT send over in the MFA reset authorize handler.

Also a small refactor (courtesy of @andrew-moores)

## How to review

1. Code Review
    - Take particular care to check that the new logic is only used in staging. Lower environments should still grab the key from 
       the configuration service
