### PR TITLE
AUT-4196: grant delete synthetics user access to the user-credentials-cmk

### DIFF
--- a/ci/terraform/test-services/dynamo-policies.tf
+++ b/ci/terraform/test-services/dynamo-policies.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "dynamo_user_read_policy_document" {
       "kms:CreateGrant",
       "kms:DescribeKey",
     ]
-    resources = [local.user_profile_kms_key_arn]
+    resources = [local.user_profile_kms_key_arn, local.user_credentials_encryption_policy_arn]
   }
 }
 
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "dynamo_user_delete_policy_document" {
       "kms:CreateGrant",
       "kms:DescribeKey",
     ]
-    resources = [local.user_profile_kms_key_arn]
+    resources = [local.user_profile_kms_key_arn, local.user_credentials_encryption_policy_arn]
   }
 }
 

--- a/ci/terraform/test-services/shared.tf
+++ b/ci/terraform/test-services/shared.tf
@@ -9,11 +9,12 @@ data "terraform_remote_state" "shared" {
 }
 
 locals {
-  lambda_code_signing_configuration_arn = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
-  authentication_vpc_arn                = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
-  authentication_private_subnet_ids     = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
-  authentication_security_group_id      = data.terraform_remote_state.shared.outputs.authentication_security_group_id
-  user_profile_kms_key_arn              = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
+  lambda_code_signing_configuration_arn  = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
+  authentication_vpc_arn                 = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
+  authentication_private_subnet_ids      = data.terraform_remote_state.shared.outputs.authentication_private_subnet_ids
+  authentication_security_group_id       = data.terraform_remote_state.shared.outputs.authentication_security_group_id
+  user_profile_kms_key_arn               = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
+  user_credentials_encryption_policy_arn = data.terraform_remote_state.shared.outputs.user_credentials_encryption_policy_arn
 
   slack_event_sns_topic_arn = data.terraform_remote_state.shared.outputs.slack_event_sns_topic_arn
   aws_account_alias         = data.terraform_remote_state.shared.outputs.aws_account_alias


### PR DESCRIPTION
## What

Grant delete synthetics user access to the user-credentials-cmk.

Create Account smoke test is currently failing as the delete synthetics lambda does not have the rights to the user-credentials CMK

## Related

https://github.com/govuk-one-login/authentication-api/pull/6459


