### PR TITLE
ATO-1437: Swap to using credentialTrustLevel from orch instead of client session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -226,12 +226,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         var vtr = new ArrayList<String>();
 
         try {
-            vtr.add(
-                    userContext
-                            .getClientSession()
-                            .getEffectiveVectorOfTrust()
-                            .getCredentialTrustLevel()
-                            .getValue());
+            vtr.add(userContext.getAuthSession().getRequestedCredentialStrength().getValue());
         } catch (Exception e) {
             LOG.warn(
                     "Error retrieving effective vector of trust for TICF CRI Request: {}",

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -179,7 +179,11 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                 authSession.setInternalCommonSubjectId(internalCommonSubjectId);
                 var userCredentials =
                         authenticationService.getUserCredentialsFromEmail(emailAddress);
-                userMfaDetail = getUserMFADetail(userContext, userCredentials, userProfile.get());
+                userMfaDetail =
+                        getUserMFADetail(
+                                authSession.getRequestedCredentialStrength(),
+                                userCredentials,
+                                userProfile.get());
                 auditContext = auditContext.withSubjectId(internalCommonSubjectId);
             } else {
                 authSession.setInternalCommonSubjectId(null);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -302,7 +302,11 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             AuditContext auditContext,
             AuthSessionItem authSessionItem) {
 
-        var userMfaDetail = getUserMFADetail(userContext, userCredentials, userProfile);
+        var userMfaDetail =
+                getUserMFADetail(
+                        authSessionItem.getRequestedCredentialStrength(),
+                        userCredentials,
+                        userProfile);
 
         boolean isPasswordChangeRequired = isPasswordResetRequired(request.getPassword());
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -183,8 +183,9 @@ public class StartHandler
                             Optional.ofNullable(startRequest.previousSessionId()),
                             sessionId,
                             startRequest.currentCredentialStrength());
-            authSession.setRequestedCredentialStrength(
-                    retrieveCredentialTrustLevel(startRequest.requestedCredentialStrength()));
+            var requestedCredentialTrustLevel =
+                    retrieveCredentialTrustLevel(startRequest.requestedCredentialStrength());
+            authSession.setRequestedCredentialStrength(requestedCredentialTrustLevel);
             if (startRequest.requestedLevelOfConfidence() != null) {
                 authSession.setRequestedLevelOfConfidence(
                         retrieveLevelOfConfidence(startRequest.requestedLevelOfConfidence()));
@@ -196,7 +197,8 @@ public class StartHandler
 
             var upliftRequired =
                     startService.isUpliftRequired(
-                            clientSession, startRequest.currentCredentialStrength());
+                            requestedCredentialTrustLevel,
+                            startRequest.currentCredentialStrength());
 
             authSessionService.addSession(authSession.withUpliftRequired(upliftRequired));
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -170,13 +170,6 @@ public class StartService {
     }
 
     public boolean isUpliftRequired(
-            ClientSession clientSession, CredentialTrustLevel currentCredentialStrength) {
-        return isUpliftRequired(
-                clientSession.getEffectiveVectorOfTrust().getCredentialTrustLevel(),
-                currentCredentialStrength);
-    }
-
-    public boolean isUpliftRequired(
             CredentialTrustLevel requestedCredentialStrength,
             CredentialTrustLevel currentCredentialStrength) {
         if (Objects.isNull(currentCredentialStrength)) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -171,12 +171,18 @@ public class StartService {
 
     public boolean isUpliftRequired(
             ClientSession clientSession, CredentialTrustLevel currentCredentialStrength) {
+        return isUpliftRequired(
+                clientSession.getEffectiveVectorOfTrust().getCredentialTrustLevel(),
+                currentCredentialStrength);
+    }
+
+    public boolean isUpliftRequired(
+            CredentialTrustLevel requestedCredentialStrength,
+            CredentialTrustLevel currentCredentialStrength) {
         if (Objects.isNull(currentCredentialStrength)) {
             return false;
         }
-        return (currentCredentialStrength.compareTo(
-                        clientSession.getEffectiveVectorOfTrust().getCredentialTrustLevel())
-                < 0);
+        return currentCredentialStrength.compareTo(requestedCredentialStrength) < 0;
     }
 
     public ClientRegistry getClient(String clientId) throws ClientNotFoundException {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -128,7 +128,8 @@ class AccountInterventionsHandlerTest {
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
                     .withEmailAddress(EMAIL)
-                    .withInternalCommonSubjectId(INTERNAL_SUBJECT_ID);
+                    .withInternalCommonSubjectId(INTERNAL_SUBJECT_ID)
+                    .withRequestedCredentialStrength(CredentialTrustLevel.LOW_LEVEL);
 
     private static final AuditContext AUDIT_CONTEXT =
             new AuditContext(
@@ -238,8 +239,6 @@ class AccountInterventionsHandlerTest {
                 .thenReturn(Optional.of(generateUserProfile()));
         when(accountInterventionsService.sendAccountInterventionsOutboundRequest(any()))
                 .thenReturn(generateAccountInterventionResponse(true, true, true, true));
-        when(userContext.getClientSession().getEffectiveVectorOfTrust().getCredentialTrustLevel())
-                .thenReturn(CredentialTrustLevel.LOW_LEVEL);
 
         var result =
                 handler.handleRequestWithUserContext(
@@ -261,8 +260,6 @@ class AccountInterventionsHandlerTest {
                 .thenReturn(Optional.of(generateUserProfile()));
         when(accountInterventionsService.sendAccountInterventionsOutboundRequest(any()))
                 .thenReturn(generateAccountInterventionResponse(true, true, true, true));
-        when(userContext.getClientSession().getEffectiveVectorOfTrust().getCredentialTrustLevel())
-                .thenReturn(CredentialTrustLevel.LOW_LEVEL);
 
         when(configurationService.isInvokeTicfCRILambdaEnabled()).thenReturn(featureSwitch);
 
@@ -401,8 +398,6 @@ class AccountInterventionsHandlerTest {
                 .thenReturn(Optional.of(generateUserProfile()));
         when(accountInterventionsService.sendAccountInterventionsOutboundRequest(any()))
                 .thenReturn(generateAccountInterventionResponse(true, true, true, true));
-        when(userContext.getClientSession().getEffectiveVectorOfTrust().getCredentialTrustLevel())
-                .thenReturn(CredentialTrustLevel.LOW_LEVEL);
         when(configurationService.isInvokeTicfCRILambdaEnabled()).thenReturn(true);
         var authSessionWithChanges =
                 authSession
@@ -439,8 +434,6 @@ class AccountInterventionsHandlerTest {
                 .thenReturn(Optional.of(generateUserProfile()));
         when(accountInterventionsService.sendAccountInterventionsOutboundRequest(any()))
                 .thenReturn(generateAccountInterventionResponse(true, true, true, true));
-        when(userContext.getClientSession().getEffectiveVectorOfTrust().getCredentialTrustLevel())
-                .thenReturn(CredentialTrustLevel.LOW_LEVEL);
 
         when(configurationService.isInvokeTicfCRILambdaEnabled()).thenReturn(true);
 
@@ -468,8 +461,6 @@ class AccountInterventionsHandlerTest {
                 .thenReturn(Optional.of(generateUserProfile()));
         when(accountInterventionsService.sendAccountInterventionsOutboundRequest(any()))
                 .thenReturn(generateAccountInterventionResponse(true, true, true, true));
-        when(userContext.getClientSession().getEffectiveVectorOfTrust().getCredentialTrustLevel())
-                .thenReturn(CredentialTrustLevel.LOW_LEVEL);
 
         when(configurationService.isInvokeTicfCRILambdaEnabled()).thenReturn(true);
         when(userContext.getClientSession()).thenReturn(null);
@@ -577,9 +568,6 @@ class AccountInterventionsHandlerTest {
                 .thenReturn(
                         generateAccountInterventionResponse(
                                 blocked, suspended, reproveIdentity, resetPassword));
-
-        when(userContext.getClientSession().getEffectiveVectorOfTrust().getCredentialTrustLevel())
-                .thenReturn(CredentialTrustLevel.LOW_LEVEL);
 
         when(configurationService.isInvokeTicfCRILambdaEnabled()).thenReturn(true);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -291,14 +291,14 @@ class AccountInterventionsHandlerTest {
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         false,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
 
                 // Testing initial registration combinations
                 Arguments.of(
@@ -307,14 +307,14 @@ class AccountInterventionsHandlerTest {
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         false,
                         AccountState.NEW,
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":false,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
 
                 // Testing password reset combinations
                 Arguments.of(
@@ -323,14 +323,14 @@ class AccountInterventionsHandlerTest {
                         ResetPasswordState.SUCCEEDED,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"SUCCEEDED\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"SUCCEEDED\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         false,
                         AccountState.EXISTING,
                         ResetPasswordState.ATTEMPTED,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"ATTEMPTED\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"ATTEMPTED\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
 
                 // Testing mfa reset combinations
                 Arguments.of(
@@ -339,21 +339,21 @@ class AccountInterventionsHandlerTest {
                         ResetPasswordState.NONE,
                         ResetMfaState.SUCCEEDED,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"SUCCEEDED\",\"mfaMethodType\":\"NONE\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"SUCCEEDED\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         true,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.ATTEMPTED,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"ATTEMPTED\",\"mfaMethodType\":\"NONE\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"ATTEMPTED\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         false,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.ATTEMPTED,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"ATTEMPTED\",\"mfaMethodType\":\"NONE\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"ATTEMPTED\",\"mfaMethodType\":\"NONE\"}"),
 
                 // Testing mfa method combinations
                 Arguments.of(
@@ -362,28 +362,28 @@ class AccountInterventionsHandlerTest {
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
                 Arguments.of(
                         true,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.EMAIL,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"EMAIL\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"EMAIL\"}"),
                 Arguments.of(
                         true,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.SMS,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"SMS\"}"),
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"SMS\"}"),
                 Arguments.of(
                         true,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.AUTH_APP,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[],\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"AUTH_APP\"}"));
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"AUTH_APP\"}"));
     }
 
     @ParameterizedTest
@@ -413,7 +413,12 @@ class AccountInterventionsHandlerTest {
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSessionWithChanges));
 
-        var result = handler.handleRequest(apiRequestEventForTICF(authenticated), context);
+        var result =
+                handler.handleRequestWithUserContext(
+                        apiRequestEventForTICF(authenticated),
+                        context,
+                        new AccountInterventionsRequest("test", authenticated),
+                        userContext);
 
         assertThat(result, hasStatus(200));
         assertEquals(DEFAULT_NO_INTERVENTIONS_RESPONSE, result.getBody());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
@@ -105,7 +106,10 @@ class CheckUserExistsHandlerTest {
     private final Session session = new Session();
     private static final String CLIENT_ID = "test-client-id";
     private final AuthSessionItem authSession =
-            new AuthSessionItem().withSessionId(SESSION_ID).withClientId(CLIENT_ID);
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withRequestedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL)
+                    .withClientId(CLIENT_ID);
     private static final String CLIENT_NAME = "test-client-name";
     private static final Subject SUBJECT = new Subject();
     private static final String SECTOR_URI = "http://sector-identifier";

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -250,7 +250,7 @@ class LoginHandlerTest {
 
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
-        usingValidAuthSession();
+        usingValidAuthSessionWithRequestedCredentialStrength(LOW_LEVEL);
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
 
@@ -302,7 +302,7 @@ class LoginHandlerTest {
 
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
-        usingValidAuthSession();
+        usingValidAuthSessionWithRequestedCredentialStrength(LOW_LEVEL);
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
 
@@ -361,7 +361,7 @@ class LoginHandlerTest {
 
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
-        usingValidAuthSessionWithAchievedCredentialStrength(MEDIUM_LEVEL);
+        usingValidAuthSessionWithAchievedAndRequestedCredentialStrength(MEDIUM_LEVEL, LOW_LEVEL);
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
 
@@ -419,7 +419,7 @@ class LoginHandlerTest {
 
         usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
-        usingValidAuthSessionWithAchievedCredentialStrength(LOW_LEVEL);
+        usingValidAuthSessionWithAchievedAndRequestedCredentialStrength(LOW_LEVEL, LOW_LEVEL);
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
 
@@ -475,7 +475,7 @@ class LoginHandlerTest {
         when(clientSession.getEffectiveVectorOfTrust()).thenReturn(vot);
 
         usingValidSession();
-        usingValidAuthSession();
+        usingValidAuthSessionWithRequestedCredentialStrength(LOW_LEVEL);
         usingApplicableUserCredentialsWithLogin(SMS, true);
 
         var event =
@@ -500,7 +500,7 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
         usingValidSession();
-        usingValidAuthSession();
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
         usingDefaultVectorOfTrust();
 
@@ -562,7 +562,7 @@ class LoginHandlerTest {
         when(authenticationService.getUserCredentialsFromEmail(EMAIL)).thenReturn(userCredentials);
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of(mfaMethod)));
         usingValidSession();
-        usingValidAuthSession();
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
 
         usingDefaultVectorOfTrust();
 
@@ -637,7 +637,7 @@ class LoginHandlerTest {
                 .thenReturn(migratedUserCredentials);
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of(mfaMethod)));
         usingValidSession();
-        usingValidAuthSession();
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
 
         usingDefaultVectorOfTrust();
 
@@ -752,7 +752,7 @@ class LoginHandlerTest {
                 .thenReturn(testUserCredentials);
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(mfaMethods));
         usingValidSession();
-        usingValidAuthSession();
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
         usingDefaultVectorOfTrust();
 
         // Act
@@ -1052,7 +1052,7 @@ class LoginHandlerTest {
                         applicableUserCredentials, CommonTestVariables.PASSWORD))
                 .thenReturn(false);
         usingValidSession();
-        usingValidAuthSession();
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
         usingDefaultVectorOfTrust();
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
@@ -1135,7 +1135,7 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
         usingValidSession();
-        usingValidAuthSession();
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
         usingApplicableUserCredentialsWithLogin(SMS, true);
         usingDefaultVectorOfTrust();
         when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -1158,7 +1158,7 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
         usingValidSession();
-        usingValidAuthSession();
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
         usingApplicableUserCredentialsWithLogin(SMS, true);
         usingDefaultVectorOfTrust();
         when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -1286,6 +1286,18 @@ class LoginHandlerTest {
 
     private void usingValidAuthSessionWithAchievedCredentialStrength(
             CredentialTrustLevel credentialTrustLevel) {
+        usingValidAuthSessionWithAchievedAndRequestedCredentialStrength(
+                credentialTrustLevel, CredentialTrustLevel.MEDIUM_LEVEL);
+    }
+
+    private void usingValidAuthSessionWithRequestedCredentialStrength(
+            CredentialTrustLevel credentialTrustLevel) {
+        usingValidAuthSessionWithAchievedAndRequestedCredentialStrength(null, credentialTrustLevel);
+    }
+
+    private void usingValidAuthSessionWithAchievedAndRequestedCredentialStrength(
+            CredentialTrustLevel achievedCredentialStrength,
+            CredentialTrustLevel requestedCredentialStrength) {
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(
                         Optional.of(
@@ -1294,7 +1306,9 @@ class LoginHandlerTest {
                                         .withEmailAddress(EMAIL)
                                         .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
                                         .withClientId(CLIENT_ID.getValue())
-                                        .withAchievedCredentialStrength(credentialTrustLevel)));
+                                        .withAchievedCredentialStrength(achievedCredentialStrength)
+                                        .withRequestedCredentialStrength(
+                                                requestedCredentialStrength)));
     }
 
     private void usingValidAuthSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -140,7 +141,8 @@ class ResetPasswordRequestHandlerTest {
                     .withSessionId(SESSION_ID)
                     .withEmailAddress(CommonTestVariables.EMAIL)
                     .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID)
-                    .withClientId(CLIENT_ID);
+                    .withClientId(CLIENT_ID)
+                    .withRequestedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
     private final ResetPasswordRequestHandler handler =
             new ResetPasswordRequestHandler(
                     configurationService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -400,7 +400,7 @@ class StartServiceTest {
     @ParameterizedTest
     @MethodSource("userStartUpliftInfo")
     void shouldCreateUserStartInfoWithCorrectUpliftRequiredValue(
-            String vtr,
+            String vtrString,
             boolean expectedIdentityRequiredValue,
             CredentialTrustLevel credentialTrustLevel,
             boolean expectedUpliftRequiredValue,
@@ -409,7 +409,7 @@ class StartServiceTest {
             MFAMethodType expectedMfaMethodType) {
         var userContext =
                 buildUserContext(
-                        vtr,
+                        vtrString,
                         true,
                         ClientType.WEB,
                         null,
@@ -417,11 +417,12 @@ class StartServiceTest {
                         Optional.of(userProfile),
                         Optional.of(userCredentials),
                         false);
-        var levelOfConfidence =
-                VectorOfTrust.parseFromAuthRequestAttribute(Collections.singletonList(vtr))
-                        .getLevelOfConfidence();
+        var requestedVtr =
+                VectorOfTrust.parseFromAuthRequestAttribute(Collections.singletonList(vtrString));
+        var requestedCredentialTrustLevel = requestedVtr.getCredentialTrustLevel();
+        var levelOfConfidence = requestedVtr.getLevelOfConfidence();
         var upliftRequired =
-                startService.isUpliftRequired(userContext.getClientSession(), credentialTrustLevel);
+                startService.isUpliftRequired(requestedCredentialTrustLevel, credentialTrustLevel);
         var userStartInfo =
                 startService.buildUserStartInfo(
                         userContext,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -119,6 +119,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, email);
         authSessionExtension.addClientIdToSession(sessionId, CLIENT_ID);
+        authSessionExtension.addRequestedCredentialStrengthToSession(sessionId, level);
 
         userStore.signUp(email, password);
         userStore.updateTermsAndConditions(email, termsAndConditionsVersion);
@@ -180,6 +181,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, email);
         authSessionExtension.addClientIdToSession(sessionId, CLIENT_ID);
+        authSessionExtension.addRequestedCredentialStrengthToSession(sessionId, level);
 
         userStore.signUp(email, password);
         userStore.updateTermsAndConditions(email, termsAndConditionsVersion);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -86,6 +86,14 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
         updateSession(getSession(sessionId).orElseThrow().withClientId(clientId));
     }
 
+    public void addRequestedCredentialStrengthToSession(
+            String sessionId, CredentialTrustLevel credentialTrustLevel) {
+        updateSession(
+                getSession(sessionId)
+                        .orElseThrow()
+                        .withRequestedCredentialStrength(credentialTrustLevel));
+    }
+
     public void addInternalCommonSubjectIdToSession(
             String sessionId, String internalCommonSubjectIdl) {
         updateSession(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/conditions/MfaHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/conditions/MfaHelperTest.java
@@ -1,12 +1,5 @@
 package uk.gov.di.authentication.shared.conditions;
 
-import com.nimbusds.oauth2.sdk.ResponseType;
-import com.nimbusds.oauth2.sdk.Scope;
-import com.nimbusds.oauth2.sdk.id.ClientID;
-import com.nimbusds.oauth2.sdk.id.State;
-import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
-import com.nimbusds.openid.connect.sdk.Nonce;
-import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -15,7 +8,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.authentication.entity.UserMfaDetail;
-import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -23,17 +15,14 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
-import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
-import java.net.URI;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
-import static java.util.Objects.nonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,7 +32,6 @@ import static uk.gov.di.authentication.shared.conditions.MfaHelper.getUserMFADet
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.AUTH_APP;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.NONE;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.SMS;
-import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class MfaHelperTest {
@@ -66,25 +54,22 @@ class MfaHelperTest {
         @MethodSource("trustLevelsToMfaRequired")
         void isMfaRequiredShouldReflectLevelOfTrustRequested(
                 CredentialTrustLevel trustLevel, boolean expectedMfaRequired) {
-            var userContext = userContextWithLevelOfTrustRequested(trustLevel);
             setupUserProfile(userProfile, PHONE_NUMBER, true, false);
-
-            var result = getUserMFADetail(userContext, userCredentials, userProfile);
+            var result = getUserMFADetail(trustLevel, userCredentials, userProfile);
 
             assertEquals(expectedMfaRequired, result.isMfaRequired());
         }
 
         @Test
         void shouldReturnAVerifiedSmsMethodWhenNoAuthAppExists() {
-            var userContext =
-                    userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
-
             var isPhoneNumberVerified = true;
             setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
 
             when(userCredentials.getMfaMethods()).thenReturn(List.of());
 
-            var result = getUserMFADetail(userContext, userCredentials, userProfile);
+            var result =
+                    getUserMFADetail(
+                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -96,9 +81,6 @@ class MfaHelperTest {
 
         @Test
         void shouldReturnAVerifiedSmsMethodWhenAuthAppExistsButIsNotEnabled() {
-            var userContext =
-                    userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
-
             var isPhoneNumberVerified = true;
             var isAuthAppEnabled = false;
             setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
@@ -106,7 +88,9 @@ class MfaHelperTest {
             var authApp = authAppMfaMethod(true, isAuthAppEnabled);
             when(userCredentials.getMfaMethods()).thenReturn(List.of(authApp));
 
-            var result = getUserMFADetail(userContext, userCredentials, userProfile);
+            var result =
+                    getUserMFADetail(
+                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -114,15 +98,14 @@ class MfaHelperTest {
 
         @Test
         void shouldReturnMethodTypeOfNoneWhenSmsMethodNotVerified() {
-            var userContext =
-                    userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
-
             var isPhoneNumberVerified = false;
             setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
 
             when(userCredentials.getMfaMethods()).thenReturn(List.of());
 
-            var result = getUserMFADetail(userContext, userCredentials, userProfile);
+            var result =
+                    getUserMFADetail(
+                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, false, NONE, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -137,8 +120,6 @@ class MfaHelperTest {
         void
                 shouldReturnAuthAppMethodWhenOneExistsWhichIsEnabledRegardlessOfWhetherPhoneNumberVerified(
                         boolean isPhoneNumberVerified) {
-            var userContext =
-                    userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
             setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
 
             var isAuthAppVerified = true;
@@ -146,7 +127,9 @@ class MfaHelperTest {
             when(userCredentials.getMfaMethods())
                     .thenReturn(List.of(authAppMfaMethod(isAuthAppVerified, true)));
 
-            var result = getUserMFADetail(userContext, userCredentials, userProfile);
+            var result =
+                    getUserMFADetail(
+                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
             var expectedResult =
                     new UserMfaDetail(true, true, MFAMethodType.AUTH_APP, PHONE_NUMBER);
 
@@ -161,16 +144,15 @@ class MfaHelperTest {
 
         @Test
         void shouldReturnVerifiedSMSMethodWhenAuthAppExistsButIsNotVerified() {
-            var userContext =
-                    userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
-
             var isPhoneNumberVerified = true;
             setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
 
             when(userCredentials.getMfaMethods())
                     .thenReturn(List.of(authAppMfaMethod(false, true)));
 
-            var result = getUserMFADetail(userContext, userCredentials, userProfile);
+            var result =
+                    getUserMFADetail(
+                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -178,9 +160,6 @@ class MfaHelperTest {
 
         @Test
         void shouldReturnUnVerifiedAuthMethodWhenPhoneNumberIsNotVerified() {
-            var userContext =
-                    userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
-
             var isAuthAppVerified = false;
             var isPhoneNumberVerified = false;
             setupUserProfile(userProfile, PHONE_NUMBER, isPhoneNumberVerified, false);
@@ -188,7 +167,9 @@ class MfaHelperTest {
             when(userCredentials.getMfaMethods())
                     .thenReturn(List.of(authAppMfaMethod(isAuthAppVerified, true)));
 
-            var result = getUserMFADetail(userContext, userCredentials, userProfile);
+            var result =
+                    getUserMFADetail(
+                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, false, AUTH_APP, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
@@ -202,8 +183,6 @@ class MfaHelperTest {
 
         @Test
         void shouldReturnRelevantMethodForAMigratedUser() {
-            var userContext =
-                    userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
             when(userProfile.getMfaMethodsMigrated()).thenReturn(true);
 
             var phoneNumberOfMigratedMethod = "+447900000000";
@@ -229,7 +208,9 @@ class MfaHelperTest {
             when(userCredentials.getMfaMethods())
                     .thenReturn(List.of(defaultSmsMethod, backupAuthAppMethod));
 
-            var result = getUserMFADetail(userContext, userCredentials, userProfile);
+            var result =
+                    getUserMFADetail(
+                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, true, SMS, phoneNumberOfMigratedMethod);
 
             assertEquals(expectedResult, result);
@@ -237,8 +218,6 @@ class MfaHelperTest {
 
         @Test
         void shouldHandleErrorsRetrievingADefaultMethodForAMigratedUser() {
-            var userContext =
-                    userContextWithLevelOfTrustRequested(CredentialTrustLevel.MEDIUM_LEVEL);
             when(userProfile.getMfaMethodsMigrated()).thenReturn(true);
 
             var isPhoneNumberVerifiedOnUserProfile = false;
@@ -253,7 +232,9 @@ class MfaHelperTest {
                             "auth-app-mfa-id");
             when(userCredentials.getMfaMethods()).thenReturn(List.of(backupAuthAppMethod));
 
-            var result = getUserMFADetail(userContext, userCredentials, userProfile);
+            var result =
+                    getUserMFADetail(
+                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
             var expectedResult = new UserMfaDetail(true, false, NONE, null);
 
             assertEquals(expectedResult, result);
@@ -337,34 +318,6 @@ class MfaHelperTest {
 
             assertEquals(Optional.empty(), result);
         }
-    }
-
-    private static UserContext userContextWithLevelOfTrustRequested(
-            CredentialTrustLevel trustLevel) {
-        var clientSession = mock(ClientSession.class);
-        var authRequestParams = generateAuthRequest(trustLevel).toParameters();
-        when(clientSession.getAuthRequestParams()).thenReturn(authRequestParams);
-
-        var userContext = mock(UserContext.class);
-        when(userContext.getClientSession()).thenReturn(clientSession);
-
-        return userContext;
-    }
-
-    private static AuthenticationRequest generateAuthRequest(
-            CredentialTrustLevel credentialTrustLevel) {
-        AuthenticationRequest.Builder builder =
-                new AuthenticationRequest.Builder(
-                                ResponseType.CODE,
-                                new Scope(OIDCScopeValue.OPENID),
-                                new ClientID("CLIENT_ID"),
-                                URI.create("http://localhost/redirect"))
-                        .state(new State())
-                        .nonce(new Nonce());
-        if (nonNull(credentialTrustLevel)) {
-            builder.customParameter("vtr", jsonArrayOf(credentialTrustLevel.getValue()));
-        }
-        return builder.build();
     }
 
     private static MFAMethod authAppMfaMethod(boolean isAuthAppVerified, boolean enabled) {


### PR DESCRIPTION
### Wider context of change

We would like to stop using clientSession and instead use the values of claims we send from orch to auth. By this point, we have claims available in auth backend that can replace the use of the auth request parameters on the clientSession.

We are storing the claims `levelOfConfidence`,`credentialTrustLevel`, and `clientId` in the auth session, as these are used outside of the StartHandler. The rest of the claims (`cookieConsent`, `_ga`, `state`, `scope`, `redirect_uri`) are only used in the StartHandler.

### What’s changed

This PR swaps to using the `credentialTrustLevel` we are storing on the auth session from orch, instead of parsing the VTR from the client session auth request params.

### Manual testing

Tested in authdev and sandpit
- Both 2fa and no 2fa journeys worked

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. See above
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a
