### PR TITLE
AUT-4426: Increment MFA uses in single count

### DIFF
--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -59,6 +59,7 @@ account_intervention_service_action_enabled = true
 # account_intervention_service_uri is stored in AWS Secrets Manager and populated using read_secrets.sh
 account_intervention_service_abort_on_error = true
 send_storage_token_to_ipv_enabled           = true
+authentication_attempts_service_enabled     = true
 auth_frontend_public_encryption_key         = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0PcOHuVXOuexYZmpOlCo

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/ReauthMetadataBuilder.java
@@ -37,8 +37,7 @@ public class ReauthMetadataBuilder {
         this.incorrectOtpAttemptCount =
                 pair(
                         "incorrect_otp_code_attempt_count",
-                        (countsByJourney.getOrDefault(CountType.ENTER_SMS_CODE, 0))
-                                + (countsByJourney.getOrDefault(CountType.ENTER_AUTH_APP_CODE, 0)));
+                        (countsByJourney.getOrDefault(CountType.ENTER_MFA_CODE, 0)));
         return this;
     }
 
@@ -75,7 +74,7 @@ public class ReauthMetadataBuilder {
         return switch (exceededType) {
             case ENTER_EMAIL -> ReauthFailureReasons.INCORRECT_EMAIL;
             case ENTER_PASSWORD -> ReauthFailureReasons.INCORRECT_PASSWORD;
-            case ENTER_AUTH_APP_CODE, ENTER_SMS_CODE -> ReauthFailureReasons.INCORRECT_OTP;
+            case ENTER_MFA_CODE -> ReauthFailureReasons.INCORRECT_OTP;
             default -> null;
         };
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -332,7 +332,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                                 .toInstant()
                                 .getEpochSecond(),
                         JourneyType.REAUTHENTICATION,
-                        CountType.ENTER_SMS_CODE);
+                        CountType.ENTER_MFA_CODE);
             }
         } else {
             processBlockedCodeSession(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -506,11 +506,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     emailAddress, codeBlockedKeyPrefix, blockDuration);
         }
 
-        if (mfaMethodType == MFAMethodType.SMS) {
-            codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
-        } else {
-            codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType);
-        }
+        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
     }
 
     private AuditService.MetadataPair[] metadataPairsForEvent(
@@ -529,11 +525,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                             pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()));
                     case AUTH_INVALID_CODE_SENT -> {
                         var failureCount =
-                                methodType.equals(MFAMethodType.AUTH_APP)
-                                        ? codeStorageService.getIncorrectMfaCodeAttemptsCount(
-                                                email, MFAMethodType.AUTH_APP)
-                                        : codeStorageService.getIncorrectMfaCodeAttemptsCount(
-                                                email);
+                                codeStorageService.getIncorrectMfaCodeAttemptsCount(email);
                         yield List.of(
                                 pair("loginFailureCount", failureCount),
                                 pair("MFACodeEntered", codeRequest.getCode()));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -322,7 +322,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                                 .toInstant()
                                 .getEpochSecond(),
                         JourneyType.REAUTHENTICATION,
-                        CountType.ENTER_AUTH_APP_CODE);
+                        CountType.ENTER_MFA_CODE);
             }
             auditFailure(codeRequest, errorResponse, authSession, auditContext);
         } else {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -76,10 +76,10 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
         }
 
         if (codeRequestType.getJourneyType() != JourneyType.REAUTHENTICATION) {
-            incrementRetryCount(MFAMethodType.AUTH_APP);
+            incrementRetryCount();
         }
 
-        if (hasExceededRetryLimit(MFAMethodType.AUTH_APP)) {
+        if (hasExceededRetryLimit()) {
             LOG.info("Exceeded code retry limit");
             return Optional.of(ErrorResponse.ERROR_1042);
         }
@@ -104,7 +104,7 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
             return Optional.of(ErrorResponse.ERROR_1043);
         }
         LOG.info("Auth code valid. Resetting code request count");
-        resetCodeIncorrectEntryCount(MFAMethodType.AUTH_APP);
+        resetCodeIncorrectEntryCount();
 
         return Optional.empty();
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
@@ -47,18 +47,17 @@ public abstract class MfaCodeProcessor {
         return codeStorageService.isBlockedForEmail(emailAddress, codeBlockedKeyPrefix);
     }
 
-    boolean hasExceededRetryLimit(MFAMethodType mfaMethodType) {
+    boolean hasExceededRetryLimit() {
         LOG.info("Max retries: {}", maxRetries);
-        return codeStorageService.getIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType)
-                >= maxRetries;
+        return codeStorageService.getIncorrectMfaCodeAttemptsCount(emailAddress) >= maxRetries;
     }
 
-    void incrementRetryCount(MFAMethodType mfaMethodType) {
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType);
+    void incrementRetryCount() {
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(emailAddress);
     }
 
-    void resetCodeIncorrectEntryCount(MFAMethodType mfaMethodType) {
-        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType);
+    void resetCodeIncorrectEntryCount() {
+        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
     }
 
     void submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -310,7 +310,7 @@ class CheckReAuthUserHandlerTest {
     void shouldReturn400WhenUserHasBeenBlockedForMfaAttempts() {
         when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
                         TEST_SUBJECT_ID, expectedRpPairwiseSub, JourneyType.REAUTHENTICATION))
-                .thenReturn(Map.of(CountType.ENTER_SMS_CODE, MAX_RETRIES));
+                .thenReturn(Map.of(CountType.ENTER_MFA_CODE, MAX_RETRIES));
 
         var result =
                 handler.handleRequestWithUserContext(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -278,9 +278,7 @@ class CheckUserExistsHandlerTest {
             when(codeStorageService.getMfaCodeBlockTimeToLive(
                             EMAIL_ADDRESS, MFAMethodType.AUTH_APP, JourneyType.PASSWORD_RESET_MFA))
                     .thenReturn(15L);
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(
-                            EMAIL_ADDRESS, MFAMethodType.AUTH_APP))
-                    .thenReturn(6);
+            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL_ADDRESS)).thenReturn(6);
             MFAMethod mfaMethod1 = verifiedMfaMethod(MFAMethodType.AUTH_APP, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod1)));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -69,10 +69,9 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_INVALID_CREDENTIALS;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_AUTH_APP_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_MFA_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_SMS_CODE;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.SMS;
 import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.CLIENT_SESSION_ID;
@@ -281,13 +280,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                         0,
                         ReauthFailureReasons.INCORRECT_PASSWORD.getValue()),
                 Arguments.arguments(
-                        ENTER_SMS_CODE,
-                        0,
-                        0,
-                        MAX_ALLOWED_RETRIES,
-                        ReauthFailureReasons.INCORRECT_OTP.getValue()),
-                Arguments.arguments(
-                        ENTER_AUTH_APP_CODE,
+                        ENTER_MFA_CODE,
                         0,
                         0,
                         MAX_ALLOWED_RETRIES,
@@ -594,8 +587,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     .thenReturn(retriesAllowed);
             case ENTER_PASSWORD -> when(configurationService.getMaxPasswordRetries())
                     .thenReturn(retriesAllowed);
-            case ENTER_AUTH_APP_CODE, ENTER_SMS_CODE, ENTER_EMAIL_CODE -> when(configurationService
-                            .getCodeMaxRetries())
+            case ENTER_MFA_CODE -> when(configurationService.getCodeMaxRetries())
                     .thenReturn(retriesAllowed);
         }
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -60,10 +60,9 @@ import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyReques
 import static uk.gov.di.authentication.frontendapi.lambda.StartHandler.REAUTHENTICATE_HEADER;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_AUTH_APP_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_MFA_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_SMS_CODE;
 import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.CLIENT_ID;
 import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.CLIENT_NAME;
 import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.CLIENT_SESSION_ID;
@@ -381,13 +380,7 @@ class StartHandlerTest {
                         0,
                         ReauthFailureReasons.INCORRECT_PASSWORD.getValue()),
                 Arguments.arguments(
-                        ENTER_SMS_CODE,
-                        0,
-                        0,
-                        MAX_ALLOWED_RETRIES,
-                        ReauthFailureReasons.INCORRECT_OTP.getValue()),
-                Arguments.arguments(
-                        ENTER_AUTH_APP_CODE,
+                        ENTER_MFA_CODE,
                         0,
                         0,
                         MAX_ALLOWED_RETRIES,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -71,10 +71,9 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_AUTH_APP_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_MFA_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_SMS_CODE;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
@@ -864,7 +863,7 @@ class VerifyCodeHandlerTest {
     }
 
     @Test
-    void shouldIncrementEnterSMSAuthenticationAttemptCountOnFailedReauthenticationAttempt() {
+    void shouldIncrementEnterMFAAuthenticationAttemptCountOnFailedReauthenticationAttempt() {
         long ttl = 120L;
         withReauthTurnedOn();
         when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -879,7 +878,7 @@ class VerifyCodeHandlerTest {
 
         verify(authenticationAttemptsService, times(1))
                 .createOrIncrementCount(
-                        TEST_SUBJECT_ID, 4070908800L, REAUTHENTICATION, ENTER_SMS_CODE);
+                        TEST_SUBJECT_ID, 4070908800L, REAUTHENTICATION, ENTER_MFA_CODE);
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1035));
         mockedNowHelperClass.close();
@@ -900,13 +899,7 @@ class VerifyCodeHandlerTest {
                         0,
                         ReauthFailureReasons.INCORRECT_PASSWORD.getValue()),
                 Arguments.arguments(
-                        ENTER_SMS_CODE,
-                        0,
-                        0,
-                        MAX_RETRIES,
-                        ReauthFailureReasons.INCORRECT_OTP.getValue()),
-                Arguments.arguments(
-                        ENTER_AUTH_APP_CODE,
+                        ENTER_MFA_CODE,
                         0,
                         0,
                         MAX_RETRIES,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -572,8 +572,7 @@ class VerifyMfaCodeHandlerTest {
                     .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, 900L);
             verifyNoInteractions(authenticationAttemptsService);
         }
-        verify(codeStorageService)
-                .deleteIncorrectMfaCodeAttemptsCount(EMAIL, MFAMethodType.AUTH_APP);
+        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
         verifyNoInteractions(cloudwatchMetricsService);
         assertAuditEventSubmittedWithMetadata(
                 FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
@@ -610,7 +609,6 @@ class VerifyMfaCodeHandlerTest {
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService, never())
                 .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-        verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
         verifyNoInteractions(cloudwatchMetricsService);
         verifyNoInteractions(authenticationAttemptsService);
         assertAuditEventSubmittedWithMetadata(
@@ -633,8 +631,7 @@ class VerifyMfaCodeHandlerTest {
                         ? null
                         : AUTH_APP_SECRET;
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.of(ErrorResponse.ERROR_1043));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL, MFAMethodType.AUTH_APP))
-                .thenReturn(3);
+        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
         var codeRequest =
                 new VerifyMfaCodeRequest(
                         MFAMethodType.AUTH_APP, CODE, journeyType, profileInformation);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -77,10 +77,9 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_AUTH_APP_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_MFA_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_SMS_CODE;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
 import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.CLIENT_SESSION_ID;
@@ -801,7 +800,7 @@ class VerifyMfaCodeHandlerTest {
     }
 
     @Test
-    void shouldIncrementAuthAppAuthenticationAttemptsCountIfIncorrectCodeEntered()
+    void shouldIncrementMFAAuthenticationAttemptsCountIfIncorrectCodeEntered()
             throws Json.JsonException {
         long ttl = 3600L;
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
@@ -820,10 +819,7 @@ class VerifyMfaCodeHandlerTest {
 
         verify(authenticationAttemptsService, times(1))
                 .createOrIncrementCount(
-                        TEST_SUBJECT_ID,
-                        1704067200L,
-                        REAUTHENTICATION,
-                        CountType.ENTER_AUTH_APP_CODE);
+                        TEST_SUBJECT_ID, 1704067200L, REAUTHENTICATION, ENTER_MFA_CODE);
 
         mockedNowHelperClass.close();
     }
@@ -837,7 +833,7 @@ class VerifyMfaCodeHandlerTest {
         withReauthTurnedOn();
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
 
-        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, CountType.ENTER_AUTH_APP_CODE, 4);
+        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
         when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
                         eq(SUBJECT_ID), any(), eq(JourneyType.REAUTHENTICATION)))
                 .thenReturn(existingCounts);
@@ -877,7 +873,7 @@ class VerifyMfaCodeHandlerTest {
         withReauthTurnedOn();
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
 
-        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, CountType.ENTER_AUTH_APP_CODE, 4);
+        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
         when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
                         eq(SUBJECT_ID), any(), eq(JourneyType.REAUTHENTICATION)))
                 .thenReturn(existingCounts);
@@ -887,10 +883,7 @@ class VerifyMfaCodeHandlerTest {
         makeCallWithCode(codeRequest);
 
         verify(authenticationAttemptsService, times(1))
-                .deleteCount(
-                        TEST_SUBJECT_ID,
-                        JourneyType.REAUTHENTICATION,
-                        CountType.ENTER_AUTH_APP_CODE);
+                .deleteCount(TEST_SUBJECT_ID, JourneyType.REAUTHENTICATION, ENTER_MFA_CODE);
 
         verify(authSessionService, never())
                 .updateSession(
@@ -933,13 +926,7 @@ class VerifyMfaCodeHandlerTest {
                         0,
                         ReauthFailureReasons.INCORRECT_PASSWORD.getValue()),
                 Arguments.arguments(
-                        ENTER_SMS_CODE,
-                        0,
-                        0,
-                        MAX_RETRIES,
-                        ReauthFailureReasons.INCORRECT_OTP.getValue()),
-                Arguments.arguments(
-                        ENTER_AUTH_APP_CODE,
+                        ENTER_MFA_CODE,
                         0,
                         0,
                         MAX_RETRIES,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -408,7 +408,7 @@ class AuthAppCodeProcessorTest {
     private void setUpRetryLimitExceededUser(CodeRequest codeRequest) {
         when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
-        when(mockCodeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL, MFAMethodType.AUTH_APP))
+        when(mockCodeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
                 .thenReturn(MAX_RETRIES + 1);
 
         this.authAppCodeProcessor =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthSessionServiceIntegrationTest.java
@@ -128,7 +128,7 @@ class AuthSessionServiceIntegrationTest {
                 new HashMap<CountType, Integer>() {
                     {
                         put(CountType.ENTER_EMAIL, 1);
-                        put(CountType.ENTER_SMS_CODE, 3);
+                        put(CountType.ENTER_MFA_CODE, 3);
                     }
                 };
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.shared.entity.NotificationType;
-import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -104,14 +103,6 @@ public class RedisExtension
 
     public int getMfaCodeAttemptsCount(String email) {
         return codeStorageService.getIncorrectMfaCodeAttemptsCount(email);
-    }
-
-    public int getMfaCodeAttemptsCount(String email, MFAMethodType mfaMethodType) {
-        return codeStorageService.getIncorrectMfaCodeAttemptsCount(email, mfaMethodType);
-    }
-
-    public void increaseMfaCodeAttemptsCount(String email, MFAMethodType mfaMethodType) {
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email, mfaMethodType);
     }
 
     public void increaseMfaCodeAttemptsCount(String email) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CountType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CountType.java
@@ -2,8 +2,11 @@ package uk.gov.di.authentication.shared.entity;
 
 public enum CountType {
     ENTER_PASSWORD("ENTER_PASSWORD"),
+    ENTER_MFA_CODE("ENTER_MFA_CODE"),
+    // TODO START remove temporary ZDD measure to keep deprecated count types
     ENTER_SMS_CODE("ENTER_SMS_CODE"),
     ENTER_AUTH_APP_CODE("ENTER_AUTH_APP_CODE"),
+    // TODO END remove temporary ZDD measure to keep deprecated count types
     ENTER_EMAIL_CODE("ENTER_EMAIL_CODE"),
     ENTER_EMAIL("ENTER_EMAIL");
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelper.java
@@ -6,10 +6,9 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import java.util.List;
 import java.util.Map;
 
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_AUTH_APP_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_MFA_CODE;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_SMS_CODE;
 
 public class ReauthAuthenticationAttemptsHelper {
 
@@ -22,8 +21,7 @@ public class ReauthAuthenticationAttemptsHelper {
                 Map.ofEntries(
                         Map.entry(ENTER_EMAIL, configurationService.getMaxEmailReAuthRetries()),
                         Map.entry(ENTER_PASSWORD, configurationService.getMaxPasswordRetries()),
-                        Map.entry(ENTER_SMS_CODE, configurationService.getCodeMaxRetries()),
-                        Map.entry(ENTER_AUTH_APP_CODE, configurationService.getCodeMaxRetries()));
+                        Map.entry(ENTER_MFA_CODE, configurationService.getCodeMaxRetries()));
 
         return reauthRelevantCountsToMaxRetries.entrySet().stream()
                 .filter(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -67,26 +67,24 @@ public class CodeStorageService {
     }
 
     public int getIncorrectMfaCodeAttemptsCount(String email) {
-        return getCount(email, MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX);
+        return getCount(email, MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX)
+                // TODO remove temporary ZDD measure to fetch existing counts using deprecated
+                //  prefixes
+                + getCount(
+                        email,
+                        MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX + MFAMethodType.SMS.getValue())
+                + getCount(
+                        email,
+                        MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX
+                                + MFAMethodType.AUTH_APP.getValue());
     }
 
     public void deleteIncorrectMfaCodeAttemptsCount(String email) {
         deleteCount(email, MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX);
-    }
-
-    public void increaseIncorrectMfaCodeAttemptsCount(String email, MFAMethodType mfaMethodType) {
-        String prefix = MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX + mfaMethodType.getValue();
-        increaseCount(email, prefix, configurationService.getLockoutCountTTL());
-    }
-
-    public int getIncorrectMfaCodeAttemptsCount(String email, MFAMethodType mfaMethodType) {
-        var prefix = MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX + mfaMethodType.getValue();
-        return getCount(email, prefix);
-    }
-
-    public void deleteIncorrectMfaCodeAttemptsCount(String email, MFAMethodType mfaMethodType) {
-        String prefix = MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX + mfaMethodType.getValue();
-        deleteCount(email, prefix);
+        // TODO remove temporary ZDD measure to delete existing counts using deprecated prefixes
+        deleteCount(email, MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX + MFAMethodType.SMS.getValue());
+        deleteCount(
+                email, MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX + MFAMethodType.AUTH_APP.getValue());
     }
 
     public void increaseIncorrectPasswordCount(String email) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/AuthenticationAttemptsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/AuthenticationAttemptsTest.java
@@ -13,7 +13,7 @@ class AuthenticationAttemptsTest {
     private static final JourneyType JOURNEY_TYPE = JourneyType.REAUTHENTICATION;
     private static final String CREATED_DATE = "2024-07-29T10:00:00Z";
     private static final String UPDATED_DATE = "2024-07-29T10:30:00Z";
-    private static final CountType COUNT_TYPE = CountType.ENTER_AUTH_APP_CODE;
+    private static final CountType COUNT_TYPE = CountType.ENTER_MFA_CODE;
     private static final long TTL = 1234567890L;
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ReauthAuthenticationAttemptsHelperTest.java
@@ -28,11 +28,10 @@ class ReauthAuthenticationAttemptsHelperTest {
                 Map.ofEntries(
                         Map.entry(CountType.ENTER_EMAIL, maxEmailRetries + 1),
                         Map.entry(CountType.ENTER_PASSWORD, maxPasswordRetries - 1),
-                        Map.entry(CountType.ENTER_AUTH_APP_CODE, maxCodeRetries),
+                        Map.entry(CountType.ENTER_MFA_CODE, maxCodeRetries),
                         Map.entry(CountType.ENTER_EMAIL_CODE, 100));
 
-        var expectedReauthCountsExceeded =
-                List.of(CountType.ENTER_EMAIL, CountType.ENTER_AUTH_APP_CODE);
+        var expectedReauthCountsExceeded = List.of(CountType.ENTER_EMAIL, CountType.ENTER_MFA_CODE);
         var actualReauthCountsExceeded =
                 ReauthAuthenticationAttemptsHelper.countTypesWhereUserIsBlockedForReauth(
                         retrievedCountTypesToCounts, configurationService);


### PR DESCRIPTION
## What

Going forward we will be merging the separate counts for uses of SMS and AUTH_APP MFA into a single count to support simple lockout logic when a user has multiple MFAs.

Here the `CodeStorageService` and `AuthenticationAttemptsService` and their uses are updated to reflect this. They recorded separate redis and DynamoDB records for the counts.

Note that currently the `AuthenticationAttemptsService` is only used for count when a user is on a REAUTHENTICATION journey.

As this change will affect the uses of existing counts, we need to make sure the now deprecated count records are included in lockout logic until the deprecated count records expire.

This means the inclusion of temporary code that can be removed later to ensure a zero-downtime deployment with no user facing changes.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
