### PR TITLE
ATO-1661: Enable SnapStart on GlobalLogoutLambda

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -2105,6 +2105,8 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
+      SnapStart:
+        ApplyOn: PublishedVersions
       Environment:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.


### PR DESCRIPTION
### Wider context of change

We recently created a GlobalLogout handler, but forgot to enable SnapStart for it. Since this lambda will not be caching anything, it should be safe to do so.

### What’s changed

The GlobalLogoutHandler now uses SnapStart

### Manual testing

Will test in dev(?)

### Checklist

- [ ] Lambdas have correct permissions for the resources they're accessing.
- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] Changes have been made to contract tests or not required.
- [ ] Changes have been made to the simulator or not required.
- [ ] Changes have been made to stubs or not required.
- [ ] Successfully deployed to authdev or not required.
- [ ] Successfully run Authentication acceptance tests against sandpit or not required.
