### PR TITLE
ATO-1625: send email from login_hint

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1982,7 +1982,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         }
 
         @Test
-        void shouldRedirectToFrontendWithoutLoginHintWhenValidLoginHintProvided() throws Exception {
+        void shouldRedirectToFrontendWithoutLoginHintWhenValidLoginHintProvidedInQueryParams() {
             registerClient(
                     CLIENT_ID, "test-client", singletonList("openid"), ClientType.WEB, false, true);
             var previousClientSessionId = "a-previous-client-session";

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
@@ -107,6 +107,10 @@ public class RequestObjectToAuthRequestHelper {
                         "cookie_consent", jwtClaimsSet.getStringClaim("cookie_consent"));
             }
 
+            if (Objects.nonNull(jwtClaimsSet.getClaim("login_hint"))) {
+                builder.loginHint(jwtClaimsSet.getStringClaim("login_hint"));
+            }
+
             return builder.build();
         } catch (ParseException | com.nimbusds.oauth2.sdk.ParseException | Json.JsonException e) {
             LOG.error("Parse exception thrown whilst converting RequestObject to Auth Request", e);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -938,7 +938,8 @@ public class AuthorisationHandler
                         .claim(
                                 "current_credential_strength",
                                 orchSession.getCurrentCredentialStrength())
-                        .claim("scope", authenticationRequest.getScope().toString());
+                        .claim("scope", authenticationRequest.getScope().toString())
+                        .claim("login_hint", authenticationRequest.getLoginHint());
 
         previousSessionId.ifPresent(id -> claimsBuilder.claim("previous_session_id", id));
         gaOpt.ifPresent(ga -> claimsBuilder.claim("_ga", ga));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -288,6 +288,7 @@ public class AuthorisationHandler
                                             Map.Entry::getKey, entry -> List.of(entry.getValue())));
             authRequest = AuthenticationRequest.parse(requestParameters);
             authRequest = stripOutReauthenticateQueryParams(authRequest);
+            authRequest = stripOutLoginHintQueryParams(authRequest);
         } catch (ParseException e) {
             LOG.warn("Authentication request could not be parsed", e);
             return generateParseExceptionResponse(e, user);
@@ -1177,6 +1178,10 @@ public class AuthorisationHandler
         return new AuthenticationRequest.Builder(authRequest)
                 .customParameter("id_token_hint")
                 .build();
+    }
+
+    private AuthenticationRequest stripOutLoginHintQueryParams(AuthenticationRequest authRequest) {
+        return new AuthenticationRequest.Builder(authRequest).loginHint(null).build();
     }
 
     private SignedJWT getReauthIdToken(AuthenticationRequest authenticationRequest) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -239,6 +239,15 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                                     "login_hint present in request object, length: {}",
                                     hint.length()));
 
+            if (loginHint.isPresent() && loginHint.get().length() > 256) {
+                return errorResponse(
+                        redirectURI,
+                        new ErrorObject(
+                                OAuth2Error.INVALID_REQUEST_CODE,
+                                "login_hint parameter is invalid"),
+                        state);
+            }
+
             LOG.info("RequestObject has passed initial validation");
             return Optional.empty();
         } catch (ParseException e) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
@@ -409,31 +409,6 @@ class RequestObjectToAuthRequestHelperTest {
     }
 
     @Test
-    void shouldReturnAuthRequestWithNoLoginHintWhenNoRequestObjectIsPresent() {
-        Scope scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.PHONE);
-        var authRequest =
-                new AuthenticationRequest.Builder(ResponseType.CODE, scope, CLIENT_ID, REDIRECT_URI)
-                        .state(STATE)
-                        .nonce(NONCE)
-                        .loginHint("test@email.com")
-                        .build();
-
-        var transformedAuthRequest = RequestObjectToAuthRequestHelper.transform(authRequest);
-
-        assertNull(transformedAuthRequest.getRequestObject());
-        assertThat(transformedAuthRequest.getState(), equalTo(authRequest.getState()));
-        assertThat(transformedAuthRequest.getNonce(), equalTo(authRequest.getNonce()));
-        assertThat(transformedAuthRequest.getClientID(), equalTo(authRequest.getClientID()));
-        assertThat(
-                transformedAuthRequest.getRedirectionURI(),
-                equalTo(authRequest.getRedirectionURI()));
-        assertThat(
-                transformedAuthRequest.getResponseType(), equalTo(authRequest.getResponseType()));
-        assertThat(transformedAuthRequest.getScope(), equalTo(authRequest.getScope()));
-        assertNull(transformedAuthRequest.getLoginHint());
-    }
-
-    @Test
     void shouldRetrieveRpSidFromRequestObject() throws JOSEException {
         var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);


### PR DESCRIPTION
### Wider context of change

Part of the `login_hint` work. This sends the email to auth from login_hint only from the request object.

### What’s changed

Gets the `login_hint` from request object, validates it's less than 256 (auth's validation limit) and passes it to auth. Removes it from it's come from the query param.

### Manual testing

I've tested with the RP stub change. The login hint is null if not given or gotten from query params.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. Upcoming
- [x] Changes have been made to stubs or not required. Upcoming
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.  **N/A**
