### PR TITLE
ATO-1697: update cloudfront to other envs from build upwards

### DIFF
--- a/ci/cloudfront-orchestration/cloudfront/build/parameters.json
+++ b/ci/cloudfront-orchestration/cloudfront/build/parameters.json
@@ -18,5 +18,9 @@
   {
     "ParameterKey": "LogDestination",
     "ParameterValue": "csls_cw_logs_destination_prodpython"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeaderManagedSecretRotationMonthWeekDaySchedule",
+    "ParameterValue": "MON#3"
   }
 ]

--- a/ci/cloudfront-orchestration/cloudfront/integration/parameters.json
+++ b/ci/cloudfront-orchestration/cloudfront/integration/parameters.json
@@ -18,5 +18,9 @@
   {
     "ParameterKey": "LogDestination",
     "ParameterValue": "csls_cw_logs_destination_prodpython"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeaderManagedSecretRotationMonthWeekDaySchedule",
+    "ParameterValue": "MON#3"
   }
 ]

--- a/ci/cloudfront-orchestration/cloudfront/production/parameters.json
+++ b/ci/cloudfront-orchestration/cloudfront/production/parameters.json
@@ -18,5 +18,9 @@
   {
     "ParameterKey": "LogDestination",
     "ParameterValue": "csls_cw_logs_destination_prodpython"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeaderManagedSecretRotationMonthWeekDaySchedule",
+    "ParameterValue": "MON#3"
   }
 ]

--- a/ci/cloudfront-orchestration/cloudfront/staging/parameters.json
+++ b/ci/cloudfront-orchestration/cloudfront/staging/parameters.json
@@ -18,5 +18,9 @@
   {
     "ParameterKey": "LogDestination",
     "ParameterValue": "csls_cw_logs_destination_prodpython"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeaderManagedSecretRotationMonthWeekDaySchedule",
+    "ParameterValue": "MON#3"
   }
 ]


### PR DESCRIPTION
### Wider context of change

Updating cloudfront to latest v2.3

### What’s changed

Updating the parameters for env other than dev for cloudfront

### Manual testing

Deployed to each env. Checked logs for traffic through waf.
