### PR TITLE
AUT-4371: Use correct email template when changing phone number

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -296,6 +296,7 @@ public class MFAMethodsPutHandler
 
         return switch (emailNotificationIdentifier) {
             case CHANGED_AUTHENTICATOR_APP -> NotificationType.CHANGED_AUTHENTICATOR_APP;
+            case CHANGED_SMS -> NotificationType.PHONE_NUMBER_UPDATED;
             case CHANGED_DEFAULT_MFA -> NotificationType.CHANGED_DEFAULT_MFA;
             case SWITCHED_MFA_METHODS -> NotificationType.SWITCHED_MFA_METHODS;
             default -> throw new IllegalArgumentException(
@@ -315,7 +316,7 @@ public class MFAMethodsPutHandler
         }
 
         LOG.info(
-                "Backup method updated successfully (notification type: '{}'). Adding confirmation message to SQS queue.",
+                "Method updated successfully (notification type: '{}'). Adding confirmation message to SQS queue.",
                 notificationType.name());
 
         NotifyRequest notifyRequest = new NotifyRequest(userEmail, notificationType, userLanguage);

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.accountmanagement.entity.NotificationType.CHANGED_AUTHENTICATOR_APP;
 import static uk.gov.di.accountmanagement.entity.NotificationType.CHANGED_DEFAULT_MFA;
+import static uk.gov.di.accountmanagement.entity.NotificationType.PHONE_NUMBER_UPDATED;
 import static uk.gov.di.accountmanagement.entity.NotificationType.SWITCHED_MFA_METHODS;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNotificationsReceived;
@@ -272,7 +273,7 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                     List.of(
                             new NotifyRequest(
                                     TEST_EMAIL,
-                                    CHANGED_DEFAULT_MFA,
+                                    PHONE_NUMBER_UPDATED,
                                     LocaleHelper.SupportedLanguage.EN)));
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
@@ -939,7 +939,7 @@ class MFAMethodsServiceIntegrationTest {
                         mfaMethodListsContainTheSameItemsIgnoringUpdatedField(
                                 expectedMethods, result.getSuccess().mfaMethods()));
                 assertEquals(
-                        MFAMethodEmailNotificationIdentifier.CHANGED_DEFAULT_MFA,
+                        MFAMethodEmailNotificationIdentifier.CHANGED_SMS,
                         result.getSuccess().emailNotificationIdentifier());
                 assertTrue(
                         mfaMethodListsContainTheSameItemsIgnoringUpdatedField(
@@ -1004,6 +1004,9 @@ class MFAMethodsServiceIntegrationTest {
                 }
 
                 assertTrue(result.isSuccess());
+                assertEquals(
+                        MFAMethodEmailNotificationIdentifier.CHANGED_DEFAULT_MFA,
+                        result.getSuccess().emailNotificationIdentifier());
             }
 
             @Test
@@ -1026,6 +1029,9 @@ class MFAMethodsServiceIntegrationTest {
                 }
 
                 assertTrue(result.isSuccess());
+                assertEquals(
+                        MFAMethodEmailNotificationIdentifier.CHANGED_DEFAULT_MFA,
+                        result.getSuccess().emailNotificationIdentifier());
             }
 
             @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/MFAMethodEmailNotificationIdentifier.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/MFAMethodEmailNotificationIdentifier.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.entity.mfa;
 
 public enum MFAMethodEmailNotificationIdentifier {
     CHANGED_AUTHENTICATOR_APP("CHANGED_AUTHENTICATOR_APP"),
+    CHANGED_SMS("CHANGED_SMS"),
     CHANGED_DEFAULT_MFA("CHANGED_DEFAULT_MFA"),
     SWITCHED_MFA_METHODS("SWITCHED_MFA_METHODS");
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
@@ -433,8 +433,14 @@ public class MFAMethodsService {
 
         databaseUpdateResult = persistentService.updateMfaMethods(updatedMethods, email);
 
+        var emailNotificationIdentifier = MFAMethodEmailNotificationIdentifier.CHANGED_DEFAULT_MFA;
+
+        if (defaultMethod.getMfaMethodType().equals(SMS.getValue())) {
+            emailNotificationIdentifier = MFAMethodEmailNotificationIdentifier.CHANGED_SMS;
+        }
+
         return mfaUpdateFailureReasonOrSortedMfaMethods(
-                databaseUpdateResult, MFAMethodEmailNotificationIdentifier.CHANGED_DEFAULT_MFA);
+                databaseUpdateResult, emailNotificationIdentifier);
     }
 
     private Result<MfaUpdateFailureReason, MfaUpdateResponse> updateAuthApp(


### PR DESCRIPTION
## What

When the account management API changes the users phone number on their default MFA method, we were sending the "user has changed their default method to a different method" email template, rather than the expected "user has changed their phone number" template.

This is corrected by making sure the MFAMethodsService returns the correct value to indicate the phone number has changed, rather than the method changed. This is similar to how it's already handled if an AUTH_APP credential changes.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
