### PR TITLE
ATO-1650: Stop sending confidence claim from orch to auth

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -952,8 +952,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             var expectedClaims =
                     new HashMap<String, Object>(
                             Map.of(
-                                    "confidence",
-                                    expectedCredentialStrength.getValue(),
                                     "requested_credential_strength",
                                     expectedCredentialStrength.getValue(),
                                     "_ga",
@@ -1015,8 +1013,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             var expectedClaims =
                     new HashMap<String, Object>(
                             Map.of(
-                                    "confidence",
-                                    expectedCredentialStrength.getValue(),
                                     "requested_credential_strength",
                                     expectedCredentialStrength.getValue(),
                                     "_ga",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -268,7 +268,6 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
         assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("rp_sector_host")));
         assertTrue(
                 Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("govuk_signin_journey_id")));
-        assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("confidence")));
         assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("state")));
         assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("client_id")));
         assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("redirect_uri")));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -13,12 +13,15 @@ import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.oidc.lambda.AuthorisationHandler;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.ServiceType;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 
 import java.net.URI;
@@ -65,6 +68,13 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
 
     private static final ConfigurationService configurationService =
             new OrchestrationToAuthenticationAuthorizeIntegrationTest.TestConfigurationService();
+
+    @RegisterExtension
+    public static final OrchSessionExtension orchSessionExtension = new OrchSessionExtension();
+
+    @RegisterExtension
+    public static final OrchClientSessionExtension orchClientSessionExtension =
+            new OrchClientSessionExtension();
 
     @BeforeEach
     void setup() {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -944,9 +944,6 @@ public class AuthorisationHandler
                         .claim("is_one_login_service", client.isOneLoginService())
                         .claim("service_type", client.getServiceType())
                         .claim("govuk_signin_journey_id", clientSessionId)
-                        // TODO: We can remove this field once we are using
-                        //       requested_credential_strength in the frontend
-                        .claim("confidence", requestedVtr.getCredentialTrustLevel().getValue())
                         .claim(
                                 "requested_credential_strength",
                                 requestedVtr.getCredentialTrustLevel().getValue())

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1695,7 +1695,9 @@ class AuthorisationHandlerTest {
 
             ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
-            assertThat(argument.getValue().getClaim("confidence"), equalTo("Cl.Cm"));
+            assertThat(
+                    argument.getValue().getClaim("requested_credential_strength"),
+                    equalTo("Cl.Cm"));
         }
 
         @Test


### PR DESCRIPTION
### Wider context of change

As part of the client session migration work, we spotted the claim `confidence` that we send from orch to auth frontend doesn't represent a levelOfConfidence as the name suggests, but instead a credentialTrustLevel. We introduced a new claim with a better name (`requested_credential_strength`) to replace this confidence claim.

We removed the confidence claim from the list of required claims in the auth frontend, and the claim is no longer used in the frontend. This means we can now safely stop sending this claim in the JAR.

### What’s changed

This PR stops sending the `confidence` claim from orch to auth. It also adds some missing assertions on the claims we send to auth.

### Manual testing

Tested in sandpit with several journeys. Auth frontend didn't complain about the claim not being sent

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. https://github.com/govuk-one-login/authentication-stubs/pull/348
- [x] Successfully deployed to authdev or not required. n/a
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a
