### PR TITLE
ATO-1657: Add secondary index on internalCommonSubjectId for OrchSession

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -3,6 +3,7 @@ package uk.gov.di.orchestration.shared.entity;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -151,6 +152,7 @@ public class OrchSessionItem {
         return this;
     }
 
+    @DynamoDbSecondaryPartitionKey(indexNames = {"InternalCommonSubjectIdIndex"})
     @DynamoDbAttribute(ATTRIBUTE_INTERNAL_COMMON_SUBJECT_ID)
     public String getInternalCommonSubjectId() {
         return internalCommonSubjectId;

--- a/template.yaml
+++ b/template.yaml
@@ -463,6 +463,15 @@ Resources:
       AttributeDefinitions:
         - AttributeName: SessionId
           AttributeType: S
+        - AttributeName: InternalCommonSubjectId
+          AttributeType: S
+      GlobalSecondaryIndexes:
+        - IndexName: InternalCommonSubjectIdIndex
+          KeySchema:
+            - AttributeName: InternalCommonSubjectId
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
       KeySchema:
         - AttributeName: SessionId
           KeyType: HASH


### PR DESCRIPTION
### Wider context of change

As part of the global logout initiative, we would like to have the ability to logout of all sessions based on an internal common subject identifier. To do this, we need to update the orch session table to add a secondary index on internalCommonSubjectId


### What’s changed

This PR adds a new global secondary index for the `OrchSession` table, on the field `internalCommonSubjectId`.

### Manual testing

Deployed to orch dev. Ran a query against the new secondary index and confirmed the index worked.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. See above
- [x] Successfully run Authentication acceptance tests against sandpit or not required. n/a
