### PR TITLE
ATO-1693: Pass channel claim to auth

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/AuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/AuthRequestHelper.java
@@ -1,0 +1,23 @@
+package uk.gov.di.authentication.oidc.helpers;
+
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class AuthRequestHelper {
+    private AuthRequestHelper() {}
+
+    /* Custom parameters on the auth request are a bit weird. They can be null, or they can be a list of strings,
+     * even if you only add 1 custom parameter.
+     * In a lot of places we check if its null then call authRequest.getCustomParameter(x).get(0)
+     * This is a helper method to get the first string in that list of strings as an optional.
+     */
+    public static Optional<String> getCustomParameterOpt(
+            AuthenticationRequest authRequest, String parameter) {
+        return Optional.ofNullable(authRequest.getCustomParameter(parameter))
+                .map(List::stream)
+                .flatMap(Stream::findFirst);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -893,6 +893,10 @@ public class AuthorisationHandler
                         authenticationRequest.toParameters(),
                         client.isIdentityVerificationSupported(),
                         configurationService.isIdentityEnabled());
+        var channel =
+                getCustomParameterOpt(authenticationRequest, "channel")
+                        .orElse(client.getChannel())
+                        .toLowerCase();
         var claimsBuilder =
                 new JWTClaimsSet.Builder()
                         .issuer(configurationService.getOrchestrationClientId())
@@ -918,7 +922,7 @@ public class AuthorisationHandler
                         .claim("redirect_uri", configurationService.getOrchestrationRedirectURI())
                         .claim("reauthenticate", reauthSub)
                         .claim("previous_govuk_signin_journey_id", reauthSid)
-                        .claim("channel", client.getChannel().toLowerCase())
+                        .claim("channel", channel)
                         .claim("authenticated", orchSession.getAuthenticated())
                         .claim("scope", authenticationRequest.getScope().toString())
                         .claim("login_hint", authenticationRequest.getLoginHint())

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/AuthRequestHelperTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/AuthRequestHelperTest.java
@@ -1,0 +1,47 @@
+package uk.gov.di.authentication.oidc.helpers;
+
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.authentication.oidc.helpers.AuthRequestHelper.getCustomParameterOpt;
+
+public class AuthRequestHelperTest {
+    @Test
+    void shouldReturnEmptyOptionalWhenCustomParameterIsNull() {
+        var authRequest = authRequestBuilder().build();
+
+        assertThat(
+                getCustomParameterOpt(authRequest, "not-a-parameter"), equalTo(Optional.empty()));
+    }
+
+    @Test
+    void shouldReturnOptionalWhenCustomParameterIsNotNull() {
+        var authRequest = authRequestBuilder().customParameter("test-parameter", "abc").build();
+
+        assertThat(
+                getCustomParameterOpt(authRequest, "test-parameter"), equalTo(Optional.of("abc")));
+    }
+
+    private AuthenticationRequest.Builder authRequestBuilder() {
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        return new AuthenticationRequest.Builder(
+                        ResponseType.CODE,
+                        scope,
+                        new ClientID("test-id"),
+                        URI.create("https://localhost:8080"))
+                .state(new State())
+                .nonce(new Nonce());
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -471,21 +471,31 @@ class AuthorisationHandlerTest {
 
         private static Stream<Arguments> clientChannelsAndExpectedChannels() {
             return Stream.of(
-                    arguments(null, Channel.WEB.getValue()),
-                    arguments(Channel.WEB.getValue(), Channel.WEB.getValue()),
-                    arguments(Channel.STRATEGIC_APP.getValue(), Channel.STRATEGIC_APP.getValue()),
-                    arguments(Channel.GENERIC_APP.getValue(), Channel.GENERIC_APP.getValue()));
+                    arguments(null, null, Channel.WEB.getValue()),
+                    arguments(null, Channel.WEB.getValue(), Channel.WEB.getValue()),
+                    arguments(
+                            null,
+                            Channel.STRATEGIC_APP.getValue(),
+                            Channel.STRATEGIC_APP.getValue()),
+                    arguments(null, Channel.GENERIC_APP.getValue(), Channel.GENERIC_APP.getValue()),
+                    arguments(Channel.WEB.getValue(), null, Channel.WEB.getValue()),
+                    arguments(Channel.GENERIC_APP.getValue(), null, Channel.GENERIC_APP.getValue()),
+                    arguments(
+                            Channel.GENERIC_APP.getValue(),
+                            Channel.WEB.getValue(),
+                            Channel.GENERIC_APP.getValue()));
         }
 
         @ParameterizedTest
         @MethodSource("clientChannelsAndExpectedChannels")
         void shouldPassTheCorrectChannelClaimToAuth(
-                String clientChannel, String expectedChannelClaim) {
+                String authRequestChannel, String clientChannel, String expectedChannelClaim) {
             when(clientService.getClient(anyString()))
                     .thenReturn(Optional.of(generateClientRegistry().withChannel(clientChannel)));
-            var requestParams =
-                    buildRequestParams(
-                            Map.of("scope", "openid profile phone", "vtr", "[\"Cl.Cm.P2\"]"));
+            var requestParams = buildRequestParams(Map.of("scope", "openid profile phone"));
+            if (authRequestChannel != null) {
+                requestParams.put("channel", authRequestChannel);
+            }
             var event = withRequestEvent(requestParams);
 
             makeHandlerRequest(event);


### PR DESCRIPTION
Paired on this with @james-peacock-gds 

### Wider context of change

We would like to support RPs providing us with a channel claim, that will be used instead of the channel defined in the client registry. We have already checked with logs that there are no clients sending us this claim at the moment, and we are validating that the channel we receive from the RP is a valid one (not present, `web`, or `generic_app`)

### What’s changed

This PR changes what channel we send based on the claim we get from the RP in the authRequest.
- If the channel is present in the auth request, and it is valid, then it used as the channel value in the JAR we sent to auth.
- If the channel is not present, it will fall back to using the client registry
- If there is no channel set in the client registry, then a default of `web` is used (note this was existing functionality)

### Manual testing

Tested in sandpit. Hit /authorize with a channel parameter of `generic_app` and saw a different login page to when we pass in `web`.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
