### PR TITLE
ATO-1643 remove any writes to redis session auth

### DIFF
--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -211,7 +210,6 @@ class UserInfoHandlerTest {
         assertEquals(objectMapper.writeValueAsString(ErrorResponse.ERROR_1000), response.getBody());
         verify(sessionService).getSessionFromRequestHeaders(request.getHeaders());
         verifyNoInteractions(accessTokenService, userInfoService, auditService);
-        verify(sessionService, never()).storeOrUpdateSession(any(), anyString());
     }
 
     @Test
@@ -232,7 +230,6 @@ class UserInfoHandlerTest {
         assertEquals(objectMapper.writeValueAsString(ErrorResponse.ERROR_1000), response.getBody());
         verify(sessionService).getSessionFromRequestHeaders(request.getHeaders());
         verifyNoInteractions(accessTokenService, userInfoService, auditService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -257,7 +254,6 @@ class UserInfoHandlerTest {
         assertEquals(objectMapper.writeValueAsString(ErrorResponse.ERROR_1000), response.getBody());
         verify(sessionService).getSessionFromRequestHeaders(request.getHeaders());
         verifyNoInteractions(accessTokenService, userInfoService, auditService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -282,7 +278,6 @@ class UserInfoHandlerTest {
         assertTrue(authChallengeHeader.get(0).contains("\"Invalid access token\""));
 
         verify(accessTokenService, never()).setAccessTokenStoreUsed(any(), anyBoolean());
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -308,7 +303,6 @@ class UserInfoHandlerTest {
         assertTrue(authChallengeHeader.get(0).contains("\"Invalid access token\""));
 
         verify(accessTokenService, never()).setAccessTokenStoreUsed(any(), anyBoolean());
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -338,7 +332,6 @@ class UserInfoHandlerTest {
         assertTrue(authChallengeHeader.get(0).contains("\"Invalid access token\""));
 
         verify(accessTokenService, never()).setAccessTokenStoreUsed(any(), anyBoolean());
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -365,7 +358,6 @@ class UserInfoHandlerTest {
         assertTrue(authChallengeHeader.get(0).contains("\"Invalid access token\""));
 
         verify(accessTokenService, never()).setAccessTokenStoreUsed(any(), anyBoolean());
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     private void withAuthSession() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/SessionHelper.java
@@ -8,7 +8,6 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 public class SessionHelper {
@@ -16,7 +15,6 @@ public class SessionHelper {
 
     public static void updateSessionWithSubject(
             UserContext userContext,
-            SessionService sessionService,
             AuthSessionService authSessionService,
             AuthenticationService authenticationService,
             ConfigurationService configurationService) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -130,15 +130,11 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             var userExists = userProfile.isPresent();
             userContext.getAuthSession().setEmailAddress(emailAddress);
 
-            var session = userContext.getSession();
-            var sessionId = userContext.getAuthSession().getSessionId();
-
             if (codeStorageService.isBlockedForEmail(
                     emailAddress,
                     CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.PASSWORD_RESET)) {
                 LOG.info("User account is locked");
                 authSessionService.updateSession(userContext.getAuthSession());
-                sessionService.storeOrUpdateSession(session, sessionId);
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.AUTH_ACCOUNT_TEMPORARILY_LOCKED,
@@ -216,7 +212,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                             userMfaDetail.mfaMethodType(),
                             getLastDigitsOfPhoneNumber(userMfaDetail),
                             lockoutInformation);
-            sessionService.storeOrUpdateSession(session, sessionId);
             authSessionService.updateSession(authSession);
 
             LOG.info("Successfully processed request");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -137,6 +137,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                     emailAddress,
                     CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.PASSWORD_RESET)) {
                 LOG.info("User account is locked");
+                authSessionService.updateSession(userContext.getAuthSession());
                 sessionService.storeOrUpdateSession(session, sessionId);
 
                 auditService.submitAuditEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -165,8 +165,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                     pair("rpPairwiseId", rpPairwiseId));
 
             LOG.info("Setting internal common subject identifier in user session");
-            sessionService.storeOrUpdateSession(
-                    userContext.getSession(), userContext.getAuthSession().getSessionId());
 
             authSessionService.updateSession(
                     authSessionItem

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -247,7 +247,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
             }
 
-            sessionService.storeOrUpdateSession(session, sessionId);
+            authSessionService.updateSession(authSession);
 
             if (errorResponse.isPresent()) {
                 handleInvalidVerificationCode(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -269,7 +269,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             if (codeRequestType.equals(CodeRequestType.PW_RESET_MFA_SMS)) {
                 SessionHelper.updateSessionWithSubject(
                         userContext,
-                        sessionService,
                         authSessionService,
                         authenticationService,
                         configurationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -298,11 +298,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
         if (JourneyType.PASSWORD_RESET_MFA.equals(codeRequest.getJourneyType())) {
             SessionHelper.updateSessionWithSubject(
-                    userContext,
-                    sessionService,
-                    authSessionService,
-                    authenticationService,
-                    configurationService);
+                    userContext, authSessionService, authenticationService, configurationService);
         }
 
         var errorResponseMaybe = mfaCodeProcessor.validateCode();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -342,7 +342,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     maybeRpPairwiseId);
         }
 
-        sessionService.storeOrUpdateSession(session, sessionId);
+        authSessionService.updateSession(authSession);
 
         if (checkErrorCountsForReauthAndEmitFailedAuditEventIfBlocked(
                 codeRequest.getJourneyType(),
@@ -399,8 +399,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 "MFA code has been successfully verified for MFA type: {}. JourneyType: {}",
                 codeRequest.getMfaMethodType().getValue(),
                 journeyType);
-
-        sessionService.storeOrUpdateSession(session, userContext.getAuthSession().getSessionId());
 
         authSessionService.updateSession(
                 authSession

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -61,7 +61,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -333,7 +332,7 @@ class CheckUserExistsHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.ERROR_1045));
-            verify(sessionService, times(1)).storeOrUpdateSession(any(Session.class), anyString());
+            verify(authSessionService, times(1)).updateSession(any(AuthSessionItem.class));
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_ACCOUNT_TEMPORARILY_LOCKED,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -181,6 +181,7 @@ class CheckUserExistsHandlerTest {
             assertEquals(
                     JsonParser.parseString(result.getBody()),
                     JsonParser.parseString(expectedResponse));
+            verify(authSessionService).updateSession(any(AuthSessionItem.class));
             assertEquals(getExpectedInternalPairwiseId(), authSession.getInternalCommonSubjectId());
         }
 
@@ -237,6 +238,7 @@ class CheckUserExistsHandlerTest {
             assertEquals(
                     JsonParser.parseString(expectedResponse),
                     JsonParser.parseString(result.getBody()));
+            verify(authSessionService).updateSession(any(AuthSessionItem.class));
             assertEquals(getExpectedInternalPairwiseId(), authSession.getInternalCommonSubjectId());
         }
 
@@ -292,6 +294,7 @@ class CheckUserExistsHandlerTest {
             var event = userExistsRequest(EMAIL_ADDRESS);
 
             var result = handler.handleRequest(event, context);
+            verify(authSessionService).updateSession(any(AuthSessionItem.class));
             assertThat(result, hasStatus(200));
             assertTrue(
                     result.getBody()
@@ -357,6 +360,7 @@ class CheckUserExistsHandlerTest {
         assertThat(checkUserExistsResponse.email(), equalTo(EMAIL_ADDRESS));
         assertFalse(checkUserExistsResponse.doesUserExist());
         assertNull(authSession.getInternalCommonSubjectId());
+        verify(authSessionService).updateSession(any(AuthSessionItem.class));
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CHECK_USER_NO_ACCOUNT_WITH_EMAIL,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -50,7 +50,6 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -211,7 +210,7 @@ class LoginHandlerReauthenticationRedisTest {
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
+        verify(authSessionService, never()).updateSession(any(AuthSessionItem.class));
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -268,7 +268,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
             verify(cloudwatchMetricsService, never())
                     .incrementAuthenticationSuccess(
                             any(), any(), any(), any(), anyBoolean(), anyBoolean());
-            verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
+            verify(authSessionService, never()).updateSession(any(AuthSessionItem.class));
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -789,8 +789,7 @@ class LoginHandlerTest {
 
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1028));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
-
+        verify(authSessionService, never()).updateSession(any(AuthSessionItem.class));
         verify(codeStorageService).getIncorrectPasswordCount(EMAIL);
         verify(codeStorageService).deleteIncorrectPasswordCount(EMAIL);
         verify(codeStorageService).saveBlockedForEmail(any(), any(), anyLong());
@@ -845,7 +844,7 @@ class LoginHandlerTest {
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
+        verify(authSessionService, never()).updateSession(any(AuthSessionItem.class));
     }
 
     @ParameterizedTest
@@ -881,7 +880,7 @@ class LoginHandlerTest {
                                 configurationService.getMaxPasswordRetries()));
 
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
+        verify(authSessionService, never()).updateSession(any(AuthSessionItem.class));
     }
 
     @ParameterizedTest
@@ -941,7 +940,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1008));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
+        verify(authSessionService, never()).updateSession(any(AuthSessionItem.class));
     }
 
     @ParameterizedTest
@@ -992,7 +991,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1008));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
+        verify(authSessionService, never()).updateSession(any(AuthSessionItem.class));
     }
 
     @Test
@@ -1007,7 +1006,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
+        verify(authSessionService, never()).updateSession(any(AuthSessionItem.class));
     }
 
     @Test
@@ -1022,7 +1021,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1000));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
+        verify(authSessionService, never()).updateSession(any(AuthSessionItem.class));
     }
 
     @Test
@@ -1055,7 +1054,7 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
+        verify(authSessionService, never()).updateSession(any(AuthSessionItem.class));
     }
 
     @Test
@@ -1077,7 +1076,6 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(500));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1078));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test
@@ -1106,7 +1104,6 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(500));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1064));
         verifyNoInteractions(cloudwatchMetricsService);
-        verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -596,7 +596,6 @@ class ResetPasswordRequestHandlerTest {
             verify(awsSqsClient, never()).send(anyString());
             verify(codeStorageService, never())
                     .saveOtpCode(anyString(), anyString(), anyLong(), any(NotificationType.class));
-            verify(sessionService, never()).storeOrUpdateSession(any(Session.class), anyString());
             verifyNoInteractions(awsSqsClient);
         }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -272,8 +272,8 @@ class VerifyCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         verify(codeStorageService).deleteOtpCode(EMAIL, emailNotificationType);
-        verify(sessionService).storeOrUpdateSession(session, SESSION_ID);
         verifyNoInteractions(accountModifiersService);
+        verify(authSessionService).updateSession(any(AuthSessionItem.class));
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -645,7 +645,6 @@ class VerifyCodeHandlerTest {
         verify(codeStorageService)
                 .deleteOtpCode(EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS);
         verify(accountModifiersService, never()).removeAccountRecoveryBlockIfPresent(anyString());
-        verify(sessionService, times(1)).storeOrUpdateSession(session, SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -683,7 +682,7 @@ class VerifyCodeHandlerTest {
 
         assertThat(result, hasStatus(204));
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
-        verify(authSessionService)
+        verify(authSessionService, atLeastOnce())
                 .updateSession(
                         argThat(
                                 as ->

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -407,7 +407,7 @@ class VerifyMfaCodeHandlerTest {
                         "P0",
                         false,
                         true);
-        verify(authSessionService, times(2))
+        verify(authSessionService, times(3))
                 .updateSession(
                         argThat(
                                 state ->
@@ -454,7 +454,7 @@ class VerifyMfaCodeHandlerTest {
                         "P0",
                         false,
                         true);
-        verify(authSessionService, times(2))
+        verify(authSessionService, times(3))
                 .updateSession(
                         argThat(
                                 state ->

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
@@ -17,8 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class SessionServiceTest {
@@ -28,18 +26,6 @@ class SessionServiceTest {
     private final Json objectMapper = SerializationService.getInstance();
 
     private final SessionService sessionService = new SessionService(configuration, redis);
-
-    @Test
-    void shouldPersistSessionToRedisWithExpiry() throws Json.JsonException {
-        when(configuration.getSessionExpiry()).thenReturn(1234L);
-
-        var session = new Session();
-
-        sessionService.storeOrUpdateSession(session, SESSION_ID);
-
-        verify(redis, times(1))
-                .saveWithExpiry(SESSION_ID, objectMapper.writeValueAsString(session), 1234L);
-    }
 
     @Test
     void shouldRetrieveSessionUsingRequestHeaders() throws Json.JsonException {
@@ -134,16 +120,6 @@ class SessionServiceTest {
                         Map.of(CookieHelper.REQUEST_COOKIE_HEADER, "gs=session-id.456;"));
 
         assertFalse(session.isPresent());
-    }
-
-    @Test
-    void shouldDeleteSessionIdFromRedis() {
-        var session = new Session();
-
-        sessionService.storeOrUpdateSession(session, "session-id");
-        sessionService.deleteSessionFromRedis(SESSION_ID);
-
-        verify(redis).deleteValue(SESSION_ID);
     }
 
     private String generateSearlizedSession() throws Json.JsonException {


### PR DESCRIPTION
### Wider context of change: 

We are now ready to remove the redis session from authentication. The first part of this requires us to remove any leftover writing to redis. We are now sure these are redundant writes as this object is no longer updated.

### What’s changed: 
- Removes any calls to StoreOrUpdateSession in the authentication code.

### Manual testing: 

- Deploy to auth dev
- Run acceptance tests - all passed but there were a couple of undefined steps - assuming these are related to work currently under development
- Ran through a couple of journeys manually:
- 2FA 
- No 2FA
- Uplift
All as expected

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
