### PR TITLE
ATO-1621: Remove Current Credential Strength Orch session

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -463,12 +463,6 @@ public class AuthCodeHandler
                         > 0) {
             session.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
         }
-        CredentialTrustLevel currentCredentialStrength = orchSession.getCurrentCredentialStrength();
-
-        if (isNull(currentCredentialStrength)
-                || lowestRequestedCredentialTrustLevel.compareTo(currentCredentialStrength) > 0) {
-            orchSession.setCurrentCredentialStrength(lowestRequestedCredentialTrustLevel);
-        }
 
         return orchAuthCodeService.generateAndSaveAuthorisationCode(
                 clientID.getValue(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -569,21 +569,8 @@ public class AuthenticationCallbackHandler
                                 clientRedirectURI, authCode, null, null, state, null, responseMode);
 
                 sessionService.storeOrUpdateSession(session, sessionId);
-                var currentCredentialStrength =
-                        userInfo.getStringClaim(
-                                AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue());
-                if (isNull(currentCredentialStrength)
-                        || lowestRequestedCredentialTrustLevel.compareTo(
-                                        CredentialTrustLevel.valueOf(currentCredentialStrength))
-                                > 0) {
-                    orchSessionService.updateSession(
-                            orchSession.withCurrentCredentialStrength(
-                                    lowestRequestedCredentialTrustLevel));
-                } else {
-                    orchSessionService.updateSession(
-                            orchSession.withCurrentCredentialStrength(
-                                    CredentialTrustLevel.valueOf(currentCredentialStrength)));
-                }
+                orchSessionService.updateSession(orchSession);
+
                 // ATO-975 logging to make sure there are no differences in production
                 LOG.info(
                         "Shared session current credential strength: {}",

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -381,10 +381,6 @@ public class AuthenticationCallbackHandler
                         userInfo.getClaim(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue())
                                 != null);
                 LOG.info(
-                        "is current_credential_strength attached to auth-external-api userinfo response: {}",
-                        userInfo.getClaim(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue())
-                                != null);
-                LOG.info(
                         "is uplift_required attached to auth-external-api userinfo response: {}",
                         userInfo.getClaim(AuthUserInfoClaims.UPLIFT_REQUIRED.getValue()) != null);
                 LOG.info(
@@ -571,18 +567,6 @@ public class AuthenticationCallbackHandler
                 sessionService.storeOrUpdateSession(session, sessionId);
                 orchSessionService.updateSession(orchSession);
 
-                // ATO-975 logging to make sure there are no differences in production
-                LOG.info(
-                        "Shared session current credential strength: {}",
-                        session.getCurrentCredentialStrength());
-                LOG.info(
-                        "Orch session current credential strength: {}",
-                        orchSession.getCurrentCredentialStrength());
-                LOG.info(
-                        "Is shared session CCS equal to Orch session CCS: {}",
-                        Objects.equals(
-                                session.getCurrentCredentialStrength(),
-                                orchSession.getCurrentCredentialStrength()));
                 cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
                 cloudwatchMetricsService.incrementSignInByClient(
                         orchAccountState,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -857,7 +857,8 @@ public class AuthenticationCallbackHandler
 
     private void logComparisonRequestCredentialTrustAndAchieved(
             UserInfo authUserInfo, CredentialTrustLevel requestedCredentialStrength) {
-
+        // TODO: This logging currently looks fine but in future we should validate that
+        // this value is non-null and >= the requested credential strength
         try {
             var userInfoAchievedCredentialStrength =
                     authUserInfo.getStringClaim(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -1073,7 +1073,6 @@ public class AuthorisationHandler
         claimsSet.add(AuthUserInfoClaims.EMAIL);
         claimsSet.add(AuthUserInfoClaims.LOCAL_ACCOUNT_ID);
         claimsSet.add(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE);
-        claimsSet.add(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH);
         claimsSet.add(AuthUserInfoClaims.UPLIFT_REQUIRED);
         claimsSet.add(AuthUserInfoClaims.ACHIEVED_CREDENTIAL_STRENGTH);
         if (identityRequired) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -782,7 +782,6 @@ public class AuthorisationHandler
                         .withSessionId(newSessionId)
                         .withBrowserSessionId(newBrowserSessionId)
                         .withTimeToLive(timeNow + configurationService.getSessionExpiry())
-                        .withCurrentCredentialStrength(null)
                         .withAuthenticated(false)
                         .withPreviousSessionId(newSessionIdForPreviousSession);
         newSession.resetProcessingIdentityAttempts();

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -935,9 +935,6 @@ public class AuthorisationHandler
                         .claim("previous_govuk_signin_journey_id", reauthSid)
                         .claim("channel", client.getChannel().toLowerCase())
                         .claim("authenticated", orchSession.getAuthenticated())
-                        .claim(
-                                "current_credential_strength",
-                                orchSession.getCurrentCredentialStrength())
                         .claim("scope", authenticationRequest.getScope().toString())
                         .claim("login_hint", authenticationRequest.getLoginHint());
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -272,7 +272,6 @@ class AuthCodeHandlerTest {
         var authorizationCode = new AuthorizationCode();
         var authRequest = generateValidSessionAndAuthRequest(requestedLevel, false);
         session.setCurrentCredentialStrength(initialLevel).setNewAccount(AccountState.NEW);
-        orchSession.setCurrentCredentialStrength(initialLevel);
         var authSuccessResponse =
                 new AuthenticationSuccessResponse(
                         authRequest.getRedirectionURI(),
@@ -433,7 +432,6 @@ class AuthCodeHandlerTest {
         var authCodeResponse = objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
         assertThat(authCodeResponse.getLocation(), equalTo(authSuccessResponse.toURI().toString()));
         assertThat(session.getCurrentCredentialStrength(), equalTo(requestedLevel));
-        assertThat(orchSession.getCurrentCredentialStrength(), equalTo(requestedLevel));
         assertFalse(orchSession.getAuthenticated());
         verify(authCodeResponseService, times(1))
                 .saveSession(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -232,8 +232,6 @@ class AuthenticationCallbackHandlerTest {
 
         session.setCurrentCredentialStrength(null);
         when(USER_INFO.getBooleanClaim("new_account")).thenReturn(true);
-        when(USER_INFO.getStringClaim(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue()))
-                .thenReturn(null);
         when(logoutService.handleReauthenticationFailureLogout(any(), any(), any(), any(), any()))
                 .thenAnswer(
                         args -> {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -152,9 +152,7 @@ class AuthenticationCallbackHandlerTest {
 
     private static final Session session = new Session().setCurrentCredentialStrength(null);
     public static final OrchSessionItem orchSession =
-            new OrchSessionItem(SESSION_ID)
-                    .withAuthenticated(false)
-                    .withCurrentCredentialStrength(null);
+            new OrchSessionItem(SESSION_ID).withAuthenticated(false);
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String CLIENT_NAME = "client-name";

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -534,46 +534,6 @@ class AuthorisationHandlerTest {
             assertEquals(false, actualAuthenticatedClaim);
         }
 
-        @Test
-        void shouldPassCurrentCredentialStrengthClaimToAuthFromSession() {
-            withExistingSession(session);
-            var currentCredentialStrength = CredentialTrustLevel.MEDIUM_LEVEL;
-            withExistingOrchSession(
-                    new OrchSessionItem(NEW_SESSION_ID)
-                            .withCurrentCredentialStrength(currentCredentialStrength));
-
-            var requestParams =
-                    buildRequestParams(
-                            Map.of("scope", "openid profile phone", "vtr", "[\"Cl.Cm.P2\"]"));
-            var event = withRequestEvent(requestParams);
-
-            makeHandlerRequest(event);
-
-            var captor = ArgumentCaptor.forClass(JWTClaimsSet.class);
-            verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
-            var actualCurrentCredentialStrengthClaim =
-                    captor.getValue().getClaim("current_credential_strength");
-            assertEquals(currentCredentialStrength, actualCurrentCredentialStrengthClaim);
-        }
-
-        @Test
-        void shouldPassNullCurrentCredentialStrengthClaimIfNewSession() {
-            withNoSession();
-
-            var requestParams =
-                    buildRequestParams(
-                            Map.of("scope", "openid profile phone", "vtr", "[\"Cl.Cm.P2\"]"));
-            var event = withRequestEvent(requestParams);
-
-            makeHandlerRequest(event);
-
-            var captor = ArgumentCaptor.forClass(JWTClaimsSet.class);
-            verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
-            var actualCurrentCredentialStrengthClaim =
-                    captor.getValue().getClaim("current_credential_strength");
-            assertEquals(null, actualCurrentCredentialStrengthClaim);
-        }
-
         @ParameterizedTest
         @ValueSource(
                 strings = {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -385,7 +385,7 @@ class AuthorisationHandlerTest {
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
             var expectedClaimSetRequest =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"local_account_id\":null, \"email_verified\":null,\"current_credential_strength\":null,\"verified_mfa_method_type\":null,\"email\":null, \"uplift_required\":null, \"achieved_credential_strength\":null}}");
+                            "{\"userinfo\":{\"local_account_id\":null, \"email_verified\":null,\"verified_mfa_method_type\":null,\"email\":null, \"uplift_required\":null, \"achieved_credential_strength\":null}}");
             var actualClaimSetRequest =
                     ClaimsSetRequest.parse(captor.getValue().getStringClaim("claim"));
             assertEquals(
@@ -426,7 +426,7 @@ class AuthorisationHandlerTest {
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
             var expectedClaimSetRequest =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"local_account_id\":null, \"phone_number_verified\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null,\"current_credential_strength\":null, \"uplift_required\":null, \"achieved_credential_strength\":null}}");
+                            "{\"userinfo\":{\"local_account_id\":null, \"phone_number_verified\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null, \"uplift_required\":null, \"achieved_credential_strength\":null}}");
             var actualClaimSetRequest =
                     ClaimsSetRequest.parse(captor.getValue().getStringClaim("claim"));
             assertEquals(
@@ -463,7 +463,7 @@ class AuthorisationHandlerTest {
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(captor.capture());
             var expectedClaimSetRequest =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"salt\":null,\"email_verified\":null,\"local_account_id\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null,\"current_credential_strength\":null, \"uplift_required\":null , \"achieved_credential_strength\":null}}");
+                            "{\"userinfo\":{\"salt\":null,\"email_verified\":null,\"local_account_id\":null,\"phone_number\":null,\"email\":null,\"verified_mfa_method_type\":null, \"uplift_required\":null , \"achieved_credential_strength\":null}}");
             var actualClaimSetRequest =
                     ClaimsSetRequest.parse(captor.getValue().getStringClaim("claim"));
             assertEquals(
@@ -1385,7 +1385,7 @@ class AuthorisationHandlerTest {
 
             var expectedClaim =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"local_account_id\":null, \"verified_mfa_method_type\":null,\"current_credential_strength\":null,\"public_subject_id\":null,\"email\":null, \"uplift_required\":null, \"achieved_credential_strength\":null}}");
+                            "{\"userinfo\":{\"local_account_id\":null, \"verified_mfa_method_type\":null,\"public_subject_id\":null,\"email\":null, \"uplift_required\":null, \"achieved_credential_strength\":null}}");
             var actualClaim = ClaimsSetRequest.parse(argument.getValue().getStringClaim("claim"));
             assertEquals(actualClaim.toJSONObject(), expectedClaim.toJSONObject());
         }
@@ -1408,7 +1408,7 @@ class AuthorisationHandlerTest {
 
             var expectedClaim =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"local_account_id\":null, \"verified_mfa_method_type\":null,\"current_credential_strength\":null,\"public_subject_id\":null,\"email\":null, \"uplift_required\":null, \"achieved_credential_strength\":null}}");
+                            "{\"userinfo\":{\"local_account_id\":null, \"verified_mfa_method_type\":null,\"public_subject_id\":null,\"email\":null, \"uplift_required\":null, \"achieved_credential_strength\":null}}");
             var actualClaim = ClaimsSetRequest.parse(argument.getValue().getStringClaim("claim"));
             assertEquals(actualClaim.toJSONObject(), expectedClaim.toJSONObject());
         }
@@ -1429,7 +1429,7 @@ class AuthorisationHandlerTest {
 
             var expectedClaim =
                     ClaimsSetRequest.parse(
-                            "{\"userinfo\":{\"legacy_subject_id\":null,\"local_account_id\":null,\"current_credential_strength\":null,\"verified_mfa_method_type\":null,\"email\":null, \"uplift_required\":null, \"achieved_credential_strength\":null}}");
+                            "{\"userinfo\":{\"legacy_subject_id\":null,\"local_account_id\":null,\"verified_mfa_method_type\":null,\"email\":null, \"uplift_required\":null, \"achieved_credential_strength\":null}}");
             var actualClaim = ClaimsSetRequest.parse(argument.getValue().getStringClaim("claim"));
             assertEquals(actualClaim.toJSONObject(), expectedClaim.toJSONObject());
         }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthUserInfoClaims.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthUserInfoClaims.java
@@ -15,7 +15,6 @@ public enum AuthUserInfoClaims {
     PHONE_VERIFIED("phone_number_verified"),
     SALT("salt"),
     VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type"),
-    CURRENT_CREDENTIAL_STRENGTH("current_credential_strength"),
     NEW_ACCOUNT("new_account"),
     UPLIFT_REQUIRED("uplift_required"),
     ACHIEVED_CREDENTIAL_STRENGTH("achieved_credential_strength");

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -18,7 +18,6 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID = "InternalCommonSubjectId";
     public static final String ATTRIBUTE_AUTHENTICATED = "Authenticated";
     public static final String ATTRIBUTE_AUTH_TIME = "AuthTime";
-    public static final String ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH = "CurrentCredentialStrength";
     public static final String ATTRIBUTE_PROCESSING_IDENTITY_ATTEMPTS =
             "ProcessingIdentityAttempts";
     public static final String ATTRIBUTE_CLIENT_SESSIONS = "ClientSessions";
@@ -191,21 +190,6 @@ public class OrchSessionItem {
 
     public OrchSessionItem withAuthTime(Long authTime) {
         this.authTime = authTime;
-        return this;
-    }
-
-    @DynamoDbAttribute(ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH)
-    public CredentialTrustLevel getCurrentCredentialStrength() {
-        return this.currentCredentialStrength;
-    }
-
-    public void setCurrentCredentialStrength(CredentialTrustLevel currentCredentialStrength) {
-        this.currentCredentialStrength = currentCredentialStrength;
-    }
-
-    public OrchSessionItem withCurrentCredentialStrength(
-            CredentialTrustLevel currentCredentialStrength) {
-        this.currentCredentialStrength = currentCredentialStrength;
         return this;
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AuthCodeResponseGenerationService.java
@@ -91,17 +91,5 @@ public class AuthCodeResponseGenerationService {
                             .withAuthenticated(true)
                             .withAccountState(OrchSessionItem.AccountState.EXISTING));
         }
-        // ATO-975 logging to make sure there are no differences in production
-        LOG.info(
-                "Shared session current credential strength: {}",
-                session.getCurrentCredentialStrength());
-        LOG.info(
-                "Orch session current credential strength: {}",
-                orchSession.getCurrentCredentialStrength());
-        LOG.info(
-                "Is shared session CCS equal to Orch session CCS: {}",
-                Objects.equals(
-                        session.getCurrentCredentialStrength(),
-                        orchSession.getCurrentCredentialStrength()));
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/AuthUserInfoClaimsTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/AuthUserInfoClaimsTest.java
@@ -18,7 +18,6 @@ class AuthUserInfoClaimsTest {
                 "email_verified",
                 "salt",
                 "local_account_id",
-                "current_credential_strength",
                 "uplift_required",
                 "rp_pairwise_id",
                 "phone_number_verified",
@@ -37,7 +36,7 @@ class AuthUserInfoClaimsTest {
 
     @Test
     void shouldReturnCorrectNumberOfClaimsSupported() {
-        assertThat(AuthUserInfoClaims.getAllValidClaims().size(), equalTo(14));
+        assertThat(AuthUserInfoClaims.getAllValidClaims().size(), equalTo(13));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Wider context of change: 
Previously we migrated this field to the Orch session from redis. This was done as the existing logic between Authentication and Orchestration required both sides to determine this value, as it was previously not set in all cases. However this left some circular and fairly fragile logic between the components. Given Authentication should be the sole component concerned with this value, we have swapped to a new value called AchievedCredentialStrength which is more reliable and only set by Auth. 

This has meant there is no need currently for Orchestration to keep this value in it's own session store. We have some logging in place 

### What’s changed
- Orchestration no longer set the value of current credential strength on it's session
- Removes it from the Authentication claims 
- Stops sending Current Credential Strength to Auth as it is no longer used
- 

### Manual testing: 

Deployed to sandpit:
- Run through a couple of journeys:
- Ran through a low confidence journey
- Came back to stub, selected medium and was presented with uplift screen

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs: 
- Orch stub PR which reflects this change: https://github.com/govuk-one-login/authentication-stubs/pull/359