### PR TITLE
ATO-1421: Remove unused getter after migration

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchClientSessionItem.java
@@ -128,12 +128,6 @@ public class OrchClientSessionItem {
         return this;
     }
 
-    // TODO: I've added this method in case we still need it during the migration.
-    // We should probably remove it if we're not using it after the migration though.
-    public VectorOfTrust getEffectiveVectorOfTrust() {
-        return VectorOfTrust.orderVtrList(vtrList).stream().findFirst().orElse(null);
-    }
-
     @DynamoDbAttribute(ATTRIBUTE_RP_PAIRWISE_ID)
     public String getRpPairwiseId() {
         // This is public because the DynamoDbMapper requires it to be for serialisation.


### PR DESCRIPTION
### Wider context of change

We have pretty much finished the client session migration to orch. There was a getter on the dynamo client session that we were not sure if we would need during the migration - `getEffectiveVectorOfTrust`. Turns out we didn't need it, as we've swapped to using a vtrList instead. This getter than therefore be removed.

### What’s changed

This PR removes an unused getter in the dynamo client session.

### Manual testing

Removing unused code, so not necessary

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. n/a 
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a
