### PR TITLE
ATO-1658: Add validation to global logout lambda

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/GlobalLogoutMessage.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/GlobalLogoutMessage.java
@@ -1,0 +1,31 @@
+package uk.gov.di.authentication.oidc.entity;
+
+import com.google.gson.annotations.Expose;
+import uk.gov.di.orchestration.shared.validation.Required;
+
+public class GlobalLogoutMessage {
+    @Expose @Required private String internalCommonSubjectId;
+    @Expose @Required private String sessionId;
+    @Expose @Required private String clientSessionId;
+
+    public GlobalLogoutMessage() {}
+
+    public GlobalLogoutMessage(
+            String internalCommonSubjectId, String sessionId, String clientSessionId) {
+        this.internalCommonSubjectId = internalCommonSubjectId;
+        this.sessionId = sessionId;
+        this.clientSessionId = clientSessionId;
+    }
+
+    public String getInternalCommonSubjectId() {
+        return internalCommonSubjectId;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandlerTest.java
@@ -41,8 +41,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.orchestration.sharedtest.helper.SqsTestHelper.getMessages;
-import static uk.gov.di.orchestration.sharedtest.helper.SqsTestHelper.inputEvent;
+import static uk.gov.di.orchestration.sharedtest.helper.SqsTestHelper.sqsEventWithPayload;
+import static uk.gov.di.orchestration.sharedtest.helper.SqsTestHelper.sqsMessageWithPayload;
 
 class BackChannelLogoutRequestHandlerTest {
 
@@ -67,7 +67,7 @@ class BackChannelLogoutRequestHandlerTest {
 
     @Test
     void shouldDoNothingIfPayloadIsInvalid() {
-        handler.handleRequest(inputEvent(null), context);
+        handler.handleRequest(sqsEventWithPayload(null), context);
 
         verify(tokenService, never())
                 .generateSignedJwtUsingExternalKey(any(), eq(Optional.of("logout+jwt")), eq(ES256));
@@ -88,7 +88,7 @@ class BackChannelLogoutRequestHandlerTest {
                         any(JWTClaimsSet.class), eq(Optional.of("logout+jwt")), eq(ES256)))
                 .thenReturn(jwt);
 
-        handler.handleRequest(inputEvent(input), context);
+        handler.handleRequest(sqsEventWithPayload(input), context);
 
         verify(request)
                 .post(URI.create("https://test.account.gov.uk"), "logout_token=serialized-payload");
@@ -117,8 +117,8 @@ class BackChannelLogoutRequestHandlerTest {
                         URI.create("https://test-2.account.gov.uk"),
                         "logout_token=serialized-payload");
 
-        var firstMessage = getMessages(firstInput, "firstMessageId");
-        var secondMessage = getMessages(secondInput, "secondMessageId");
+        var firstMessage = sqsMessageWithPayload(firstInput, "firstMessageId");
+        var secondMessage = sqsMessageWithPayload(secondInput, "secondMessageId");
         List<SQSEvent.SQSMessage> messageList = new ArrayList<>();
         firstMessage.ifPresent(messageList::add);
         secondMessage.ifPresent(messageList::add);
@@ -157,8 +157,8 @@ class BackChannelLogoutRequestHandlerTest {
                         URI.create("https://test-2.account.gov.uk"),
                         "logout_token=serialized-payload");
 
-        var firstMessage = getMessages(firstInput, "firstMessageId");
-        var secondMessage = getMessages(secondInput, "secondMessageId");
+        var firstMessage = sqsMessageWithPayload(firstInput, "firstMessageId");
+        var secondMessage = sqsMessageWithPayload(secondInput, "secondMessageId");
         List<SQSEvent.SQSMessage> messageList = new ArrayList<>();
         firstMessage.ifPresent(messageList::add);
         secondMessage.ifPresent(messageList::add);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandlerTest.java
@@ -16,7 +16,6 @@ import uk.gov.di.authentication.oidc.services.HttpRequestService;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.entity.BackChannelLogoutMessage;
 import uk.gov.di.orchestration.shared.helpers.NowHelper.NowClock;
-import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.TokenService;
 
 import java.net.URI;
@@ -28,10 +27,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.nimbusds.jose.JWSAlgorithm.*;
+import static com.nimbusds.jose.JWSAlgorithm.ES256;
 import static java.time.Clock.fixed;
 import static java.time.ZoneId.systemDefault;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
@@ -43,7 +41,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.orchestration.sharedtest.exceptions.Unchecked.unchecked;
+import static uk.gov.di.orchestration.sharedtest.helper.SqsTestHelper.getMessages;
+import static uk.gov.di.orchestration.sharedtest.helper.SqsTestHelper.inputEvent;
 
 class BackChannelLogoutRequestHandlerTest {
 
@@ -211,27 +210,5 @@ class BackChannelLogoutRequestHandlerTest {
                 description.appendText("is a uuid");
             }
         };
-    }
-
-    private SQSEvent inputEvent(BackChannelLogoutMessage payload) {
-        var messages = getMessages(payload, "messageId");
-        var event = new SQSEvent();
-        event.setRecords(messages.map(List::of).orElse(emptyList()));
-
-        return event;
-    }
-
-    private Optional<SQSEvent.SQSMessage> getMessages(
-            BackChannelLogoutMessage payload, String messageId) {
-        return Optional.ofNullable(payload)
-                .map(unchecked(SerializationService.getInstance()::writeValueAsString))
-                .map(
-                        body -> {
-                            var message = new SQSEvent.SQSMessage();
-                            message.setBody(body);
-                            message.setMessageId(messageId);
-
-                            return message;
-                        });
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandlerTest.java
@@ -1,0 +1,59 @@
+package uk.gov.di.authentication.oidc.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static uk.gov.di.orchestration.sharedtest.helper.SqsTestHelper.sqsEventWithPayload;
+
+public class GlobalLogoutHandlerTest {
+    private final Context context = mock(Context.class);
+    private final GlobalLogoutHandler globalLogoutHandler = new GlobalLogoutHandler();
+
+    private static Stream<Arguments> invalidMessages() {
+        return Stream.of(
+                Arguments.of(
+                        Named.of(
+                                "Missing internal_common_subject_id",
+                                Map.ofEntries(
+                                        Map.entry("session_id", "sid"),
+                                        Map.entry("client_session_id", "csid")))),
+                Arguments.of(
+                        Named.of(
+                                "Missing session_id",
+                                Map.ofEntries(
+                                        Map.entry("internal_common_subject_id", "icsid"),
+                                        Map.entry("client_session_id", "csid")))),
+                Arguments.of(
+                        Named.of(
+                                "Missing client_session_id",
+                                Map.ofEntries(
+                                        Map.entry("session_id", "sid"),
+                                        Map.entry("internal_common_subject_id", "icsid")))),
+                Arguments.of(Named.of("Invalid JSON", "{")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidMessages")
+    void shouldRejectInvalidMessage(Object payload) {
+        var input = sqsEventWithPayload("test-message-id", payload);
+
+        var response = globalLogoutHandler.handleRequest(input, context);
+
+        assertThat(response, equalTo(failedMessages("test-message-id")));
+    }
+
+    private SQSBatchResponse failedMessages(String... messageIds) {
+        return new SQSBatchResponse(
+                Stream.of(messageIds).map(SQSBatchResponse.BatchItemFailure::new).toList());
+    }
+}

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/SqsTestHelper.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/SqsTestHelper.java
@@ -1,0 +1,35 @@
+package uk.gov.di.orchestration.sharedtest.helper;
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import uk.gov.di.orchestration.shared.services.SerializationService;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+import static uk.gov.di.orchestration.sharedtest.exceptions.Unchecked.unchecked;
+
+public class SqsTestHelper {
+    private SqsTestHelper() {}
+
+    public static <T> SQSEvent inputEvent(T payload) {
+        var messages = getMessages(payload, "messageId");
+        var event = new SQSEvent();
+        event.setRecords(messages.map(List::of).orElse(emptyList()));
+
+        return event;
+    }
+
+    public static <T> Optional<SQSEvent.SQSMessage> getMessages(T payload, String messageId) {
+        return Optional.ofNullable(payload)
+                .map(unchecked(SerializationService.getInstance()::writeValueAsString))
+                .map(
+                        body -> {
+                            var message = new SQSEvent.SQSMessage();
+                            message.setBody(body);
+                            message.setMessageId(messageId);
+
+                            return message;
+                        });
+    }
+}

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/SqsTestHelper.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/SqsTestHelper.java
@@ -12,15 +12,16 @@ import static uk.gov.di.orchestration.sharedtest.exceptions.Unchecked.unchecked;
 public class SqsTestHelper {
     private SqsTestHelper() {}
 
-    public static <T> SQSEvent inputEvent(T payload) {
-        var messages = getMessages(payload, "messageId");
+    public static <T> SQSEvent sqsEventWithPayload(T payload) {
+        var messages = sqsMessageWithPayload(payload, "messageId");
         var event = new SQSEvent();
         event.setRecords(messages.map(List::of).orElse(emptyList()));
 
         return event;
     }
 
-    public static <T> Optional<SQSEvent.SQSMessage> getMessages(T payload, String messageId) {
+    public static <T> Optional<SQSEvent.SQSMessage> sqsMessageWithPayload(
+            T payload, String messageId) {
         return Optional.ofNullable(payload)
                 .map(unchecked(SerializationService.getInstance()::writeValueAsString))
                 .map(

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/SqsTestHelper.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/SqsTestHelper.java
@@ -13,7 +13,11 @@ public class SqsTestHelper {
     private SqsTestHelper() {}
 
     public static <T> SQSEvent sqsEventWithPayload(T payload) {
-        var messages = sqsMessageWithPayload(payload, "messageId");
+        return sqsEventWithPayload("messageId", payload);
+    }
+
+    public static <T> SQSEvent sqsEventWithPayload(String messageId, T payload) {
+        var messages = sqsMessageWithPayload(payload, messageId);
         var event = new SQSEvent();
         event.setRecords(messages.map(List::of).orElse(emptyList()));
 


### PR DESCRIPTION
### Wider context of change

We have previously created a lambda to be used for global logout. At the moment, the lambda does nothing. We would like to start by adding validation for the message we get from SQS to make sure all the fields we need are present.

### What’s changed

This PR adds validation for the message we get from SQS in the GlobalLogoutHandler. The fields we require are:
- `internal_common_subject_id`
- `session_id`
- `client_session_id`

### Manual testing

Deployed to orch dev. Tested by sending 5 messages
- Valid message
- Message with missing ICSID
- Message with missing session ID,
- Message with missing client session ID
- Message with invalid JSON

The first one was successful, the last 4 failed as expected.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
