### PR TITLE
ATO-1679: Send is_smoke_test claim to auth frontend

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -43,6 +43,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISATION_INITIATED;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISATION_REQUEST_PARSED;
@@ -367,6 +368,7 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
                 equalTo(credentialTrustLevel.getValue()));
         assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("scope")));
         assertTrue(Objects.isNull(signedJWT.getJWTClaimsSet().getClaim("login_hint")));
+        assertFalse(signedJWT.getJWTClaimsSet().getBooleanClaim("is_smoke_test"));
     }
 
     private String getLocationResponseHeader(APIGatewayProxyResponseEvent response) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -935,7 +935,8 @@ public class AuthorisationHandler
                         .claim("channel", client.getChannel().toLowerCase())
                         .claim("authenticated", orchSession.getAuthenticated())
                         .claim("scope", authenticationRequest.getScope().toString())
-                        .claim("login_hint", authenticationRequest.getLoginHint());
+                        .claim("login_hint", authenticationRequest.getLoginHint())
+                        .claim("is_smoke_test", client.isSmokeTest());
 
         previousSessionId.ifPresent(id -> claimsBuilder.claim("previous_session_id", id));
         gaOpt.ifPresent(ga -> claimsBuilder.claim("_ga", ga));


### PR DESCRIPTION
### Wider context of change

We would like to move auth away from using their own client registry, and have them rely on orch's client registry instead. To do this, we need to send claims from orch to auth that represent the values in the client registry.

### What’s changed

This PR adds the claim `is_smoke_test` to the JAR that is sent from orch to auth. 

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

PR for adding claim to orch stub: TODO
