### PR TITLE
AUT-4449: Enable SnapStart on Auth external api lambdas

### DIFF
--- a/ci/terraform/auth-external-api/authdev1.tfvars
+++ b/ci/terraform/auth-external-api/authdev1.tfvars
@@ -7,3 +7,6 @@ internal_sector_uri = "https://identity.authdev1.sandpit.account.gov.uk"
 # Signing Keys
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENB3csRUIdoaTHNn079Jl7JpiXzxF0p2ZIddCErxtIhGMTTqtbQZJCPesSKUVE/DQbpIko3mLoisuFgmQfFouCw=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM0ZehmrdDd89uYEFMTakbS7JgwCGXK7CAYMcVvy1pP5yV4O2mnDjYmvjZpvio2ctgOPxDuBb38QP1HD9WAOR2w=="
+
+# Performance Tuning
+snapstart_enabled = true

--- a/ci/terraform/auth-external-api/authdev2.tfvars
+++ b/ci/terraform/auth-external-api/authdev2.tfvars
@@ -7,3 +7,6 @@ internal_sector_uri = "https://identity.authdev2.sandpit.account.gov.uk"
 # Signing Keys
 orch_to_auth_public_signing_key      = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/Yz722IDLN1mPqkPTihkwAkp/rUmBhnWynwAkE/YZlskX+N7VmwIjupla7O6hczlIOqkmPdQ1ayDqI8yY2QOiw=="
 orch_stub_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwe8ey1GnTbH6E69EJFUkt4WQc1KltJwzOYNWUmK/+GxooRp+j9i9KWQ0WlV4gVI0iQkHY3ZKq+RWk94tSDHbyQ=="
+
+# Performance Tuning
+snapstart_enabled = true

--- a/ci/terraform/auth-external-api/build.tfvars
+++ b/ci/terraform/auth-external-api/build.tfvars
@@ -14,5 +14,5 @@ new_auth_api_vpc_endpoint_id = "vpce-042c5d3d97d7438d9"
 # Logging
 logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]
 
-# Sizing
-lambda_min_concurrency = 1
+# Performance Tuning
+snapstart_enabled = true

--- a/ci/terraform/auth-external-api/integration.tfvars
+++ b/ci/terraform/auth-external-api/integration.tfvars
@@ -12,5 +12,5 @@ orch_api_vpc_endpoint_id = "vpce-0704b783d794cea52"
 # Logging
 logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]
 
-# Sizing
-lambda_min_concurrency = 1
+# Performance Tuning
+snapstart_enabled = true

--- a/ci/terraform/auth-external-api/production.tfvars
+++ b/ci/terraform/auth-external-api/production.tfvars
@@ -13,6 +13,5 @@ orch_api_vpc_endpoint_id = "vpce-0dd5d6bf9c2a1eade"
 logging_endpoint_arns    = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]
 cloudwatch_log_retention = 30
 
-# Sizing
-lambda_max_concurrency = 10
-lambda_min_concurrency = 3
+# Performance Tuning
+snapstart_enabled = true

--- a/ci/terraform/auth-external-api/sandpit.tfvars
+++ b/ci/terraform/auth-external-api/sandpit.tfvars
@@ -8,3 +8,6 @@ orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F
 
 # VPC
 orch_api_vpc_endpoint_id = "vpce-0028f62dad635589a"
+
+# Performance Tuning
+snapstart_enabled = true


### PR DESCRIPTION
## What

AUT-4449: Enable SnapStart on Auth external api lambdas

## How to review

1. Code Review &  deploy in dev environment 
2. lambda  Auth-user and Auth-token lambda should show SnapStart enabled in lambda configuration on console