### PR TITLE
ATO-1705: Add logging for invalid channel values

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
@@ -111,6 +111,10 @@ public class RequestObjectToAuthRequestHelper {
                 builder.loginHint(jwtClaimsSet.getStringClaim("login_hint"));
             }
 
+            if (Objects.nonNull(jwtClaimsSet.getStringClaim("channel"))) {
+                builder.customParameter("channel", jwtClaimsSet.getStringClaim("channel"));
+            }
+
             return builder.build();
         } catch (ParseException | com.nimbusds.oauth2.sdk.ParseException | Json.JsonException e) {
             LOG.error("Parse exception thrown whilst converting RequestObject to Auth Request", e);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -44,6 +44,7 @@ import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.conditions.DocAppUserHelper;
 import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
+import uk.gov.di.orchestration.shared.entity.Channel;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
@@ -374,6 +375,16 @@ public class AuthorisationHandler
                     user);
         }
         authRequest = RequestObjectToAuthRequestHelper.transform(authRequest);
+
+        var channelParams = authRequest.getCustomParameter("channel");
+        if (channelParams != null) {
+            var channel = channelParams.stream().findFirst().orElse(null);
+            LOG.info("Channel parameter found: {}", channel);
+            LOG.info(
+                    "Is channel parameter valid? {}",
+                    List.of(Channel.WEB.getValue(), Channel.GENERIC_APP.getValue())
+                            .contains(channel));
+        }
 
         try {
             cloudwatchMetricsService.putEmbeddedValue(


### PR DESCRIPTION
### Wider context of change

We would like to start accepting `channel` in the authorise request to orch. Before we add validation for this we need to check if any RPs are already sending `channel` in the request, and if this will cause the validation to fail.

### What’s changed

This PR checks if the `channel` parameter exists on the authorise request. If it does, it will log the value, and also log whether the claim is considered valid (`web` or `generic_app`)

### Manual testing

Updated a test to send `channel` in the auth request. Saw the logs appear in the test log. I think this should be enough?

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
