### PR TITLE
AUT-4303: Staging auth-ext-api EnvironmentConfiguration

### DIFF
--- a/backend-template.yaml
+++ b/backend-template.yaml
@@ -213,6 +213,14 @@ Mappings:
       orchToAuthSigningPublicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPrCBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA==
       orchStubToAuthSigningPublicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmzWAucozlF6eykmgikXj2kI03O7VWwuA51+3Ak+stF2dddC60WXEKhrFumKBUnE5GhJNg4v0iN948Mwl+vz5Xw==
     staging:
+      accessTokenStoreSigningKey: arn:aws:kms:eu-west-2:758531536632:key/35cfcec1-e8f1-4ffc-950d-80e836c594ca
+      auditPayloadSigningKey: arn:aws:kms:eu-west-2:758531536632:key/60b5781c-9507-4faf-ab0b-faef7cd7dbd6
+      authCodeStoreSigningKey: arn:aws:kms:eu-west-2:758531536632:key/b52a2843-0d62-404a-a04c-5d47ba9ae54e
+      authSessionTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/4ee87f07-df3a-4745-9734-6e9cc7995270
+      dataStoreAccountId: 758531536632
+      eventsTopicEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/c289d5e1-1fd7-4629-9f3d-c059aabed970
+      userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/36434b6d-1d77-4cee-af4b-70cf39109e52
+      userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/a152899b-1c48-4053-b883-74855739fc16
       cloudwatchLogRetentionInDays: 7
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       IsSplunkEnabled: "Yes"

--- a/backend-template.yaml
+++ b/backend-template.yaml
@@ -473,12 +473,15 @@ Resources:
   AuthExternalApiExecutionLogSubscriptionFilter:
     Condition: IsSplunkEnabled
     Type: AWS::Logs::SubscriptionFilter
+    DependsOn:
+      - AuthExternalApiStage
     Properties:
       DestinationArn: !Ref LoggingSubscriptionEndpointArn
       FilterPattern: ""
       LogGroupName: !Sub
-        - API-Gateway-Execution-Logs_${AuthExternalApi}/${Env}
-        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+        - API-Gateway-Execution-Logs_${AuthExternalApi}/${StageName}
+        - StageName:
+            !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
 
   AuthExternalApiDashboard:
     Type: AWS::CloudWatch::Dashboard

--- a/sam-deploy-authdevs.sh
+++ b/sam-deploy-authdevs.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Ensure we're in the root directory of the repo
-cd "$(git rev-parse --show-toplevel)" > /dev/null 2>&1 || exit
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 
 environments=("authdev1" "authdev2" "dev")
 
@@ -40,8 +40,8 @@ O_CLEAN="" # -c, --clean
 O_DEPLOY=0 # -x, --auth-external
 
 POSITIONAL=()
-TEMPLATE_FILE="${TEMPLATE_FILE:-backend-template.yaml}"
-SAMCONFIG_FILE=${SAMCONFIG_FILE:-scripts/dev-samconfig.toml}
+TEMPLATE_FILE="${TEMPLATE_FILE:-${DIR}/backend-template.yaml}"
+SAMCONFIG_FILE=${SAMCONFIG_FILE:-${DIR}/scripts/dev-samconfig.toml}
 CONFIRM_CHANGESET_OPTION="--no-confirm-changeset"
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## What

Staging auth-ext-api EnvironmentConfiguration

Additional tweaks in the deploy-authdevs equivalent script that deploys auth-external-api in authdevs using the new cloudformation template.

## How to review

For the staging EnvironmentConfiguration, observe deployment in staging (kicked off by artifact promotion from build).

Deploy scripts, run as usual
```
 $ ./sam-deploy-authdevs.sh -h 
Usage:
    ./sam-deploy-authdevs.sh [options] <environment>

Options:
    -b, --build                 run gradle and buildZip tasks
    --no-build                  do not run gradle and buildZip tasks
    -p, --prompt                prompt for confirmation before sam deploy
    -c, --clean                 run gradle clean before build
    -h, --help                  display this help message

    -x, --auth-external         deploy the auth-external API

Arguments:
    environment                 the environment to deploy to. Valid environments are: authdev1 authdev2 dev
```