### PR TITLE
ATO-1651: Remove authenticated getters

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -132,7 +132,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var redisSession = redis.getSession(sessionID);
         var orchSession = orchSessionExtension.getSession(sessionID).get();
 
-        assertTrue(redisSession.isAuthenticated());
+        assertTrue(orchSession.getAuthenticated());
         assertThat(redisSession.isNewAccount(), equalTo(Session.AccountState.EXISTING));
         assertThat(orchSession.getIsNewAccount(), equalTo(OrchSessionItem.AccountState.EXISTING));
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_ISSUED));
@@ -179,7 +179,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var redisSession = redis.getSession(sessionID);
         var orchSession = orchSessionExtension.getSession(sessionID).get();
 
-        assertFalse(redisSession.isAuthenticated());
+        assertFalse(orchSession.getAuthenticated());
         assertThat(
                 redisSession.isNewAccount(),
                 equalTo(Session.AccountState.EXISTING_DOC_APP_JOURNEY));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -736,7 +736,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         var orchSession = orchSessionExtension.getSession(SESSION_ID).get();
 
         assertThat(redisSession.isNewAccount(), equalTo(Session.AccountState.EXISTING));
-        assertTrue(redisSession.isAuthenticated());
+        assertTrue(orchSession.getAuthenticated());
 
         assertThat(orchSession.getIsNewAccount(), equalTo(OrchSessionItem.AccountState.EXISTING));
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -202,6 +202,9 @@ class AuthCodeHandlerTest {
         doAnswer(
                         (i) -> {
                             session.setAuthenticated(true).setNewAccount(EXISTING);
+                            orchSession
+                                    .withAuthenticated(true)
+                                    .setIsNewAccount(OrchSessionItem.AccountState.EXISTING);
                             return null;
                         })
                 .when(authCodeResponseService)
@@ -308,7 +311,7 @@ class AuthCodeHandlerTest {
         assertThat(authCodeResponse.getLocation(), equalTo(authSuccessResponse.toURI().toString()));
         assertThat(session.getCurrentCredentialStrength(), equalTo(finalLevel));
         assertThat(session.getCurrentCredentialStrength(), equalTo(finalLevel));
-        assertTrue(session.isAuthenticated());
+        assertTrue(orchSession.getAuthenticated());
 
         verify(authCodeResponseService, times(1))
                 .saveSession(
@@ -431,7 +434,7 @@ class AuthCodeHandlerTest {
         assertThat(authCodeResponse.getLocation(), equalTo(authSuccessResponse.toURI().toString()));
         assertThat(session.getCurrentCredentialStrength(), equalTo(requestedLevel));
         assertThat(orchSession.getCurrentCredentialStrength(), equalTo(requestedLevel));
-        assertFalse(session.isAuthenticated());
+        assertFalse(orchSession.getAuthenticated());
         verify(authCodeResponseService, times(1))
                 .saveSession(
                         anyBoolean(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -1013,8 +1013,6 @@ class AuthenticationCallbackHandlerTest {
                                 eq(reproveIdentity),
                                 any());
                 verifyNoInteractions(logoutService);
-                verify(sessionService)
-                        .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
 
@@ -1038,8 +1036,6 @@ class AuthenticationCallbackHandlerTest {
                                 CLIENT_ID.getValue(),
                                 intervention);
                 verifyNoInteractions(initiateIPVAuthorisationService);
-                verify(sessionService)
-                        .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
 
@@ -1069,8 +1065,6 @@ class AuthenticationCallbackHandlerTest {
                                 eq(reproveIdentity),
                                 any());
                 verifyNoInteractions(logoutService);
-                verify(sessionService)
-                        .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
 
@@ -1094,8 +1088,8 @@ class AuthenticationCallbackHandlerTest {
                                 CLIENT_ID.toString(),
                                 intervention);
                 verifyNoInteractions(initiateIPVAuthorisationService);
-                verify(sessionService)
-                        .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
+                verify(orchSessionService, times(2))
+                        .updateSession(argThat(OrchSessionItem::getAuthenticated));
 
                 assertNoAuthorisationCodeGeneratedAndSaved();
             }
@@ -1123,8 +1117,6 @@ class AuthenticationCallbackHandlerTest {
                                 eq(reproveIdentity),
                                 any());
                 verifyNoInteractions(logoutService);
-                verify(sessionService)
-                        .storeOrUpdateSession(argThat(Session::isAuthenticated), anyString());
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
 
@@ -1517,7 +1509,6 @@ class AuthenticationCallbackHandlerTest {
         assertThat(
                 Session.AccountState.NEW,
                 equalTo(sessionSaveCaptor.getAllValues().get(0).isNewAccount()));
-        assertTrue(sessionSaveCaptor.getAllValues().get(0).isAuthenticated());
     }
 
     private void assertOrchSessionUpdated() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -85,10 +85,6 @@ public class Session {
         return this;
     }
 
-    public boolean isAuthenticated() {
-        return authenticated;
-    }
-
     public Session setAuthenticated(boolean authenticated) {
         this.authenticated = authenticated;
         return this;

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
@@ -74,14 +74,6 @@ class AuthCodeResponseGenerationServiceTest {
         authCodeResponseGenerationService.saveSession(
                 false, sessionService, session, SESSION_ID, orchSessionService, orchSession);
 
-        verify(sessionService)
-                .storeOrUpdateSession(
-                        argThat(
-                                s ->
-                                        s.isAuthenticated()
-                                                && s.isNewAccount()
-                                                        == Session.AccountState.EXISTING),
-                        eq(SESSION_ID));
         verify(orchSessionService)
                 .updateSession(
                         argThat(


### PR DESCRIPTION
### Wider context of change

Remove getters of the authenticated flag from tests, and the getter itself from the shared session

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

Tested in dev
### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
