### PR TITLE
ATO-1621: Adds method comments

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -318,15 +318,43 @@ public class AuthSessionItem {
         return this;
     }
 
+    /**
+     * Returns the {@link uk.gov.di.authentication.shared.entity.CredentialTrustLevel} the user has
+     * achieved in this session. This will be null initially and is set at the end of a user's
+     * journey. This value is reported back to Orchestration in the /userinfo response.
+     *
+     * @return {{@link uk.gov.di.authentication.shared.entity.CredentialTrustLevel}: the level of
+     *     credential trust a user has achieved.
+     */
     @DynamoDbAttribute(ATTRIBUTE_ACHIEVED_CREDENTIAL_STRENGTH)
     public CredentialTrustLevel getAchievedCredentialStrength() {
         return this.achievedCredentialStrength;
     }
 
+    /**
+     * Sets the {@link uk.gov.di.authentication.shared.entity.CredentialTrustLevel} the user has
+     * achieved in this session. Modifies the session object in place. This should only be called
+     * towards the end of a user's journey once we're sure they've presented valid credentials to
+     * achieve the level we're about to set. Usages of this should be careful not to downshift a
+     * user's Credential Trust level.
+     *
+     * @param credentialStrength - the level of Credential Trust a user has achieved
+     */
     public void setAchievedCredentialStrength(CredentialTrustLevel credentialStrength) {
         this.achievedCredentialStrength = credentialStrength;
     }
 
+    /**
+     * Builder like method which both sets the level of Credential Trust the user has achieved in
+     * this session and returns the modified session object, enabling method chaining. This should
+     * only be called towards the end of a user's journey once we're sure they've presented valid
+     * credentials to achieve the level we're about to set. Usages of this should be careful not to
+     * downshift a user's Credential Trust level.
+     *
+     * @param credentialStrength - the level of Credential Trust a user has achieved
+     * @return {@link uk.gov.di.authentication.shared.entity.AuthSessionItem} - the now modified
+     *     session object.
+     */
     public AuthSessionItem withAchievedCredentialStrength(CredentialTrustLevel credentialStrength) {
         this.achievedCredentialStrength = credentialStrength;
         return this;


### PR DESCRIPTION

### Wider context of change
We have now established the value Achieved Credential Strength as the replacement for Current Credential Strength. I have added some javaDoc style code comments to each of the methods for this value.


### What’s changed: 

- Adds method comments to explain the what this value represents and any context that might need to be considered when using these methods


### Manual testing: 

- N/A just code comments

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
