### PR TITLE
BAU: Remove temporary logging

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -277,24 +277,10 @@ public class TokenHandler
                     400, e.getErrorObject().toJSONObject().toJSONString());
         }
 
-        // ATO-1372: add logging to see how many RPs are sending the correct code verifiers
-        var codeChallenge = authRequest.getCodeChallenge();
-        var codeVerifierString = requestBody.get("code_verifier");
-
-        try {
-            if (!isPKCEValid(
-                    Optional.ofNullable(codeChallenge), Optional.ofNullable(codeVerifierString))) {
-                LOG.info("PKCE validation failed");
-            } else {
-                LOG.info("PKCE validation passed");
-            }
-        } catch (Exception e) {
-            LOG.info("PKCE FAILED {}", e.getMessage());
-        }
-
         if (configurationService.isPkceEnabled()) {
             if (!isPKCEValid(
-                    Optional.ofNullable(codeChallenge), Optional.ofNullable(codeVerifierString))) {
+                    Optional.ofNullable(authRequest.getCodeChallenge()),
+                    Optional.ofNullable(requestBody.get("code_verifier")))) {
                 LOG.warn("PKCE validation failed, returning invalid_grant error");
                 return generateInvalidGrantPKCEVerificationCodeApiGatewayProxyResponse();
             }


### PR DESCRIPTION
### Wider context of change
We previously added this logging to check enabling PKCE was backwards compatible. Now this feature is enabled we can remove the logging.


### What’s changed
Removes the logging

### Manual testing
- N/A just deletes the logging
- 
### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
