### PR TITLE
ATO-1749: Write state to dynamo alongside redis

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -42,6 +42,7 @@ import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -119,7 +120,8 @@ public class DocAppCallbackHandler
                         configurationService,
                         new RedisConnectionService(configurationService),
                         kmsConnectionService,
-                        new JwksService(configurationService, kmsConnectionService));
+                        new JwksService(configurationService, kmsConnectionService),
+                        new StateStorageService(configurationService));
         this.tokenService =
                 new DocAppCriService(configurationService, kmsConnectionService, this.docAppCriApi);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
@@ -143,7 +145,8 @@ public class DocAppCallbackHandler
                         configurationService,
                         redis,
                         kmsConnectionService,
-                        new JwksService(configurationService, kmsConnectionService));
+                        new JwksService(configurationService, kmsConnectionService),
+                        new StateStorageService(configurationService));
         this.tokenService =
                 new DocAppCriService(configurationService, kmsConnectionService, this.docAppCriApi);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -58,6 +58,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 
 import java.net.URI;
@@ -136,6 +137,9 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
     @RegisterExtension
     public static final OrchAuthCodeExtension orchAuthCodeExtension = new OrchAuthCodeExtension();
+
+    @RegisterExtension
+    public static final StateStorageExtension stateStorageExtension = new StateStorageExtension();
 
     protected static ConfigurationService configurationService;
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -53,6 +53,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.RpPublicKeyCacheExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 
 import java.net.HttpCookie;
@@ -142,6 +143,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @RegisterExtension
     public static final OrchClientSessionExtension orchClientSessionExtention =
             new OrchClientSessionExtension();
+
+    @RegisterExtension
+    public static final StateStorageExtension stateStorageExtension = new StateStorageExtension();
 
     private static final String ENCRYPTION_KEY_ID = UUID.randomUUID().toString();
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 
 import java.net.URI;
@@ -80,6 +81,9 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
     @RegisterExtension
     public static final OrchClientSessionExtension orchClientSessionExtension =
             new OrchClientSessionExtension();
+
+    @RegisterExtension
+    public static final StateStorageExtension stateStorageExtension = new StateStorageExtension();
 
     @BeforeEach
     void setup() {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -42,6 +42,7 @@ import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.sharedtest.helper.TestClockHelper;
 
 import java.net.MalformedURLException;
@@ -96,12 +97,14 @@ class IPVAuthorisationServiceTest {
             mock(RedisConnectionService.class);
     private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
     private final JwksService jwksService = mock(JwksService.class);
+    private final StateStorageService stateStorageService = mock(StateStorageService.class);
     private final IPVAuthorisationService authorisationService =
             new IPVAuthorisationService(
                     configurationService,
                     redisConnectionService,
                     kmsConnectionService,
                     jwksService,
+                    stateStorageService,
                     TestClockHelper.getInstance());
     private PrivateKey privateKey;
 
@@ -224,7 +227,7 @@ class IPVAuthorisationServiceTest {
     }
 
     @Test
-    void shouldSaveStateToRedis() throws Json.JsonException {
+    void shouldSaveStateToRedisAndDynamo() throws Json.JsonException {
         var sessionId = "session-id";
         authorisationService.storeState(sessionId, STATE);
 
@@ -233,6 +236,7 @@ class IPVAuthorisationServiceTest {
                         STATE_STORAGE_PREFIX + sessionId,
                         objectMapper.writeValueAsString(STATE),
                         SESSION_EXPIRY);
+        verify(stateStorageService).storeState(STATE_STORAGE_PREFIX + sessionId, STATE.getValue());
     }
 
     @Nested

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -75,6 +75,7 @@ import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.shared.services.TokenValidationService;
 
 import java.net.URI;
@@ -180,12 +181,14 @@ public class AuthorisationHandler
         this.clientService = new DynamoClientService(configurationService);
         var kmsConnectionService = new KmsConnectionService(configurationService);
         var jwksService = new JwksService(configurationService, kmsConnectionService);
+        var stateStorageService = new StateStorageService(configurationService);
         this.docAppAuthorisationService =
                 new DocAppAuthorisationService(
                         configurationService,
                         new RedisConnectionService(configurationService),
                         kmsConnectionService,
-                        jwksService);
+                        jwksService,
+                        stateStorageService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService);
@@ -209,9 +212,14 @@ public class AuthorisationHandler
         this.clientService = new DynamoClientService(configurationService);
         var kmsConnectionService = new KmsConnectionService(configurationService);
         var jwksService = new JwksService(configurationService, kmsConnectionService);
+        var stateStorageService = new StateStorageService(configurationService);
         this.docAppAuthorisationService =
                 new DocAppAuthorisationService(
-                        configurationService, redis, kmsConnectionService, jwksService);
+                        configurationService,
+                        redis,
+                        kmsConnectionService,
+                        jwksService,
+                        stateStorageService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService, redis);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -169,19 +169,25 @@ public class AuthorisationHandler
 
     public AuthorisationHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
+        var kmsConnectionService = new KmsConnectionService(configurationService);
+        var jwksService = new JwksService(configurationService, kmsConnectionService);
+        var stateStorageService = new StateStorageService(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
+        this.noSessionOrchestrationService =
+                new NoSessionOrchestrationService(configurationService);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
         this.orchestrationAuthorizationService =
-                new OrchestrationAuthorizationService(configurationService);
+                new OrchestrationAuthorizationService(
+                        configurationService,
+                        kmsConnectionService,
+                        noSessionOrchestrationService,
+                        stateStorageService);
         this.auditService = new AuditService(configurationService);
         this.queryParamsAuthorizeValidator =
                 new QueryParamsAuthorizeValidator(configurationService);
         this.requestObjectAuthorizeValidator =
                 new RequestObjectAuthorizeValidator(configurationService);
         this.clientService = new DynamoClientService(configurationService);
-        var kmsConnectionService = new KmsConnectionService(configurationService);
-        var jwksService = new JwksService(configurationService, kmsConnectionService);
-        var stateStorageService = new StateStorageService(configurationService);
         this.docAppAuthorisationService =
                 new DocAppAuthorisationService(
                         configurationService,
@@ -190,8 +196,6 @@ public class AuthorisationHandler
                         jwksService,
                         stateStorageService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.noSessionOrchestrationService =
-                new NoSessionOrchestrationService(configurationService);
         this.tokenValidationService = new TokenValidationService(jwksService, configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
         this.authorisationService = new AuthorisationService(configurationService);

--- a/template.yaml
+++ b/template.yaml
@@ -2660,8 +2660,7 @@ Resources:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref UserProfileTableReadAccessPolicy
         - !Ref UserProfileTableWriteAccessPolicy
-        - !Ref AuthUserInfoTableReadAccessPolicy
-        - !Ref AuthUserInfoTableWriteAccessPolicy
+        - !Ref AuthUserInfoTableReadWriteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref RedisParametersAccessPolicy
         - !Ref StorageTokenSigningKmsAccessPolicy
@@ -5178,12 +5177,18 @@ Resources:
               - kms:DescribeKey
             Resource: !GetAtt AuthUserInfoTableEncryptionKey.Arn
 
-  AuthUserInfoTableWriteAccessPolicy:
+  AuthUserInfoTableReadWriteAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
+          - Sid: AllowAuthUserInfoTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt AuthUserInfoTable.Arn
           - Sid: AllowAuthUserInfoTableWriteAccess
             Effect: Allow
             Action:

--- a/template.yaml
+++ b/template.yaml
@@ -2672,6 +2672,7 @@ Resources:
         - !Ref OrchSessionTableReadWriteAndDeleteAccessPolicy
         - !Ref ClientSessionTableReadWriteAndDeleteAccessPolicy
         - !Ref OrchAuthCodeTableWriteAccessPolicy
+        - !Ref StateStorageTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -3333,6 +3334,7 @@ Resources:
         - !Ref OrchSessionTableReadAndWriteAccessPolicy
         - !Ref OrchSessionTableDeleteAccessPolicy
         - !Ref ClientSessionTableWriteAccessPolicy
+        - !Ref StateStorageTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -6351,6 +6353,27 @@ Resources:
       Tags:
         - Key: Name
           Value: ClientRateLimitTable
+  #endregion
+  #region StateStorage policies
+  StateStorageTableWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowStateStorageTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+            Resource: !GetAtt StateStorageTable.Arn
+          - Sid: AllowStateStorageTableDecryptionAndEncryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+            Resource: !GetAtt StateStorageTableEncryptionKey.Arn
+
   #endregion
   #region IPV token signing key pair
 


### PR DESCRIPTION
### Wider context of change

We would like to migrate away from redis and use a dynamo table in orch to store state by session ID. We have already created a dynamo table in orch, as well as a service class to interact with this table.  

### What’s changed

This PR starts writing to the dynamo table in all places where we are saving the state by session ID in redis. This is only in `OrchestrationAuthorizationService`, `DocAppAuthorisationService`, and `IPVAuthorisationService`. 

### Manual testing

Tested in sandpit. Performed:
- an auth only journey
- a doc app journey

Checked the dynamo table afterwards and saw both state values in the table stored against the prefixed session ID (with the correct prefix)

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

Stacked on https://github.com/govuk-one-login/authentication-api/pull/6747
