### PR TITLE
AUT-4303: Allow Auth access to dynamo table enc key in staging

### DIFF
--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -629,7 +629,7 @@ data "aws_iam_policy_document" "cross_account_table_encryption_key_access_policy
   }
 
   dynamic "statement" {
-    for_each = var.environment != "production" && var.environment != "integration" && var.environment != "staging" ? ["1"] : []
+    for_each = var.environment != "production" && var.environment != "integration" ? ["1"] : []
     content {
       sid    = "Allow Auth access to dynamo table encryption key"
       effect = "Allow"


### PR DESCRIPTION
## What

Allow cross account access to user-profile table encryption key in staging.
Required by auth-external-api deployed to the new strategic staging account via secure pipelines.

Issue: [AUT-4303]
