### PR TITLE
ATO-1621: remove ccs auth session

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -101,16 +101,7 @@ public class UserInfoService {
                     authSession.getVerifiedMfaMethodType());
             LOG.info("verified_mfa value: {}", authSession.getVerifiedMfaMethodType());
         }
-        if (accessTokenInfo
-                .getClaims()
-                .contains(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue())) {
-            userInfo.setClaim(
-                    AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue(),
-                    authSession.getCurrentCredentialStrength());
-            LOG.info(
-                    "current_credential_strength value: {}",
-                    authSession.getCurrentCredentialStrength());
-        }
+
         if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.UPLIFT_REQUIRED.getValue())) {
             userInfo.setClaim(
                     AuthUserInfoClaims.UPLIFT_REQUIRED.getValue(), authSession.getUpliftRequired());

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -73,7 +73,6 @@ public class UserInfoServiceTest {
     private static final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withVerifiedMfaMethodType(TEST_VERIFIED_MFA_METHOD_TYPE)
-                    .withCurrentCredentialStrength(TEST_CURRENT_CREDENTIAL_STRENGTH)
                     .withAchievedCredentialStrength(TEST_ACHIEVED_CREDENTIAL_STRENGTH)
                     .withUpliftRequired(TEST_UPLIFT_REQUIRED);
 
@@ -102,7 +101,6 @@ public class UserInfoServiceTest {
             Boolean expectedPhoneNumberVerified,
             String expectedSalt,
             MFAMethodType expectedVerifiedMfaMethod,
-            CredentialTrustLevel expectedCurrentCredentialStrength,
             Boolean expectedUpliftRequired,
             CredentialTrustLevel expectedAchievedCredentialStrength) {
         UserInfo actual = userInfoService.populateUserInfo(mockAccessTokenStore, authSession);
@@ -120,8 +118,6 @@ public class UserInfoServiceTest {
         assertEquals(expectedPhoneNumberVerified, actual.getPhoneNumberVerified());
         assertEquals(expectedSalt, actual.getClaim("salt"));
         assertEquals(expectedVerifiedMfaMethod, actual.getClaim("verified_mfa_method_type"));
-        assertEquals(
-                expectedCurrentCredentialStrength, actual.getClaim("current_credential_strength"));
         assertEquals(TEST_PASSWORD_RESET_TIME, actual.getClaim("password_reset_time"));
         assertEquals(expectedUpliftRequired, actual.getClaim("uplift_required"));
         assertEquals(
@@ -143,7 +139,6 @@ public class UserInfoServiceTest {
                         null,
                         null,
                         null,
-                        null,
                         null),
                 Arguments.of(
                         getMockAccessTokenStore(
@@ -153,7 +148,6 @@ public class UserInfoServiceTest {
                         null,
                         TEST_EMAIL,
                         TEST_EMAIL_VERIFIED,
-                        null,
                         null,
                         null,
                         null,
@@ -172,7 +166,6 @@ public class UserInfoServiceTest {
                                         "phone_number_verified",
                                         "salt",
                                         "verified_mfa_method_type",
-                                        "current_credential_strength",
                                         "uplift_required",
                                         "achieved_credential_strength")),
                         TEST_LEGACY_SUBJECT_ID,
@@ -184,7 +177,6 @@ public class UserInfoServiceTest {
                         TEST_PHONE_VERIFIED,
                         bytesToBase64(TEST_SALT),
                         TEST_VERIFIED_MFA_METHOD_TYPE,
-                        TEST_CURRENT_CREDENTIAL_STRENGTH,
                         TEST_UPLIFT_REQUIRED,
                         TEST_ACHIEVED_CREDENTIAL_STRENGTH));
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 
 public record StartRequest(
         @Expose @SerializedName("previous-session-id") String previousSessionId,
@@ -10,8 +9,6 @@ public record StartRequest(
         @Expose @SerializedName("previous-govuk-signin-journey-id")
                 String previousGovUkSigninJourneyId,
         @Expose @SerializedName("authenticated") boolean authenticated,
-        @Expose @SerializedName("current-credential-strength")
-                CredentialTrustLevel currentCredentialStrength,
         @Expose @SerializedName("cookie_consent") String cookieConsent,
         @Expose @SerializedName("_ga") String ga,
         @Expose @SerializedName("requested_credential_strength") String requestedCredentialStrength,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -180,9 +180,7 @@ public class StartHandler
         try {
             var authSession =
                     authSessionService.getUpdatedPreviousSessionOrCreateNew(
-                            Optional.ofNullable(startRequest.previousSessionId()),
-                            sessionId,
-                            startRequest.currentCredentialStrength());
+                            Optional.ofNullable(startRequest.previousSessionId()), sessionId);
             var requestedCredentialTrustLevel =
                     retrieveCredentialTrustLevel(startRequest.requestedCredentialStrength());
             authSession.setRequestedCredentialStrength(requestedCredentialTrustLevel);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -411,7 +411,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         authSessionService.updateSession(
                 authSession
                         .withVerifiedMfaMethodType(codeRequest.getMfaMethodType())
-                        .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL)
                         .withAchievedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL));
 
         var clientId = userContext.getClientId();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -607,7 +607,6 @@ class StartHandlerTest {
                         rpPairwiseIdForReauth,
                         previousGovUkSignInJourneyId,
                         authenticated,
-                        null,
                         COOKIE_CONSENT,
                         null,
                         CredentialTrustLevel.MEDIUM_LEVEL.getValue(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -520,7 +520,7 @@ class StartHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSession(anyString())).thenReturn(Optional.of(session));
-        when(authSessionService.getUpdatedPreviousSessionOrCreateNew(any(), any(), any()))
+        when(authSessionService.getUpdatedPreviousSessionOrCreateNew(any(), any()))
                 .thenReturn(new AuthSessionItem().withSessionId(SESSION_ID));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -234,7 +234,6 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
-        assertThat(authSession.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
         assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
@@ -312,7 +311,6 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
-        assertThat(authSession.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
         assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
@@ -355,7 +353,6 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
-        assertThat(authSession.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
         assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(phoneNumberCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
@@ -398,7 +395,6 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
-        assertThat(authSession.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
@@ -446,7 +442,6 @@ class VerifyMfaCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
-        assertThat(authSession.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
         assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(authAppCodeProcessor).processSuccessfulCodeRequest(anyString(), anyString());
         verify(codeStorageService, never())

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -222,7 +222,6 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         session.setCurrentCredentialStrength(credentialTrustLevel);
-        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         authSession.setIsNewAccount(AuthSessionItem.AccountState.NEW);
         var result =
                 makeCallWithCode(
@@ -264,7 +263,6 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         session.setCurrentCredentialStrength(credentialTrustLevel);
-        authSession.setCurrentCredentialStrength(credentialTrustLevel);
 
         var mfaCodeRequest =
                 new VerifyMfaCodeRequest(
@@ -298,7 +296,6 @@ class VerifyMfaCodeHandlerTest {
         when(configurationService.getInternalSectorUri()).thenReturn("http://" + SECTOR_HOST);
         when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
         session.setCurrentCredentialStrength(credentialTrustLevel);
-        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
         var result =
@@ -342,7 +339,6 @@ class VerifyMfaCodeHandlerTest {
         when(phoneNumberCodeProcessor.validateCode()).thenReturn(Optional.empty());
         authSession.setIsNewAccount(AuthSessionItem.AccountState.NEW);
         session.setCurrentCredentialStrength(credentialTrustLevel);
-        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
@@ -384,7 +380,6 @@ class VerifyMfaCodeHandlerTest {
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
         session.setCurrentCredentialStrength(credentialTrustLevel);
-        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
@@ -431,7 +426,6 @@ class VerifyMfaCodeHandlerTest {
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
         session.setCurrentCredentialStrength(credentialTrustLevel);
-        authSession.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -14,7 +14,6 @@ import uk.gov.di.authentication.external.domain.AuthExternalApiAuditableEvent;
 import uk.gov.di.authentication.external.entity.AuthUserInfoClaims;
 import uk.gov.di.authentication.external.lambda.UserInfoHandler;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
@@ -128,7 +127,6 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
         assertNull(userInfoResponse.getPhoneNumberVerified());
         assertNull(userInfoResponse.getClaim("salt"));
         assertNull(userInfoResponse.getClaim("verified_mfa_method_type"));
-        assertNull(userInfoResponse.getClaim("current_credential_strength"));
         assertNull(userInfoResponse.getClaim("uplift_required"));
 
         assertThat(
@@ -173,7 +171,6 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                 List.of(
                         OIDCScopeValue.EMAIL.getValue(),
                         AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue(),
-                        AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue(),
                         AuthUserInfoClaims.UPLIFT_REQUIRED.getValue()),
                 true);
         withAuthSessionNewAccount();
@@ -193,10 +190,6 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
         assertThat(
                 userInfoResponse.getClaim(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue()),
                 equalTo("AUTH_APP"));
-        assertThat(
-                userInfoResponse.getClaim(
-                        AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue()),
-                equalTo("MEDIUM_LEVEL"));
         assertTrue(
                 (Boolean) userInfoResponse.getClaim(AuthUserInfoClaims.UPLIFT_REQUIRED.getValue()));
     }
@@ -336,7 +329,6 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                         .get()
                         .withAccountState(AuthSessionItem.AccountState.NEW)
                         .withVerifiedMfaMethodType(MFAMethodType.AUTH_APP)
-                        .withCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL)
                         .withUpliftRequired(true));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -51,16 +51,11 @@ class AuthSessionServiceIntegrationTest {
 
         AuthSessionItem previousSession =
                 authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
-                        Optional.of(PREVIOUS_SESSION_ID),
-                        SESSION_ID,
-                        CredentialTrustLevel.MEDIUM_LEVEL);
+                        Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
         var previousSessionItem = authSessionExtension.getSession(PREVIOUS_SESSION_ID);
 
         assertTrue(previousSessionItem.isEmpty());
         assertThat(previousSession.getSessionId(), is(SESSION_ID));
-        assertThat(
-                previousSession.getCurrentCredentialStrength(),
-                is(CredentialTrustLevel.MEDIUM_LEVEL));
     }
 
     @Test
@@ -71,12 +66,8 @@ class AuthSessionServiceIntegrationTest {
 
         AuthSessionItem previousSession =
                 authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
-                        Optional.of(PREVIOUS_SESSION_ID),
-                        SESSION_ID,
-                        CredentialTrustLevel.MEDIUM_LEVEL);
+                        Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
         assertThat(previousSession.getSessionId(), is(SESSION_ID));
-        assertEquals(
-                CredentialTrustLevel.MEDIUM_LEVEL, previousSession.getCurrentCredentialStrength());
     }
 
     @Test
@@ -109,19 +100,13 @@ class AuthSessionServiceIntegrationTest {
 
         AuthSessionItem retrievedSession =
                 authSessionExtension.getUpdatedPreviousSessionOrCreateNew(
-                        Optional.of(PREVIOUS_SESSION_ID),
-                        SESSION_ID,
-                        CredentialTrustLevel.MEDIUM_LEVEL);
+                        Optional.of(PREVIOUS_SESSION_ID), SESSION_ID);
         var retrievedPreviousSession = authSessionExtension.getSession(PREVIOUS_SESSION_ID);
 
         assertTrue(retrievedPreviousSession.isEmpty());
         assertThat(retrievedSession.getSessionId(), equalTo(SESSION_ID));
         assertThat(
                 retrievedSession.getIsNewAccount(), equalTo(AuthSessionItem.AccountState.EXISTING));
-
-        assertThat(
-                retrievedSession.getCurrentCredentialStrength(),
-                equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -111,11 +111,9 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
     }
 
     public AuthSessionItem getUpdatedPreviousSessionOrCreateNew(
-            Optional<String> previousSessionId,
-            String sessionId,
-            CredentialTrustLevel credentialTrustLevel) {
+            Optional<String> previousSessionId, String sessionId) {
         return authSessionService.getUpdatedPreviousSessionOrCreateNew(
-                previousSessionId, sessionId, credentialTrustLevel);
+                previousSessionId, sessionId);
     }
 
     public void updateSession(AuthSessionItem sessionItem) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -22,7 +22,6 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_IS_NEW_ACCOUNT = "isNewAccount";
     public static final String ATTRIBUTE_RESET_PASSWORD_STATE = "resetPasswordState";
     public static final String ATTRIBUTE_RESET_MFA_STATE = "resetMfaState";
-    public static final String ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH = "currentCredentialStrength";
     public static final String ATTRIBUTE_VERIFIED_MFA_METHOD_TYPE = "VerifiedMfaMethodType";
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
     public static final String ATTRIBUTE_UPLIFT_REQUIRED = "UpliftRequired";
@@ -178,21 +177,6 @@ public class AuthSessionItem {
 
     public AuthSessionItem withResetMfaState(ResetMfaState resetMfaState) {
         this.resetMfaState = resetMfaState;
-        return this;
-    }
-
-    @DynamoDbAttribute(ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH)
-    public CredentialTrustLevel getCurrentCredentialStrength() {
-        return this.currentCredentialStrength;
-    }
-
-    public void setCurrentCredentialStrength(CredentialTrustLevel currentCredentialStrength) {
-        this.currentCredentialStrength = currentCredentialStrength;
-    }
-
-    public AuthSessionItem withCurrentCredentialStrength(
-            CredentialTrustLevel currentCredentialStrength) {
-        this.currentCredentialStrength = currentCredentialStrength;
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -7,7 +7,6 @@ import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.exceptions.AuthSessionException;
 import uk.gov.di.authentication.shared.helpers.InputSanitiser;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -67,9 +66,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
     }
 
     public AuthSessionItem getUpdatedPreviousSessionOrCreateNew(
-            Optional<String> previousSessionId,
-            String newSessionId,
-            CredentialTrustLevel currentCredentialStrength) {
+            Optional<String> previousSessionId, String newSessionId) {
 
         try {
             Optional<AuthSessionItem> previousAuthSession = Optional.empty();
@@ -82,7 +79,6 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                         previousAuthSession
                                 .get()
                                 .withSessionId(newSessionId)
-                                .withCurrentCredentialStrength(currentCredentialStrength)
                                 .withResetPasswordState(AuthSessionItem.ResetPasswordState.NONE)
                                 .withResetMfaState(AuthSessionItem.ResetMfaState.NONE)
                                 .withTimeToLive(
@@ -99,8 +95,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
                 return updatedSession;
             } else {
                 LOG.info("New Auth session item created with sessionId: {}", newSessionId);
-                return generateNewAuthSession(newSessionId)
-                        .withCurrentCredentialStrength(currentCredentialStrength);
+                return generateNewAuthSession(newSessionId);
             }
         } catch (Exception e) {
             LOG.error(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -9,7 +9,6 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.exceptions.AuthSessionException;
 
 import java.time.Instant;
@@ -97,7 +96,7 @@ class AuthSessionServiceTest {
 
         var newSession =
                 authSessionService.getUpdatedPreviousSessionOrCreateNew(
-                        Optional.empty(), NEW_SESSION_ID, null);
+                        Optional.empty(), NEW_SESSION_ID);
 
         verifyNoInteractions(dynamoDbClient);
         assertEquals(NEW_SESSION_ID, newSession.getSessionId());
@@ -110,7 +109,7 @@ class AuthSessionServiceTest {
 
         var newSession =
                 authSessionService.getUpdatedPreviousSessionOrCreateNew(
-                        Optional.of(SESSION_ID), NEW_SESSION_ID, null);
+                        Optional.of(SESSION_ID), NEW_SESSION_ID);
 
         verifyNoInteractions(dynamoDbClient);
         assertEquals(NEW_SESSION_ID, newSession.getSessionId());
@@ -123,7 +122,7 @@ class AuthSessionServiceTest {
 
         var updatedSession =
                 authSessionService.getUpdatedPreviousSessionOrCreateNew(
-                        Optional.of(SESSION_ID), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL);
+                        Optional.of(SESSION_ID), NEW_SESSION_ID);
 
         assertThat(updatedSession.getSessionId(), is(NEW_SESSION_ID));
         assertTrue(updatedSession.getTimeToLive() > Instant.now().getEpochSecond());
@@ -139,11 +138,9 @@ class AuthSessionServiceTest {
 
         var authSession =
                 authSessionService.getUpdatedPreviousSessionOrCreateNew(
-                        Optional.of(SESSION_ID), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL);
+                        Optional.of(SESSION_ID), NEW_SESSION_ID);
 
         assertThat(authSession.getSessionId(), is(NEW_SESSION_ID));
-        assertThat(
-                authSession.getCurrentCredentialStrength(), is(CredentialTrustLevel.MEDIUM_LEVEL));
         assertThat(
                 authSession.getResetPasswordState(), is(AuthSessionItem.ResetPasswordState.NONE));
         assertThat(authSession.getResetMfaState(), is(AuthSessionItem.ResetMfaState.NONE));
@@ -155,11 +152,9 @@ class AuthSessionServiceTest {
 
         var authSession =
                 authSessionService.getUpdatedPreviousSessionOrCreateNew(
-                        Optional.empty(), NEW_SESSION_ID, CredentialTrustLevel.MEDIUM_LEVEL);
+                        Optional.empty(), NEW_SESSION_ID);
 
         assertThat(authSession.getSessionId(), is(NEW_SESSION_ID));
-        assertThat(
-                authSession.getCurrentCredentialStrength(), is(CredentialTrustLevel.MEDIUM_LEVEL));
     }
 
     @Test


### PR DESCRIPTION
### Wider context of change: 

We're migrating away from using the field CurrentCredential Strength on the new separate sessions we've setup, as we're aiming to make this a solely authentication owned value, which is given to Orchestration. Now we've migrated the main usage of this value to AchievedCredentialStrength, we can now remove getting and setting it.

### What’s changed: 
- Stops sending orchestration the value of Current Credential Strength - because this value was previously null in _some_ cases, the orchestration side of the code is set up to be able to handle this being null - so it's safe to remove this now.
- Stop setting it in VerifyMfaCode handler 
- Stop setting it initially in the start handler based on the Orchestration derived value -  we're removing this value completely so we can remove this.

### Manual testing: 
- Deployed to authdev2 
- Run through a couple of journeys
- Run through an of uplift journey

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
