### PR TITLE
ATO-1711: add logging to check isIdentityVerificationRequired values

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -22,4 +22,6 @@ public record StartRequest(
         @Expose @SerializedName("cookie_consent_shared") boolean isCookieConsentShared,
         @Expose @SerializedName("is_smoke_test") boolean isSmokeTest,
         @Expose @SerializedName("is_one_login_service") boolean isOneLoginService,
-        @Expose @SerializedName("subject_type") String subjectType) {}
+        @Expose @SerializedName("subject_type") String subjectType,
+        @Expose @SerializedName("is_identity_verification_required")
+                boolean isIdentityVerificationRequired) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -283,7 +283,8 @@ public class StartHandler
                             reauthenticate,
                             isBlockedForReauth,
                             isUserAuthenticatedWithValidProfile,
-                            upliftRequired);
+                            upliftRequired,
+                            startRequest.isIdentityVerificationRequired());
 
             StartResponse startResponse = new StartResponse(userStartInfo, clientStartInfo);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -109,7 +109,8 @@ public class StartService {
             boolean reauthenticate,
             boolean isBlockedForReauth,
             boolean isAuthenticated,
-            boolean upliftRequired) {
+            boolean upliftRequired,
+            boolean identityRequiredFromFrontend) {
         var identityRequired = false;
         var clientRegistry = userContext.getClient().orElseThrow();
         identityRequired =
@@ -117,6 +118,10 @@ public class StartService {
                         levelOfConfidence,
                         clientRegistry.isIdentityVerificationSupported(),
                         identityEnabled);
+
+        LOG.info(
+                "isIdentityVerificationRequired is equal {}",
+                identityRequired == identityRequiredFromFrontend);
 
         var userIsAuthenticated = isAuthenticated && !reauthenticate;
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -312,6 +312,7 @@ class StartHandlerTest {
                         anyBoolean(),
                         anyBoolean(),
                         eq(false),
+                        anyBoolean(),
                         anyBoolean());
     }
 
@@ -338,6 +339,7 @@ class StartHandlerTest {
                         anyBoolean(),
                         anyBoolean(),
                         eq(true),
+                        anyBoolean(),
                         anyBoolean());
     }
 
@@ -515,6 +517,7 @@ class StartHandlerTest {
                         anyBoolean(),
                         anyBoolean(),
                         anyBoolean(),
+                        anyBoolean(),
                         anyBoolean()))
                 .thenReturn(userStartInfo);
     }
@@ -559,6 +562,7 @@ class StartHandlerTest {
                         false,
                         false,
                         false,
-                        TEST_SUBJECT_TYPE));
+                        TEST_SUBJECT_TYPE,
+                        false));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -158,6 +158,7 @@ class StartServiceTest {
                         false,
                         false,
                         isAuthenticated,
+                        false,
                         false);
 
         assertThat(userStartInfo.isUpliftRequired(), equalTo(false));
@@ -204,6 +205,7 @@ class StartServiceTest {
                         false,
                         false,
                         false,
+                        false,
                         false);
 
         assertThat(userStartInfo.isIdentityRequired(), equalTo(expectedIdentityRequiredValue));
@@ -225,6 +227,7 @@ class StartServiceTest {
                         true,
                         false,
                         isBlockedForReauth,
+                        false,
                         false,
                         false);
 
@@ -361,6 +364,7 @@ class StartServiceTest {
                         true,
                         false,
                         true,
+                        false,
                         false);
 
         assertThat(userStartInfo.isAuthenticated(), equalTo(false));
@@ -400,7 +404,8 @@ class StartServiceTest {
                         false,
                         false,
                         false,
-                        upliftRequired);
+                        upliftRequired,
+                        false);
 
         assertThat(userStartInfo.isUpliftRequired(), equalTo(expectedUpliftRequiredValue));
     }
@@ -472,7 +477,16 @@ class StartServiceTest {
 
         var userStartInfo =
                 startService.buildUserStartInfo(
-                        userContext, NONE, "true", "tracking-id", true, false, false, false, false);
+                        userContext,
+                        NONE,
+                        "true",
+                        "tracking-id",
+                        true,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false);
 
         assertThat(userStartInfo.mfaMethodType(), equalTo(expectedMfaMethodType));
     }
@@ -496,7 +510,16 @@ class StartServiceTest {
 
         var userStartInfo =
                 startService.buildUserStartInfo(
-                        userContext, NONE, "true", "tracking-id", true, false, false, false, false);
+                        userContext,
+                        NONE,
+                        "true",
+                        "tracking-id",
+                        true,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false);
 
         assertThat(userStartInfo.mfaMethodType(), equalTo(MFAMethodType.NONE));
     }


### PR DESCRIPTION
### Wider context of change

We would like to move authentication away from using the ClientRegistry. To do this we need to pass information about the client from orch to auth, and store them on the auth session. A few fields we need have already been added as part of the client session migration.

### What’s changed

Gets is_identity_verification_required from frontend and logs if the same value as expected

### Manual testing

N/A

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
