### PR TITLE
ATO-1658: Add validation for empty strings for global logout

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/GlobalLogoutMessage.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/GlobalLogoutMessage.java
@@ -3,59 +3,11 @@ package uk.gov.di.authentication.oidc.entity;
 import com.google.gson.annotations.Expose;
 import uk.gov.di.orchestration.shared.validation.Required;
 
-public class GlobalLogoutMessage {
-    @Expose @Required private String clientId;
-    @Expose @Required private String eventId;
-    @Expose @Required private String sessionId;
-    @Expose @Required private String clientSessionId;
-    @Expose @Required private String internalCommonSubjectId;
-    @Expose @Required private String persistentSessionId;
-    @Expose @Required private String ipAddress;
-
-    public GlobalLogoutMessage() {}
-
-    public GlobalLogoutMessage(
-            String clientId,
-            String eventId,
-            String sessionId,
-            String clientSessionId,
-            String internalCommonSubjectId,
-            String persistentSessionId,
-            String ipAddress) {
-        this.clientId = clientId;
-        this.eventId = eventId;
-        this.sessionId = sessionId;
-        this.clientSessionId = clientSessionId;
-        this.internalCommonSubjectId = internalCommonSubjectId;
-        this.persistentSessionId = persistentSessionId;
-        this.ipAddress = ipAddress;
-    }
-
-    public String getClientId() {
-        return clientId;
-    }
-
-    public String getEventId() {
-        return eventId;
-    }
-
-    public String getSessionId() {
-        return sessionId;
-    }
-
-    public String getClientSessionId() {
-        return clientSessionId;
-    }
-
-    public String getInternalCommonSubjectId() {
-        return internalCommonSubjectId;
-    }
-
-    public String getPersistentSessionId() {
-        return persistentSessionId;
-    }
-
-    public String getIpAddress() {
-        return ipAddress;
-    }
-}
+public record GlobalLogoutMessage(
+        @Expose @Required String clientId,
+        @Expose @Required String eventId,
+        @Expose @Required String sessionId,
+        @Expose @Required String clientSessionId,
+        @Expose @Required String internalCommonSubjectId,
+        @Expose @Required String persistentSessionId,
+        @Expose @Required String ipAddress) {}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/GlobalLogoutValidationException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/GlobalLogoutValidationException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+public class GlobalLogoutValidationException extends RuntimeException {
+    public GlobalLogoutValidationException(String message) {
+        super(message);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.orchestration.shared.services.SerializationService;
 import java.util.ArrayList;
 import java.util.List;
 
+import static uk.gov.di.authentication.oidc.validators.GlobalLogoutValidator.validate;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
@@ -54,6 +55,7 @@ public class GlobalLogoutHandler implements RequestHandler<SQSEvent, Object> {
         var request =
                 SerializationService.getInstance()
                         .readValue(message.getBody(), GlobalLogoutMessage.class);
+        validate(request);
         LOG.info(
                 "Received request to global logout user with session {} and client session {}",
                 request.sessionId(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandler.java
@@ -56,8 +56,8 @@ public class GlobalLogoutHandler implements RequestHandler<SQSEvent, Object> {
                         .readValue(message.getBody(), GlobalLogoutMessage.class);
         LOG.info(
                 "Received request to global logout user with session {} and client session {}",
-                request.getSessionId(),
-                request.getClientSessionId());
+                request.sessionId(),
+                request.clientSessionId());
         // TODO: Add logic for global logout (ATO-1660)
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/GlobalLogoutValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/GlobalLogoutValidator.java
@@ -1,0 +1,39 @@
+package uk.gov.di.authentication.oidc.validators;
+
+import uk.gov.di.authentication.oidc.entity.GlobalLogoutMessage;
+import uk.gov.di.authentication.oidc.exceptions.GlobalLogoutValidationException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GlobalLogoutValidator {
+    private GlobalLogoutValidator() {}
+
+    public static void validate(GlobalLogoutMessage message) {
+        List<String> invalidFields = new ArrayList<>();
+        if (message.clientId().isEmpty()) {
+            invalidFields.add("clientId");
+        }
+        if (message.eventId().isEmpty()) {
+            invalidFields.add("eventId");
+        }
+        if (message.sessionId().isEmpty()) {
+            invalidFields.add("sessionId");
+        }
+        if (message.clientSessionId().isEmpty()) {
+            invalidFields.add("clientSessionId");
+        }
+        if (message.internalCommonSubjectId().isEmpty()) {
+            invalidFields.add("internalCommonSubjectId");
+        }
+        if (message.persistentSessionId().isEmpty()) {
+            invalidFields.add("persistentSessionId");
+        }
+        if (message.ipAddress().isEmpty()) {
+            invalidFields.add("ipAddress");
+        }
+        if (!invalidFields.isEmpty()) {
+            throw new GlobalLogoutValidationException("Fields are empty strings: " + invalidFields);
+        }
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandlerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.oidc.entity.GlobalLogoutMessage;
 
 import java.util.stream.Stream;
 
@@ -20,7 +21,10 @@ public class GlobalLogoutHandlerTest {
 
     private static Stream<Arguments> invalidMessages() {
         return Stream.of(
-                Arguments.of(Named.of("Missing required fields", "{}")),
+                Arguments.of(
+                        Named.of(
+                                "Missing required fields",
+                                new GlobalLogoutMessage(null, null, null, null, null, null, null))),
                 Arguments.of(Named.of("Invalid JSON", "{")));
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandlerTest.java
@@ -25,6 +25,10 @@ public class GlobalLogoutHandlerTest {
                         Named.of(
                                 "Missing required fields",
                                 new GlobalLogoutMessage(null, null, null, null, null, null, null))),
+                Arguments.of(
+                        Named.of(
+                                "Fields are empty strings",
+                                new GlobalLogoutMessage("", "", "", "", "", "", ""))),
                 Arguments.of(Named.of("Invalid JSON", "{")));
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/validators/GlobalLogoutValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/validators/GlobalLogoutValidatorTest.java
@@ -1,0 +1,62 @@
+package uk.gov.di.authentication.oidc.validators;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.oidc.entity.GlobalLogoutMessage;
+import uk.gov.di.authentication.oidc.exceptions.GlobalLogoutValidationException;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.di.authentication.oidc.validators.GlobalLogoutValidator.validate;
+
+public class GlobalLogoutValidatorTest {
+
+    private static Stream<Arguments> invalidMessages() {
+        return Stream.of(
+                Arguments.of(
+                        Named.of(
+                                "clientId is empty string",
+                                new GlobalLogoutMessage("", "a", "a", "a", "a", "a", "a"))),
+                Arguments.of(
+                        Named.of(
+                                "eventId is empty string",
+                                new GlobalLogoutMessage("a", "", "a", "a", "a", "a", "a"))),
+                Arguments.of(
+                        Named.of(
+                                "sessionId is empty string",
+                                new GlobalLogoutMessage("a", "a", "", "a", "a", "a", "a"))),
+                Arguments.of(
+                        Named.of(
+                                "clientSessionId is empty string",
+                                new GlobalLogoutMessage("a", "a", "a", "", "a", "a", "a"))),
+                Arguments.of(
+                        Named.of(
+                                "internalCommonSubjectId is empty string",
+                                new GlobalLogoutMessage("a", "a", "a", "a", "", "a", "a"))),
+                Arguments.of(
+                        Named.of(
+                                "persistentSessionId is empty string",
+                                new GlobalLogoutMessage("a", "a", "a", "a", "a", "", "a"))),
+                Arguments.of(
+                        Named.of(
+                                "ipAddress is empty string",
+                                new GlobalLogoutMessage("a", "a", "a", "a", "a", "a", ""))));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidMessages")
+    public void shouldThrowExceptionWhenValidationFails(GlobalLogoutMessage invalidMessage) {
+        assertThrows(GlobalLogoutValidationException.class, () -> validate(invalidMessage));
+    }
+
+    @Test
+    void shouldNotThrowWhenValidationIsSuccessful() {
+        var validMessage = new GlobalLogoutMessage("a", "a", "a", "a", "a", "a", "a");
+        assertDoesNotThrow(() -> validate(validMessage));
+    }
+}


### PR DESCRIPTION
### Wider context of change

We are using the SerialisationService in the GlobalLogoutHandler to check if required fields are provided, but we are not checking if the string fields are empty or not. This is mainly a problem for internalCommonSubjectId, as we query dynamo using this field, and dynamo doesn't like empty strings.

### What’s changed

This PR adds GlobalLogoutValidator, that checks that all String fields on a GlobalLogoutMessage are not empty strings. I've also added tests for this new validator.

This PR also uses this new validator in GlobalLogoutHandler, after deserialising the message, to check that all the fields  are not empty strings.

### Manual testing


### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.
- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] Changes have been made to contract tests or not required.
- [ ] Changes have been made to the simulator or not required.
- [ ] Changes have been made to stubs or not required.
- [ ] Successfully deployed to authdev or not required.
- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
