### PR TITLE
AUT-4449: Enable SnapStart on Auth ext lambdas in Staging only

### DIFF
--- a/ci/terraform/auth-external-api/staging.tfvars
+++ b/ci/terraform/auth-external-api/staging.tfvars
@@ -14,6 +14,5 @@ new_auth_api_vpc_endpoint_id = "vpce-07078f5f005fe5efc"
 # Logging
 logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]
 
-# Sizing
-lambda_max_concurrency = 10
-lambda_min_concurrency = 3
+# Performance Tuning
+snapstart_enabled = true

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -52,6 +52,8 @@ module "auth_token" {
   max_provisioned_concurrency = lookup(var.performance_tuning, "auth-token", local.default_performance_parameters).max_concurrency
   scaling_trigger             = lookup(var.performance_tuning, "auth-token", local.default_performance_parameters).scaling_trigger
 
+  snapstart = var.snapstart_enabled
+
   source_bucket           = aws_s3_bucket.auth_ext_source_bucket.bucket
   lambda_zip_file         = aws_s3_object.auth_ext_api_release_zip.key
   lambda_zip_file_version = aws_s3_object.auth_ext_api_release_zip.version_id

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -48,6 +48,8 @@ module "auth_userinfo" {
   max_provisioned_concurrency = lookup(var.performance_tuning, "auth-userinfo", local.default_performance_parameters).max_concurrency
   scaling_trigger             = lookup(var.performance_tuning, "auth-userinfo", local.default_performance_parameters).scaling_trigger
 
+  snapstart = var.snapstart_enabled
+
   source_bucket           = aws_s3_bucket.auth_ext_source_bucket.bucket
   lambda_zip_file         = aws_s3_object.auth_ext_api_release_zip.key
   lambda_zip_file_version = aws_s3_object.auth_ext_api_release_zip.version_id

--- a/ci/terraform/auth-external-api/variables.tf
+++ b/ci/terraform/auth-external-api/variables.tf
@@ -131,7 +131,7 @@ locals {
 }
 
 variable "snapstart_enabled" {
-  description = "The flag to enable AWS Lambda SnapStart for Lambdas , make sure you set prvsoned_concurrency to 0 for the lambda to work with SnapStart"
+  description = "The flag to enable AWS Lambda SnapStart for Lambdas, Make sure you set Provisoned_concurrency to 0 for the lambda to work with SnapStart"
   type        = bool
   default     = false
 }

--- a/ci/terraform/auth-external-api/variables.tf
+++ b/ci/terraform/auth-external-api/variables.tf
@@ -130,6 +130,12 @@ locals {
   }
 }
 
+variable "snapstart_enabled" {
+  description = "The flag to enable AWS Lambda SnapStart for Lambdas , make sure you set prvsoned_concurrency to 0 for the lambda to work with SnapStart"
+  type        = bool
+  default     = false
+}
+
 variable "vpc_environment" {
   description = "The name of the environment this environment is sharing the VPC , this var is only for Authdevs env and must be overide using Authdevs.tfvars, default value should be null always."
   type        = string


### PR DESCRIPTION
## What

AUT-4449: Enable SnapStart on Auth ext lambdas in Staging only


## How to review

For example:

1. Code Review
1. Deploy to sandpit/authdev's  with `./deploy-sandpit.sh -x -p `
1. Ensure that  no changes to Lambda config for SnapStart
