### PR TITLE
AUT-4256: ResetPasswordRequest now returns mfaMethods

### DIFF
--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -14,7 +14,8 @@ module "frontend_api_reset_password_request_role" {
     local.account_modifiers_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     aws_iam_policy.dynamo_auth_session_read_policy.arn,
-    aws_iam_policy.dynamo_auth_session_write_policy.arn
+    aws_iam_policy.dynamo_auth_session_write_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
   ]
   extra_tags = {
     Service = "reset-password-request"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequestHandlerResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequestHandlerResponse.java
@@ -3,8 +3,12 @@ package uk.gov.di.authentication.frontendapi.entity;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import uk.gov.di.authentication.frontendapi.entity.mfa.MfaMethodResponse;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+
+import java.util.List;
 
 public record ResetPasswordRequestHandlerResponse(
         @SerializedName("mfaMethodType") @Expose @Required MFAMethodType mfaMethodType,
+        @SerializedName("mfaMethods") @Expose @Required List<MfaMethodResponse> mfaMethodResponses,
         @SerializedName("phoneNumberLastThree") @Expose String phoneNumberLastThree) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/FrontendApiPhoneNumberHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/FrontendApiPhoneNumberHelper.java
@@ -16,11 +16,16 @@ public class FrontendApiPhoneNumberHelper {
     public static String getLastDigitsOfPhoneNumber(UserMfaDetail userMfaDetail) {
         if (userMfaDetail.phoneNumber() != null
                 && !userMfaDetail.phoneNumber().isEmpty()
-                && userMfaDetail.phoneNumber().length() >= NUMBER_OF_LAST_DIGITS
                 && MFAMethodType.SMS.equals(userMfaDetail.mfaMethodType())) {
-            return userMfaDetail
-                    .phoneNumber()
-                    .substring(userMfaDetail.phoneNumber().length() - NUMBER_OF_LAST_DIGITS);
+            return getLastDigitsOfPhoneNumber(userMfaDetail.phoneNumber());
+        } else {
+            return null;
+        }
+    }
+
+    public static String getLastDigitsOfPhoneNumber(String phoneNumber) {
+        if (phoneNumber != null && phoneNumber.length() >= NUMBER_OF_LAST_DIGITS) {
+            return phoneNumber.substring(phoneNumber.length() - NUMBER_OF_LAST_DIGITS);
         } else {
             return null;
         }


### PR DESCRIPTION
## What

Our reset password journey needs to know which MFA methods a user has in order to present them as choices after entering their email OTP successfully.

Here we add the `mfaMethods` to the `ResetPasswordRequest` handler, as we do with the LoginHandler.

Existing returned attributes remain the same, but the data source is updated to use the same `MFAMethodsService` response that is needed for getting the `mfaMethods`.

Permission is given to the lamda to write user data as it now needs write generated MFA IDs for MFA methods that don't have them (`MFAMethodsService` handles that specifically).

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
