### PR TITLE
AUT-4297: rename mobile channel to generic app channel

### DIFF
--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -83,7 +83,7 @@ class ClientConfigValidationServiceTest {
                         null,
                         null,
                         null,
-                        Channel.MOBILE.getValue()),
+                        Channel.GENERIC_APP.getValue()),
                 Arguments.of(
                         singletonList("http://localhost/post-redirect-logout"),
                         "http://back-channel.com",

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -485,7 +485,7 @@ class AuthorisationHandlerTest {
                     arguments(null, Channel.WEB.getValue()),
                     arguments(Channel.WEB.getValue(), Channel.WEB.getValue()),
                     arguments(Channel.STRATEGIC_APP.getValue(), Channel.STRATEGIC_APP.getValue()),
-                    arguments(Channel.MOBILE.getValue(), Channel.MOBILE.getValue()));
+                    arguments(Channel.GENERIC_APP.getValue(), Channel.GENERIC_APP.getValue()));
         }
 
         @ParameterizedTest

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Channel.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/Channel.java
@@ -3,7 +3,7 @@ package uk.gov.di.orchestration.shared.entity;
 public enum Channel {
     WEB("web"),
     STRATEGIC_APP("strategic_app"),
-    MOBILE("mobile");
+    GENERIC_APP("generic_app");
 
     private final String value;
 


### PR DESCRIPTION
### Wider context of change
Part of enabling the generic_app flow on auth. This property is given by RP, and passed to Auth via orch. Orch only does validation that it is a valid channel. This channel currently has no uses, so is not live.

This renaming is because "mobile" felt like it lacked the specificity of what this channel really means, and could easily be confused with all mobile, and not generic mobile (in contrast to specific mobile as for strategic app)

### What’s changed
Changed the name of the channel from "mobile" to "generic_app"

### Manual testing
N/A

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs
Original PR: https://github.com/govuk-one-login/authentication-api/pull/6519
