### PR TITLE
AUT-4302: Session redis and dynamodb cross-account access for auth-ext-api

### DIFF
--- a/ci/terraform/shared/authdev1.tfvars
+++ b/ci/terraform/shared/authdev1.tfvars
@@ -67,6 +67,7 @@ stub_rp_clients = [
 enforce_code_signing = false
 
 # CIDR blocks
+new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/23"]
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # Sizing

--- a/ci/terraform/shared/authdev2.tfvars
+++ b/ci/terraform/shared/authdev2.tfvars
@@ -66,6 +66,7 @@ stub_rp_clients = [
 enforce_code_signing = false
 
 # CIDR blocks
+new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/23"]
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # Sizing

--- a/ci/terraform/shared/build.tfvars
+++ b/ci/terraform/shared/build.tfvars
@@ -8,6 +8,7 @@ auth_new_account_id      = "058264536367"
 # CIDR blocks
 orch_privatesub_cidr_blocks       = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
 orch_protectedsub_cidr_blocks     = ["10.1.4.0/23", "10.1.6.0/23", "10.1.8.0/23"]
+new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/23"]
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # App-specific

--- a/ci/terraform/shared/dev.tfvars
+++ b/ci/terraform/shared/dev.tfvars
@@ -8,6 +8,7 @@ auth_new_account_id      = "975050272416"
 # CIDR blocks
 orch_privatesub_cidr_blocks       = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
 orch_protectedsub_cidr_blocks     = ["10.1.4.0/23", "10.1.6.0/23", "10.1.8.0/23"]
+new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/23"]
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # App Specific

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -843,7 +843,7 @@ resource "aws_dynamodb_resource_policy" "id_reverification_state" {
 
 
 locals {
-  allowed_env                = ["dev", "authdev1", "authdev2", "sandpit"]
+  allowed_env                = ["staging", "build", "dev", "authdev1", "authdev2", "sandpit"]
   allow_cross_account_access = contains(local.allowed_env, var.environment)
 }
 

--- a/ci/terraform/shared/integration.tfvars
+++ b/ci/terraform/shared/integration.tfvars
@@ -8,6 +8,7 @@ auth_new_account_id      = "211125600642"
 # CIDR blocks
 orch_privatesub_cidr_blocks       = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
 orch_protectedsub_cidr_blocks     = ["10.1.4.0/23", "10.1.6.0/23", "10.1.8.0/23"]
+new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/23"]
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # App Specific

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -833,7 +833,7 @@ data "aws_iam_policy_document" "auth_dynamo_table_encryption_key_access_policy" 
   }
 
   dynamic "statement" {
-    for_each = var.environment != "production" && var.environment != "integration" && var.environment != "staging" ? ["1"] : []
+    for_each = var.environment != "production" && var.environment != "integration" ? ["1"] : []
     content {
       sid    = "Allow Auth access to dynamo table encryption key"
       effect = "Allow"

--- a/ci/terraform/shared/production.tfvars
+++ b/ci/terraform/shared/production.tfvars
@@ -8,6 +8,7 @@ auth_new_account_id      = "211125303002"
 # CIDR blocks
 orch_privatesub_cidr_blocks       = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
 orch_protectedsub_cidr_blocks     = ["10.1.4.0/23", "10.1.6.0/23", "10.1.8.0/23"]
+new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/23"]
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # App Specific

--- a/ci/terraform/shared/security-groups.tf
+++ b/ci/terraform/shared/security-groups.tf
@@ -89,6 +89,19 @@ resource "aws_security_group_rule" "allow_incoming_session_redis_from_new_auth" 
   type        = "ingress"
 }
 
+resource "aws_security_group_rule" "allow_incoming_session_redis_from_new_auth_private_subnet" {
+  count = length(var.new_auth_privatesub_cidr_blocks) == 0 ? 0 : 1
+
+  description       = "Allow ingress to Redis from new Auth equivalent environment private subnets"
+  security_group_id = aws_security_group.redis_security_group.id
+
+  from_port   = local.redis_port_number
+  protocol    = "tcp"
+  cidr_blocks = var.new_auth_privatesub_cidr_blocks
+  to_port     = local.redis_port_number
+  type        = "ingress"
+}
+
 # Frontend Redis security group
 
 resource "aws_security_group" "frontend_redis_security_group" {

--- a/ci/terraform/shared/staging.tfvars
+++ b/ci/terraform/shared/staging.tfvars
@@ -9,6 +9,7 @@ auth_new_account_id      = "851725205974"
 # CIDR blocks
 orch_privatesub_cidr_blocks       = ["10.1.10.0/23", "10.1.12.0/23", "10.1.14.0/23"]
 orch_protectedsub_cidr_blocks     = ["10.1.4.0/23", "10.1.6.0/23", "10.1.8.0/23"]
+new_auth_privatesub_cidr_blocks   = ["10.6.10.0/23", "10.6.12.0/23", "10.6.14.0/23"]
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 # App Specific

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -164,3 +164,9 @@ variable "new_auth_protectedsub_cidr_blocks" {
   default     = []
   description = "New Auth equivalent environment protected subnets"
 }
+
+variable "new_auth_privatesub_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "New Auth equivalent environment private subnets"
+}


### PR DESCRIPTION
## What

1. Session redis access from new_auth private subnets - required by lambdas deployed to new auth accounts
2. Allow cross-account access upto staging environment for dynamodb tables and customer managed keys associated with the tables

Issue: [AUT-4302] [AUT-4213]

## How to review

Deployed and tested in authdev1, dev. Terraform apply logs in the jira ticket

[AUT-4302]: https://govukverify.atlassian.net/browse/AUT-4302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUT-4213]: https://govukverify.atlassian.net/browse/AUT-4213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ