### PR TITLE
ATO-1684: Validate auth code is not empty string

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -191,7 +191,7 @@ public class TokenService {
                                 OAuth2Error.INVALID_REQUEST_CODE,
                                 "Request is missing redirect_uri parameter"));
             }
-            if (!requestBody.containsKey("code")) {
+            if (!requestBody.containsKey("code") || requestBody.get("code").isEmpty()) {
                 return Optional.of(
                         new ErrorObject(
                                 OAuth2Error.INVALID_REQUEST_CODE,

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
@@ -421,6 +421,26 @@ class TokenServiceTest {
     }
 
     @Test
+    void shouldReturnErrorIfCodeIEmptyStringWhenValidatingTokenRequest() {
+        Map<String, List<String>> customParams = new HashMap<>();
+        customParams.put(
+                "grant_type", Collections.singletonList(GrantType.AUTHORIZATION_CODE.getValue()));
+        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
+        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
+        customParams.put("code", Collections.singletonList(""));
+        Optional<ErrorObject> errorObject =
+                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
+
+        assertThat(
+                errorObject,
+                equalTo(
+                        Optional.of(
+                                new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE,
+                                        "Request is missing code parameter"))));
+    }
+
+    @Test
     void shouldReturnErrorIfGrantIsInvalidWhenValidatingTokenRequest() {
         Map<String, List<String>> customParams = new HashMap<>();
         customParams.put("grant_type", Collections.singletonList("client_credentials"));


### PR DESCRIPTION
### Wider context of change:
We've seen a couple of RP's attach empty strings in the auth code field, which causes our DynamoDB query to throw an exception as the AttributeValue cannot be an empty string.

To fix this, we can add another condition to our validation which checks the auth code is not empty

### What’s changed:
We now return an `invalid_request` error when the auth code is an empty string.

### Manual testing:
- I don't think this needs manually testing but happy to be challenged on it!

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
