### PR TITLE
AUT-4466: Configure Home vpc endpoint ids for MM V2 API

### DIFF
--- a/ci/terraform/account-management/integration.tfvars
+++ b/ci/terraform/account-management/integration.tfvars
@@ -19,3 +19,6 @@ openapi_spec_filename = "openapi_v2.yaml"
 # Feature flags
 mfa_method_management_api_enabled = false
 ais_call_in_authenticate_enabled  = true
+
+#Vpc endpoint IDs
+home_vpc_endpoint_id = "vpce-0e594accb3d775457"

--- a/ci/terraform/account-management/production.tfvars
+++ b/ci/terraform/account-management/production.tfvars
@@ -45,3 +45,6 @@ logging_endpoint_arns    = ["arn:aws:logs:eu-west-2:885513274347:destination:csl
 
 # FMS
 am_api_fms_tag_value = "accountmanagementprod"
+
+#Vpc endpoint IDs
+home_vpc_endpoint_id = "vpce-0d7972874707185a0"

--- a/ci/terraform/account-management/staging.tfvars
+++ b/ci/terraform/account-management/staging.tfvars
@@ -34,4 +34,5 @@ lambda_max_concurrency = 3
 mfa_method_management_api_enabled = true
 ais_call_in_authenticate_enabled  = true
 
+#Vpc endpoint IDs
 home_vpc_endpoint_id = "vpce-0c9ce65be09f99db7"


### PR DESCRIPTION
## What

Configure Home vpc endpoint ids for MM V2 API

Method Management is not currently live.  This configuration is to support dormant testing of the API.

## How to review

1. Code Review

## Related PRs

#6701 