### PR TITLE
AUT-4249: Allow VerifyMfaCode API to use BACKUP AUTH_APP

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -187,7 +187,7 @@ class AuthAppCodeProcessorTest {
 
     @ParameterizedTest
     @MethodSource("validatorParamsWithoutRegistrationJourney")
-    void returnsAnErrorIfDefaultMethodIsNotAuthAppForMigratedUser(JourneyType journeyType) {
+    void returnsNoErrorOnValidAuthCodeToBackupMethodForMigratedUser(JourneyType journeyType) {
         when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
 
@@ -218,34 +218,7 @@ class AuthAppCodeProcessorTest {
                         mockAuditService,
                         mockAccountModifiersService);
 
-        assertEquals(Optional.of(ErrorResponse.ERROR_1081), authAppCodeProcessor.validateCode());
-    }
-
-    @ParameterizedTest
-    @MethodSource("validatorParamsWithoutRegistrationJourney")
-    void returnsAnErrorIfThereIsNoDefaultMethodForMigratedUser(JourneyType journeyType) {
-        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-
-        var userCredentials = new UserCredentials().withMfaMethods(List.of(BACKUP_AUTH_APP_METHOD));
-        when(mockDynamoService.getUserCredentialsFromEmail(EMAIL)).thenReturn(userCredentials);
-        when(mockDynamoService.getUserProfileByEmail(EMAIL))
-                .thenReturn(new UserProfile().withMfaMethodsMigrated(true));
-
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, "000000", journeyType);
-
-        this.authAppCodeProcessor =
-                new AuthAppCodeProcessor(
-                        mockUserContext,
-                        mockCodeStorageService,
-                        mockConfigurationService,
-                        mockDynamoService,
-                        MAX_RETRIES,
-                        codeRequest,
-                        mockAuditService,
-                        mockAccountModifiersService);
-
-        assertEquals(Optional.of(ErrorResponse.ERROR_1081), authAppCodeProcessor.validateCode());
+        assertEquals(Optional.empty(), authAppCodeProcessor.validateCode());
     }
 
     @ParameterizedTest

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -171,7 +171,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("existingUserAuthAppJourneyTypes")
-    void whenAuthAppMethodIsBackupReturnsErrorForMigratedUser(JourneyType journeyType) {
+    void whenAuthAppMethodIsBackupReturns204ForMigratedUser(JourneyType journeyType) {
         var emailAddressOfMigratedUser = "migrated.user@example.com";
         setupUser(sessionId, emailAddressOfMigratedUser, true);
 
@@ -200,11 +200,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Optional.of(codeRequest),
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
-        assertThat(response, hasStatus(400));
-        assertTrue(
-                response.getBody()
-                        .contains(
-                                "Attempting to validate auth app code for user without auth app method"));
+        assertThat(response, hasStatus(204));
     }
 
     @Test


### PR DESCRIPTION
## What

Previously we had restrictive logic that only allowed a AUTH_APP to be verified if it was the DEFAULT MFA method.

Here this is broadened to allow use a users AUTH_APP MFA method that has any priority.

This is OK for now as we only allow one AUTH_APP MFA method per user. Should this change in the future the VerifyMfaCode API will need a new `mfaMethodId` attribute to allow the frontend to specify which MFA method the code is for.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
