### PR TITLE
ATO-1780: create rate limit service

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/ClientRequestInfo.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/ClientRequestInfo.java
@@ -1,0 +1,10 @@
+package uk.gov.di.authentication.oidc.entity;
+
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+
+public record ClientRequestInfo(String clientID, Integer rateLimit) {
+
+    public static ClientRequestInfo fromClientRegistry(ClientRegistry client) {
+        return new ClientRequestInfo(client.getClientID(), client.getRateLimit());
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RateLimitAlgorithm.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RateLimitAlgorithm.java
@@ -1,0 +1,5 @@
+package uk.gov.di.authentication.oidc.entity;
+
+public interface RateLimitAlgorithm {
+    RateLimitDecision getClientRateLimitDecision(ClientRequestInfo clientRequestInfo);
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RateLimitDecision.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RateLimitDecision.java
@@ -8,8 +8,9 @@ public class RateLimitDecision {
         // Future Rate Limit Actions
     }
 
-    public static final RateLimitDecision NONE = new RateLimitDecision(false, RateLimitAction.NONE);
-    public static final RateLimitDecision REDIRECT_TO_RP =
+    public static final RateLimitDecision UNDER_LIMIT_NO_ACTION =
+            new RateLimitDecision(false, RateLimitAction.NONE);
+    public static final RateLimitDecision OVER_LIMIT_RETURN_TO_RP =
             new RateLimitDecision(true, RateLimitAction.RETURN_TO_RP);
 
     private final boolean hasExceededRateLimit;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RateLimitDecision.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RateLimitDecision.java
@@ -1,0 +1,36 @@
+package uk.gov.di.authentication.oidc.entity;
+
+public class RateLimitDecision {
+
+    public enum RateLimitAction {
+        NONE,
+        RETURN_TO_RP
+        // Future Rate Limit Actions
+    }
+
+    public static final RateLimitDecision NONE = new RateLimitDecision(false, RateLimitAction.NONE);
+    public static final RateLimitDecision REDIRECT_TO_RP =
+            new RateLimitDecision(true, RateLimitAction.RETURN_TO_RP);
+
+    private final boolean hasExceededRateLimit;
+    private final RateLimitAction action;
+
+    public RateLimitDecision(boolean hasExceededRateLimit, RateLimitAction rateLimitAction) {
+
+        if (!hasExceededRateLimit && !rateLimitAction.equals(RateLimitAction.NONE)) {
+            throw new IllegalArgumentException(
+                    "Action must be NONE if rate limit has not been exceeded");
+        }
+
+        this.hasExceededRateLimit = hasExceededRateLimit;
+        this.action = rateLimitAction;
+    }
+
+    public RateLimitAction getAction() {
+        return action;
+    }
+
+    public boolean hasExceededRateLimit() {
+        return hasExceededRateLimit;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -30,6 +30,8 @@ import org.jetbrains.annotations.Nullable;
 import uk.gov.di.authentication.app.domain.DocAppAuditableEvent;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
+import uk.gov.di.authentication.oidc.entity.RateLimitAlgorithm;
+import uk.gov.di.authentication.oidc.entity.RateLimitDecision;
 import uk.gov.di.authentication.oidc.exceptions.IncorrectRedirectUriException;
 import uk.gov.di.authentication.oidc.exceptions.InvalidAuthenticationRequestException;
 import uk.gov.di.authentication.oidc.exceptions.InvalidHttpMethodException;
@@ -135,6 +137,10 @@ public class AuthorisationHandler
     private final TokenValidationService tokenValidationService;
     private final AuthFrontend authFrontend;
     private final AuthorisationService authorisationService;
+    // ATO-1778: This is a hardcoded No-op algorithm.
+    // We will replace this with a proper implementation in future work
+    private final RateLimitAlgorithm noOpRateLimitAlgorithm =
+            (ignored) -> RateLimitDecision.UNDER_LIMIT_NO_ACTION;
 
     public AuthorisationHandler(
             ConfigurationService configurationService,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -40,6 +40,7 @@ import uk.gov.di.authentication.oidc.exceptions.MissingRedirectUriException;
 import uk.gov.di.authentication.oidc.helpers.RequestObjectToAuthRequestHelper;
 import uk.gov.di.authentication.oidc.services.AuthorisationService;
 import uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService;
+import uk.gov.di.authentication.oidc.services.RateLimitService;
 import uk.gov.di.authentication.oidc.validators.QueryParamsAuthorizeValidator;
 import uk.gov.di.authentication.oidc.validators.RequestObjectAuthorizeValidator;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
@@ -141,6 +142,7 @@ public class AuthorisationHandler
     // We will replace this with a proper implementation in future work
     private final RateLimitAlgorithm noOpRateLimitAlgorithm =
             (ignored) -> RateLimitDecision.UNDER_LIMIT_NO_ACTION;
+    private final RateLimitService rateLimitService;
 
     public AuthorisationHandler(
             ConfigurationService configurationService,
@@ -156,7 +158,8 @@ public class AuthorisationHandler
             NoSessionOrchestrationService noSessionOrchestrationService,
             TokenValidationService tokenValidationService,
             AuthFrontend authFrontend,
-            AuthorisationService authorisationService) {
+            AuthorisationService authorisationService,
+            RateLimitService rateLimitService) {
         this.configurationService = configurationService;
         this.orchSessionService = orchSessionService;
         this.orchClientSessionService = orchClientSessionService;
@@ -171,6 +174,7 @@ public class AuthorisationHandler
         this.tokenValidationService = tokenValidationService;
         this.authFrontend = authFrontend;
         this.authorisationService = authorisationService;
+        this.rateLimitService = rateLimitService;
     }
 
     public AuthorisationHandler(ConfigurationService configurationService) {
@@ -205,6 +209,7 @@ public class AuthorisationHandler
         this.tokenValidationService = new TokenValidationService(jwksService, configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
         this.authorisationService = new AuthorisationService(configurationService);
+        this.rateLimitService = new RateLimitService(noOpRateLimitAlgorithm);
     }
 
     public AuthorisationHandler(
@@ -236,6 +241,7 @@ public class AuthorisationHandler
         this.tokenValidationService = new TokenValidationService(jwksService, configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
         this.authorisationService = new AuthorisationService(configurationService);
+        this.rateLimitService = new RateLimitService(noOpRateLimitAlgorithm);
     }
 
     public AuthorisationHandler() {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RateLimitService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RateLimitService.java
@@ -1,0 +1,22 @@
+package uk.gov.di.authentication.oidc.services;
+
+import uk.gov.di.authentication.oidc.entity.ClientRequestInfo;
+import uk.gov.di.authentication.oidc.entity.RateLimitAlgorithm;
+import uk.gov.di.authentication.oidc.entity.RateLimitDecision;
+
+public class RateLimitService {
+
+    private final RateLimitAlgorithm rateLimitAlgorithm;
+
+    public RateLimitService(RateLimitAlgorithm rateLimitAlgorithm) {
+        this.rateLimitAlgorithm = rateLimitAlgorithm;
+    }
+
+    public RateLimitDecision getClientRateLimitDecision(ClientRequestInfo clientRequestInfo) {
+        if (clientRequestInfo.rateLimit() == null) {
+            return RateLimitDecision.UNDER_LIMIT_NO_ACTION;
+        }
+
+        return rateLimitAlgorithm.getClientRateLimitDecision(clientRequestInfo);
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -59,6 +59,7 @@ import uk.gov.di.authentication.oidc.exceptions.MissingClientIDException;
 import uk.gov.di.authentication.oidc.exceptions.MissingRedirectUriException;
 import uk.gov.di.authentication.oidc.services.AuthorisationService;
 import uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService;
+import uk.gov.di.authentication.oidc.services.RateLimitService;
 import uk.gov.di.authentication.oidc.validators.QueryParamsAuthorizeValidator;
 import uk.gov.di.authentication.oidc.validators.RequestObjectAuthorizeValidator;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
@@ -173,6 +174,7 @@ class AuthorisationHandlerTest {
             mock(RequestObjectAuthorizeValidator.class);
     private final QueryParamsAuthorizeValidator queryParamsAuthorizeValidator =
             mock(QueryParamsAuthorizeValidator.class);
+    private final RateLimitService rateLimitService = mock(RateLimitService.class);
     private final ClientService clientService = mock(ClientService.class);
     private static final String EXPECTED_NEW_SESSION_COOKIE_STRING =
             "gs=a-new-session-id.client-session-id; Max-Age=3600; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;";
@@ -294,7 +296,8 @@ class AuthorisationHandlerTest {
                         noSessionOrchestrationService,
                         tokenValidationService,
                         authFrontend,
-                        authorisationService);
+                        authorisationService,
+                        rateLimitService);
         orchSession = new OrchSessionItem(SESSION_ID);
         when(orchClientSessionService.generateClientSession(any(), any(), any(), any(), any()))
                 .thenReturn(orchClientSession);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RateLimitServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RateLimitServiceTest.java
@@ -1,0 +1,50 @@
+package uk.gov.di.authentication.oidc.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.oidc.entity.ClientRequestInfo;
+import uk.gov.di.authentication.oidc.entity.RateLimitAlgorithm;
+import uk.gov.di.authentication.oidc.entity.RateLimitDecision;
+import uk.gov.di.orchestration.sharedtest.helper.Constants;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class RateLimitServiceTest {
+
+    private static final RateLimitAlgorithm noActionAlgorithm =
+            (client) -> RateLimitDecision.UNDER_LIMIT_NO_ACTION;
+    private static final RateLimitAlgorithm alwaysReturnToRpAction =
+            (client) -> RateLimitDecision.OVER_LIMIT_RETURN_TO_RP;
+
+    @Test
+    void itReturnsNoActionDecisionWhenTheClientHasNoRateLimit() {
+        var rateLimitService = new RateLimitService(alwaysReturnToRpAction);
+        var rateLimitDecision =
+                rateLimitService.getClientRateLimitDecision(
+                        new ClientRequestInfo(Constants.TEST_CLIENT_ID, null));
+        assertFalse(rateLimitDecision.hasExceededRateLimit());
+        assertEquals(RateLimitDecision.RateLimitAction.NONE, rateLimitDecision.getAction());
+    }
+
+    @ParameterizedTest
+    @MethodSource("rateLimitAlgosAndOutcomes")
+    void itDelegatesToTheRateLimitAlgoWhenClientHasARateLimitConfigured(
+            RateLimitAlgorithm algorithm, RateLimitDecision outcome) {
+        var rateLimitService = new RateLimitService(algorithm);
+        var rateLimitDecision =
+                rateLimitService.getClientRateLimitDecision(
+                        new ClientRequestInfo(Constants.TEST_CLIENT_ID, 400));
+        assertEquals(outcome, rateLimitDecision);
+    }
+
+    private static Stream<Arguments> rateLimitAlgosAndOutcomes() {
+        return Stream.of(
+                Arguments.of(noActionAlgorithm, RateLimitDecision.UNDER_LIMIT_NO_ACTION),
+                Arguments.of(alwaysReturnToRpAction, RateLimitDecision.OVER_LIMIT_RETURN_TO_RP));
+    }
+}

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/Constants.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/Constants.java
@@ -2,9 +2,9 @@ package uk.gov.di.orchestration.sharedtest.helper;
 
 public final class Constants {
     private Constants() {}
-    ;
 
     public static final String ENVIRONMENT = "test";
+    public static final String TEST_CLIENT_ID = "test-client-id";
     public static final String SESSION_ID = "session-id";
     public static final String CLIENT_SESSION_ID = "client-session-id";
     public static final String CLIENT_NAME = "test-client";

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -409,6 +409,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("TEST_CLIENTS_ENABLED");
     }
 
+    public boolean isRpRateLimitingEnabled() {
+        return getFlagOrFalse("RP_RATE_LIMITING_ENABLED");
+    }
+
     public String getExternalTokenSigningKeyAlias() {
         return System.getenv("EXTERNAL_TOKEN_SIGNING_KEY_ALIAS");
     }

--- a/template.yaml
+++ b/template.yaml
@@ -132,6 +132,16 @@ Conditions:
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]
+  IsRpRateLimitingEnabled: !Not [
+      !Or [
+        #Disabled in all environments for now
+        !Equals [dev, !Ref Environment],
+        !Equals [build, !Ref Environment],
+        !Equals [staging, !Ref Environment],
+        !Equals [integration, !Ref Environment],
+        !Equals [production, !Ref Environment],
+      ],
+    ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -3277,6 +3287,10 @@ Resources:
               orchToAuthKeyArn,
             ]
           REDIS_KEY: session
+          RP_RATE_LIMITING_ENABLED: !If
+            - IsRpRateLimitingEnabled
+            - true
+            - false
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           TXMA_AUDIT_ENCODED_ENABLED: true


### PR DESCRIPTION
### Wider context of change:

As part of adding RP rate limiting to the Authorization handler, we now need to create a RateLimit Service. This PR adds that. The service is quite generic right as we have not yet implemented the algorithm which will be used for rate limiting.

### What’s changed: 
- Adds a rateLimitService which has a No Action outcome if the client does not have a rate limit configured
- Delegates to the algorithm if the client does have a rate limit configured
- Adds a RateLimitDecision class to represent the state (has or hasn't exceeded limit) and the action (what we do about it) 
- Adds a feature flag to the authorization handler 
- Adds feature flagged call to rate limit service - right now this is hardcoded to a no op implementation

### Manual testing: 
- Deployed to dev 
- Check feature flag is false
- Hit authorize just to check nothing weird happened

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->