### PR TITLE
Revert "AUT-4248: Handle migration to phone + email OTP identifiers"

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -256,8 +256,6 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             String code =
                     codeStorageService
                             .getOtpCode(codeIdentifier, notificationType)
-                            .or( // Temporary fallback for old phone number key with just email
-                                    () -> codeStorageService.getOtpCode(email, notificationType))
                             .orElseGet(
                                     () -> generateAndSaveNewCode(codeIdentifier, notificationType));
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -315,12 +315,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             code =
                     codeStorageService
                             .getOtpCode(codeIdentifier, notificationType)
-                            .or( // Temporary fallback for old phone number key with just email
-                                    () ->
-                                            notificationType.isForPhoneNumber()
-                                                    ? codeStorageService.getOtpCode(
-                                                            emailAddress, notificationType)
-                                                    : Optional.empty())
                             .orElseGet(
                                     () -> generateAndSaveNewCode(codeIdentifier, notificationType));
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -318,14 +318,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     PhoneNumberHelper.formatPhoneNumber(requestedMfaMethod.getDestination());
             identifier = emailAddress.concat(formattedPhoneNumber);
         }
-        return codeStorageService
-                .getOtpCode(identifier, notificationType)
-                .or( // Temporary fallback for old phone number key with just email
-                        () ->
-                                notificationType.isForPhoneNumber()
-                                        ? codeStorageService.getOtpCode(
-                                                emailAddress, notificationType)
-                                        : Optional.empty());
+        return codeStorageService.getOtpCode(identifier, notificationType);
     }
 
     private void handleInvalidVerificationCode(
@@ -485,10 +478,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             identifier = emailAddress.concat(formattedPhoneNumber);
         }
         codeStorageService.deleteOtpCode(identifier, notificationType);
-        if (notificationType.isForPhoneNumber()) {
-            // Temporary fallback for old phone number key with just email
-            codeStorageService.deleteOtpCode(emailAddress, notificationType);
-        }
 
         var metadataPairArray =
                 metadataPairs(notificationType, journeyType, codeRequest, loginFailureCount, false);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -122,12 +122,7 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
         var storedCode =
                 isTestClient
                         ? configurationService.getTestClientVerifyPhoneNumberOTP()
-                        : codeStorageService
-                                .getOtpCode(codeIdentifier, notificationType)
-                                .or( // Temporary fallback for old phone number key with just email
-                                        () ->
-                                                codeStorageService.getOtpCode(
-                                                        emailAddress, notificationType));
+                        : codeStorageService.getOtpCode(codeIdentifier, notificationType);
 
         var errorResponse =
                 ValidationHelper.validateVerificationCode(
@@ -141,8 +136,6 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
 
         if (errorResponse.isEmpty()) {
             codeStorageService.deleteOtpCode(codeIdentifier, notificationType);
-            // Temporary fallback for old phone number key with just email
-            codeStorageService.deleteOtpCode(emailAddress, notificationType);
         }
 
         return errorResponse;

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -125,7 +125,10 @@ class PhoneNumberCodeProcessorTest {
                 codeRequestType);
 
         phoneNumberCodeProcessor.validateCode();
-        verify(codeStorageService).deleteOtpCode(CommonTestVariables.EMAIL, notificationType);
+        verify(codeStorageService)
+                .deleteOtpCode(
+                        CommonTestVariables.EMAIL.concat(CommonTestVariables.UK_MOBILE_NUMBER),
+                        notificationType);
     }
 
     @Test
@@ -174,7 +177,9 @@ class PhoneNumberCodeProcessorTest {
 
         phoneNumberCodeProcessor.validateCode();
         verify(codeStorageService, never())
-                .deleteOtpCode(CommonTestVariables.EMAIL, notificationType);
+                .deleteOtpCode(
+                        CommonTestVariables.EMAIL.concat(CommonTestVariables.UK_MOBILE_NUMBER),
+                        notificationType);
     }
 
     @Test


### PR DESCRIPTION
## What

While making changes to how codes are stored, we added logic to handle existing sessions where users had codes stored against just their email, not email + phone combo. 

For that period if time the previously generated OTPs will no longer be valid and users would have to request new OTPs.

Since previous OTPs will now have been invalidated due to TTL or deleted we can now revert this migration.

This reverts commit 96282beb1d2bfef618d50873299cad94f270f5c6.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
