### PR TITLE
ATO-1649 Move no session cookie logs to warn

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -110,6 +110,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     public static final Scope SCOPE = new Scope(OIDCScopeValue.OPENID);
     public static final State RP_STATE = new State();
     public static final State ORCH_TO_AUTH_STATE = new State();
+    private static final String ERROR_ENDPOINT = "error";
     private static final String BLOCKED_ENDPOINT = "unavailable-permanent";
     private static final String SUSPENDED_ENDPOINT = "unavailable-temporary";
 
@@ -313,6 +314,16 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(expectedURI));
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue, singletonList(AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED));
+    }
+
+    @Test
+    void shouldRedirectToFrontendErrorPageWhenNoSessionCookieAndNoQueryParams() {
+        var response = makeRequest(Optional.empty(), emptyMap(), emptyMap());
+
+        var expectedURI =
+                buildURI(configurationService.getAuthFrontendBaseURL(), ERROR_ENDPOINT).toString();
+        assertThat(response, hasStatus(302));
+        assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(expectedURI));
     }
 
     @Test

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -259,7 +259,7 @@ public class AuthenticationCallbackHandler
                     CookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
 
             if (sessionCookiesIds == null) {
-                return handleMissingSession(input);
+                return handleCrossBrowserError(input);
             }
 
             var sessionId = sessionCookiesIds.getSessionId();
@@ -655,15 +655,9 @@ public class AuthenticationCallbackHandler
             return RedirectService.redirectToFrontendErrorPage(
                     authFrontend.errorURI(),
                     new Error("Cannot retrieve auth request params from client session id"));
-        }
-    }
-
-    private APIGatewayProxyResponseEvent handleMissingSession(APIGatewayProxyRequestEvent input)
-            throws ParseException {
-        try {
-            return handleCrossBrowserError(input);
         } catch (NoSessionException e) {
-            throw new AuthenticationCallbackException("No session cookie found", e);
+            return RedirectService.redirectToFrontendErrorPageForNoSessionCookies(
+                    authFrontend.errorURI(), e);
         }
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -444,8 +444,6 @@ class AuthenticationCallbackHandlerTest {
         var event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> queryParameters = new HashMap<>();
-        queryParameters.put("error", OAuth2Error.ACCESS_DENIED_CODE);
-        queryParameters.put("state", STATE.getValue());
         event.setQueryStringParameters(queryParameters);
         event.setHeaders(Collections.emptyMap());
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/RedirectService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/RedirectService.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
+import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 
 import java.net.URI;
 import java.util.Map;
@@ -19,6 +20,18 @@ public class RedirectService {
         LOG.atError()
                 .withThrowable(error)
                 .log("Redirecting to frontend error page: {}", errorPageUriStr);
+        return generateApiGatewayProxyResponse(
+                302, "", Map.of(ResponseHeaders.LOCATION, errorPageUriStr), null);
+    }
+
+    public static APIGatewayProxyResponseEvent redirectToFrontendErrorPageForNoSessionCookies(
+            URI errorPageUri, NoSessionException error) {
+        var errorPageUriStr = errorPageUri.toString();
+        LOG.atWarn()
+                .withThrowable(error)
+                .log(
+                        "Redirecting to frontend error page for no session cookies: {}",
+                        errorPageUriStr);
         return generateApiGatewayProxyResponse(
                 302, "", Map.of(ResponseHeaders.LOCATION, errorPageUriStr), null);
     }


### PR DESCRIPTION


### Wider context of change

- We're getting multiple production-authentication-callback-alarms which can be attributed to there being no session cookie. There is no value in continuing to receive these alarms.

### What’s changed

- To reduce alarm noise, stop logging no session cookie as ERROR, instead log as WARN

### Manual testing

This is limited to logging - no testing carried out.
<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [X] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [X] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [X] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [X] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [X] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [X] Successfully run Authentication acceptance tests against sandpit or not required.
