### PR TITLE
ATO-1658: Use correct field names from event

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/GlobalLogoutMessage.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/GlobalLogoutMessage.java
@@ -4,21 +4,21 @@ import com.google.gson.annotations.Expose;
 import uk.gov.di.orchestration.shared.validation.Required;
 
 public class GlobalLogoutMessage {
-    @Expose @Required private String internalCommonSubjectId;
+    @Expose @Required private String userId;
     @Expose @Required private String sessionId;
-    @Expose @Required private String clientSessionId;
+    @Expose @Required private String govukSigninJourneyId;
 
     public GlobalLogoutMessage() {}
 
     public GlobalLogoutMessage(
             String internalCommonSubjectId, String sessionId, String clientSessionId) {
-        this.internalCommonSubjectId = internalCommonSubjectId;
+        this.userId = internalCommonSubjectId;
         this.sessionId = sessionId;
-        this.clientSessionId = clientSessionId;
+        this.govukSigninJourneyId = clientSessionId;
     }
 
     public String getInternalCommonSubjectId() {
-        return internalCommonSubjectId;
+        return userId;
     }
 
     public String getSessionId() {
@@ -26,6 +26,6 @@ public class GlobalLogoutMessage {
     }
 
     public String getClientSessionId() {
-        return clientSessionId;
+        return govukSigninJourneyId;
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandlerTest.java
@@ -23,22 +23,22 @@ public class GlobalLogoutHandlerTest {
         return Stream.of(
                 Arguments.of(
                         Named.of(
-                                "Missing internal_common_subject_id",
+                                "Missing user_id",
                                 Map.ofEntries(
                                         Map.entry("session_id", "sid"),
-                                        Map.entry("client_session_id", "csid")))),
+                                        Map.entry("govuk_signin_journey_id", "csid")))),
                 Arguments.of(
                         Named.of(
                                 "Missing session_id",
                                 Map.ofEntries(
-                                        Map.entry("internal_common_subject_id", "icsid"),
-                                        Map.entry("client_session_id", "csid")))),
+                                        Map.entry("user_id", "icsid"),
+                                        Map.entry("govuk_signin_journey_id", "csid")))),
                 Arguments.of(
                         Named.of(
-                                "Missing client_session_id",
+                                "Missing govuk_signin_journey_id",
                                 Map.ofEntries(
                                         Map.entry("session_id", "sid"),
-                                        Map.entry("internal_common_subject_id", "icsid")))),
+                                        Map.entry("user_id", "icsid")))),
                 Arguments.of(Named.of("Invalid JSON", "{")));
     }
 


### PR DESCRIPTION
### Wider context of change

We have a GlobalLogout lambda that will be consuming messages from a TxMA queue. When the lambda was created there was a bit of ambiguity as to what the incoming message will look like. We recently had a meeting with home to discuss this and decide on the names of the field and the format of the message.

### What’s changed

Home are going to be sending us `govuk_signin_journey_id` instead of `client_session_id` and `user_id` instead of `internal_common_subject_id`. This PR updates the validation to check for the new field names.

I've left the getters as the orch names for these fields so it's easier to use the message in orch.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
