### PR TITLE
ATO-1779: add ratelimit to client registry

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
@@ -47,6 +47,7 @@ public class ClientRegistry {
     private String channel;
     private boolean maxAgeEnabled = false;
     private boolean pkceEnforced = false;
+    private Integer rateLimit;
 
     private static final Set<String> RS256_MAPPINGS =
             Set.of(JWSAlgorithm.RS256.getName(), "RSA256");
@@ -513,6 +514,20 @@ public class ClientRegistry {
 
     public ClientRegistry withPKCEEnforced(boolean pkceEnforced) {
         this.pkceEnforced = pkceEnforced;
+        return this;
+    }
+
+    @DynamoDbAttribute("RateLimit")
+    public Integer getRateLimit() {
+        return rateLimit;
+    }
+
+    public void setRateLimit(Integer rateLimit) {
+        this.rateLimit = rateLimit;
+    }
+
+    public ClientRegistry withRateLimit(Integer rateLimit) {
+        this.rateLimit = rateLimit;
         return this;
     }
 }


### PR DESCRIPTION
### Wider context of change

We want to add rateLimit to the client registry to be able to add rate limiting.

### What’s changed

Rate limit has been added to the client registry. It's been made an `Integer` so it allows null as not all client registries will have rate limiting. I've made all instances as `Integer` unlike `pkceEnforced` which is only `Boolean` for some and `boolean` for the rest as I wasn't sure we'd want `0` as the default if the rate limit is null.

### Manual testing

Ran journeys on sandpit and all good

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
