### PR TITLE
BAU: Log exception thrown when verifying code

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -198,7 +198,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     client,
                     userProfile);
         } catch (Exception e) {
-            LOG.error("Unexpected exception thrown");
+            LOG.error("Unexpected exception thrown", e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
     }


### PR DESCRIPTION
## What

VerifyMfaCodeHandler wraps the logic for verifying codes in a try/catch, but does not log the exception thrown.

This makes it difficult to diagnose errors. A lot happens within the try catch that could be failing.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
