### PR TITLE
ATO-1471: remove table policies

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -10,10 +10,6 @@ data "aws_dynamodb_table" "client_registry_table" {
   name = "${var.environment}-client-registry"
 }
 
-data "aws_dynamodb_table" "identity_credentials_table" {
-  name = "${var.environment}-identity-credentials"
-}
-
 data "aws_dynamodb_table" "doc_app_cri_credential_table" {
   name = "${var.environment}-doc-app-credential"
 }
@@ -180,95 +176,6 @@ data "aws_iam_policy_document" "dynamo_client_registration_read_policy_document"
       "kms:DescribeKey",
     ]
     resources = [local.client_registry_encryption_key_arn]
-  }
-}
-
-data "aws_iam_policy_document" "dynamo_identity_write_access_policy_document" {
-  statement {
-    sid    = "AllowAccessToDynamoTables"
-    effect = "Allow"
-
-    actions = [
-      "dynamodb:UpdateItem",
-      "dynamodb:PutItem",
-    ]
-    resources = [
-      data.aws_dynamodb_table.identity_credentials_table.arn,
-    ]
-  }
-
-  statement {
-    sid    = "AllowAccessToKms"
-    effect = "Allow"
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:CreateGrant",
-      "kms:DescribeKey",
-    ]
-    resources = [local.identity_credentials_encryption_key_arn]
-  }
-}
-
-data "aws_iam_policy_document" "dynamo_identity_delete_access_policy_document" {
-  statement {
-    sid    = "AllowAccessToDynamoTables"
-    effect = "Allow"
-
-    actions = [
-      "dynamodb:DeleteItem",
-    ]
-    resources = [
-      data.aws_dynamodb_table.identity_credentials_table.arn,
-    ]
-  }
-
-  statement {
-    sid    = "AllowAccessToKms"
-    effect = "Allow"
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:CreateGrant",
-      "kms:DescribeKey",
-    ]
-    resources = [local.identity_credentials_encryption_key_arn]
-  }
-}
-
-data "aws_iam_policy_document" "dynamo_identity_read_access_policy_document" {
-  statement {
-    sid    = "AllowAccessToDynamoTables"
-    effect = "Allow"
-
-    actions = [
-      "dynamodb:BatchGetItem",
-      "dynamodb:DescribeTable",
-      "dynamodb:Get*",
-      "dynamodb:Query",
-      "dynamodb:Scan",
-    ]
-    resources = [
-      data.aws_dynamodb_table.identity_credentials_table.arn,
-    ]
-  }
-
-  statement {
-    sid    = "AllowAccessToKms"
-    effect = "Allow"
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:CreateGrant",
-      "kms:DescribeKey",
-    ]
-    resources = [local.identity_credentials_encryption_key_arn]
   }
 }
 
@@ -949,29 +856,6 @@ resource "aws_iam_policy" "dynamo_user_write_access_policy" {
   policy = data.aws_iam_policy_document.dynamo_user_write_policy_document.json
 }
 
-resource "aws_iam_policy" "dynamo_identity_credentials_write_access_policy" {
-  name_prefix = "dynamo-access-policy"
-  path        = "/${var.environment}/oidc-default/"
-  description = "IAM policy for managing write permissions to the Dynamo Identity credentials table"
-
-  policy = data.aws_iam_policy_document.dynamo_identity_write_access_policy_document.json
-}
-
-resource "aws_iam_policy" "dynamo_identity_credentials_read_access_policy" {
-  name_prefix = "dynamo-access-policy"
-  path        = "/${var.environment}/oidc-default/"
-  description = "IAM policy for managing read permissions to the Dynamo Identity credentials table"
-
-  policy = data.aws_iam_policy_document.dynamo_identity_read_access_policy_document.json
-}
-
-resource "aws_iam_policy" "dynamo_identity_credentials_delete_access_policy" {
-  name_prefix = "dynamo-access-policy"
-  path        = "/${var.environment}/oidc-default/"
-  description = "IAM policy for managing delete permissions to the Dynamo Identity credentials table"
-
-  policy = data.aws_iam_policy_document.dynamo_identity_delete_access_policy_document.json
-}
 
 resource "aws_iam_policy" "dynamo_doc_app_write_access_policy" {
   name_prefix = "dynamo-access-policy"

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -54,11 +54,9 @@ locals {
   di_auth_ext_api_id                          = data.terraform_remote_state.auth-ext-api.outputs.di_auth_ext_api_id
   vpce_id                                     = data.terraform_remote_state.auth-ext-api.outputs.vpce_id
   client_registry_encryption_key_arn          = data.terraform_remote_state.shared.outputs.client_registry_encryption_key_arn
-  identity_credentials_encryption_key_arn     = data.terraform_remote_state.shared.outputs.identity_credentials_encryption_key_arn
   account_modifiers_encryption_policy_arn     = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
   common_passwords_encryption_policy_arn      = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
   client_registry_encryption_policy_arn       = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
-  identity_credentials_encryption_policy_arn  = data.terraform_remote_state.shared.outputs.identity_credentials_encryption_policy_arn
   doc_app_credential_encryption_policy_arn    = data.terraform_remote_state.shared.outputs.doc_app_credential_encryption_policy_arn
   doc_app_credential_encryption_key_arn       = data.terraform_remote_state.shared.outputs.doc_app_credential_encryption_key_arn
   user_credentials_encryption_policy_arn      = data.terraform_remote_state.shared.outputs.user_credentials_encryption_policy_arn

--- a/ci/terraform/shared/kms-policies.tf
+++ b/ci/terraform/shared/kms-policies.tf
@@ -64,27 +64,6 @@ data "aws_iam_policy_document" "doc_app_credential_encryption_key_policy_documen
   }
 }
 
-resource "aws_iam_policy" "identity_credentials_encryption_key_kms_policy" {
-  name        = "${var.environment}-identity-credentials-table-encryption-key-kms-policy"
-  path        = "/"
-  description = "IAM policy for managing KMS encryption of the identity credentials table"
-
-  policy = data.aws_iam_policy_document.identity_credentials_encryption_key_policy_document.json
-}
-
-data "aws_iam_policy_document" "identity_credentials_encryption_key_policy_document" {
-  statement {
-    sid    = "AllowAccessToIdentityCredentialsTableKmsEncryptionKey"
-    effect = "Allow"
-
-    actions = [
-      "kms:*",
-    ]
-    resources = [
-      aws_kms_key.identity_credentials_table_encryption_key.arn
-    ]
-  }
-}
 
 resource "aws_iam_policy" "client_registry_encryption_key_kms_policy" {
   name        = "${var.environment}-client-registry-table-encryption-key-kms-policy"

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -201,9 +201,6 @@ output "client_registry_encryption_policy_arn" {
   value = aws_iam_policy.client_registry_encryption_key_kms_policy.arn
 }
 
-output "identity_credentials_encryption_policy_arn" {
-  value = aws_iam_policy.identity_credentials_encryption_key_kms_policy.arn
-}
 
 output "doc_app_credential_encryption_policy_arn" {
   value = aws_iam_policy.doc_app_credential_encryption_key_kms_policy.arn


### PR DESCRIPTION
### Wider context of change
In previous work, we migrated this table to the Orchestration account. Now we've done so, we can clear up the old table. Now we can remove the table policies that are unused 

### What’s changed:
- Deletes unused table policies 
- Deletes table CMK policies 
- Deletes table CMK ARN output

### Manual testing: 
Deploy to sandpit (both shared and oidc)
- Removed the expected policies
- Also ran through an ID journey just in case (wasn't expecting this to affect anything) and was fine

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
