### PR TITLE
AUT-4248: SMS OTP identification using email and phone number

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
@@ -104,6 +104,8 @@ public class MFAMethodsRetrieveHandler
             return switch (retrieveResult.getFailure()) {
                 case UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP -> generateApiGatewayProxyErrorResponse(
                         500, ErrorResponse.ERROR_1078);
+                case USER_DOES_NOT_HAVE_ACCOUNT -> generateApiGatewayProxyErrorResponse(
+                        500, ErrorResponse.ERROR_1010);
             };
         }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -69,6 +69,7 @@ import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
+import static uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT;
 
 public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -354,6 +355,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             return switch (retrieveMfaMethods.getFailure()) {
                 case UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP -> generateApiGatewayProxyErrorResponse(
                         500, ErrorResponse.ERROR_1078);
+                case USER_DOES_NOT_HAVE_ACCOUNT -> generateApiGatewayProxyErrorResponse(
+                        500, ErrorResponse.ERROR_1010);
             };
         }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -231,6 +231,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             String code =
                     codeStorageService
                             .getOtpCode(codeIdentifier, notificationType)
+                            .or( // Temporary fallback for old phone number key with just email
+                                    () -> codeStorageService.getOtpCode(email, notificationType))
                             .orElseGet(
                                     () -> generateAndSaveNewCode(codeIdentifier, notificationType));
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import uk.gov.di.authentication.shared.helpers.TestClientHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
@@ -226,10 +227,12 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
 
             var notificationType = (request.isResendCodeRequest()) ? VERIFY_PHONE_NUMBER : MFA_SMS;
 
+            String codeIdentifier = email.concat(PhoneNumberHelper.formatPhoneNumber(phoneNumber));
             String code =
                     codeStorageService
-                            .getOtpCode(email, notificationType)
-                            .orElseGet(() -> generateAndSaveOtpCode(email, notificationType));
+                            .getOtpCode(codeIdentifier, notificationType)
+                            .orElseGet(
+                                    () -> generateAndSaveNewCode(codeIdentifier, notificationType));
 
             AuditableEvent auditableEvent;
             if (TestClientHelper.isTestClientWithAllowedEmail(userContext, configurationService)) {
@@ -267,7 +270,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         }
     }
 
-    private String generateAndSaveOtpCode(String identifier, NotificationType notificationType) {
+    private String generateAndSaveNewCode(String identifier, NotificationType notificationType) {
         LOG.info("No existing OTP found; generating new code");
         String newCode = codeGeneratorService.sixDigitCode();
         codeStorageService.saveOtpCode(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -318,6 +318,12 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             code =
                     codeStorageService
                             .getOtpCode(codeIdentifier, notificationType)
+                            .or( // Temporary fallback for old phone number key with just email
+                                    () ->
+                                            notificationType.isForPhoneNumber()
+                                                    ? codeStorageService.getOtpCode(
+                                                            emailAddress, notificationType)
+                                                    : Optional.empty())
                             .orElseGet(
                                     () -> generateAndSaveNewCode(codeIdentifier, notificationType));
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaRequest;
-import uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
@@ -78,6 +77,7 @@ import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.E
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.INTERNAL_COMMON_SUBJECT_ID;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.SESSION_ID;
+import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.UK_MOBILE_NUMBER;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
@@ -152,7 +152,7 @@ class MfaHandlerTest {
                     INTERNAL_COMMON_SUBJECT_ID,
                     EMAIL,
                     IP_ADDRESS,
-                    CommonTestVariables.UK_MOBILE_NUMBER,
+                    UK_MOBILE_NUMBER,
                     DI_PERSISTENT_SESSION_ID,
                     Optional.of(ENCODED_DEVICE_DETAILS));
 
@@ -174,7 +174,7 @@ class MfaHandlerTest {
 
     private static final NotifyRequest notifyRequest =
             new NotifyRequest(
-                    CommonTestVariables.UK_MOBILE_NUMBER,
+                    UK_MOBILE_NUMBER,
                     MFA_SMS,
                     CODE,
                     SupportedLanguage.EN,
@@ -197,8 +197,7 @@ class MfaHandlerTest {
         when(configurationService.getDefaultOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(configurationService.getCodeMaxRetries()).thenReturn(MAX_CODE_RETRIES);
         when(codeGeneratorService.sixDigitCode()).thenReturn(CODE);
-        when(authenticationService.getPhoneNumber(EMAIL))
-                .thenReturn(Optional.of(CommonTestVariables.UK_MOBILE_NUMBER));
+        when(authenticationService.getPhoneNumber(EMAIL)).thenReturn(Optional.of(UK_MOBILE_NUMBER));
         usingValidClientSession(TEST_CLIENT_ID);
         when(userProfile.getMfaMethodsMigrated()).thenReturn(false);
         when(authenticationService.getUserProfileFromEmail(EMAIL))
@@ -234,7 +233,8 @@ class MfaHandlerTest {
                                 partiallyContainsJsonString(
                                         objectMapper.writeValueAsString(notifyRequest),
                                         "unique_notification_reference")));
-        verify(codeStorageService).saveOtpCode(EMAIL, CODE, CODE_EXPIRY_TIME, MFA_SMS);
+        verify(codeStorageService)
+                .saveOtpCode(EMAIL.concat(UK_MOBILE_NUMBER), CODE, CODE_EXPIRY_TIME, MFA_SMS);
         assertThat(result, hasStatus(204));
 
         verify(auditService)
@@ -279,7 +279,13 @@ class MfaHandlerTest {
                                         objectMapper.writeValueAsString(
                                                 notifyRequestWithNumberFromMigratedMethod),
                                         "unique_notification_reference")));
-        verify(codeStorageService).saveOtpCode(EMAIL, CODE, CODE_EXPIRY_TIME, MFA_SMS);
+        verify(codeStorageService)
+                .saveOtpCode(
+                        EMAIL.concat(PHONE_NUMBER_FOR_DEFAULT_SMS_METHOD),
+                        CODE,
+                        CODE_EXPIRY_TIME,
+                        MFA_SMS);
+
         assertThat(result, hasStatus(204));
 
         verify(auditService)
@@ -351,11 +357,11 @@ class MfaHandlerTest {
     void shouldReturn204ForSuccessfulMfaRequestWhenResendingCode() throws Json.JsonException {
         usingValidSession();
 
-        when(codeStorageService.getOtpCode(EMAIL, VERIFY_PHONE_NUMBER))
+        when(codeStorageService.getOtpCode(EMAIL.concat(UK_MOBILE_NUMBER), VERIFY_PHONE_NUMBER))
                 .thenReturn(Optional.of(CODE));
         NotifyRequest verifyPhoneNumberNotifyRequest =
                 new NotifyRequest(
-                        CommonTestVariables.UK_MOBILE_NUMBER,
+                        UK_MOBILE_NUMBER,
                         VERIFY_PHONE_NUMBER,
                         CODE,
                         SupportedLanguage.EN,
@@ -670,7 +676,8 @@ class MfaHandlerTest {
                                 partiallyContainsJsonString(
                                         objectMapper.writeValueAsString(notifyRequest),
                                         "unique_notification_reference")));
-        verify(codeStorageService).saveOtpCode(EMAIL, CODE, CODE_EXPIRY_TIME, MFA_SMS);
+        verify(codeStorageService)
+                .saveOtpCode(EMAIL.concat(UK_MOBILE_NUMBER), CODE, CODE_EXPIRY_TIME, MFA_SMS);
         assertThat(result, hasStatus(204));
 
         verify(auditService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -34,6 +34,7 @@ import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
@@ -648,6 +649,7 @@ class SendNotificationHandlerTest {
         usingValidSession();
         usingValidClientSession(CLIENT_ID);
 
+        var formattedPhoneNumber = PhoneNumberHelper.formatPhoneNumber(phoneNumber);
         var body =
                 format(
                         "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"journeyType\": \"%s\" }",
@@ -658,9 +660,14 @@ class SendNotificationHandlerTest {
 
         assertEquals(204, result.getStatusCode());
         verify(codeGeneratorService).sixDigitCode();
-        verify(codeStorageService).getOtpCode(EMAIL, VERIFY_PHONE_NUMBER);
         verify(codeStorageService)
-                .saveOtpCode(EMAIL, TEST_SIX_DIGIT_CODE, CODE_EXPIRY_TIME, VERIFY_PHONE_NUMBER);
+                .getOtpCode(EMAIL.concat(formattedPhoneNumber), VERIFY_PHONE_NUMBER);
+        verify(codeStorageService)
+                .saveOtpCode(
+                        EMAIL.concat(formattedPhoneNumber),
+                        TEST_SIX_DIGIT_CODE,
+                        CODE_EXPIRY_TIME,
+                        VERIFY_PHONE_NUMBER);
         verify(emailSqsClient)
                 .send(
                         argThat(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -239,7 +239,11 @@ class PhoneNumberCodeProcessorTest {
     @Test
     void shouldThrowExceptionForSignInPhoneNumberCode() {
         setupPhoneNumberCode(
-                new VerifyMfaCodeRequest(MFAMethodType.SMS, INVALID_CODE, JourneyType.SIGN_IN),
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS,
+                        INVALID_CODE,
+                        JourneyType.SIGN_IN,
+                        CommonTestVariables.UK_MOBILE_NUMBER),
                 CodeRequestType.SMS_SIGN_IN);
 
         var expectedException =
@@ -310,7 +314,11 @@ class PhoneNumberCodeProcessorTest {
     @Test
     void shouldNotUpdateDynamoOrCreateAuditEventWhenSignIn() {
         setupPhoneNumberCode(
-                new VerifyMfaCodeRequest(MFAMethodType.SMS, VALID_CODE, JourneyType.SIGN_IN),
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS,
+                        VALID_CODE,
+                        JourneyType.SIGN_IN,
+                        CommonTestVariables.UK_MOBILE_NUMBER),
                 CodeRequestType.SMS_REGISTRATION);
 
         phoneNumberCodeProcessor.processSuccessfulCodeRequest(IP_ADDRESS, PERSISTENT_ID);
@@ -407,9 +415,12 @@ class PhoneNumberCodeProcessorTest {
         when(userProfile.getPhoneNumber()).thenReturn(differentPhoneNumber);
         when(configurationService.isTestClientsEnabled()).thenReturn(false);
         when(codeStorageService.getOtpCode(
-                        CommonTestVariables.EMAIL, NotificationType.VERIFY_PHONE_NUMBER))
+                        CommonTestVariables.EMAIL.concat(codeRequest.getProfileInformation()),
+                        NotificationType.VERIFY_PHONE_NUMBER))
                 .thenReturn(Optional.of(VALID_CODE));
-        when(codeStorageService.getOtpCode(CommonTestVariables.EMAIL, NotificationType.MFA_SMS))
+        when(codeStorageService.getOtpCode(
+                        CommonTestVariables.EMAIL.concat(codeRequest.getProfileInformation()),
+                        NotificationType.MFA_SMS))
                 .thenReturn(Optional.of(VALID_CODE));
         when(codeStorageService.isBlockedForEmail(
                         CommonTestVariables.EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
@@ -433,7 +444,8 @@ class PhoneNumberCodeProcessorTest {
         when(userContext.getAuthSession()).thenReturn(authSession);
         when(configurationService.isTestClientsEnabled()).thenReturn(false);
         when(codeStorageService.getOtpCode(
-                        CommonTestVariables.EMAIL, NotificationType.VERIFY_PHONE_NUMBER))
+                        CommonTestVariables.EMAIL.concat(codeRequest.getProfileInformation()),
+                        NotificationType.VERIFY_PHONE_NUMBER))
                 .thenReturn(Optional.of(VALID_CODE));
         when(codeStorageService.isBlockedForEmail(
                         CommonTestVariables.EMAIL, CODE_BLOCKED_KEY_PREFIX))
@@ -456,7 +468,8 @@ class PhoneNumberCodeProcessorTest {
         when(userContext.getAuthSession()).thenReturn(authSession);
         when(configurationService.isTestClientsEnabled()).thenReturn(false);
         when(codeStorageService.getOtpCode(
-                        CommonTestVariables.EMAIL, NotificationType.VERIFY_PHONE_NUMBER))
+                        CommonTestVariables.EMAIL.concat(codeRequest.getProfileInformation()),
+                        NotificationType.VERIFY_PHONE_NUMBER))
                 .thenReturn(Optional.of(VALID_CODE));
         when(codeStorageService.isBlockedForEmail(
                         CommonTestVariables.EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
@@ -60,7 +60,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         void
                 shouldReturn204WithExistingRedisCachedCodeAndTriggerVerifyPhoneNotificationTypeWhenResendingVerifyPhoneCode() {
             String previouslyIssuedPhoneCode =
-                    redis.generateAndSavePhoneNumberCode(USER_EMAIL, 900L);
+                    redis.generateAndSavePhoneNumberCode(
+                            USER_EMAIL.concat(USER_PHONE_NUMBER), 900L);
 
             var response =
                     makeRequest(
@@ -218,7 +219,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         void
                 shouldReturn204WithExistingRedisCachedCodeAndTriggerVerifyPhoneNotificationTypeWhenResendingVerifyPhoneCode() {
             String previouslyIssuedPhoneCode =
-                    redis.generateAndSavePhoneNumberCode(USER_EMAIL, 900L);
+                    redis.generateAndSavePhoneNumberCode(
+                            USER_EMAIL.concat(MIGRATED_PHONE_NUMBER_1), 900L);
 
             var response =
                     makeRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -58,6 +58,7 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String EMAIL_ADDRESS = "test@test.com";
+    private static final String PHONE_NUMBER = "+447712345432";
     private static final String CLIENT_ID = "test-client-id";
     private static final String REDIRECT_URI = "http://localhost/redirect";
     public static final String CLIENT_SESSION_ID = "a-client-session-id";
@@ -301,7 +302,8 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
             names = {"SIGN_IN", "PASSWORD_RESET_MFA"})
     void shouldReturnMaxReachedAndSetBlockWhenSignInSmsCodeAttemptsExceedMaxRetryCount(
             JourneyType journeyType) throws Json.JsonException {
-        setUpTestWithoutSignUp(sessionId, withScope());
+        setUpTestWithSignUp(sessionId, withScope());
+        userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
         for (int i = 0; i < 6; i++) {
             redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
         }
@@ -328,6 +330,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
     void shouldReturnMaxReachedAndSingalLogoutWhenReauthSmsCodeAttemptsExceedMaxRetryCount()
             throws Json.JsonException {
         setUpTestWithSignUp(sessionId, withScope());
+        userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
         for (int i = 0; i < 5; i++) {
             redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
         }
@@ -356,9 +359,10 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 this.sessionId, internalCommonSubjectId);
         setUpTestWithoutSignUp(sessionId, withScope());
         userStore.signUp(EMAIL_ADDRESS, "password", SUBJECT);
+        userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
         userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");
 
-        var code = redis.generateAndSaveMfaCode(EMAIL_ADDRESS, 900);
+        var code = redis.generateAndSaveMfaCode(EMAIL_ADDRESS.concat(PHONE_NUMBER), 900);
         var codeRequest = new VerifyCodeRequest(NotificationType.MFA_SMS, code, journeyType);
 
         var response =
@@ -388,9 +392,10 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 this.sessionId, internalCommonSubjectId);
         setUpTestWithoutSignUp(sessionId, withScope());
         userStore.signUp(EMAIL_ADDRESS, "password", SUBJECT);
+        userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
         userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");
 
-        var code = redis.generateAndSaveMfaCode(EMAIL_ADDRESS, 900);
+        var code = redis.generateAndSaveMfaCode(EMAIL_ADDRESS.concat(PHONE_NUMBER), 900);
         var codeRequest = new VerifyCodeRequest(NotificationType.MFA_SMS, code, journeyType);
 
         var response =
@@ -413,9 +418,10 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
             throws Exception {
         setUpTestWithoutSignUp(sessionId, withScope());
         userStore.signUp(EMAIL_ADDRESS, "password", SUBJECT);
+        userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
         userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");
 
-        var code = redis.generateAndSaveMfaCode(EMAIL_ADDRESS, 900);
+        var code = redis.generateAndSaveMfaCode(EMAIL_ADDRESS.concat(PHONE_NUMBER), 900);
         var codeRequest =
                 new VerifyCodeRequest(
                         NotificationType.MFA_SMS, code, JourneyType.PASSWORD_RESET_MFA);
@@ -446,9 +452,10 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         authSessionExtension.addInternalCommonSubjectIdToSession(
                 this.sessionId, internalCommonSubjectId);
         setUpTestWithSignUp(sessionId, withScope());
+        userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
         userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");
 
-        redis.generateAndSaveMfaCode(EMAIL_ADDRESS, 900);
+        redis.generateAndSaveMfaCode(EMAIL_ADDRESS.concat(PHONE_NUMBER).concat("123123"), 900);
         var codeRequest = new VerifyCodeRequest(NotificationType.MFA_SMS, "123456", journeyType);
 
         var response =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -731,7 +731,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         String invalidCode = "999999";
         VerifyMfaCodeRequest codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.SMS, invalidCode, JourneyType.REGISTRATION);
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, invalidCode, JourneyType.REGISTRATION, PHONE_NUMBER);
 
         var response =
                 makeRequest(
@@ -751,7 +752,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void whenValidPhoneNumberOtpCodeForRegistrationReturn204AndSetPhoneNumber() {
-        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
+        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS.concat(PHONE_NUMBER), 900);
         var codeRequest =
                 new VerifyMfaCodeRequest(
                         MFAMethodType.SMS, code, JourneyType.REGISTRATION, PHONE_NUMBER);
@@ -781,7 +782,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void whenValidPhoneNumberOtpCodeForAccountRecoveryReturn204AndUpdatePhoneNumber() {
-        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
+        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS.concat(PHONE_NUMBER), 900);
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, ALTERNATIVE_PHONE_NUMBER);
         userStore.setAccountVerified(EMAIL_ADDRESS);
         var codeRequest =
@@ -812,7 +813,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void
             whenValidPhoneNumberOtpCodeForAccountRecoveryReturn204UpdatePhoneNumberAndRemoveAuthAppWhenPresent() {
-        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
+        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS.concat(PHONE_NUMBER), 900);
         setUpAuthAppRequest(JourneyType.ACCOUNT_RECOVERY);
         var codeRequest =
                 new VerifyMfaCodeRequest(
@@ -842,7 +843,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn204WhenSuccessfulSMSRegistrationRequestAndOverwriteExistingPhoneNumber() {
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, "+447700900111");
-        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
+        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS.concat(PHONE_NUMBER), 900);
         var codeRequest =
                 new VerifyMfaCodeRequest(
                         MFAMethodType.SMS, code, JourneyType.REGISTRATION, PHONE_NUMBER);
@@ -867,7 +868,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void whenValidPhoneNumberCodeForRegistrationReturn204AndInvalidateAuthApp() {
         userStore.addMfaMethod(
                 EMAIL_ADDRESS, MFAMethodType.AUTH_APP, false, true, AUTH_APP_SECRET_BASE_32);
-        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
+        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS.concat(PHONE_NUMBER), 900);
         var codeRequest =
                 new VerifyMfaCodeRequest(
                         MFAMethodType.SMS, code, JourneyType.REGISTRATION, PHONE_NUMBER);
@@ -895,7 +896,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             names = {"REGISTRATION", "ACCOUNT_RECOVERY"})
     void whenInvalidPhoneNumberCodeHasExpiredReturn400(JourneyType journeyType) {
         setUpSmsRequest(journeyType, PHONE_NUMBER);
-        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 1);
+        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS.concat(PHONE_NUMBER), 1);
         var codeRequest =
                 new VerifyMfaCodeRequest(
                         MFAMethodType.SMS, code, journeyType, ALTERNATIVE_PHONE_NUMBER);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -12,70 +12,86 @@ public enum NotificationType implements TemplateAware {
             "VERIFY_EMAIL_TEMPLATE_ID",
             Map.of(SupportedLanguage.CY, "VERIFY_EMAIL_TEMPLATE_ID_CY"),
             MFAMethodType.EMAIL,
-            true),
+            true,
+            false),
     VERIFY_PHONE_NUMBER(
             "VERIFY_PHONE_NUMBER_TEMPLATE_ID",
             Map.of(SupportedLanguage.CY, "VERIFY_PHONE_NUMBER_TEMPLATE_ID_CY"),
             MFAMethodType.SMS,
-            false),
+            false,
+            true),
     MFA_SMS(
             "MFA_SMS_TEMPLATE_ID",
             Map.of(SupportedLanguage.CY, "MFA_SMS_TEMPLATE_ID_CY"),
             MFAMethodType.SMS,
-            false),
+            false,
+            true),
     PASSWORD_RESET_CONFIRMATION(
             "PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID",
             Map.of(SupportedLanguage.CY, "PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID_CY"),
             MFAMethodType.NONE,
-            true),
+            true,
+            false),
     PASSWORD_RESET_CONFIRMATION_SMS(
             "PASSWORD_RESET_CONFIRMATION_SMS_TEMPLATE_ID",
             Map.of(SupportedLanguage.CY, "PASSWORD_RESET_CONFIRMATION_SMS_TEMPLATE_ID_CY"),
             MFAMethodType.NONE,
-            false),
+            false,
+            true),
     ACCOUNT_CREATED_CONFIRMATION(
             "ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID",
             Map.of(SupportedLanguage.CY, "ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID_CY"),
             MFAMethodType.NONE,
-            true),
+            true,
+            false),
     RESET_PASSWORD_WITH_CODE(
             "RESET_PASSWORD_WITH_CODE_TEMPLATE_ID",
             Map.of(SupportedLanguage.CY, "RESET_PASSWORD_WITH_CODE_TEMPLATE_ID_CY"),
             MFAMethodType.EMAIL,
-            true),
+            true,
+            false),
     VERIFY_CHANGE_HOW_GET_SECURITY_CODES(
             "VERIFY_CHANGE_HOW_GET_SECURITY_CODES_TEMPLATE_ID",
             Map.of(SupportedLanguage.CY, "VERIFY_CHANGE_HOW_GET_SECURITY_CODES_TEMPLATE_ID_CY"),
             MFAMethodType.EMAIL,
-            true),
+            true,
+            false),
     CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION(
             "CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION_TEMPLATE_ID",
             Map.of(
                     SupportedLanguage.CY,
                     "CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION_TEMPLATE_ID_CY"),
             MFAMethodType.NONE,
-            true),
+            true,
+            false),
     TERMS_AND_CONDITIONS_BULK_EMAIL(
-            "TERMS_AND_CONDITIONS_BULK_EMAIL_TEMPLATE_ID", MFAMethodType.NONE, true);
+            "TERMS_AND_CONDITIONS_BULK_EMAIL_TEMPLATE_ID", MFAMethodType.NONE, true, false);
 
     private final String templateName;
     private final MFAMethodType mfaMethodType;
     private final boolean isEmail;
+    private final boolean isForPhoneNumber;
 
     private Map<SupportedLanguage, String> languageSpecificTemplates = new HashMap<>();
 
-    NotificationType(String templateName, MFAMethodType mfaMethodType, boolean isEmail) {
+    NotificationType(
+            String templateName,
+            MFAMethodType mfaMethodType,
+            boolean isEmail,
+            boolean isForPhoneNumber) {
         this.templateName = templateName;
         this.mfaMethodType = mfaMethodType;
         this.isEmail = isEmail;
+        this.isForPhoneNumber = isForPhoneNumber;
     }
 
     NotificationType(
             String templateName,
             Map<SupportedLanguage, String> languageSpecificTemplates,
             MFAMethodType mfaMethodType,
-            boolean isEmail) {
-        this(templateName, mfaMethodType, isEmail);
+            boolean isEmail,
+            boolean isForPhoneNumber) {
+        this(templateName, mfaMethodType, isEmail, isForPhoneNumber);
         this.languageSpecificTemplates = languageSpecificTemplates;
     }
 
@@ -93,5 +109,9 @@ public enum NotificationType implements TemplateAware {
 
     public boolean isEmail() {
         return isEmail;
+    }
+
+    public boolean isForPhoneNumber() {
+        return isForPhoneNumber;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -169,13 +169,13 @@ public class CodeStorageService {
     }
 
     public void saveOtpCode(
-            String emailAddress,
+            String unhashedIdentifier,
             String code,
             long codeExpiryTime,
             NotificationType notificationType) {
-        String hashedEmailAddress = HashHelper.hashSha256String(emailAddress);
+        String hashedIdentifier = HashHelper.hashSha256String(unhashedIdentifier);
         String prefix = getPrefixForNotificationType(notificationType);
-        String key = prefix + hashedEmailAddress;
+        String key = prefix + hashedIdentifier;
         try {
             redisConnectionService.saveWithExpiry(key, code, codeExpiryTime);
         } catch (Exception e) {
@@ -183,18 +183,19 @@ public class CodeStorageService {
         }
     }
 
-    public Optional<String> getOtpCode(String emailAddress, NotificationType notificationType) {
+    public Optional<String> getOtpCode(
+            String unhashedIdentifier, NotificationType notificationType) {
         String prefix = getPrefixForNotificationType(notificationType);
         return Optional.ofNullable(
                 redisConnectionService.getValue(
-                        prefix + HashHelper.hashSha256String(emailAddress)));
+                        prefix + HashHelper.hashSha256String(unhashedIdentifier)));
     }
 
-    public void deleteOtpCode(String emailAddress, NotificationType notificationType) {
+    public void deleteOtpCode(String unhashedIdentifier, NotificationType notificationType) {
         String prefix = getPrefixForNotificationType(notificationType);
         long numberOfKeysRemoved =
                 redisConnectionService.deleteValue(
-                        prefix + HashHelper.hashSha256String(emailAddress));
+                        prefix + HashHelper.hashSha256String(unhashedIdentifier));
 
         if (numberOfKeysRemoved == 0) {
             LOG.info(format("No %s key was deleted", prefix));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
@@ -28,6 +28,7 @@ import static uk.gov.di.authentication.shared.conditions.MfaHelper.getPrimaryMFA
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.BACKUP;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.AUTH_APP;
+import static uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT;
 
 public class MFAMethodsService {
     private static final Logger LOG = LogManager.getLogger(MFAMethodsService.class);
@@ -41,6 +42,9 @@ public class MFAMethodsService {
     public Result<MfaRetrieveFailureReason, List<MFAMethod>> getMfaMethods(String email) {
         var userProfile = persistentService.getUserProfileByEmail(email);
         var userCredentials = persistentService.getUserCredentialsFromEmail(email);
+        if (userProfile == null || userCredentials == null) {
+            return Result.failure(USER_DOES_NOT_HAVE_ACCOUNT);
+        }
         if (Boolean.TRUE.equals(userProfile.getMfaMethodsMigrated())) {
             return Result.success(getMfaMethodsForMigratedUser(userCredentials));
         } else {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaRetrieveFailureReason.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaRetrieveFailureReason.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.services.mfa;
 
 public enum MfaRetrieveFailureReason {
-    UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP
+    UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP,
+    USER_DOES_NOT_HAVE_ACCOUNT
 }


### PR DESCRIPTION
## What

This pull request implements changes related to storing and verifying SMS One-Time Passcodes (OTPs) using both the user's email address and phone number as identifiers.

Previously, SMS OTPs were identified solely by the user's email address. With the introduction of support for multiple SMS MFA methods, it is necessary to uniquely identify OTPs for each phone number associated with a user. This includes a migration fallback to ensures a smooth transition for users during deployment.

## How to review

1. Code review, commit-by-commit
1. Deploy
1. Run though all account creation, sign in, password reset and MFA reset with SMS MFA methods

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
