### PR TITLE
ATO-1770: Set rpSectorIdentifierHost on auth session and add logging

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -24,4 +24,5 @@ public record StartRequest(
         @Expose @SerializedName("is_one_login_service") boolean isOneLoginService,
         @Expose @SerializedName("subject_type") String subjectType,
         @Expose @SerializedName("is_identity_verification_required")
-                boolean isIdentityVerificationRequired) {}
+                boolean isIdentityVerificationRequired,
+        @Expose @SerializedName("rp_sector_identifier_host") String rpSectorIdentifierHost) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -162,6 +162,7 @@ public class StartHandler
             authSession.setIsSmokeTest(startRequest.isSmokeTest());
             authSession.setIsOneLoginService(startRequest.isOneLoginService());
             authSession.setSubjectType(startRequest.subjectType());
+            authSession.setRpSectorIdentifierHost(startRequest.rpSectorIdentifierHost());
 
             isUserAuthenticatedWithValidProfile =
                     startRequest.authenticated() && !startService.isUserProfileEmpty(authSession);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -70,7 +70,8 @@ class CheckReAuthUserHandlerTest {
     private static final String DIFFERENT_EMAIL_USED_TO_REAUTHENTICATE =
             "not.signedin.email@digital.cabinet-office.gov.uk";
     private static final String TEST_SUBJECT_ID = "subject-id";
-    private static final String INTERNAL_SECTOR_URI = "http://www.example.com";
+    private static final String SECTOR_IDENTIFIER_HOST = "example.com";
+    private static final String INTERNAL_SECTOR_URI = "http://" + SECTOR_IDENTIFIER_HOST;
     private static final String TEST_RP_PAIRWISE_ID = "TEST_RP_PAIRWISE_ID";
     private static final UserProfile USER_PROFILE =
             new UserProfile()
@@ -89,7 +90,8 @@ class CheckReAuthUserHandlerTest {
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
                     .withEmailAddress(EMAIL_USED_TO_SIGN_IN)
-                    .withClientId(CLIENT_ID);
+                    .withClientId(CLIENT_ID)
+                    .withRpSectorIdentifierHost(SECTOR_IDENTIFIER_HOST);
 
     private final AuditContext testAuditContextWithoutAuditEncoded =
             new AuditContext(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -90,13 +90,15 @@ class CheckUserExistsHandlerTest {
     private CheckUserExistsHandler handler;
     private static final Json objectMapper = SerializationService.getInstance();
     private static final String CLIENT_ID = "test-client-id";
+    private static final String SECTOR_HOST = "sector-identifier";
+    private static final String SECTOR_URI = "http://" + SECTOR_HOST;
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
                     .withRequestedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL)
-                    .withClientId(CLIENT_ID);
+                    .withClientId(CLIENT_ID)
+                    .withRpSectorIdentifierHost(SECTOR_HOST);
     private static final Subject SUBJECT = new Subject();
-    private static final String SECTOR_URI = "http://sector-identifier";
     private static final String EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final ByteBuffer SALT =
             ByteBuffer.wrap("a-test-salt".getBytes(StandardCharsets.UTF_8));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -73,6 +73,7 @@ class LoginHandlerReauthenticationRedisTest {
     private static final String EMAIL = CommonTestVariables.EMAIL;
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     public static final int MAX_ALLOWED_PASSWORD_RETRIES = 6;
+    private static final String SECTOR_IDENTIFIER_HOST = "test.com";
     private final UserCredentials userCredentials =
             new UserCredentials().withEmail(EMAIL).withPassword(CommonTestVariables.PASSWORD);
 
@@ -244,7 +245,8 @@ class LoginHandlerReauthenticationRedisTest {
                                         .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
                                         .withClientId(CLIENT_ID.getValue())
                                         .withClientName(CLIENT_NAME)
-                                        .withIsSmokeTest(false)));
+                                        .withIsSmokeTest(false)
+                                        .withRpSectorIdentifierHost(SECTOR_IDENTIFIER_HOST)));
     }
 
     private UserCredentials usingApplicableUserCredentials(MFAMethodType mfaMethodType) {
@@ -280,7 +282,7 @@ class LoginHandlerReauthenticationRedisTest {
         return new ClientRegistry()
                 .withClientID(CLIENT_ID.getValue())
                 .withClientName(CLIENT_NAME)
-                .withSectorIdentifierUri("https://test.com")
+                .withSectorIdentifierUri("https://" + SECTOR_IDENTIFIER_HOST)
                 .withSubjectType("public");
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -91,6 +91,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
 
     private static final String EMAIL = CommonTestVariables.EMAIL;
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
+    private static final String SECTOR_IDENTIFIER_HOST = "test.com";
     public static final int MAX_ALLOWED_RETRIES = 6;
     private final UserCredentials userCredentials =
             new UserCredentials().withEmail(EMAIL).withPassword(CommonTestVariables.PASSWORD);
@@ -533,7 +534,8 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                                         .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
                                         .withClientId(CLIENT_ID.getValue())
                                         .withClientName(CLIENT_NAME)
-                                        .withIsSmokeTest(false)));
+                                        .withIsSmokeTest(false)
+                                        .withRpSectorIdentifierHost(SECTOR_IDENTIFIER_HOST)));
     }
 
     private UserCredentials usingApplicableUserCredentials(MFAMethodType mfaMethodType) {
@@ -569,7 +571,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
         return new ClientRegistry()
                 .withClientID(CLIENT_ID.getValue())
                 .withClientName(CLIENT_NAME)
-                .withSectorIdentifierUri("https://test.com")
+                .withSectorIdentifierUri("https://" + SECTOR_IDENTIFIER_HOST)
                 .withSubjectType("public");
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -100,6 +100,7 @@ class LoginHandlerTest {
 
     private static final String EMAIL = CommonTestVariables.EMAIL;
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
+    private static final String SECTOR_IDENTIFIER_HOST = "test.com";
     public static final int MAX_ALLOWED_PASSWORD_RETRIES = 6;
     private final UserCredentials userCredentials =
             new UserCredentials().withEmail(EMAIL).withPassword(CommonTestVariables.PASSWORD);
@@ -1165,7 +1166,8 @@ class LoginHandlerTest {
                                         .withAchievedCredentialStrength(achievedCredentialStrength)
                                         .withRequestedCredentialStrength(
                                                 requestedCredentialStrength)
-                                        .withClientName(CLIENT_NAME)));
+                                        .withClientName(CLIENT_NAME)
+                                        .withRpSectorIdentifierHost(SECTOR_IDENTIFIER_HOST)));
     }
 
     private void usingValidAuthSessionInSmokeTest() {
@@ -1178,7 +1180,8 @@ class LoginHandlerTest {
                                         .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
                                         .withClientId(CLIENT_ID.getValue())
                                         .withRequestedCredentialStrength(MEDIUM_LEVEL)
-                                        .withIsSmokeTest(true)));
+                                        .withIsSmokeTest(true)
+                                        .withRpSectorIdentifierHost(SECTOR_IDENTIFIER_HOST)));
     }
 
     private void usingValidAuthSession() {
@@ -1230,7 +1233,7 @@ class LoginHandlerTest {
         return new ClientRegistry()
                 .withClientID(CLIENT_ID.getValue())
                 .withClientName(CLIENT_NAME)
-                .withSectorIdentifierUri("https://test.com")
+                .withSectorIdentifierUri("https://" + SECTOR_IDENTIFIER_HOST)
                 .withSubjectType("public");
     }
 
@@ -1241,7 +1244,8 @@ class LoginHandlerTest {
                                 new ClientRegistry()
                                         .withSmokeTest(true)
                                         .withClientID(CLIENT_ID.getValue())
-                                        .withSectorIdentifierUri("https://test.com")));
+                                        .withSectorIdentifierUri(
+                                                "https://" + SECTOR_IDENTIFIER_HOST)));
     }
 
     private void verifyInternalCommonSubjectIdentifierSaved() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
@@ -103,7 +103,8 @@ class MfaResetAuthorizeHandlerTest {
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
                     .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID)
-                    .withClientId(CLIENT_ID);
+                    .withClientId(CLIENT_ID)
+                    .withRpSectorIdentifierHost("gov.uk");
     private static MfaResetAuthorizeHandler handler;
     private static UserProfile userProfile = new UserProfile();
 
@@ -116,7 +117,7 @@ class MfaResetAuthorizeHandlerTest {
         when(userContext.getUserProfile()).thenReturn(Optional.of(userProfile));
         when(userContext.getTxmaAuditEncoded()).thenReturn(ENCODED_DEVICE_DETAILS);
 
-        when(clientRegistry.getSectorIdentifierUri()).thenReturn("htttps://gov.uk");
+        when(clientRegistry.getSectorIdentifierUri()).thenReturn("https://gov.uk");
 
         when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -80,6 +80,7 @@ class SignUpHandlerTest {
     private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final Subject INTERNAL_SUBJECT_ID = new Subject();
+    private static final String SECTOR_IDENTIFIER_HOST = "test.com";
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT_ID.getValue(), "test.account.gov.uk", SALT);
@@ -87,7 +88,8 @@ class SignUpHandlerTest {
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
                     .withAccountState(AuthSessionItem.AccountState.UNKNOWN)
-                    .withClientId(CLIENT_ID.getValue());
+                    .withClientId(CLIENT_ID.getValue())
+                    .withRpSectorIdentifierHost(SECTOR_IDENTIFIER_HOST);
 
     private SignUpHandler handler;
 
@@ -327,7 +329,7 @@ class SignUpHandlerTest {
         return new ClientRegistry()
                 .withClientID(CLIENT_ID.getValue())
                 .withClientName("test-client")
-                .withSectorIdentifierUri("https://test.com")
+                .withSectorIdentifierUri("https://" + SECTOR_IDENTIFIER_HOST)
                 .withSubjectType("pairwise");
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -81,6 +81,7 @@ class StartHandlerTest {
     public static final String TEST_CLIENT_NAME = "test_client_name";
     private static final String TEST_RP_PAIRWISE_ID = "test_rp_pairwise_id";
     private static final String TEST_PREVIOUS_SIGN_IN_JOURNEY_ID = "test_journey_id";
+    private static final String TEST_RP_SUBJECT_ID_HOST = "example.com";
     private static final int MAX_ALLOWED_RETRIES = 6;
     private static final String SESSION_ID = "session-id";
     public static final State STATE = new State();
@@ -523,6 +524,7 @@ class StartHandlerTest {
                         false,
                         false,
                         TEST_SUBJECT_TYPE,
-                        false));
+                        false,
+                        TEST_RP_SUBJECT_ID_HOST));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -128,7 +128,8 @@ class VerifyCodeHandlerTest {
                     .withEmailAddress(EMAIL)
                     .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID)
                     .withClientId(CLIENT_ID)
-                    .withClientName(CLIENT_NAME);
+                    .withClientName(CLIENT_NAME)
+                    .withRpSectorIdentifierHost(CLIENT_SECTOR_HOST);
     private final ClientService clientService = mock(ClientService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -122,7 +122,8 @@ class VerifyMfaCodeHandlerTest {
                     .withEmailAddress(EMAIL)
                     .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID)
                     .withClientId(CLIENT_ID)
-                    .withClientName(CLIENT_NAME);
+                    .withClientName(CLIENT_NAME)
+                    .withRpSectorIdentifierHost(CLIENT_SECTOR_HOST);
     private final Json objectMapper = SerializationService.getInstance();
     public VerifyMfaCodeHandler handler;
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -47,6 +47,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             URI.create(System.getenv("STUB_RELYING_PARTY_REDIRECT_URI"));
     private static final ClientID CLIENT_ID = new ClientID("test-client");
     private static final String CLIENT_NAME = "some-client-name";
+    private static final String SECTOR_IDENTIFIER_HOST = "test.com";
 
     @BeforeEach
     void setup() {
@@ -85,7 +86,12 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         }
 
         registerClient(
-                "joe.bloggs+1@digital.cabinet-office.gov.uk", CLIENT_ID, CLIENT_NAME, REDIRECT_URI);
+                "joe.bloggs+1@digital.cabinet-office.gov.uk",
+                CLIENT_ID,
+                CLIENT_NAME,
+                REDIRECT_URI,
+                "https://" + SECTOR_IDENTIFIER_HOST);
+        authSessionStore.addRpSectorIdentifierHostToSession(sessionId, SECTOR_IDENTIFIER_HOST);
 
         var request = new CheckUserExistsRequest(emailAddress);
         var response =
@@ -131,7 +137,12 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         redis.blockMfaCodesForEmail(emailAddress, codeBlockedKeyPrefix);
 
         registerClient(
-                "joe.bloggs+1@digital.cabinet-office.gov.uk", CLIENT_ID, CLIENT_NAME, REDIRECT_URI);
+                "joe.bloggs+1@digital.cabinet-office.gov.uk",
+                CLIENT_ID,
+                CLIENT_NAME,
+                REDIRECT_URI,
+                "https://" + SECTOR_IDENTIFIER_HOST);
+        authSessionStore.addRpSectorIdentifierHostToSession(sessionId, SECTOR_IDENTIFIER_HOST);
 
         var request = new CheckUserExistsRequest(emailAddress);
         var response =
@@ -162,7 +173,13 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         var clientSessionId = IdGenerator.generate();
-        registerClient(emailAddress, CLIENT_ID, CLIENT_NAME, REDIRECT_URI);
+        registerClient(
+                emailAddress,
+                CLIENT_ID,
+                CLIENT_NAME,
+                REDIRECT_URI,
+                "https://" + SECTOR_IDENTIFIER_HOST);
+        authSessionStore.addRpSectorIdentifierHostToSession(sessionId, SECTOR_IDENTIFIER_HOST);
         BaseFrontendRequest request = new CheckUserExistsRequest(emailAddress);
 
         var response =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -63,6 +63,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
     private final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
     private static final Scope SCOPE = new Scope(OIDCScopeValue.OPENID);
+    private static final String SECTOR_IDENTIFIER_HOST = "test.com";
     protected final Json objectMapper =
             new SerializationService(
                     Map.of(MfaMethodResponse.class, new MfaMethodResponseAdapter()));
@@ -83,7 +84,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 singletonList("http://localhost/post-redirect-logout"),
                 "http://example.com",
                 String.valueOf(ServiceType.MANDATORY),
-                "https://test.com",
+                "https://" + SECTOR_IDENTIFIER_HOST,
                 "public");
     }
 
@@ -107,6 +108,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         authSessionExtension.addClientIdToSession(sessionId, CLIENT_ID);
         authSessionExtension.addRequestedCredentialStrengthToSession(sessionId, level);
         authSessionExtension.addClientNameToSession(sessionId, CLIENT_NAME);
+        authSessionExtension.addRpSectorIdentifierHostToSession(sessionId, SECTOR_IDENTIFIER_HOST);
 
         userStore.signUp(email, password);
         userStore.updateTermsAndConditions(email, termsAndConditionsVersion);
@@ -163,6 +165,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         authSessionExtension.addClientIdToSession(sessionId, CLIENT_ID);
         authSessionExtension.addRequestedCredentialStrengthToSession(sessionId, level);
         authSessionExtension.addClientNameToSession(sessionId, CLIENT_NAME);
+        authSessionExtension.addRpSectorIdentifierHostToSession(sessionId, SECTOR_IDENTIFIER_HOST);
 
         userStore.signUp(email, password);
         userStore.updateTermsAndConditions(email, termsAndConditionsVersion);
@@ -264,6 +267,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, email);
         authSessionExtension.addClientIdToSession(sessionId, CLIENT_ID);
+        authSessionExtension.addRpSectorIdentifierHostToSession(sessionId, SECTOR_IDENTIFIER_HOST);
 
         userStore.signUp(email, password);
         userStore.updateTermsAndConditions(email, CURRENT_TERMS_AND_CONDITIONS);
@@ -291,6 +295,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, email);
         authSessionExtension.addClientIdToSession(sessionId, CLIENT_ID);
+        authSessionExtension.addRpSectorIdentifierHostToSession(sessionId, SECTOR_IDENTIFIER_HOST);
         var headers = validHeadersWithSessionId(sessionId);
 
         var response =
@@ -311,6 +316,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, email);
         authSessionExtension.addClientIdToSession(sessionId, CLIENT_ID);
+        authSessionExtension.addRpSectorIdentifierHostToSession(sessionId, SECTOR_IDENTIFIER_HOST);
         var headers = validHeadersWithSessionId(sessionId);
 
         var request = new LoginRequest(email, password, JourneyType.SIGN_IN);
@@ -345,6 +351,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, email);
         authSessionExtension.addClientIdToSession(sessionId, CLIENT_ID);
+        authSessionExtension.addRpSectorIdentifierHostToSession(sessionId, SECTOR_IDENTIFIER_HOST);
         var headers = validHeadersWithSessionId(sessionId);
 
         var request = new LoginRequest(email, password, JourneyType.SIGN_IN);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
@@ -80,6 +80,7 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
     private static final ClientID CLIENT_ID = new ClientID("test-client");
     private static final String CLIENT_NAME = "some-client-name";
     private static final String testRsaKeyId = "test-key-rsa";
+    private static final String SECTOR_IDENTIFIER_HOST = "test.com";
     private static RSAKey rsaKey;
 
     private static WireMockServer wireMockServer;
@@ -203,6 +204,7 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
         authSessionStore.addEmailToSession(sessionId, USER_EMAIL);
         authSessionStore.addInternalCommonSubjectIdToSession(sessionId, internalCommonSubjectId);
         authSessionStore.addClientIdToSession(sessionId, CLIENT_ID.getValue());
+        authSessionStore.addRpSectorIdentifierHostToSession(sessionId, SECTOR_IDENTIFIER_HOST);
     }
 
     private static void registerClient() {
@@ -216,7 +218,7 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
                 singletonList("http://localhost/post-redirect-logout"),
                 "http://example.com",
                 String.valueOf(ServiceType.MANDATORY),
-                "https://test.com",
+                "https://" + SECTOR_IDENTIFIER_HOST,
                 "public");
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -30,6 +30,7 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
             URI.create(System.getenv("STUB_RELYING_PARTY_REDIRECT_URI"));
     private static final ClientID CLIENT_ID = new ClientID("test-client");
     private static final String CLIENT_NAME = "some-client-name";
+    private static final String SECTOR_IDENTIFIER_HOST = "test.com";
 
     @BeforeEach
     public void setUp() {
@@ -50,7 +51,9 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         authSessionStore.addEmailToSession(sessionId, email);
         String persistentSessionId = "test-persistent-id";
         var clientSessionId = IdGenerator.generate();
-        registerClient(email, CLIENT_ID, CLIENT_NAME, REDIRECT_URI);
+        registerClient(
+                email, CLIENT_ID, CLIENT_NAME, REDIRECT_URI, "https://" + SECTOR_IDENTIFIER_HOST);
+        authSessionStore.addRpSectorIdentifierHostToSession(sessionId, SECTOR_IDENTIFIER_HOST);
 
         var response =
                 makeRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -41,6 +41,7 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     public static final String ENCODED_DEVICE_INFORMATION =
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
     private static final String SESSION_ID = "session-id";
+    private static final String SECTOR_IDENTIFIER_HOST = "test.com";
     private final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
 
     @BeforeEach
@@ -142,12 +143,13 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 singletonList("http://localhost/post-redirect-logout"),
                 "http://example.com",
                 String.valueOf(ServiceType.MANDATORY),
-                "https://test.com",
+                "https://" + SECTOR_IDENTIFIER_HOST,
                 "public");
     }
 
     private void withAuthSession() {
         authSessionExtension.addSession(SESSION_ID);
         authSessionExtension.addClientIdToSession(SESSION_ID, CLIENT_ID);
+        authSessionExtension.addRpSectorIdentifierHostToSession(SESSION_ID, SECTOR_IDENTIFIER_HOST);
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -264,7 +264,11 @@ public abstract class HandlerIntegrationTest<Q, S> {
     }
 
     public static void registerClient(
-            String emailAddress, ClientID clientId, String clientName, URI redirectUri) {
+            String emailAddress,
+            ClientID clientId,
+            String clientName,
+            URI redirectUri,
+            String sectorIdentifierUri) {
         clientStore.registerClient(
                 clientId.getValue(),
                 clientName,
@@ -277,7 +281,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
                 singletonList("http://localhost/post-redirect-logout"),
                 "http://example.com",
                 valueOf(ServiceType.MANDATORY),
-                "https://test.com",
+                sectorIdentifierUri,
                 "public");
     }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthSessionExtension.java
@@ -114,6 +114,14 @@ public class AuthSessionExtension extends DynamoExtension implements AfterEachCa
         updateSession(getSession(sessionId).orElseThrow().withClientName(clientName));
     }
 
+    public void addRpSectorIdentifierHostToSession(
+            String sessionId, String rpSectorIdentifierHost) {
+        updateSession(
+                getSession(sessionId)
+                        .orElseThrow()
+                        .withRpSectorIdentifierHost(rpSectorIdentifierHost));
+    }
+
     public AuthSessionItem getUpdatedPreviousSessionOrCreateNew(
             Optional<String> previousSessionId, String sessionId) {
         return authSessionService.getUpdatedPreviousSessionOrCreateNew(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -42,6 +42,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_IS_SMOKE_TEST = "IsSmokeTest";
     public static final String ATTRIBUTE_IS_ONE_LOGIN_SERVICE = "IsOneLoginService";
     public static final String ATTRIBUTE_SUBJECT_TYPE = "SubjectType";
+    public static final String ATTRIBUTE_RP_SECTOR_IDENTIFIER_HOST = "RpSectorIdentifierHost";
 
     public enum AccountState {
         NEW,
@@ -83,6 +84,7 @@ public class AuthSessionItem {
     private boolean isSmokeTest;
     private boolean isOneLoginService;
     private String subjectType;
+    private String rpSectorIdentifierHost;
 
     public AuthSessionItem() {
         this.codeRequestCountMap = new HashMap<>();
@@ -449,6 +451,20 @@ public class AuthSessionItem {
 
     public AuthSessionItem withSubjectType(String subjectType) {
         this.subjectType = subjectType;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_RP_SECTOR_IDENTIFIER_HOST)
+    public String getRpSectorIdentifierHost() {
+        return rpSectorIdentifierHost;
+    }
+
+    public void setRpSectorIdentifierHost(String rpSectorIdentifierHost) {
+        this.rpSectorIdentifierHost = rpSectorIdentifierHost;
+    }
+
+    public AuthSessionItem withRpSectorIdentifierHost(String rpSectorIdentifierHost) {
+        this.rpSectorIdentifierHost = rpSectorIdentifierHost;
         return this;
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
@@ -42,6 +42,8 @@ class ClientSubjectHelperTest {
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
     private static final String CLIENT_ID_1 = "test-client-id-1";
     private static final String CLIENT_ID_2 = "test-client-id-2";
+    private static final String CLIENT_SECTOR_HOST_1 = "test.com";
+    private static final String CLIENT_SECTOR_HOST_2 = "not.test.com";
 
     private AuthSessionItem AUTH_SESSION_FOR_CLIENT_1;
     private AuthSessionItem AUTH_SESSION_FOR_CLIENT_2;
@@ -59,23 +61,33 @@ class ClientSubjectHelperTest {
                         .withSessionId("test-auth-session-1")
                         .withClientId(CLIENT_ID_1)
                         .withIsOneLoginService(false)
-                        .withSubjectType(PAIRWISE.toString());
+                        .withSubjectType(PAIRWISE.toString())
+                        .withRpSectorIdentifierHost(CLIENT_SECTOR_HOST_1);
         AUTH_SESSION_FOR_CLIENT_2 =
                 new AuthSessionItem()
                         .withSessionId("test-auth-session-2")
                         .withClientId(CLIENT_ID_2)
                         .withIsOneLoginService(false)
-                        .withSubjectType(PAIRWISE.toString());
+                        .withSubjectType(PAIRWISE.toString())
+                        .withRpSectorIdentifierHost(CLIENT_SECTOR_HOST_2);
     }
 
     @Test
     void shouldReturnDifferentSubjectIDForMultipleClientsWithDifferentSectors() {
         ClientRegistry clientRegistry1 =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_1, PAIRWISE.toString(), "https://test.com", false);
+                        keyPair,
+                        CLIENT_ID_1,
+                        PAIRWISE.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        false);
         ClientRegistry clientRegistry2 =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_2, PAIRWISE.toString(), "https://not-test.com", false);
+                        keyPair,
+                        CLIENT_ID_2,
+                        PAIRWISE.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_2,
+                        false);
 
         Subject subject1 =
                 ClientSubjectHelper.getSubject(
@@ -99,10 +111,18 @@ class ClientSubjectHelperTest {
     void shouldReturnSameSubjectIDForMultipleClientsWithSameSector() {
         var clientRegistry1 =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_1, PAIRWISE.toString(), "https://test.com", false);
+                        keyPair,
+                        CLIENT_ID_1,
+                        PAIRWISE.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        false);
         var clientRegistry2 =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_2, PAIRWISE.toString(), "https://test.com", false);
+                        keyPair,
+                        CLIENT_ID_2,
+                        PAIRWISE.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        false);
 
         Subject subject1 =
                 ClientSubjectHelper.getSubject(
@@ -126,10 +146,18 @@ class ClientSubjectHelperTest {
     void shouldReturnSameSubjectIDForMultipleClientsWithPublicSubjectType() {
         ClientRegistry clientRegistry1 =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_1, PUBLIC.toString(), "https://test.com", false);
+                        keyPair,
+                        CLIENT_ID_1,
+                        PUBLIC.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        false);
         ClientRegistry clientRegistry2 =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_2, PUBLIC.toString(), "https://test.com", false);
+                        keyPair,
+                        CLIENT_ID_2,
+                        PUBLIC.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        false);
 
         Subject subject1 =
                 ClientSubjectHelper.getSubject(
@@ -154,7 +182,11 @@ class ClientSubjectHelperTest {
     void shouldReturnPairwiseSubjectIdWhenClientTypeIsPairwise() {
         var clientRegistry1 =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_1, PAIRWISE.toString(), "https://test.com", false);
+                        keyPair,
+                        CLIENT_ID_1,
+                        PAIRWISE.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        false);
 
         var subject =
                 ClientSubjectHelper.getSubject(
@@ -171,10 +203,18 @@ class ClientSubjectHelperTest {
     void shouldReturnPairwiseSubjectIdWhenClientTypeIsPairwiseAndIsAOneLoginService() {
         var clientRegistry1 =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_1, PAIRWISE.toString(), "https://test.com", true);
+                        keyPair,
+                        CLIENT_ID_1,
+                        PAIRWISE.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        true);
         var clientRegistry2 =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_2, PAIRWISE.toString(), "https://test.com", false);
+                        keyPair,
+                        CLIENT_ID_2,
+                        PAIRWISE.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        false);
 
         var subject1 =
                 ClientSubjectHelper.getSubject(
@@ -199,7 +239,11 @@ class ClientSubjectHelperTest {
     void shouldNotReturnPairwiseSubjectIdWhenClientTypeIsPublic() {
         var clientRegistry1 =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_1, PUBLIC.toString(), "https://test.com", false);
+                        keyPair,
+                        CLIENT_ID_1,
+                        PUBLIC.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        false);
 
         var subject =
                 ClientSubjectHelper.getSubject(
@@ -217,7 +261,11 @@ class ClientSubjectHelperTest {
     void shouldGetHostAsSectorIdentifierWhenDefinedByClient() {
         var clientRegistry =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_1, PUBLIC.toString(), "https://test.com", false);
+                        keyPair,
+                        CLIENT_ID_1,
+                        PUBLIC.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        false);
 
         var sectorId =
                 ClientSubjectHelper.getSectorIdentifierForClient(
@@ -248,7 +296,11 @@ class ClientSubjectHelperTest {
     void shouldUseHostOfInternalSectorUriWhenOneLoginServiceAndClientHasRegisteredSector() {
         var clientRegistry =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_1, PUBLIC.toString(), "https://test.com", true);
+                        keyPair,
+                        CLIENT_ID_1,
+                        PUBLIC.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        true);
 
         var sectorId =
                 ClientSubjectHelper.getSectorIdentifierForClient(
@@ -358,7 +410,11 @@ class ClientSubjectHelperTest {
     void shouldBeValidClientWithSectorId() {
         var clientRegistry =
                 generateClientRegistryPairwise(
-                        keyPair, CLIENT_ID_1, PUBLIC.toString(), "https://test.com", false);
+                        keyPair,
+                        CLIENT_ID_1,
+                        PUBLIC.toString(),
+                        "https://" + CLIENT_SECTOR_HOST_1,
+                        false);
 
         assertTrue(ClientSubjectHelper.hasValidClientConfig(clientRegistry));
     }
@@ -370,7 +426,7 @@ class ClientSubjectHelperTest {
                         keyPair,
                         CLIENT_ID_1,
                         PUBLIC.toString(),
-                        "https://test.com",
+                        "https://" + CLIENT_SECTOR_HOST_1,
                         List.of("https://www.test.com", "https://www.test2.com"),
                         false);
 


### PR DESCRIPTION
### Wider context of change

We have been calculating the `rpSectorIdentifierHost` in orch and have started to send the claim from orch to auth backend. By this point auth frontend should be sending this claim to auth backend as `rp_sector_identifier_host`. 

This claim is currently being calculated in auth, but the calculation is the same as the one in orch. We want to set this new claim on the auth session and use that instead of calculating the `rpSectorIdentifierHost` a second time. This is mainly to remove usages of the auth client registry, so we can rely on orch's client registry instead.

### What’s changed

This PR sets the rpSectorIdentifierHost on the auth session, and also adds logging to check whether the calculation using the client registry is the same as the one using the pre-calculated auth session field. 

I've also added logging to check if the subject IDs calculated from both fields above are equal too. 

### Manual testing

Tested by deploying FE changes and this PR to sandpit. 
- Did a full auth journey and saw the logs confirming that both the new claim on the auth session and the field in the client registry are equal.
- Also saw the logs that confirmed the subject id calculated from both of these fields was the same
Will test in dev once FE change has been merged.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

Need this PR to be merged first: https://github.com/govuk-one-login/authentication-frontend/pull/2830
