### PR TITLE
AUT-4315: update rules for phone number in userinfo response

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 
 import java.util.Map;
 import java.util.Optional;
@@ -67,7 +68,10 @@ public class UserInfoHandler
     public UserInfoHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
         this.userInfoService =
-                new UserInfoService(new DynamoService(configurationService), configurationService);
+                new UserInfoService(
+                        new DynamoService(configurationService),
+                        new MFAMethodsService(configurationService),
+                        configurationService);
         this.accessTokenService =
                 new AccessTokenService(
                         configurationService, new CloudwatchMetricsService(configurationService));

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -12,6 +12,7 @@ import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 
 import java.nio.ByteBuffer;
 import java.util.Base64;
@@ -19,13 +20,16 @@ import java.util.Base64;
 public class UserInfoService {
 
     private final AuthenticationService authenticationService;
+    private final MFAMethodsService mfaMethodsService;
     private final ConfigurationService configurationService;
     private static final Logger LOG = LogManager.getLogger(UserInfoService.class);
 
     public UserInfoService(
             AuthenticationService authenticationService,
+            MFAMethodsService mfaMethodsService,
             ConfigurationService configurationService) {
         this.authenticationService = authenticationService;
+        this.mfaMethodsService = mfaMethodsService;
         this.configurationService = configurationService;
     }
 

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -103,7 +103,7 @@ public class UserInfoService {
     public record PhoneData(String phoneNumber, boolean phoneNumberVerified) {}
 
     public PhoneData getPhoneDataIfSMSIsDefault(UserProfile userProfile) {
-        var retrievedMfaMethods = mfaMethodsService.getMfaMethods(userProfile.getEmail());
+        var retrievedMfaMethods = mfaMethodsService.getMfaMethods(userProfile.getEmail(), true);
         if (retrievedMfaMethods.isFailure()) {
             LOG.warn("Default MFA retrieval failed, error: {}", retrievedMfaMethods.getFailure());
             return new PhoneData(null, false);

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -105,7 +105,7 @@ public class UserInfoServiceTest {
                 .thenReturn(generateUserProfile().withMfaMethodsMigrated(false));
         when(authenticationService.getUserCredentialsFromSubject(TEST_SUBJECT.getValue()))
                 .thenReturn(generateUserCredentials());
-        when(mfaMethodsService.getMfaMethods(any(), any()))
+        when(mfaMethodsService.getMfaMethods(any()))
                 .thenReturn(
                         Result.success(
                                 List.of(generatePhoneNumberMFAMethod(PriorityIdentifier.DEFAULT))));
@@ -193,7 +193,7 @@ public class UserInfoServiceTest {
     void shouldReturnMigratedPhoneNumberWhenPhoneIsMigrated() {
         when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
                 .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
-        when(mfaMethodsService.getMfaMethods(any(), any()))
+        when(mfaMethodsService.getMfaMethods(any()))
                 .thenReturn(
                         Result.success(
                                 List.of(
@@ -213,7 +213,7 @@ public class UserInfoServiceTest {
     void shouldReturnNullForMigratedPhoneNumberWhenSMSIsNotDefaultMFAMethod() {
         when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
                 .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
-        when(mfaMethodsService.getMfaMethods(any(), any()))
+        when(mfaMethodsService.getMfaMethods(any()))
                 .thenReturn(
                         Result.success(
                                 List.of(
@@ -233,7 +233,7 @@ public class UserInfoServiceTest {
     void shouldReturnNullForPhoneNumberWhenMFARetrievalFails() {
         when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
                 .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
-        when(mfaMethodsService.getMfaMethods(any(), any()))
+        when(mfaMethodsService.getMfaMethods(any()))
                 .thenReturn(
                         Result.failure(
                                 MfaRetrieveFailureReason
@@ -252,7 +252,7 @@ public class UserInfoServiceTest {
     void shouldReturnNullForPhoneNumberWhenNoMFAMethodsFound() {
         when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
                 .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
-        when(mfaMethodsService.getMfaMethods(any(), any())).thenReturn(Result.success(List.of()));
+        when(mfaMethodsService.getMfaMethods(any())).thenReturn(Result.success(List.of()));
 
         UserInfo actual =
                 userInfoService.populateUserInfo(

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -3,13 +3,18 @@ package uk.gov.di.authentication.external.services;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkBytes;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -17,6 +22,7 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
+import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 
 import java.nio.ByteBuffer;
 import java.util.Base64;
@@ -24,6 +30,9 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -93,7 +102,13 @@ public class UserInfoServiceTest {
             Boolean expectedUpliftRequired,
             CredentialTrustLevel expectedAchievedCredentialStrength) {
         when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
-                .thenReturn(generateUserProfile());
+                .thenReturn(generateUserProfile().withMfaMethodsMigrated(false));
+        when(authenticationService.getUserCredentialsFromSubject(TEST_SUBJECT.getValue()))
+                .thenReturn(generateUserCredentials());
+        when(mfaMethodsService.getMfaMethods(any(), any()))
+                .thenReturn(
+                        Result.success(
+                                List.of(generatePhoneNumberMFAMethod(PriorityIdentifier.DEFAULT))));
 
         UserInfo actual =
                 userInfoService.populateUserInfo(mockAccessTokenStore, generateAuthSessionItem());
@@ -174,6 +189,80 @@ public class UserInfoServiceTest {
                         TEST_ACHIEVED_CREDENTIAL_STRENGTH));
     }
 
+    @Test
+    void shouldReturnMigratedPhoneNumberWhenPhoneIsMigrated() {
+        when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
+                .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
+        when(mfaMethodsService.getMfaMethods(any(), any()))
+                .thenReturn(
+                        Result.success(
+                                List.of(
+                                        generateAuthAppMFAMethod(PriorityIdentifier.BACKUP),
+                                        generatePhoneNumberMFAMethod(PriorityIdentifier.DEFAULT))));
+
+        UserInfo actual =
+                userInfoService.populateUserInfo(
+                        getMockAccessTokenStore(List.of("phone_number", "phone_number_verified")),
+                        generateAuthSessionItem());
+
+        assertEquals(TEST_PHONE, actual.getPhoneNumber());
+        assertTrue(actual.getPhoneNumberVerified());
+    }
+
+    @Test
+    void shouldReturnNullForMigratedPhoneNumberWhenSMSIsNotDefaultMFAMethod() {
+        when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
+                .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
+        when(mfaMethodsService.getMfaMethods(any(), any()))
+                .thenReturn(
+                        Result.success(
+                                List.of(
+                                        generateAuthAppMFAMethod(PriorityIdentifier.DEFAULT),
+                                        generatePhoneNumberMFAMethod(PriorityIdentifier.BACKUP))));
+
+        UserInfo actual =
+                userInfoService.populateUserInfo(
+                        getMockAccessTokenStore(List.of("phone_number", "phone_number_verified")),
+                        generateAuthSessionItem());
+
+        assertNull(actual.getPhoneNumber());
+        assertFalse(actual.getPhoneNumberVerified());
+    }
+
+    @Test
+    void shouldReturnNullForPhoneNumberWhenMFARetrievalFails() {
+        when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
+                .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
+        when(mfaMethodsService.getMfaMethods(any(), any()))
+                .thenReturn(
+                        Result.failure(
+                                MfaRetrieveFailureReason
+                                        .UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP));
+
+        UserInfo actual =
+                userInfoService.populateUserInfo(
+                        getMockAccessTokenStore(List.of("phone_number", "phone_number_verified")),
+                        generateAuthSessionItem());
+
+        assertNull(actual.getPhoneNumber());
+        assertFalse(actual.getPhoneNumberVerified());
+    }
+
+    @Test
+    void shouldReturnNullForPhoneNumberWhenNoMFAMethodsFound() {
+        when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
+                .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
+        when(mfaMethodsService.getMfaMethods(any(), any())).thenReturn(Result.success(List.of()));
+
+        UserInfo actual =
+                userInfoService.populateUserInfo(
+                        getMockAccessTokenStore(List.of("phone_number", "phone_number_verified")),
+                        generateAuthSessionItem());
+
+        assertNull(actual.getPhoneNumber());
+        assertFalse(actual.getPhoneNumberVerified());
+    }
+
     private static UserProfile generateUserProfile() {
         return new UserProfile()
                 .withLegacySubjectID(TEST_LEGACY_SUBJECT_ID)
@@ -186,11 +275,29 @@ public class UserInfoServiceTest {
                 .withSalt(TEST_SALT);
     }
 
+    private static UserCredentials generateUserCredentials() {
+        return new UserCredentials().withSubjectID(TEST_SUBJECT.getValue()).withEmail(TEST_EMAIL);
+    }
+
     private static AuthSessionItem generateAuthSessionItem() {
         return new AuthSessionItem()
                 .withVerifiedMfaMethodType(TEST_VERIFIED_MFA_METHOD_TYPE)
                 .withAchievedCredentialStrength(TEST_ACHIEVED_CREDENTIAL_STRENGTH)
                 .withUpliftRequired(TEST_UPLIFT_REQUIRED);
+    }
+
+    private static MFAMethod generatePhoneNumberMFAMethod(PriorityIdentifier priorityIdentifier) {
+        return MFAMethod.smsMfaMethod(
+                true, true, TEST_PHONE, priorityIdentifier, "phone-number-mfa-identifier");
+    }
+
+    private static MFAMethod generateAuthAppMFAMethod(PriorityIdentifier priorityIdentifier) {
+        return MFAMethod.authAppMfaMethod(
+                "auth-app-credential-value",
+                true,
+                true,
+                priorityIdentifier,
+                "auth-app-mfa-identifier");
     }
 
     private static AccessTokenStore getMockAccessTokenStore(List<String> claims) {

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.external.entity.AuthUserInfoClaims.ACHIEVED_CREDENTIAL_STRENGTH;
@@ -105,7 +106,7 @@ public class UserInfoServiceTest {
                 .thenReturn(generateUserProfile().withMfaMethodsMigrated(false));
         when(authenticationService.getUserCredentialsFromSubject(TEST_SUBJECT.getValue()))
                 .thenReturn(generateUserCredentials());
-        when(mfaMethodsService.getMfaMethods(any()))
+        when(mfaMethodsService.getMfaMethods(any(), anyBoolean()))
                 .thenReturn(
                         Result.success(
                                 List.of(generatePhoneNumberMFAMethod(PriorityIdentifier.DEFAULT))));
@@ -193,7 +194,7 @@ public class UserInfoServiceTest {
     void shouldReturnMigratedPhoneNumberWhenPhoneIsMigrated() {
         when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
                 .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
-        when(mfaMethodsService.getMfaMethods(any()))
+        when(mfaMethodsService.getMfaMethods(any(), anyBoolean()))
                 .thenReturn(
                         Result.success(
                                 List.of(
@@ -213,7 +214,7 @@ public class UserInfoServiceTest {
     void shouldReturnNullForMigratedPhoneNumberWhenSMSIsNotDefaultMFAMethod() {
         when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
                 .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
-        when(mfaMethodsService.getMfaMethods(any()))
+        when(mfaMethodsService.getMfaMethods(any(), anyBoolean()))
                 .thenReturn(
                         Result.success(
                                 List.of(
@@ -233,7 +234,7 @@ public class UserInfoServiceTest {
     void shouldReturnNullForPhoneNumberWhenMFARetrievalFails() {
         when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
                 .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
-        when(mfaMethodsService.getMfaMethods(any()))
+        when(mfaMethodsService.getMfaMethods(any(), anyBoolean()))
                 .thenReturn(
                         Result.failure(
                                 MfaRetrieveFailureReason
@@ -252,7 +253,8 @@ public class UserInfoServiceTest {
     void shouldReturnNullForPhoneNumberWhenNoMFAMethodsFound() {
         when(authenticationService.getUserProfileFromSubject(TEST_SUBJECT.getValue()))
                 .thenReturn(generateUserProfile().withMfaMethodsMigrated(true));
-        when(mfaMethodsService.getMfaMethods(any())).thenReturn(Result.success(List.of()));
+        when(mfaMethodsService.getMfaMethods(any(), anyBoolean()))
+                .thenReturn(Result.success(List.of()));
 
         UserInfo actual =
                 userInfoService.populateUserInfo(

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 
 import java.nio.ByteBuffer;
 import java.util.Base64;
@@ -32,6 +33,7 @@ public class UserInfoServiceTest {
     private UserInfoService userInfoService;
     private ConfigurationService configurationService;
     private AuthenticationService authenticationService;
+    private MFAMethodsService mfaMethodsService;
     public static final ByteBuffer TEST_SALT = ByteBuffer.allocate(10);
     private static final Subject TEST_SUBJECT = new Subject();
     private static final String TEST_RP_SECTOR_HOST = "test-rp-sector-uri";
@@ -65,8 +67,10 @@ public class UserInfoServiceTest {
     @BeforeEach
     public void setUp() {
         authenticationService = mock(DynamoService.class);
+        mfaMethodsService = mock(MFAMethodsService.class);
         configurationService = mock(ConfigurationService.class);
-        userInfoService = new UserInfoService(authenticationService, configurationService);
+        userInfoService =
+                new UserInfoService(authenticationService, mfaMethodsService, configurationService);
 
         when(authenticationService.getOrGenerateSalt(any(UserProfile.class)))
                 .thenReturn(SdkBytes.fromByteBuffer(TEST_SALT).asByteArray());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
@@ -99,6 +99,11 @@ public class MFAMethodsService {
             String email, boolean readOnly) {
         var userProfile = persistentService.getUserProfileByEmail(email);
         var userCredentials = persistentService.getUserCredentialsFromEmail(email);
+        return getMfaMethods(userProfile, userCredentials, readOnly);
+    }
+
+    public Result<MfaRetrieveFailureReason, List<MFAMethod>> getMfaMethods(
+            UserProfile userProfile, UserCredentials userCredentials, boolean readOnly) {
         if (userProfile == null || userCredentials == null) {
             return Result.failure(USER_DOES_NOT_HAVE_ACCOUNT);
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
@@ -95,7 +95,7 @@ public class MFAMethodsService {
         return getMfaMethods(email, false);
     }
 
-    private Result<MfaRetrieveFailureReason, List<MFAMethod>> getMfaMethods(
+    public Result<MfaRetrieveFailureReason, List<MFAMethod>> getMfaMethods(
             String email, boolean readOnly) {
         var userProfile = persistentService.getUserProfileByEmail(email);
         var userCredentials = persistentService.getUserCredentialsFromEmail(email);
@@ -174,16 +174,18 @@ public class MFAMethodsService {
                 mfaIdentifier = method.getMfaIdentifier();
             } else {
                 mfaIdentifier = UUID.randomUUID().toString();
-                var result =
-                        persistentService.setMfaIdentifierForNonMigratedUserEnabledAuthApp(
-                                userProfile.getEmail(), mfaIdentifier);
-                if (result.isFailure()) {
-                    LOG.error(
-                            "Unexpected error updating non migrated auth app mfa identifier: {}",
-                            result.getFailure());
-                    return Result.failure(
-                            MfaRetrieveFailureReason
-                                    .UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP);
+                if (!readOnly) {
+                    var result =
+                            persistentService.setMfaIdentifierForNonMigratedUserEnabledAuthApp(
+                                    userProfile.getEmail(), mfaIdentifier);
+                    if (result.isFailure()) {
+                        LOG.error(
+                                "Unexpected error updating non migrated auth app mfa identifier: {}",
+                                result.getFailure());
+                        return Result.failure(
+                                MfaRetrieveFailureReason
+                                        .UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP);
+                    }
                 }
             }
             return Result.success(


### PR DESCRIPTION
## What

Update rules for phone number in userinfo response

This PR redeploys #6518 with an additional change in eff1bffe2fd57f6717f03d059f51dc462575afcc which extends the readOnly flag in 'getMfaMethodForNonMigratedUser' to auth apps for non migrated users.

## How to review

1. Code Review
1. Deploy to a test environment

Test cases (using orch stub to view the userinfo json)

- Sign in a non-migrated user with an SMS MFA.  Check that the phone_number is correct and phone_number_verified is true
- Sign in a non-migrated user with an Auth App MFA.  Check that the phone_number is missing and phone_number_verified is false
- Sign in a migrated user with a default SMS MFA and a backup Auth App.  Check that the phone_number is the default and phone_number_verified is true
- Sign in a migrated user with a default Auth App MFA and a backup SMS MFA.  Check that the phone_number is missing and phone_number_verified is false
- Sign in a migrated user with a default SMS MFA and no backup.  Check that the phone_number is the default and phone_number_verified is true
- Sign in a migrated user with a default Auth App MFA and a no backup.  Check that the phone_number is missing and phone_number_verified is false

## Related PRs

#6518 
#6483 
