### PR TITLE
ATO-1637 Disallow POST authorize requests

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -1002,7 +1002,7 @@ resource "aws_api_gateway_resource" "orch_authorisation_resource" {
 }
 
 resource "aws_api_gateway_method" "orch_authorisation_method" {
-  for_each    = var.orch_authorisation_enabled ? toset(["GET", "POST"]) : []
+  for_each    = var.orch_authorisation_enabled ? toset(["GET"]) : []
   rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
   resource_id = aws_api_gateway_resource.orch_authorisation_resource[0].id
   http_method = each.key
@@ -1036,7 +1036,7 @@ resource "aws_api_gateway_method" "orch_auth_code_method" {
 }
 
 resource "aws_api_gateway_integration" "orch_authorisation_integration" {
-  for_each    = var.orch_authorisation_enabled ? toset(["GET", "POST"]) : []
+  for_each    = var.orch_authorisation_enabled ? toset(["GET"]) : []
   rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
   resource_id = aws_api_gateway_resource.orch_authorisation_resource[0].id
   http_method = aws_api_gateway_method.orch_authorisation_method[each.key].http_method

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -30,7 +30,7 @@ module "authorize" {
 
   endpoint_name   = "authorize"
   path_part       = var.orch_authorisation_enabled ? "authorize-auth" : "authorize"
-  endpoint_method = ["GET", "POST"]
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -113,7 +113,6 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachOrchSes
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.updateAttachedLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.updateAttachedSessionIdToLogs;
-import static uk.gov.di.orchestration.shared.helpers.RequestBodyHelper.parseRequestBody;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
 
 public class AuthorisationHandler
@@ -265,21 +264,17 @@ public class AuthorisationHandler
 
         AuthenticationRequest authRequest;
         try {
-            Map<String, String> parameterMap =
-                    switch (input.getHttpMethod()) {
-                        case "GET" -> input.getQueryStringParameters();
-                        case "POST" -> parseRequestBody(input.getBody());
-                        default -> {
-                            LOG.warn(
-                                    String.format(
-                                            "Authentication request sent with invalid HTTP method %s",
-                                            input.getHttpMethod()));
-                            throw new InvalidHttpMethodException(
-                                    String.format(
-                                            "Authentication request does not support %s requests",
-                                            input.getHttpMethod()));
-                        }
-                    };
+            if (!"GET".equals(input.getHttpMethod())) {
+                LOG.warn(
+                        String.format(
+                                "Authentication request sent with invalid HTTP method %s",
+                                input.getHttpMethod()));
+                throw new InvalidHttpMethodException(
+                        String.format(
+                                "Authentication request does not support %s requests",
+                                input.getHttpMethod()));
+            }
+            Map<String, String> parameterMap = input.getQueryStringParameters();
             Map<String, List<String>> requestParameters =
                     parameterMap.entrySet().stream()
                             .collect(

--- a/template.yaml
+++ b/template.yaml
@@ -3182,23 +3182,6 @@ Resources:
           ApiId:
             !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
 
-  AuthorisationFunctionCrossAccountPostPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref AuthorisationFunction.Alias
-      Action: lambda:InvokeFunction
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub
-        - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/POST/authorize"
-        - AccountId:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              authAccountId,
-            ]
-          ApiId:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
-
   AuthorisationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:


### PR DESCRIPTION
### Wider context of change

Support for POST authorise requests was added in 2023 as it was anticipated that this would be required by HMRC. This is no longer the case so there is no requirement to support POST authorise requests. 

### What’s changed

- update terraform for API gateway and authorize endpoint to only allow authorise requests with GET
- In AuthorisationHandler, only support authorise requests with GET
- update unit test for allowed http methods
- remove redundant unit tests for POST requests

### Manual testing

Deployed terraform changes to sandpit and observed the following:
- POST request from RP stub is not permitted (403 response)
- GET request from RP stub remains successful


### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
