### PR TITLE
ATO-1743: create a doc app credential dynamo table and CMK

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -914,6 +914,63 @@ Resources:
 
   #endregion
 
+  #region Doc App Credential DynamoDB Table
+
+  DocAppCredentialTableEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS encryption key for Doc App Credential DynamoDB table
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Sid: AllowDynamodbAccessToEncryptionKey
+            Effect: Allow
+            Principal:
+              Service: dynamodb.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+
+  DocAppCredentialTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${Environment}-Orch-Doc-App-Credential
+      AttributeDefinitions:
+        - AttributeName: SubjectID
+          AttributeType: S
+      KeySchema:
+        - AttributeName: SubjectID
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEEnabled: true
+        KMSMasterKeyId: !GetAtt DocAppCredentialTableEncryptionKey.Arn
+        SSEType: KMS
+      TimeToLiveSpecification:
+        AttributeName: TimeToExist
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - Key: Name
+          Value: DocAppCredentialTable
+
+  #endregion
+
   #region Fetch JWKS Lambda
 
   FetchJwksFunction:


### PR DESCRIPTION
### Wider context of change

 Migrating the docApp credential table from auth to orch account. It is a dynamo to dynamo migration

### What’s changed

created to the dynamo and CMK for docApp credential

### Manual testing

deployed to dev