### PR TITLE
ATO-1652: Cleanup is new account getters

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -27,7 +27,6 @@ import uk.gov.di.orchestration.shared.entity.MFAMethodType;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ServiceType;
-import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
@@ -129,11 +128,9 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 authCodeResponse.getLocation(),
                 startsWith("https://rp-build.build.stubs.account.gov.uk/?code="));
 
-        var redisSession = redis.getSession(sessionID);
         var orchSession = orchSessionExtension.getSession(sessionID).get();
 
         assertTrue(orchSession.getAuthenticated());
-        assertThat(redisSession.isNewAccount(), equalTo(Session.AccountState.EXISTING));
         assertThat(orchSession.getIsNewAccount(), equalTo(OrchSessionItem.AccountState.EXISTING));
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_ISSUED));
 
@@ -176,13 +173,9 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 authCodeResponse.getLocation(),
                 startsWith("https://rp-build.build.stubs.account.gov.uk/?code="));
 
-        var redisSession = redis.getSession(sessionID);
         var orchSession = orchSessionExtension.getSession(sessionID).get();
 
         assertFalse(orchSession.getAuthenticated());
-        assertThat(
-                redisSession.isNewAccount(),
-                equalTo(Session.AccountState.EXISTING_DOC_APP_JOURNEY));
         assertThat(
                 orchSession.getIsNewAccount(),
                 equalTo(OrchSessionItem.AccountState.EXISTING_DOC_APP_JOURNEY));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -35,7 +35,6 @@ import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.ServiceType;
-import uk.gov.di.orchestration.shared.entity.Session;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
@@ -731,13 +730,10 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 internalCommonSubjectId, CLIENT_SESSION_ID, userInfo);
     }
 
-    private void assertSessionUpdatedWhenReturnCodeRequestedAndPresent() throws Json.JsonException {
-        var redisSession = redis.getSession(SESSION_ID);
+    private void assertSessionUpdatedWhenReturnCodeRequestedAndPresent() {
         var orchSession = orchSessionExtension.getSession(SESSION_ID).get();
 
-        assertThat(redisSession.isNewAccount(), equalTo(Session.AccountState.EXISTING));
         assertTrue(orchSession.getAuthenticated());
-
         assertThat(orchSession.getIsNewAccount(), equalTo(OrchSessionItem.AccountState.EXISTING));
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -599,9 +599,6 @@ class AuthenticationCallbackHandlerTest {
                 .storeOrUpdateSession(sessionSaveCaptor.capture(), anyString());
         verify(orchSessionService, times(3)).updateSession(orchSessionCaptor.capture());
         assertThat(
-                Session.AccountState.UNKNOWN,
-                equalTo(sessionSaveCaptor.getAllValues().get(0).isNewAccount()));
-        assertThat(
                 OrchSessionItem.AccountState.UNKNOWN,
                 equalTo(orchSessionCaptor.getAllValues().get(0).getIsNewAccount()));
     }
@@ -1506,9 +1503,6 @@ class AuthenticationCallbackHandlerTest {
         assertThat(
                 sessionSaveCaptor.getAllValues().get(0).getCurrentCredentialStrength(),
                 equalTo(lowestCredentialTrustLevel));
-        assertThat(
-                Session.AccountState.NEW,
-                equalTo(sessionSaveCaptor.getAllValues().get(0).isNewAccount()));
     }
 
     private void assertOrchSessionUpdated() {
@@ -1518,6 +1512,9 @@ class AuthenticationCallbackHandlerTest {
         assertThat(
                 orchSessionCaptor.getAllValues().get(0).getCurrentCredentialStrength(),
                 equalTo(lowestCredentialTrustLevel));
+        assertThat(
+                orchSessionCaptor.getAllValues().get(0).getIsNewAccount(),
+                equalTo(OrchSessionItem.AccountState.NEW));
     }
 
     private void assertClientSessionUpdated() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Session.java
@@ -76,10 +76,6 @@ public class Session {
         return this;
     }
 
-    public AccountState isNewAccount() {
-        return isNewAccount;
-    }
-
     public Session setNewAccount(AccountState isNewAccount) {
         this.isNewAccount = isNewAccount;
         return this;

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationServiceTest.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -87,14 +86,6 @@ class AuthCodeResponseGenerationServiceTest {
     void saveSessionUpdatesDocAppSessionWithDocAppState() {
         authCodeResponseGenerationService.saveSession(
                 true, sessionService, session, SESSION_ID, orchSessionService, orchSession);
-
-        verify(sessionService)
-                .storeOrUpdateSession(
-                        argThat(
-                                s ->
-                                        s.isNewAccount()
-                                                == Session.AccountState.EXISTING_DOC_APP_JOURNEY),
-                        eq(SESSION_ID));
         verify(orchSessionService)
                 .updateSession(
                         argThat(


### PR DESCRIPTION
### Wider context of change

Session cleanup

### What’s changed

Remove getters for is new account. It was just being used in tests still.

### Manual testing

Tested in dev
### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
