### PR TITLE
ATO-1676: use cookie_consent_shared instead of client registry

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -18,4 +18,5 @@ public record StartRequest(
         @Expose @SerializedName("redirect_uri") String redirectUri,
         @Expose @SerializedName("scope") String scope,
         @Expose @SerializedName("client_name") String clientName,
-        @Expose @SerializedName("service_type") String serviceType) {}
+        @Expose @SerializedName("service_type") String serviceType,
+        @Expose @SerializedName("cookie_consent_shared") boolean isCookieConsentShared) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -211,11 +211,12 @@ public class StartHandler
                             authSession.getClientName(),
                             scopes,
                             redirectURI,
-                            state);
+                            state,
+                            startRequest.isCookieConsentShared());
 
             var cookieConsent =
                     startService.getCookieConsentValue(
-                            startRequest.cookieConsent(), startRequest.clientId());
+                            startRequest.cookieConsent(), startRequest.isCookieConsentShared());
             var gaTrackingId = startRequest.ga();
             var reauthenticateHeader =
                     getHeaderValueFromHeaders(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -503,7 +503,7 @@ class StartHandlerTest {
         when(startService.buildUserContext(eq(session), any(AuthSessionItem.class)))
                 .thenReturn(userContext);
         when(startService.buildClientStartInfo(
-                        eq(clientRegistry), any(), any(), any(), any(), any()))
+                        eq(clientRegistry), any(), any(), any(), any(), any(), anyBoolean()))
                 .thenReturn(clientStartInfo);
         when(startService.buildUserStartInfo(
                         eq(userContext),
@@ -554,6 +554,7 @@ class StartHandlerTest {
                         REDIRECT_URL.toString(),
                         SCOPE.toString(),
                         CLIENT_NAME,
-                        ServiceType.MANDATORY.toString()));
+                        ServiceType.MANDATORY.toString(),
+                        false));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -526,7 +526,8 @@ class StartServiceTest {
                         CLIENT_NAME,
                         scopes.toStringList(),
                         REDIRECT_URI,
-                        STATE);
+                        STATE,
+                        cookieConsentShared);
 
         assertThat(clientStartInfo.cookieConsentShared(), equalTo(cookieConsentShared));
         assertThat(clientStartInfo.clientName(), equalTo(CLIENT_NAME));
@@ -555,7 +556,7 @@ class StartServiceTest {
                                         cookieConsentShared)));
 
         assertThat(
-                startService.getCookieConsentValue(cookieConsentValue, CLIENT_ID.getValue()),
+                startService.getCookieConsentValue(cookieConsentValue, cookieConsentShared),
                 equalTo(expectedValue));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -535,7 +535,9 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 "client_name",
                                 TEST_CLIENT_NAME,
                                 "service_type",
-                                ServiceType.MANDATORY.toString()));
+                                ServiceType.MANDATORY.toString(),
+                                "cookie_consent_shared",
+                                false));
         previousSessionIdOpt.ifPresent(
                 previousSessionId -> requestBodyMap.put("previous-session-id", previousSessionId));
         requestedLevelOfConfidenceOpt.ifPresent(


### PR DESCRIPTION
### Wider context of change

We would like to move authentication away from using the ClientRegistry. To do this we need to pass information about the client from orch to auth, and store them on the auth session. A few fields we need have already been added as part of the client session migration.

### What’s changed

This PR swaps to using the cookie_consent_shared claim sent from orch instead of the ClientRegistry.isCookieConsentShared() method.

### Manual testing

Tested in authdev2, did a couple of journeys and all got the cookie from the frontend.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
