### PR TITLE
ATO-1670: Set client_name on auth session in StartHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -16,4 +16,5 @@ public record StartRequest(
         @Expose @SerializedName("state") String state,
         @Expose @SerializedName("client_id") String clientId,
         @Expose @SerializedName("redirect_uri") String redirectUri,
-        @Expose @SerializedName("scope") String scope) {}
+        @Expose @SerializedName("scope") String scope,
+        @Expose @SerializedName("client_name") String clientName) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -186,6 +186,7 @@ public class StartHandler
                         retrieveLevelOfConfidence(startRequest.requestedLevelOfConfidence()));
             }
             authSession.setClientId(startRequest.clientId());
+            authSession.setClientName(startRequest.clientName());
 
             isUserAuthenticatedWithValidProfile =
                     startRequest.authenticated() && !startService.isUserProfileEmpty(authSession);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -67,6 +67,7 @@ import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_SMS_CODE;
 import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.CLIENT_ID;
+import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.CLIENT_NAME;
 import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.DI_PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.ENCODED_DEVICE_DETAILS;
@@ -549,6 +550,7 @@ class StartHandlerTest {
                         STATE.toString(),
                         TEST_CLIENT_ID,
                         REDIRECT_URL.toString(),
-                        SCOPE.toString()));
+                        SCOPE.toString(),
+                        CLIENT_NAME));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -167,6 +167,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 actualAuthSession.getRequestedLevelOfConfidence(),
                 equalTo(requestedLevelOfConfidenceOpt.orElse(null)));
         assertThat(actualAuthSession.getClientId(), equalTo(CLIENT_ID));
+        assertThat(actualAuthSession.getClientName(), equalTo(TEST_CLIENT_NAME));
     }
 
     @Test
@@ -209,6 +210,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 actualAuthSession.getRequestedLevelOfConfidence(),
                 equalTo(LevelOfConfidence.LOW_LEVEL));
         assertThat(actualAuthSession.getClientId(), equalTo(CLIENT_ID));
+        assertThat(actualAuthSession.getClientName(), equalTo(TEST_CLIENT_NAME));
         assertTxmaAuditEventsSubmittedWithMatchingNames(
                 txmaAuditQueue, List.of(AUTH_START_INFO_FOUND, AUTH_REAUTH_REQUESTED));
     }
@@ -529,7 +531,9 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 "client_id",
                                 CLIENT_ID,
                                 "redirect_uri",
-                                redirectUri));
+                                redirectUri,
+                                "client_name",
+                                TEST_CLIENT_NAME));
         previousSessionIdOpt.ifPresent(
                 previousSessionId -> requestBodyMap.put("previous-session-id", previousSessionId));
         requestedLevelOfConfidenceOpt.ifPresent(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -38,6 +38,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_REQUESTED_LEVEL_OF_CONFIDENCE =
             "RequestedLevelOfConfidence";
     public static final String ATTRIBUTE_CLIENT_ID = "ClientId";
+    public static final String ATTRIBUTE_CLIENT_NAME = "ClientName";
 
     public enum AccountState {
         NEW,
@@ -75,6 +76,7 @@ public class AuthSessionItem {
     private CredentialTrustLevel requestedCredentialStrength;
     private LevelOfConfidence requestedLevelOfConfidence;
     private String clientId;
+    private String clientName;
 
     public AuthSessionItem() {
         this.codeRequestCountMap = new HashMap<>();
@@ -385,6 +387,20 @@ public class AuthSessionItem {
 
     public AuthSessionItem withClientId(String clientId) {
         this.clientId = clientId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_CLIENT_NAME)
+    public String getClientName() {
+        return clientName;
+    }
+
+    public void setClientName(String clientName) {
+        this.clientName = clientName;
+    }
+
+    public AuthSessionItem withClientName(String clientName) {
+        this.clientName = clientName;
         return this;
     }
 


### PR DESCRIPTION
### Wider context of change

We are now sending the `client_name` claim from the frontend to the backend. We would like to use this claim instead of using the ClientRegistry.getClientName() method. To do this, we will need to add this claim to the auth session

### What’s changed

The `clientName` field has been added to the auth session. We are also setting this field in the StartHandler, using the claim we get from the frontend.

### Manual testing

Deployed to sandpit. Started a journey and checked the AuthSession dynamo table in AWS. Confirmed that the ClientName field was set there.

Finished a couple of journeys and they all passed successfully.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. n/a
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a

