### PR TITLE
ATO-1440: Basic OTel configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,7 @@ subprojects {
         xray
         pact_consumer
         pact_provider
+        open_telemetry
     }
 
     // Check dependencies using:
@@ -226,6 +227,10 @@ subprojects {
         pact_consumer "au.com.dius.pact.consumer:junit5:${dependencyVersions.pact}"
 
         pact_provider "au.com.dius.pact.provider:junit5:${dependencyVersions.pact}"
+
+        open_telemetry platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.15.0-alpha"),
+                "io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2-autoconfigure",
+                "io.opentelemetry.instrumentation:opentelemetry-java-http-client"
     }
 }
 

--- a/client-registry-api/build.gradle
+++ b/client-registry-api/build.gradle
@@ -21,7 +21,8 @@ dependencies {
 
     implementation project(":orchestration-shared")
 
-    runtimeOnly configurations.logging_runtime
+    runtimeOnly configurations.logging_runtime,
+            configurations.open_telemetry
 
     testImplementation configurations.tests,
             configurations.lambda_tests,

--- a/doc-checking-app-api/build.gradle
+++ b/doc-checking-app-api/build.gradle
@@ -21,7 +21,8 @@ dependencies {
 
     implementation project(":orchestration-shared")
 
-    runtimeOnly configurations.logging_runtime
+    runtimeOnly configurations.logging_runtime,
+            configurations.open_telemetry
 
     testImplementation configurations.tests,
             configurations.apache,

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -22,7 +22,8 @@ dependencies {
 
     implementation project(":orchestration-shared")
 
-    runtimeOnly configurations.logging_runtime
+    runtimeOnly configurations.logging_runtime,
+            configurations.open_telemetry
 
     testImplementation configurations.tests,
             configurations.apache,

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -27,6 +27,8 @@ dependencies {
             project(":client-registry-api"),
             project(":doc-checking-app-api")
 
+    runtimeOnly configurations.open_telemetry
+
     implementation project(path: ':ipv-api')
 
     testImplementation configurations.tests,

--- a/template.yaml
+++ b/template.yaml
@@ -333,6 +333,7 @@ Globals:
                 dynatraceSecretArn,
               ]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
+        OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING: "true"
         JAVA_TOOL_OPTIONS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 '--add-reads=jdk.jfr=ALL-UNNAMED'"
     MemorySize: 1536
     Timeout: 30


### PR DESCRIPTION
### Wider context of change
We would like to instrument our lambdas with Open Telemetry (OTel) so that we can see more detailed traces in Dynatrace. The OTel libraries have auto-instrumentation for most of the stuff we need, so just installing it and setting an env var is enough to give us 90%.

### What’s changed
- Install the OTel packages in all Orch modules
- Set the environment variable to enable lambda tracing conditionally

### Manual testing

Tested in dev, including a function without otel (slack notifications)

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
