### PR TITLE
ATO-1689: use AuthSession subjectType instead of client registry

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -199,8 +199,6 @@ public class StartHandler
                             requestedCredentialTrustLevel,
                             authSession.getAchievedCredentialStrength());
 
-            LOG.info("subject type is: {}", startRequest.subjectType());
-
             authSessionService.addSession(authSession.withUpliftRequired(upliftRequired));
 
             var userContext = startService.buildUserContext(session, authSession);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -13,7 +13,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.nimbusds.openid.connect.sdk.SubjectType.PUBLIC;
@@ -29,10 +28,7 @@ public class ClientSubjectHelper {
             AuthSessionItem authSession,
             AuthenticationService authenticationService,
             String internalSectorURI) {
-        LOG.info(
-                "clientSubjectHelper subjectType is equal to auth session {}",
-                Objects.equals(client.getSubjectType(), authSession.getSubjectType()));
-        if (PUBLIC.toString().equalsIgnoreCase(client.getSubjectType())) {
+        if (PUBLIC.toString().equalsIgnoreCase(authSession.getSubjectType())) {
             return new Subject(userProfile.getPublicSubjectID());
         } else {
             return new Subject(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
@@ -41,12 +41,10 @@ class ClientSubjectHelperTest {
     private static final Scope SCOPES =
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
     private static final String CLIENT_ID_1 = "test-client-id-1";
-    private static final AuthSessionItem AUTH_SESSION_FOR_CLIENT_1 =
-            new AuthSessionItem().withSessionId("test-auth-session-1").withClientId(CLIENT_ID_1);
     private static final String CLIENT_ID_2 = "test-client-id-2";
-    private static final AuthSessionItem AUTH_SESSION_FOR_CLIENT_2 =
-            new AuthSessionItem().withSessionId("test-auth-session-2").withClientId(CLIENT_ID_2);
 
+    private AuthSessionItem AUTH_SESSION_FOR_CLIENT_1;
+    private AuthSessionItem AUTH_SESSION_FOR_CLIENT_2;
     private KeyPair keyPair;
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final UserProfile userProfile = generateUserProfile();
@@ -56,6 +54,18 @@ class ClientSubjectHelperTest {
         keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
         when(authenticationService.getOrGenerateSalt(userProfile))
                 .thenReturn(SaltHelper.generateNewSalt());
+        AUTH_SESSION_FOR_CLIENT_1 =
+                new AuthSessionItem()
+                        .withSessionId("test-auth-session-1")
+                        .withClientId(CLIENT_ID_1)
+                        .withIsOneLoginService(false)
+                        .withSubjectType(PAIRWISE.toString());
+        AUTH_SESSION_FOR_CLIENT_2 =
+                new AuthSessionItem()
+                        .withSessionId("test-auth-session-2")
+                        .withClientId(CLIENT_ID_2)
+                        .withIsOneLoginService(false)
+                        .withSubjectType(PAIRWISE.toString());
     }
 
     @Test
@@ -71,14 +81,14 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry1,
-                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
+                        AUTH_SESSION_FOR_CLIENT_1,
                         authenticationService,
                         INTERNAL_SECTOR_URI);
         Subject subject2 =
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry2,
-                        AUTH_SESSION_FOR_CLIENT_2.withIsOneLoginService(false),
+                        AUTH_SESSION_FOR_CLIENT_2,
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -98,14 +108,14 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry1,
-                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
+                        AUTH_SESSION_FOR_CLIENT_1,
                         authenticationService,
                         INTERNAL_SECTOR_URI);
         Subject subject2 =
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry2,
-                        AUTH_SESSION_FOR_CLIENT_2.withIsOneLoginService(false),
+                        AUTH_SESSION_FOR_CLIENT_2,
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -125,14 +135,14 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry1,
-                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
+                        AUTH_SESSION_FOR_CLIENT_1.withSubjectType(PUBLIC.toString()),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
         Subject subject2 =
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry2,
-                        AUTH_SESSION_FOR_CLIENT_2.withIsOneLoginService(false),
+                        AUTH_SESSION_FOR_CLIENT_2.withSubjectType(PUBLIC.toString()),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -150,7 +160,7 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry1,
-                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
+                        AUTH_SESSION_FOR_CLIENT_1,
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -177,7 +187,7 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry2,
-                        AUTH_SESSION_FOR_CLIENT_2.withIsOneLoginService(false),
+                        AUTH_SESSION_FOR_CLIENT_2,
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -195,7 +205,7 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry1,
-                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
+                        AUTH_SESSION_FOR_CLIENT_1.withSubjectType(PUBLIC.toString()),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -212,7 +222,7 @@ class ClientSubjectHelperTest {
         var sectorId =
                 ClientSubjectHelper.getSectorIdentifierForClient(
                         clientRegistry,
-                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
+                        AUTH_SESSION_FOR_CLIENT_1.withSubjectType(PUBLIC.toString()),
                         INTERNAL_SECTOR_URI);
 
         assertThat(sectorId, equalTo("test.com"));
@@ -226,7 +236,9 @@ class ClientSubjectHelperTest {
         var sectorId =
                 ClientSubjectHelper.getSectorIdentifierForClient(
                         clientRegistry,
-                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(true),
+                        AUTH_SESSION_FOR_CLIENT_1
+                                .withIsOneLoginService(true)
+                                .withSubjectType(PUBLIC.toString()),
                         INTERNAL_SECTOR_URI);
 
         assertThat(sectorId, equalTo("test.account.gov.uk"));
@@ -241,7 +253,9 @@ class ClientSubjectHelperTest {
         var sectorId =
                 ClientSubjectHelper.getSectorIdentifierForClient(
                         clientRegistry,
-                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(true),
+                        AUTH_SESSION_FOR_CLIENT_1
+                                .withIsOneLoginService(true)
+                                .withSubjectType(PUBLIC.toString()),
                         INTERNAL_SECTOR_URI);
 
         assertThat(sectorId, equalTo("test.account.gov.uk"));
@@ -256,7 +270,7 @@ class ClientSubjectHelperTest {
         var sectorId =
                 ClientSubjectHelper.getSectorIdentifierForClient(
                         clientRegistry,
-                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
+                        AUTH_SESSION_FOR_CLIENT_1.withSubjectType(PUBLIC.toString()),
                         INTERNAL_SECTOR_URI);
 
         assertThat(sectorId, equalTo("localhost"));
@@ -278,7 +292,7 @@ class ClientSubjectHelperTest {
                 () ->
                         ClientSubjectHelper.getSectorIdentifierForClient(
                                 clientRegistry,
-                                AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
+                                AUTH_SESSION_FOR_CLIENT_1.withSubjectType(PUBLIC.toString()),
                                 INTERNAL_SECTOR_URI),
                 "Expected to throw exception");
     }


### PR DESCRIPTION
### Wider context of change

We would like to move authentication away from using the ClientRegistry. To do this we need to pass information about the client from orch to auth, and store them on the auth session. A few fields we need have already been added as part of the client session migration.

### What’s changed

This PR swaps to using the subject_type claim sent from orch (that's then set on AuthSession) instead of the ClientRegistry.getSubjectType() method for ClientSubjectHelper

### Manual testing

Tested in authdev2, did a couple of journeys and all got the cookie from the frontend.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**