### PR TITLE
ATO-1688: set SubjectType on AuthSessionItem

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -21,4 +21,5 @@ public record StartRequest(
         @Expose @SerializedName("service_type") String serviceType,
         @Expose @SerializedName("cookie_consent_shared") boolean isCookieConsentShared,
         @Expose @SerializedName("is_smoke_test") boolean isSmokeTest,
-        @Expose @SerializedName("is_one_login_service") boolean isOneLoginService) {}
+        @Expose @SerializedName("is_one_login_service") boolean isOneLoginService,
+        @Expose @SerializedName("subject_type") String subjectType) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -188,6 +188,8 @@ public class StartHandler
             authSession.setClientId(startRequest.clientId());
             authSession.setClientName(startRequest.clientName());
             authSession.setIsSmokeTest(startRequest.isSmokeTest());
+            authSession.setIsOneLoginService(startRequest.isOneLoginService());
+            authSession.setSubjectType(startRequest.subjectType());
 
             isUserAuthenticatedWithValidProfile =
                     startRequest.authenticated() && !startService.isUserProfileEmpty(authSession);
@@ -197,10 +199,9 @@ public class StartHandler
                             requestedCredentialTrustLevel,
                             authSession.getAchievedCredentialStrength());
 
-            authSessionService.addSession(
-                    authSession
-                            .withUpliftRequired(upliftRequired)
-                            .withIsOneLoginService(startRequest.isOneLoginService()));
+            LOG.info("subject type is: {}", startRequest.subjectType());
+
+            authSessionService.addSession(authSession.withUpliftRequired(upliftRequired));
 
             var userContext = startService.buildUserContext(session, authSession);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -92,6 +92,7 @@ class StartHandlerTest {
     private static final Json objectMapper = SerializationService.getInstance();
     private static final String COOKIE_CONSENT = "accept";
     private static final Scope SCOPE = new Scope(OIDCScopeValue.OPENID.getValue());
+    private static final String TEST_SUBJECT_TYPE = "pairwise";
 
     private StartHandler handler;
     private final Context context = mock(Context.class);
@@ -557,6 +558,7 @@ class StartHandlerTest {
                         ServiceType.MANDATORY.toString(),
                         false,
                         false,
-                        false));
+                        false,
+                        TEST_SUBJECT_TYPE));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -67,6 +67,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     public static final String PREVIOUS_SESSION_ID = "4waJ14KA9IyxKzY7bIGIA3hUDos";
     private static final Optional<String> WITH_PREVIOUS_SESSION = Optional.of(PREVIOUS_SESSION_ID);
     private static final Optional<String> NO_PREVIOUS_SESSION = Optional.empty();
+    private static final String TEST_SUBJECT_TYPE = "pairwise";
 
     @RegisterExtension
     protected static final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
@@ -169,6 +170,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(actualAuthSession.getClientId(), equalTo(CLIENT_ID));
         assertThat(actualAuthSession.getClientName(), equalTo(TEST_CLIENT_NAME));
         assertFalse(actualAuthSession.getIsSmokeTest());
+        assertThat(actualAuthSession.getSubjectType(), equalTo(TEST_SUBJECT_TYPE));
     }
 
     @Test
@@ -534,7 +536,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 Map.entry("service_type", ServiceType.MANDATORY.toString()),
                                 Map.entry("cookie_consent_shared", false),
                                 Map.entry("is_smoke_test", false),
-                                Map.entry("is_one_login_service", false)));
+                                Map.entry("is_one_login_service", false),
+                                Map.entry("subject_type", TEST_SUBJECT_TYPE)));
         previousSessionIdOpt.ifPresent(
                 previousSessionId -> requestBodyMap.put("previous-session-id", previousSessionId));
         requestedLevelOfConfidenceOpt.ifPresent(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -41,6 +41,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_CLIENT_NAME = "ClientName";
     public static final String ATTRIBUTE_IS_SMOKE_TEST = "IsSmokeTest";
     public static final String ATTRIBUTE_IS_ONE_LOGIN_SERVICE = "IsOneLoginService";
+    public static final String ATTRIBUTE_SUBJECT_TYPE = "SubjectType";
 
     public enum AccountState {
         NEW,
@@ -81,6 +82,7 @@ public class AuthSessionItem {
     private String clientName;
     private boolean isSmokeTest;
     private boolean isOneLoginService;
+    private String subjectType;
 
     public AuthSessionItem() {
         this.codeRequestCountMap = new HashMap<>();
@@ -433,6 +435,20 @@ public class AuthSessionItem {
 
     public AuthSessionItem withIsOneLoginService(boolean isOneLoginService) {
         this.isOneLoginService = isOneLoginService;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_SUBJECT_TYPE)
+    public String getSubjectType() {
+        return subjectType;
+    }
+
+    public void setSubjectType(String subjectType) {
+        this.subjectType = subjectType;
+    }
+
+    public AuthSessionItem withSubjectType(String subjectType) {
+        this.subjectType = subjectType;
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -13,6 +13,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.nimbusds.openid.connect.sdk.SubjectType.PUBLIC;
@@ -28,6 +29,9 @@ public class ClientSubjectHelper {
             AuthSessionItem authSession,
             AuthenticationService authenticationService,
             String internalSectorURI) {
+        LOG.info(
+                "clientSubjectHelper subjectType is equal to auth session {}",
+                Objects.equals(client.getSubjectType(), authSession.getSubjectType()));
         if (PUBLIC.toString().equalsIgnoreCase(client.getSubjectType())) {
             return new Subject(userProfile.getPublicSubjectID());
         } else {


### PR DESCRIPTION
### Wider context of change

We would like to move authentication away from using the ClientRegistry. To do this we need to pass information about the client from orch to auth, and store them on the auth session. A few fields we need have already been added as part of the client session migration.

### What’s changed

This PR gets subject_type from the frontend and sets it on the AuthSession. It also adds a console log to check the value

### Manual testing

Ran on authdev2 with frontend change

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
