### PR TITLE
ATO-1686: Send subject_type claim to auth frontend

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -11,6 +11,7 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
+import com.nimbusds.openid.connect.sdk.SubjectType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -369,6 +370,9 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
         assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("scope")));
         assertTrue(Objects.isNull(signedJWT.getJWTClaimsSet().getClaim("login_hint")));
         assertFalse(signedJWT.getJWTClaimsSet().getBooleanClaim("is_smoke_test"));
+        assertThat(
+                signedJWT.getJWTClaimsSet().getClaim("subject_type"),
+                equalTo(SubjectType.PUBLIC.toString()));
     }
 
     private String getLocationResponseHeader(APIGatewayProxyResponseEvent response) {
@@ -387,7 +391,7 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
                 "https://example.com",
                 String.valueOf(ServiceType.MANDATORY),
                 RP_SECTOR_URI,
-                "public",
+                SubjectType.PUBLIC.toString(),
                 ClientType.WEB,
                 ES256.getName(),
                 identitySupported);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -936,7 +936,8 @@ public class AuthorisationHandler
                         .claim("authenticated", orchSession.getAuthenticated())
                         .claim("scope", authenticationRequest.getScope().toString())
                         .claim("login_hint", authenticationRequest.getLoginHint())
-                        .claim("is_smoke_test", client.isSmokeTest());
+                        .claim("is_smoke_test", client.isSmokeTest())
+                        .claim("subject_type", client.getSubjectType());
 
         previousSessionId.ifPresent(id -> claimsBuilder.claim("previous_session_id", id));
         gaOpt.ifPresent(ga -> claimsBuilder.claim("_ga", ga));


### PR DESCRIPTION
### Wider context of change

We would like to move auth away from using their own client registry, and have them rely on orch's client registry instead. To do this, we need to send claims from orch to auth that represent the values in the client registry.

### What’s changed

This PR adds the claim `subject_type` to the JAR that is sent from orch to auth. 

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

TODO: PR for adding claim to orch stub
