### PR TITLE
ATO-982: Remove setting and deleting

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -993,9 +993,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
     private void assertRedirectToSuspendedPage(APIGatewayProxyResponseEvent response) {
         assertThat(response, hasStatus(302));
-        assertThrows(
-                uk.gov.di.orchestration.shared.serialization.Json.JsonException.class,
-                () -> redis.getSession(SESSION_ID));
+        assertTrue(orchSessionExtension.getSession(SESSION_ID).isEmpty());
 
         URI redirectLocationHeader =
                 URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
@@ -1019,9 +1017,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
     private void assertRedirectToBlockedPage(APIGatewayProxyResponseEvent response) {
         assertThat(response, hasStatus(302));
-        assertThrows(
-                uk.gov.di.orchestration.shared.serialization.Json.JsonException.class,
-                () -> redis.getSession(SESSION_ID));
+        assertTrue(orchSessionExtension.getSession(SESSION_ID).isEmpty());
 
         URI redirectLocationHeader =
                 URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
@@ -1129,9 +1125,7 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     }
 
     private void assertSessionIsDeleted() {
-        var session = redis.getFromRedis(SESSION_ID);
         var orchSession = orchSessionExtension.getSession(SESSION_ID);
-        assertNull(session);
         assertTrue(orchSession.isEmpty());
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -685,11 +685,8 @@ public class AuthorisationHandler
                         newSessionId);
 
             } else {
-                var previousSession = existingSession.get();
                 var previousSessionId = previousSessionIdFromCookie.get();
-                session =
-                        sessionService.updateWithNewSessionId(
-                                previousSession, previousSessionId, newSessionId);
+                session = new Session();
 
                 orchSession =
                         updateOrchSession(newSessionId, existingOrchSessionOptional.get(), timeNow);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -637,16 +637,12 @@ public class AuthorisationHandler
                 browserSessionIdFromSession.isPresent()
                         && !Objects.equals(browserSessionIdFromSession, browserSessionIdFromCookie);
 
-        Session session;
         OrchSessionItem orchSession;
         var newSessionId = IdGenerator.generate();
         var newBrowserSessionId = IdGenerator.generate();
-        var existingSession = previousSessionIdFromCookie.flatMap(sessionService::getSession);
         if (previousSessionIdFromCookie.isEmpty()
-                || existingSession.isEmpty()
                 || existingOrchSessionOptional.isEmpty()
                 || doesBrowserSessionIdFromSessionNotMatchCookie) {
-            session = sessionService.generateSession();
             orchSession = createNewOrchSession(newSessionId, newBrowserSessionId);
             LOG.info("Created session with id: {}", newSessionId);
             // We re-assign here to ensure that we only pass auth previous session id
@@ -665,7 +661,6 @@ public class AuthorisationHandler
                             maxAgeParam,
                             timeNow)) {
                 var newSessionIdForPreviousSession = IdGenerator.generate();
-                session = new Session();
 
                 orchSession =
                         updateOrchSessionDueToMaxAgeExpiry(
@@ -686,7 +681,6 @@ public class AuthorisationHandler
 
             } else {
                 var previousSessionId = previousSessionIdFromCookie.get();
-                session = new Session();
 
                 orchSession =
                         updateOrchSession(newSessionId, existingOrchSessionOptional.get(), timeNow);
@@ -714,7 +708,6 @@ public class AuthorisationHandler
         orchSession.addClientSession(clientSessionId);
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         updateAttachedLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
-        sessionService.storeOrUpdateSession(session, newSessionId);
         orchSessionService.addSession(orchSession);
         LOG.info("Session saved successfully");
         return generateAuthRedirect(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -665,12 +665,7 @@ public class AuthorisationHandler
                             maxAgeParam,
                             timeNow)) {
                 var newSessionIdForPreviousSession = IdGenerator.generate();
-                session =
-                        updateSharedSessionDueToMaxAgeExpiry(
-                                existingSession.get(),
-                                previousSessionIdFromCookie.get(),
-                                newSessionIdForPreviousSession,
-                                newSessionId);
+                session = new Session();
 
                 orchSession =
                         updateOrchSessionDueToMaxAgeExpiry(
@@ -782,18 +777,6 @@ public class AuthorisationHandler
                         .withPreviousSessionId(newSessionIdForPreviousSession);
         newSession.resetProcessingIdentityAttempts();
         newSession.resetClientSessions();
-        return newSession;
-    }
-
-    private Session updateSharedSessionDueToMaxAgeExpiry(
-            Session previousSession,
-            String previousSessionId,
-            String newSessionIdForPreviousSession,
-            String newSessionId) {
-        sessionService.updateWithNewSessionId(
-                previousSession, previousSessionId, newSessionIdForPreviousSession);
-        var newSession = sessionService.copySessionForMaxAge(previousSession);
-        sessionService.storeOrUpdateSession(newSession, newSessionId);
         return newSession;
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -662,7 +662,6 @@ class AuthorisationHandlerTest {
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
-            verify(sessionService).storeOrUpdateSession(session, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
             verify(orchSessionService).deleteSession(SESSION_ID);
             verify(orchClientSessionService).storeClientSession(orchClientSession);
@@ -734,7 +733,6 @@ class AuthorisationHandlerTest {
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
-            verify(sessionService).storeOrUpdateSession(session, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
             verify(orchSessionService).deleteSession(SESSION_ID);
             verify(orchClientSessionService).storeClientSession(orchClientSession);
@@ -783,7 +781,6 @@ class AuthorisationHandlerTest {
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
 
-            verify(sessionService).storeOrUpdateSession(session, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
             verify(orchSessionService).deleteSession(SESSION_ID);
             verify(orchClientSessionService).storeClientSession(orchClientSession);
@@ -2778,6 +2775,7 @@ class AuthorisationHandlerTest {
 
             ArgumentCaptor<OrchSessionItem> addSessionCaptor =
                     ArgumentCaptor.forClass(OrchSessionItem.class);
+            ArgumentCaptor<Session> newSharedSesisonCaptor = ArgumentCaptor.forClass(Session.class);
             if (maxAgeExpired) {
                 verify(orchSessionService, times(2)).addSession(addSessionCaptor.capture());
                 OrchSessionItem updatedPreviousSession = addSessionCaptor.getAllValues().get(0);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -2778,11 +2778,8 @@ class AuthorisationHandlerTest {
 
             ArgumentCaptor<OrchSessionItem> addSessionCaptor =
                     ArgumentCaptor.forClass(OrchSessionItem.class);
-            ArgumentCaptor<Session> newSharedSesisonCaptor = ArgumentCaptor.forClass(Session.class);
             if (maxAgeExpired) {
                 verify(orchSessionService, times(2)).addSession(addSessionCaptor.capture());
-                verify(sessionService, times(2))
-                        .storeOrUpdateSession(newSharedSesisonCaptor.capture(), anyString());
                 OrchSessionItem updatedPreviousSession = addSessionCaptor.getAllValues().get(0);
                 OrchSessionItem newOrchSession = addSessionCaptor.getAllValues().get(1);
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -338,7 +338,7 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
+
             verify(orchSessionService).addSession(any());
             verify(orchClientSessionService).storeClientSession(orchClientSession);
 
@@ -595,7 +595,6 @@ class AuthorisationHandlerTest {
                                 .contains("lng="));
             }
 
-            verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
             verify(orchClientSessionService).storeClientSession(orchClientSession);
 
             verify(auditService)
@@ -1006,7 +1005,7 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
+
             verify(orchSessionService).addSession(any());
 
             verify(requestObjectAuthorizeValidator).validate(any());
@@ -1063,7 +1062,7 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
+
             verify(orchSessionService).addSession(any());
 
             verify(auditService)
@@ -1149,7 +1148,6 @@ class AuthorisationHandlerTest {
                     extractSessionId(
                             diPersistentCookieString, EXPECTED_BASE_PERSISTENT_COOKIE_VALUE);
             assertTrue(isValidPersistentSessionCookieWithDoubleDashedTimestamp(sessionId));
-            verify(sessionService).storeOrUpdateSession(newSession, NEW_SESSION_ID);
             verify(orchSessionService).addSession(any());
 
             verify(requestObjectAuthorizeValidator).validate(any());
@@ -1741,10 +1739,6 @@ class AuthorisationHandlerTest {
             withExistingOrchSession(null);
             APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
-            verify(sessionService).generateSession();
-            verify(sessionService)
-                    .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
-
             verify(orchSessionService).addSession(orchSessionCaptor.capture());
             var actualOrchSession = orchSessionCaptor.getValue();
             assertEquals(NEW_SESSION_ID, actualOrchSession.getSessionId());
@@ -1769,10 +1763,6 @@ class AuthorisationHandlerTest {
             withExistingSession(null);
             withExistingOrchSession(null);
             APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
-
-            verify(sessionService).generateSession();
-            verify(sessionService)
-                    .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
             verify(orchSessionService).addSession(orchSessionCaptor.capture());
             var actualOrchSession = orchSessionCaptor.getValue();
@@ -1799,10 +1789,6 @@ class AuthorisationHandlerTest {
             withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
             APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(null);
 
-            verify(sessionService).generateSession();
-            verify(sessionService)
-                    .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
-
             verify(orchSessionService).addSession(orchSessionCaptor.capture());
             var actualOrchSession = orchSessionCaptor.getValue();
             assertEquals(NEW_SESSION_ID, actualOrchSession.getSessionId());
@@ -1827,10 +1813,6 @@ class AuthorisationHandlerTest {
             withExistingSession(session);
             withExistingOrchSession(orchSession.withBrowserSessionId(null));
             var response = makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
-
-            verify(sessionService, never()).generateSession();
-            verify(sessionService)
-                    .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
             verify(orchSessionService).addSession(orchSessionCaptor.capture());
             var actualOrchSession = orchSessionCaptor.getValue();
@@ -1861,10 +1843,6 @@ class AuthorisationHandlerTest {
             withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
             APIGatewayProxyResponseEvent response = makeRequestWithBSIDInCookie(BROWSER_SESSION_ID);
 
-            verify(sessionService, never()).generateSession();
-            verify(sessionService)
-                    .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
-
             verify(orchSessionService).addSession(orchSessionCaptor.capture());
             var actualOrchSession = orchSessionCaptor.getValue();
             assertEquals(NEW_SESSION_ID, actualOrchSession.getSessionId());
@@ -1890,10 +1868,6 @@ class AuthorisationHandlerTest {
             withExistingOrchSession(orchSession.withBrowserSessionId(BROWSER_SESSION_ID));
             APIGatewayProxyResponseEvent response =
                     makeRequestWithBSIDInCookie(DIFFERENT_BROWSER_SESSION_ID);
-
-            verify(sessionService).generateSession();
-            verify(sessionService)
-                    .storeOrUpdateSession(sessionCaptor.capture(), eq(NEW_SESSION_ID));
 
             verify(orchSessionService).addSession(orchSessionCaptor.capture());
             var actualOrchSession = orchSessionCaptor.getValue();

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -114,8 +114,6 @@ public class LogoutService {
             LOG.info("Deleting Orch Client session");
             orchClientSessionService.deleteStoredClientSession(clientSessionId);
         }
-        LOG.info("Deleting Session");
-        sessionService.deleteStoredSession(request.getSessionId());
 
         LOG.info("Deleting Orch Session");
         orchSessionService.deleteSession(request.getSessionId());

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/LogoutServiceTest.java
@@ -204,7 +204,6 @@ class LogoutServiceTest {
 
         verify(orchClientSessionService)
                 .deleteStoredClientSession(orchSession.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -237,7 +236,6 @@ class LogoutServiceTest {
 
         verify(orchClientSessionService)
                 .deleteStoredClientSession(orchSession.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -270,7 +268,6 @@ class LogoutServiceTest {
 
         verify(orchClientSessionService)
                 .deleteStoredClientSession(orchSession.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -304,7 +301,6 @@ class LogoutServiceTest {
 
         verify(orchClientSessionService)
                 .deleteStoredClientSession(orchSession.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -352,7 +348,6 @@ class LogoutServiceTest {
 
         verify(orchClientSessionService)
                 .deleteStoredClientSession(orchSession.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -386,7 +381,6 @@ class LogoutServiceTest {
 
         verify(orchClientSessionService)
                 .deleteStoredClientSession(orchSession.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -427,7 +421,6 @@ class LogoutServiceTest {
 
         verify(orchClientSessionService)
                 .deleteStoredClientSession(orchSession.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(backChannelLogoutService)
                 .sendLogoutMessage(argThat(withClientId("client-id")), eq(rpPairwiseId.get()));
@@ -503,7 +496,6 @@ class LogoutServiceTest {
                 .deleteStoredClientSession(orchSession.getClientSessions().get(0));
         verify(orchClientSessionService).deleteStoredClientSession("client-session-id-2");
         verify(orchClientSessionService).deleteStoredClientSession("client-session-id-3");
-        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(auditService)
                 .submitAuditEvent(
@@ -556,7 +548,6 @@ class LogoutServiceTest {
 
         verify(orchClientSessionService)
                 .deleteStoredClientSession(orchSession.getClientSessions().get(0));
-        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(backChannelLogoutService)
                 .sendLogoutMessage(argThat(withClientId("client-id")), eq(rpPairwiseId.get()));
@@ -595,7 +586,6 @@ class LogoutServiceTest {
 
         verify(orchClientSessionService, times(1)).deleteStoredClientSession(clientSessionId1);
         verify(orchClientSessionService, times(1)).deleteStoredClientSession(clientSessionId2);
-        verify(sessionService).deleteStoredSession(SESSION_ID);
         verify(orchSessionService).deleteSession(SESSION_ID);
         verify(backChannelLogoutService)
                 .sendLogoutMessage(argThat(withClientId(clientId1)), eq("rp-pairwise-id-client-1"));


### PR DESCRIPTION
### Wider context of change:
We've now stopped reading the shared session in Orchestration, so we can stop two things:


### What’s changed:
- No longer deleting  the Redis session on logout - these will expire in an hour, so we no longer need to delete them 
- Stop setting an initial session at /authorize for both Doc app and Auth journeys. The redis session is no longer read anywhere so we can stop setting it finally!

### Manual testing: 
- Deployed to dev
- Run through an auth only journey
- Run through a max_age=0  journey
- Run through an identity journey
- Test a logout journey

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
