### PR TITLE
ATO-1437: Swap to using remaining claims from orch instead of client session

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -202,9 +202,7 @@ public class StartHandler
             var cookieConsent =
                     startService.getCookieConsentValue(
                             startRequest.cookieConsent(), startRequest.clientId());
-            var gaTrackingId =
-                    startService.getGATrackingId(
-                            userContext.getClientSession().getAuthRequestParams());
+            var gaTrackingId = startRequest.ga();
             var reauthenticateHeader =
                     getHeaderValueFromHeaders(
                             input.getHeaders(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -4,7 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.id.State;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -36,7 +36,10 @@ import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -194,10 +197,15 @@ public class StartHandler
 
             var userContext = startService.buildUserContext(session, clientSession, authSession);
 
+            var scopes = List.of(startRequest.scope().split(" "));
+            var redirectURI = new URI(startRequest.redirectUri());
+            var state = new State(startRequest.state());
             attachLogFieldToLogs(
                     CLIENT_ID,
                     userContext.getClient().map(ClientRegistry::getClientID).orElse(UNKNOWN));
-            var clientStartInfo = startService.buildClientStartInfo(userContext);
+            var clientStartInfo =
+                    startService.buildClientStartInfo(
+                            userContext.getClient().orElseThrow(), scopes, redirectURI, state);
 
             var cookieConsent =
                     startService.getCookieConsentValue(
@@ -288,8 +296,10 @@ public class StartHandler
             var errorMessage = "Unable to serialize start response";
             LOG.error(errorMessage, e);
             return generateApiGatewayProxyResponse(400, errorMessage);
-        } catch (ParseException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1038);
+        } catch (URISyntaxException e) {
+            var errorMessage = "Unable to parse redirect URI";
+            LOG.error(errorMessage, e);
+            return generateApiGatewayProxyResponse(400, errorMessage);
         }
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -201,8 +201,7 @@ public class StartHandler
 
             var cookieConsent =
                     startService.getCookieConsentValue(
-                            userContext.getClientSession().getAuthRequestParams(),
-                            userContext.getClient().get().getClientID());
+                            startRequest.cookieConsent(), startRequest.clientId());
             var gaTrackingId =
                     startService.getGATrackingId(
                             userContext.getClientSession().getAuthRequestParams());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -34,7 +34,6 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static java.util.function.Predicate.not;
-import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.COOKIE_CONSENT;
 import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.GA;
 
 public class StartService {
@@ -186,13 +185,12 @@ public class StartService {
         return null;
     }
 
-    public String getCookieConsentValue(
-            Map<String, List<String>> authRequestParameters, String clientID) {
+    public String getCookieConsentValue(String cookieConsentValue, String clientID) {
         try {
-            if (validCookieConsentValueIsPresent(authRequestParameters)
+            if (validCookieConsentValueIsPresent(cookieConsentValue)
                     && isClientCookieConsentShared(clientID)) {
                 LOG.info("Sharing cookie_consent");
-                return authRequestParameters.get(COOKIE_CONSENT).get(0);
+                return cookieConsentValue;
             }
             return null;
         } catch (ClientNotFoundException e) {
@@ -271,12 +269,9 @@ public class StartService {
                                                 clientID)));
     }
 
-    private boolean validCookieConsentValueIsPresent(
-            Map<String, List<String>> authRequestParameters) {
-        return authRequestParameters.containsKey(COOKIE_CONSENT)
-                && !authRequestParameters.get(COOKIE_CONSENT).isEmpty()
-                && authRequestParameters.get(COOKIE_CONSENT).get(0) != null
+    private boolean validCookieConsentValueIsPresent(String cookieConsent) {
+        return cookieConsent != null
                 && List.of(COOKIE_CONSENT_ACCEPT, COOKIE_CONSENT_REJECT, COOKIE_CONSENT_NOT_ENGAGED)
-                        .contains(authRequestParameters.get(COOKIE_CONSENT).get(0));
+                        .contains(cookieConsent);
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -1,9 +1,6 @@
 package uk.gov.di.authentication.frontendapi.services;
 
-import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.State;
-import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.ClientStartInfo;
@@ -81,33 +78,6 @@ public class StartService {
             throw new RuntimeException("Error when creating UserContext", e);
         }
         return userContext;
-    }
-
-    public ClientStartInfo buildClientStartInfo(UserContext userContext) throws ParseException {
-        List<String> scopes;
-        URI redirectURI;
-        State state;
-        try {
-            var authenticationRequest =
-                    AuthenticationRequest.parse(
-                            userContext.getClientSession().getAuthRequestParams());
-            if (Objects.nonNull(authenticationRequest.getRequestObject())) {
-                var claimSet = authenticationRequest.getRequestObject().getJWTClaimsSet();
-                scopes = Scope.parse((String) claimSet.getClaim("scope")).toStringList();
-                redirectURI = URI.create((String) claimSet.getClaim("redirect_uri"));
-                state = State.parse((String) claimSet.getClaim("state"));
-            } else {
-                scopes = authenticationRequest.getScope().toStringList();
-                redirectURI = authenticationRequest.getRedirectionURI();
-                state = authenticationRequest.getState();
-            }
-        } catch (ParseException e) {
-            throw new ParseException("Unable to parse authentication request");
-        } catch (java.text.ParseException e) {
-            throw new RuntimeException("Unable to parse claims in request object");
-        }
-        return buildClientStartInfo(
-                userContext.getClient().orElseThrow(), scopes, redirectURI, state);
     }
 
     public ClientStartInfo buildClientStartInfo(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -106,7 +106,12 @@ public class StartService {
         } catch (java.text.ParseException e) {
             throw new RuntimeException("Unable to parse claims in request object");
         }
-        var clientRegistry = userContext.getClient().orElseThrow();
+        return buildClientStartInfo(
+                userContext.getClient().orElseThrow(), scopes, redirectURI, state);
+    }
+
+    public ClientStartInfo buildClientStartInfo(
+            ClientRegistry clientRegistry, List<String> scopes, URI redirectURI, State state) {
         var clientInfo =
                 new ClientStartInfo(
                         clientRegistry.getClientName(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -28,13 +28,11 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
 import static java.lang.String.format;
 import static java.util.function.Predicate.not;
-import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.GA;
 
 public class StartService {
 
@@ -174,15 +172,6 @@ public class StartService {
                 .filter(MFAMethod::isMethodVerified)
                 .map(MFAMethod::getMfaMethodType)
                 .anyMatch(MFAMethodType.AUTH_APP.getValue()::equals);
-    }
-
-    public String getGATrackingId(Map<String, List<String>> authRequestParameters) {
-        if (authRequestParameters.containsKey(GA)) {
-            String gaId = authRequestParameters.get(GA).get(0);
-            LOG.info("GA value present in request {}", gaId);
-            return gaId;
-        }
-        return null;
     }
 
     public String getCookieConsentValue(String cookieConsentValue, String clientID) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -167,7 +167,6 @@ class StartHandlerTest {
             throws ParseException, Json.JsonException {
         var userStartInfo = getUserStartInfo(cookieConsentValue, gaTrackingId);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
-        when(startService.getGATrackingId(anyMap())).thenReturn(gaTrackingId);
         usingValidClientSession();
         usingValidSession();
 
@@ -595,7 +594,6 @@ class StartHandlerTest {
         when(startService.buildUserContext(eq(session), any(), any(AuthSessionItem.class)))
                 .thenReturn(userContext);
         when(startService.buildClientStartInfo(userContext)).thenReturn(clientStartInfo);
-        when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.buildUserStartInfo(
                         eq(userContext),
                         any(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -596,7 +596,6 @@ class StartHandlerTest {
                 .thenReturn(userContext);
         when(startService.buildClientStartInfo(userContext)).thenReturn(clientStartInfo);
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
-        when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
         when(startService.buildUserStartInfo(
                         eq(userContext),
                         any(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.frontendapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -164,7 +163,7 @@ class StartHandlerTest {
     @ParameterizedTest
     @MethodSource("cookieConsentGaTrackingIdValues")
     void shouldReturn200WithStartResponse(String cookieConsentValue, String gaTrackingId)
-            throws ParseException, Json.JsonException {
+            throws Json.JsonException {
         var userStartInfo = getUserStartInfo(cookieConsentValue, gaTrackingId);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         usingValidClientSession();
@@ -191,7 +190,7 @@ class StartHandlerTest {
 
     @Test
     void shouldReturn200WithAuthenticatedFalseWhenAReauthenticationJourney()
-            throws ParseException, Json.JsonException {
+            throws Json.JsonException {
         var isAuthenticated = false;
         var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
@@ -232,7 +231,7 @@ class StartHandlerTest {
 
     @Test
     void shouldNotCallAuthenticationAttemptsServiceWhenFeatureFlagIsOff()
-            throws ParseException, Json.JsonException {
+            throws Json.JsonException {
         var isAuthenticated = false;
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(false);
         var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
@@ -254,8 +253,7 @@ class StartHandlerTest {
     }
 
     @Test
-    void shouldUseCountsAgainstTheRpPairwiseIdWhenThereIsNoSubjectId()
-            throws ParseException, Json.JsonException {
+    void shouldUseCountsAgainstTheRpPairwiseIdWhenThereIsNoSubjectId() throws Json.JsonException {
         var isAuthenticated = false;
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
         when(userProfile.getSubjectID()).thenReturn(null);
@@ -274,8 +272,7 @@ class StartHandlerTest {
     }
 
     @Test
-    void checkAuditEventStillEmittedWhenTICFHeaderNotProvided()
-            throws ParseException, Json.JsonException {
+    void checkAuditEventStillEmittedWhenTICFHeaderNotProvided() throws Json.JsonException {
         var isAuthenticated = false;
         var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
@@ -307,8 +304,7 @@ class StartHandlerTest {
     }
 
     @Test
-    void shouldConsiderUserNotAuthenticatedWhenUserProfileNotPresent()
-            throws ParseException, Json.JsonException {
+    void shouldConsiderUserNotAuthenticatedWhenUserProfileNotPresent() throws Json.JsonException {
         withNoUserProfilePresent();
         var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
@@ -334,8 +330,7 @@ class StartHandlerTest {
     }
 
     @Test
-    void considersUserAuthenticatedWhenUserProfilePresent()
-            throws ParseException, Json.JsonException {
+    void considersUserAuthenticatedWhenUserProfilePresent() throws Json.JsonException {
         withUserProfilePresent();
         var userStartInfo = new UserStartInfo(false, false, true, null, null, null, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
@@ -362,7 +357,7 @@ class StartHandlerTest {
 
     @Test
     void shouldReturn200WithAuthenticatedTrueWhenReauthenticateHeaderNotSetToTrue()
-            throws Json.JsonException, ParseException {
+            throws Json.JsonException {
         withUserProfilePresent();
         var isAuthenticated = true;
         usingValidSession();
@@ -429,7 +424,7 @@ class StartHandlerTest {
             int expectedPasswordAttemptCount,
             int expectedOtpAttemptCount,
             String expectedFailureReason)
-            throws ParseException, Json.JsonException {
+            throws Json.JsonException {
         var userStartInfo = new UserStartInfo(false, false, true, null, null, null, true);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
@@ -506,30 +501,6 @@ class StartHandlerTest {
         verifyNoInteractions(auditService);
     }
 
-    @Test
-    void shouldReturn400WhenBuildClientStartInfoThrowsException()
-            throws ParseException, Json.JsonException {
-        when(startService.buildUserContext(
-                        eq(session), eq(clientSession), any(AuthSessionItem.class)))
-                .thenReturn(userContext);
-        when(startService.buildClientStartInfo(userContext))
-                .thenThrow(new ParseException("Unable to parse authentication request"));
-        usingValidClientSession();
-        usingValidSession();
-
-        var event =
-                apiRequestEventWithHeadersAndBody(
-                        VALID_HEADERS, makeRequestBodyWithAuthenticatedField(false));
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
-
-        assertThat(result, hasStatus(400));
-
-        String expectedResponse = objectMapper.writeValueAsString(ErrorResponse.ERROR_1038);
-        assertThat(result, hasBody(expectedResponse));
-
-        verifyNoInteractions(auditService);
-    }
-
     private String makeRequestBodyWithAuthenticatedField(boolean authenticated)
             throws Json.JsonException {
         return makeRequestBody(null, null, null, authenticated);
@@ -589,11 +560,11 @@ class StartHandlerTest {
     }
 
     private void usingStartServiceThatReturns(
-            UserContext userContext, ClientStartInfo clientStartInfo, UserStartInfo userStartInfo)
-            throws ParseException {
+            UserContext userContext, ClientStartInfo clientStartInfo, UserStartInfo userStartInfo) {
         when(startService.buildUserContext(eq(session), any(), any(AuthSessionItem.class)))
                 .thenReturn(userContext);
-        when(startService.buildClientStartInfo(userContext)).thenReturn(clientStartInfo);
+        when(startService.buildClientStartInfo(eq(clientRegistry), any(), any(), any()))
+                .thenReturn(clientStartInfo);
         when(startService.buildUserStartInfo(
                         eq(userContext),
                         any(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -602,20 +602,9 @@ class StartServiceTest {
                                         REDIRECT_URI.toString(),
                                         CLIENT_ID.getValue(),
                                         cookieConsentShared)));
-        var authRequest =
-                new AuthenticationRequest.Builder(
-                                new ResponseType(ResponseType.Value.CODE),
-                                SCOPES,
-                                CLIENT_ID,
-                                REDIRECT_URI)
-                        .state(new State())
-                        .nonce(new Nonce())
-                        .customParameter("cookie_consent", cookieConsentValue)
-                        .build();
 
         assertThat(
-                startService.getCookieConsentValue(
-                        authRequest.toParameters(), CLIENT_ID.getValue()),
+                startService.getCookieConsentValue(cookieConsentValue, CLIENT_ID.getValue()),
                 equalTo(expectedValue));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -6,7 +6,6 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -530,8 +529,7 @@ class StartServiceTest {
             boolean cookieConsentShared,
             ClientType clientType,
             SignedJWT signedJWT,
-            boolean oneLoginService)
-            throws ParseException {
+            boolean oneLoginService) {
         var userContext =
                 buildUserContext(
                         jsonArrayOf("Cl.Cm"),
@@ -542,8 +540,14 @@ class StartServiceTest {
                         Optional.empty(),
                         Optional.empty(),
                         oneLoginService);
+        var scopes = Objects.nonNull(signedJWT) ? DOC_APP_SCOPES : SCOPES;
 
-        var clientStartInfo = startService.buildClientStartInfo(userContext);
+        var clientStartInfo =
+                startService.buildClientStartInfo(
+                        userContext.getClient().orElseThrow(),
+                        scopes.toStringList(),
+                        REDIRECT_URI,
+                        STATE);
 
         assertThat(clientStartInfo.cookieConsentShared(), equalTo(cookieConsentShared));
         assertThat(clientStartInfo.clientName(), equalTo(CLIENT_NAME));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -35,7 +35,6 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
-import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
@@ -557,38 +556,6 @@ class StartServiceTest {
             expectedScopes = DOC_APP_SCOPES;
         }
         assertThat(clientStartInfo.scopes(), equalTo(expectedScopes.toStringList()));
-    }
-
-    @Test
-    void shouldReturnGaTrackingIdWhenPresentInAuthRequest() {
-        var gaTrackingId = IdGenerator.generate();
-        var authRequest =
-                new AuthenticationRequest.Builder(
-                                new ResponseType(ResponseType.Value.CODE),
-                                SCOPES,
-                                CLIENT_ID,
-                                REDIRECT_URI)
-                        .state(new State())
-                        .nonce(new Nonce())
-                        .customParameter("_ga", gaTrackingId)
-                        .build();
-
-        assertThat(startService.getGATrackingId(authRequest.toParameters()), equalTo(gaTrackingId));
-    }
-
-    @Test
-    void shouldReturnNullWhenGaTrackingIdIsNotPresentInAuthRequest() {
-        var authRequest =
-                new AuthenticationRequest.Builder(
-                                new ResponseType(ResponseType.Value.CODE),
-                                SCOPES,
-                                CLIENT_ID,
-                                REDIRECT_URI)
-                        .state(new State())
-                        .nonce(new Nonce())
-                        .build();
-
-        assertThat(startService.getGATrackingId(authRequest.toParameters()), equalTo(null));
     }
 
     @ParameterizedTest

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -508,16 +508,6 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             AuthenticationRequest authRequest,
             Optional<LevelOfConfidence> levelOfConfidenceOpt,
             String credentialStrength) {
-        return makeRequestBody(
-                isAuthenticated, authRequest, levelOfConfidenceOpt, credentialStrength, Map.of());
-    }
-
-    private String makeRequestBody(
-            boolean isAuthenticated,
-            AuthenticationRequest authRequest,
-            Optional<LevelOfConfidence> levelOfConfidenceOpt,
-            String credentialStrength,
-            Map<String, Object> paramOverrides) {
         Map<String, Object> requestBodyMap =
                 new HashMap<>(
                         Map.of(
@@ -541,7 +531,6 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 levelOfConfidence ->
                         requestBodyMap.put(
                                 "requested_level_of_confidence", levelOfConfidence.getValue()));
-        requestBodyMap.putAll(paramOverrides);
         return SerializationService.getInstance().writeValueAsString(requestBodyMap);
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -310,6 +310,45 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
+    void shouldReturn400WhenRedirectURIIsInvalid() throws Exception {
+        String sessionId = redis.createSession();
+        userStore.signUp(EMAIL, "password");
+        authSessionExtension.addSession(sessionId);
+        var state = new State();
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        var builder =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
+                        .nonce(new Nonce())
+                        .state(state)
+                        .customParameter("client_id", CLIENT_ID)
+                        .customParameter("redirect_uri", "invalid-redirect-uri/@'[]l.#,;][")
+                        .customParameter("vtr", jsonArrayOf("P1.Cl.Cm"));
+        var authRequest = builder.build();
+
+        redis.createClientSession(CLIENT_SESSION_ID, TEST_CLIENT_NAME, authRequest.toParameters());
+
+        registerWebClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR());
+
+        var headers = standardHeadersWithSessionId(sessionId);
+        headers.put("Reauthenticate", "true");
+
+        var response =
+                makeRequest(
+                        Optional.of(
+                                makeRequestBody(
+                                        true,
+                                        authRequest,
+                                        Optional.of(LevelOfConfidence.LOW_LEVEL),
+                                        "Cl.Cm")),
+                        headers,
+                        Map.of());
+        assertThat(response, hasStatus(400));
+        assertThat(response.getBody(), equalTo("Unable to parse redirect URI"));
+    }
+
+    @Test
     void userShouldNotComeBackAsAuthenticatedWhenSessionIsAuthenticatedButNoUserProfileExists()
             throws Json.JsonException {
         var scope = new Scope(OIDCScopeValue.OPENID);


### PR DESCRIPTION
### Wider context of change

We would like to stop using clientSession and instead use the values of claims we send from orch to auth. By this point, we have claims available in auth backend that can replace the use of the auth request parameters on the clientSession.

We are storing the claims `levelOfConfidence`,`credentialTrustLevel`, and `clientId` in the auth session, as these are used outside of the StartHandler. The rest of the claims (`cookieConsent`, `_ga`, `state`, `scope`, `redirect_uri`) are only used in the StartHandler.

### What’s changed

This PR uses the following claims from orch, instead of the auth request parameters in the client session:
- `cookieConsent`
- `_ga`
- `state`
- `scope`
- `redirect_uri`

These claims are only used in the StartHandler, so the scope of these changes are quite small.

### Manual testing

Tested in sandpit and authdev
- Did a couple of auth and identity journeys, seemed to work as expected

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. See above
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a
