### PR TITLE
ATO-1696/Add channel to audit event

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -467,6 +467,9 @@ public class AuthorisationHandler
             auditEventExtensions.add(pair("maximumSessionAge", maxAgeParam.get()));
         }
 
+        getCustomParameterOpt(authRequest, "channel")
+                .ifPresent(channel -> auditEventExtensions.add(pair("channel", channel)));
+
         auditService.submitAuditEvent(
                 OidcAuditableEvent.AUTHORISATION_REQUEST_PARSED,
                 authRequest.getClientID().getValue(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -99,11 +99,11 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.text.ParseException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -111,6 +111,7 @@ import java.util.stream.Stream;
 import static com.nimbusds.oauth2.sdk.OAuth2Error.INVALID_REQUEST;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -740,7 +741,7 @@ class AuthorisationHandlerTest {
             verify(orchClientSessionService).storeClientSession(orchClientSession);
 
             verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, false, "LOW_LEVEL");
+                    Map.of("credential_trust_level", "LOW_LEVEL"));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -1202,7 +1203,7 @@ class AuthorisationHandlerTest {
             APIGatewayProxyRequestEvent event = withRequestEvent(requestParams);
 
             makeHandlerRequest(event);
-            verifyAuthorisationRequestParsedAuditEvent(rpSid, false, false, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent(Map.of("rpSid", rpSid));
         }
 
         @Test
@@ -1212,8 +1213,7 @@ class AuthorisationHandlerTest {
 
             makeHandlerRequest(event);
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, false, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent();
         }
 
         @Test
@@ -1223,8 +1223,7 @@ class AuthorisationHandlerTest {
 
             makeHandlerRequest(event);
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, false, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent();
         }
 
         @Test
@@ -1234,8 +1233,7 @@ class AuthorisationHandlerTest {
 
             makeHandlerRequest(event);
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, true, false, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent(Map.of("identityRequested", true));
         }
 
         @Test
@@ -1249,9 +1247,7 @@ class AuthorisationHandlerTest {
             APIGatewayProxyRequestEvent event = withRequestEvent(requestParams);
 
             makeHandlerRequest(event);
-
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, false, "MEDIUM_LEVEL", 123);
+            verifyAuthorisationRequestParsedAuditEvent(Map.of("maximumSessionAge", 123));
         }
 
         @Test
@@ -1266,16 +1262,8 @@ class AuthorisationHandlerTest {
 
             makeHandlerRequest(event);
 
-            verify(auditService)
-                    .submitAuditEvent(
-                            OidcAuditableEvent.AUTHORISATION_REQUEST_PARSED,
-                            CLIENT_ID.getValue(),
-                            BASE_AUDIT_USER,
-                            pair("rpSid", ""),
-                            pair("identityRequested", false),
-                            pair("reauthRequested", false),
-                            pair("credential_trust_level", "MEDIUM_LEVEL"),
-                            pair("channel", Channel.GENERIC_APP.toString()));
+            verifyAuthorisationRequestParsedAuditEvent(
+                    Map.of("channel", Channel.GENERIC_APP.toString()));
         }
 
         @Test
@@ -1324,8 +1312,7 @@ class AuthorisationHandlerTest {
 
             makeHandlerRequest(event);
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, false, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent();
             ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
 
@@ -1347,8 +1334,7 @@ class AuthorisationHandlerTest {
 
             makeHandlerRequest(event);
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, false, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent();
             ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
 
@@ -1368,8 +1354,7 @@ class AuthorisationHandlerTest {
 
             makeHandlerRequest(event);
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, false, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent();
             ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
 
@@ -1438,8 +1423,7 @@ class AuthorisationHandlerTest {
 
             makeHandlerRequest(event);
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, true, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent(Map.of("reauthRequested", true));
 
             ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
@@ -1465,8 +1449,7 @@ class AuthorisationHandlerTest {
 
             makeHandlerRequest(event);
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, false, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent();
 
             ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
@@ -1489,8 +1472,8 @@ class AuthorisationHandlerTest {
 
             URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, false, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent();
+
             assertThat(uri.getQuery(), not(containsString("reauthenticate")));
             assertThat(uri.getQuery(), not(containsString("previous_govuk_signin_journey_id")));
         }
@@ -1535,8 +1518,8 @@ class AuthorisationHandlerTest {
             assertThat(response, hasStatus(302));
             assertEquals(expectedURI, response.getHeaders().get(ResponseHeaders.LOCATION));
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, true, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent(Map.of("reauthRequested", true));
+
             verify(auditService)
                     .submitAuditEvent(
                             AUTHORISATION_REQUEST_ERROR,
@@ -1589,8 +1572,7 @@ class AuthorisationHandlerTest {
             assertThat(response, hasStatus(302));
             assertEquals(expectedURI, response.getHeaders().get(ResponseHeaders.LOCATION));
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, true, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent(Map.of("reauthRequested", true));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -1660,8 +1642,7 @@ class AuthorisationHandlerTest {
 
             makeHandlerRequest(event);
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, false, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent();
 
             ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
@@ -1701,8 +1682,7 @@ class AuthorisationHandlerTest {
 
             makeHandlerRequest(event);
 
-            verifyAuthorisationRequestParsedAuditEvent(
-                    AuditService.UNKNOWN, false, false, "MEDIUM_LEVEL");
+            verifyAuthorisationRequestParsedAuditEvent();
 
             ArgumentCaptor<JWTClaimsSet> argument = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchestrationAuthorizationService).getSignedAndEncryptedJWT(argument.capture());
@@ -3102,43 +3082,35 @@ class AuthorisationHandlerTest {
                 .build();
     }
 
-    private void verifyAuthorisationRequestParsedAuditEvent(
-            String rpSid,
-            boolean identityRequested,
-            boolean reauthRequested,
-            String credentialTrustLevel) {
-        verifyAuthorisationRequestParsedAuditEvent(
-                rpSid, identityRequested, reauthRequested, credentialTrustLevel, null);
+    private void verifyAuthorisationRequestParsedAuditEvent() {
+        verifyAuthorisationRequestParsedAuditEvent(Map.of());
     }
 
     private void verifyAuthorisationRequestParsedAuditEvent(
-            String rpSid,
-            boolean identityRequested,
-            boolean reauthRequested,
-            String credentialTrustLevel,
-            Integer maxAge) {
-        if (Objects.isNull(maxAge)) {
-            verify(auditService)
-                    .submitAuditEvent(
-                            OidcAuditableEvent.AUTHORISATION_REQUEST_PARSED,
-                            CLIENT_ID.getValue(),
-                            BASE_AUDIT_USER,
-                            pair("rpSid", rpSid),
-                            pair("identityRequested", identityRequested),
-                            pair("reauthRequested", reauthRequested),
-                            pair("credential_trust_level", credentialTrustLevel));
-        } else {
-            verify(auditService)
-                    .submitAuditEvent(
-                            OidcAuditableEvent.AUTHORISATION_REQUEST_PARSED,
-                            CLIENT_ID.getValue(),
-                            BASE_AUDIT_USER,
-                            pair("rpSid", rpSid),
-                            pair("identityRequested", identityRequested),
-                            pair("reauthRequested", reauthRequested),
-                            pair("credential_trust_level", credentialTrustLevel),
-                            pair("maximumSessionAge", maxAge));
-        }
+            Map<String, Object> extraOrSubstituteMetadata) {
+        Map<String, Object> metadataPairs = new HashMap<>();
+        metadataPairs.put("rpSid", AuditService.UNKNOWN);
+        metadataPairs.put("identityRequested", false);
+        metadataPairs.put("reauthRequested", false);
+        metadataPairs.put("credential_trust_level", "MEDIUM_LEVEL");
+        metadataPairs.putAll(extraOrSubstituteMetadata);
+        AuditService.MetadataPair[] expectedMetadataPairs =
+                metadataPairs.entrySet().stream()
+                        .map(entry -> pair(entry.getKey(), entry.getValue()))
+                        .toArray(AuditService.MetadataPair[]::new);
+        ArgumentCaptor<AuditService.MetadataPair[]> metadataPairCaptor =
+                ArgumentCaptor.forClass(AuditService.MetadataPair[].class);
+
+        verify(auditService)
+                .submitAuditEvent(
+                        eq(OidcAuditableEvent.AUTHORISATION_REQUEST_PARSED),
+                        eq(CLIENT_ID.getValue()),
+                        eq(BASE_AUDIT_USER),
+                        metadataPairCaptor.capture());
+
+        assertThat(
+                Arrays.asList(metadataPairCaptor.getValue()),
+                containsInAnyOrder(expectedMetadataPairs));
     }
 
     private static ECKey generateECSigningKey() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -1255,6 +1255,30 @@ class AuthorisationHandlerTest {
         }
 
         @Test
+        void shouldSendAuditRequestParsedWithChannel() {
+            var client = generateClientRegistry();
+            client.setMaxAgeEnabled(true);
+            when(configService.supportMaxAgeEnabled()).thenReturn(true);
+            when(clientService.getClient(anyString())).thenReturn(Optional.of(client));
+            Map<String, String> requestParams =
+                    buildRequestParams(Map.of("channel", Channel.GENERIC_APP.toString()));
+            APIGatewayProxyRequestEvent event = withRequestEvent(requestParams);
+
+            makeHandlerRequest(event);
+
+            verify(auditService)
+                    .submitAuditEvent(
+                            OidcAuditableEvent.AUTHORISATION_REQUEST_PARSED,
+                            CLIENT_ID.getValue(),
+                            BASE_AUDIT_USER,
+                            pair("rpSid", ""),
+                            pair("identityRequested", false),
+                            pair("reauthRequested", false),
+                            pair("credential_trust_level", "MEDIUM_LEVEL"),
+                            pair("channel", Channel.GENERIC_APP.toString()));
+        }
+
+        @Test
         void shouldAddPreviousSessionIdClaimIfThereIsAnExistingOrchSession() throws ParseException {
             when(sessionService.getSession(any())).thenReturn(Optional.of(new Session()));
             when(orchSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(orchSession));


### PR DESCRIPTION
### Wider context of change

- We are now allowing RPs to specify `channel` in the auth request and if they do so, this overrides the value in the client registry.

### What’s changed

- When RPs specify `channel` in the auth request, include `channel` when submitting the request parsed event to audit 
- Refactored authoriseRequestHandler to improve readability: extracted a method to sendAuthRequestParsedAuditEvent.
