### PR TITLE
ATO-1420: Swap to using orch client session in remaining places

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -468,7 +468,7 @@ public class AuthenticationCallbackHandler
                                 .withIpAddress(IpAddressHelper.extractIpAddress(input));
 
                 CredentialTrustLevel requestedCredentialTrustLevel =
-                        VectorOfTrust.getLowestCredentialTrustLevel(clientSession.getVtrList());
+                        VectorOfTrust.getLowestCredentialTrustLevel(orchClientSession.getVtrList());
                 CredentialTrustLevel credentialTrustLevel =
                         Optional.ofNullable(session.getCurrentCredentialStrength())
                                 .map(
@@ -554,7 +554,7 @@ public class AuthenticationCallbackHandler
                             persistentSessionId,
                             reproveIdentity,
                             VectorOfTrust.getRequestedLevelsOfConfidence(
-                                    clientSession.getVtrList()));
+                                    orchClientSession.getVtrList()));
                 }
 
                 URI clientRedirectURI = authenticationRequest.getRedirectionURI();
@@ -568,7 +568,7 @@ public class AuthenticationCallbackHandler
                         stateHash);
 
                 CredentialTrustLevel lowestRequestedCredentialTrustLevel =
-                        VectorOfTrust.getLowestCredentialTrustLevel(clientSession.getVtrList());
+                        VectorOfTrust.getLowestCredentialTrustLevel(orchClientSession.getVtrList());
                 if (isNull(session.getCurrentCredentialStrength())
                         || lowestRequestedCredentialTrustLevel.compareTo(
                                         session.getCurrentCredentialStrength())

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -74,6 +74,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -728,6 +729,24 @@ public class AuthenticationCallbackHandler
             boolean docAppJourney,
             ClientSession clientSession,
             String verifiedMfaMethodType) {
+        return buildDimensions(
+                accountState,
+                clientId,
+                clientSession.getClientName(),
+                clientSession.getVtrList(),
+                isTestJourney,
+                docAppJourney,
+                verifiedMfaMethodType);
+    }
+
+    private Map<String, String> buildDimensions(
+            AccountState accountState,
+            String clientId,
+            String clientName,
+            List<VectorOfTrust> vtrList,
+            boolean isTestJourney,
+            boolean docAppJourney,
+            String verifiedMfaMethodType) {
         Map<String, String> dimensions =
                 new HashMap<>(
                         Map.of(
@@ -742,7 +761,7 @@ public class AuthenticationCallbackHandler
                                 "IsDocApp",
                                 Boolean.toString(docAppJourney),
                                 "ClientName",
-                                clientSession.getClientName()));
+                                clientName));
 
         if (Objects.nonNull(verifiedMfaMethodType)) {
             dimensions.put("MfaMethod", verifiedMfaMethodType);
@@ -750,7 +769,7 @@ public class AuthenticationCallbackHandler
             LOG.info(
                     "No mfa method to set. User is either authenticated or signing in from a low level service");
         }
-        var orderedVtrList = VectorOfTrust.orderVtrList(clientSession.getVtrList());
+        var orderedVtrList = VectorOfTrust.orderVtrList(vtrList);
         var mfaRequired = MfaHelper.mfaRequired(orderedVtrList);
 
         var levelOfConfidence = LevelOfConfidence.NONE.getValue();

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -442,7 +442,7 @@ public class AuthenticationCallbackHandler
                 clientSessionService.updateStoredClientSession(clientSessionId, clientSession);
                 orchClientSessionService.updateStoredClientSession(orchClientSession);
 
-                var docAppJourney = isDocCheckingAppUserWithSubjectId(clientSession);
+                var docAppJourney = isDocCheckingAppUserWithSubjectId(orchClientSession);
                 Map<String, String> dimensions =
                         buildDimensions(
                                 accountState,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -36,7 +36,6 @@ import uk.gov.di.orchestration.shared.conditions.MfaHelper;
 import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
@@ -448,9 +447,10 @@ public class AuthenticationCallbackHandler
                         buildDimensions(
                                 accountState,
                                 clientId,
+                                orchClientSession.getClientName(),
+                                orchClientSession.getVtrList(),
                                 isTestJourney,
                                 docAppJourney,
-                                clientSession,
                                 userInfo.getClaim(
                                         AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
                                         String.class));
@@ -720,23 +720,6 @@ public class AuthenticationCallbackHandler
                             : OrchSessionItem.AccountState.EXISTING;
         }
         return accountState;
-    }
-
-    private Map<String, String> buildDimensions(
-            AccountState accountState,
-            String clientId,
-            boolean isTestJourney,
-            boolean docAppJourney,
-            ClientSession clientSession,
-            String verifiedMfaMethodType) {
-        return buildDimensions(
-                accountState,
-                clientId,
-                clientSession.getClientName(),
-                clientSession.getVtrList(),
-                isTestJourney,
-                docAppJourney,
-                verifiedMfaMethodType);
     }
 
     private Map<String, String> buildDimensions(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -378,7 +378,7 @@ public class AuthenticationCallbackHandler
 
                 boolean identityRequired =
                         identityRequired(
-                                clientSession.getAuthRequestParams(),
+                                orchClientSession.getAuthRequestParams(),
                                 client.isIdentityVerificationSupported(),
                                 configurationService.isIdentityEnabled());
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -617,7 +617,10 @@ public class AuthenticationCallbackHandler
                                 orchSession.getCurrentCredentialStrength()));
                 cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
                 cloudwatchMetricsService.incrementSignInByClient(
-                        orchAccountState, clientId, clientSession.getClientName(), isTestJourney);
+                        orchAccountState,
+                        clientId,
+                        orchClientSession.getClientName(),
+                        isTestJourney);
 
                 LOG.info("Successfully processed request");
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/conditions/DocAppUserHelper.java
@@ -5,7 +5,6 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
-import uk.gov.di.orchestration.shared.entity.ClientSession;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
@@ -41,14 +40,6 @@ public class DocAppUserHelper {
                     .filter(client -> client.getClientType().equals(ClientType.APP.getValue()))
                     .isPresent();
         }
-    }
-
-    public static boolean isDocCheckingAppUserWithSubjectId(ClientSession clientSession) {
-        boolean isDocCheckingUser =
-                clientSession.getDocAppSubjectId() != null
-                        && hasDocCheckingScope(clientSession.getAuthRequestParams());
-        LOG.info("User is Doc Checking App user: {}", isDocCheckingUser);
-        return isDocCheckingUser;
     }
 
     public static boolean isDocCheckingAppUserWithSubjectId(


### PR DESCRIPTION
### Wider context of change

We have verified that the orch client session is in sync with the client session previously, and in most places we have been using the orch client session instead of the redis client session for some time now. There were a few prod places where its still using the redis client session though.

### What’s changed

This PR updates the remaining few places to use the orch client session instead of the redis client session. After this PR, the only uses of the redis client session in orch would be in tests, or in the client session service (which will also be removed)

### Manual testing

Deployed to sandpit, tested a few auth and identity journeys. All seemed fine.
Also did a docapp journey to check nothing has broken there

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. See above
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a
