### PR TITLE
AUT-4297: add mobile as enum on orch

### DIFF
--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -73,6 +73,18 @@ class ClientConfigValidationServiceTest {
                         null,
                         Channel.STRATEGIC_APP.getValue()),
                 Arguments.of(
+                        null,
+                        null,
+                        PublicKeySource.JWKS.getValue(),
+                        null,
+                        "https://valid.jwks.url.gov.uk",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        Channel.MOBILE.getValue()),
+                Arguments.of(
                         singletonList("http://localhost/post-redirect-logout"),
                         "http://back-channel.com",
                         PublicKeySource.STATIC.getValue(),

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Channel.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Channel.java
@@ -2,7 +2,8 @@ package uk.gov.di.orchestration.shared.entity;
 
 public enum Channel {
     WEB("web"),
-    STRATEGIC_APP("strategic_app");
+    STRATEGIC_APP("strategic_app"),
+    MOBILE("mobile");
 
     private final String value;
 


### PR DESCRIPTION
## What
Added "mobile" to orch's Channel enum. Orch doesn't do much with this value - they just get it from the ClientRegistry and pass it to Auth. The only use of the enum is in `ClientRegistrationRequestHandler`, which checks if that channel is valid.

The default value is still `web`, as a number of clients don't have a channel property, and only a single client will use the new `mobile` channel. 

Currently, no clients use this channel. To complete this work, a client registry change should be made for gov.uk app integration client, client-id `5o5i_n_2oBqvrAiy6f0JW_jzUBE`, and any future client registry entries for gov.uk app. This won't happen until the parent ticket is complete.

## How to review
1. Code Review

## Checklist

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration. **See related PRs**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs
Change to orch stub: https://github.com/govuk-one-login/authentication-stubs/pull/349