### PR TITLE
AUT-4408: Manage dependency between api exec logs creation and subscription

### DIFF
--- a/ci/cloudformation/auth/api/auth-internal-api.yaml
+++ b/ci/cloudformation/auth/api/auth-internal-api.yaml
@@ -119,16 +119,35 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref AuthInternalApiAccessLogGroup
 
+  AuthInternalApiExecutionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      KmsKeyId: !GetAtt MainKmsKey.Arn
+      LogGroupName: !Sub
+        - API-Gateway-Execution-Logs_${AuthInternalApi}/${StageName}
+        - StageName:
+            !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      RetentionInDays:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          cloudwatchLogRetentionInDays,
+        ]
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-AuthInternalApiExecutionLogGroup"
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Source
+          Value: govuk-one-login/authentication-api/ci/cloudformation/auth/api/auth-internal-api.yaml
+
   AuthInternalApiExecutionLogSubscriptionFilter:
     Condition: IsSplunkEnabled
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Ref LoggingSubscriptionEndpointArn
       FilterPattern: ""
-      LogGroupName: !Sub
-        - API-Gateway-Execution-Logs_${AuthInternalApi}/${StageName}
-        - StageName:
-            !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      LogGroupName: !Ref AuthInternalApiExecutionLogGroup
 
   AuthInternalApiDashboard:
     Type: AWS::CloudWatch::Dashboard


### PR DESCRIPTION
## What

Manage dependency between api exec logs creation and subscription

`API-Gateway-Execution-Logs_${AuthInternalApi}/${StageName}` CloudWatch log group gets created automatically by Serverless::Api. Though not quick enough (during the first ever deployment) for the SubscriptionFilter, and the deployment fails with dependency issues. 
Tried and tested solution: Creating the log group explicitly to workaround the dependency issue.

Issue: [AUT-4408]

<!-- Describe what you have changed and why -->

## How to review

Test this in authdevs via either CLI (`./sam-deploy-authdevs.sh`) or GHA [deployment](https://github.com/govuk-one-login/authentication-api/actions/workflows/deploy-api-modules-sp-dev.yml) 

[AUT-4408]: https://govukverify.atlassian.net/browse/AUT-4408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ