### PR TITLE
ATO-1682: Add logging to check for isSmokeTest equality

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -485,8 +485,11 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         if (userProfile.getTermsAndConditions() == null) {
             return false;
         }
-        var isSmokeTestClient =
+        boolean isSmokeTestClient =
                 userContext.getClient().map(ClientRegistry::isSmokeTest).orElse(false);
+        LOG.info(
+                "isSmokeTest on auth session equal to client registry? {}",
+                userContext.getAuthSession().getIsSmokeTest() == isSmokeTestClient);
         return TermsAndConditionsHelper.hasTermsAndConditionsBeenAccepted(
                 userProfile.getTermsAndConditions(),
                 configurationService.getTermsAndConditionsVersion(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -251,8 +251,11 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                     if (request.getPhoneNumber() == null) {
                         return generateApiGatewayProxyResponse(400, ERROR_1011);
                     }
-                    var isSmokeTest =
+                    boolean isSmokeTest =
                             userContext.getClient().map(ClientRegistry::isSmokeTest).orElse(false);
+                    LOG.info(
+                            "isSmokeTest on auth session equal to client registry? {}",
+                            userContext.getAuthSession().getIsSmokeTest() == isSmokeTest);
                     var errorResponse =
                             ValidationHelper.validatePhoneNumber(
                                     request.getPhoneNumber(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -205,9 +205,12 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
     }
 
     private boolean isValidTestNumberForEnvironment(String phoneNumber) {
+        boolean isSmokeTestClient =
+                userContext.getClient().map(ClientRegistry::isSmokeTest).orElse(false);
+        LOG.info(
+                "isSmokeTest on auth session equal to client registry? {}",
+                userContext.getAuthSession().getIsSmokeTest() == isSmokeTestClient);
         return ValidationHelper.isValidTestNumberForEnvironment(
-                phoneNumber,
-                configurationService.getEnvironment(),
-                userContext.getClient().map(ClientRegistry::isSmokeTest).orElse(false));
+                phoneNumber, configurationService.getEnvironment(), isSmokeTestClient);
     }
 }


### PR DESCRIPTION
### Wider context of change

We would like to move authentication away from using the ClientRegistry. To do this we need to pass information about the client from orch to auth, and store them on the auth session. A few fields we need have already been added as part of the client session migration.

We are storing the isSmokeTest claim on the auth session. We would like to check that this claim is the same as the one on the client registry

### What’s changed

This PR logs whether the new `isSmokeTest` claim is equal to the value from the client registry, just before all the places where the getter is used.

### Manual testing

Logging, no testing needed

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
