### PR TITLE
AUT-4159: Add egress security group to mfa-reset-authorize lambda

### DIFF
--- a/ci/terraform/oidc/mfa-reset-authorize.tf
+++ b/ci/terraform/oidc/mfa-reset-authorize.tf
@@ -71,6 +71,7 @@ module "mfa_reset_authorize" {
   security_group_ids = [
     local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
+    local.authentication_egress_security_group_id,
   ]
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.mfa_reset_authorize_role.arn


### PR DESCRIPTION
## What

- This is required so that the lambda can hit an endpoint outside of the VPC. Required for hitting IPV's public JWKS endpoint.

## How to review

1. Code Review
