### PR TITLE
AUT-4428: Add AUTH_MFA_METHOD_MIGRATION_ATTEMPTED audit event

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -11,7 +11,8 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     AUTH_ACCOUNT_MANAGEMENT_AUTHENTICATE_INTERVENTION_FAILURE,
     AUTH_DELETE_ACCOUNT,
     AUTH_SEND_OTP,
-    AUTH_EMAIL_FRAUD_CHECK_BYPASSED;
+    AUTH_EMAIL_FRAUD_CHECK_BYPASSED,
+    AUTH_MFA_METHOD_MIGRATION_ATTEMPTED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/MfaMethodsMigrationHelperTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/MfaMethodsMigrationHelperTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
@@ -33,6 +34,7 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 class MfaMethodsMigrationHelperTest {
     private static final String EMAIL = "email@example.com";
     private static MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
+    private static AuditContext auditContext = mock(AuditContext.class);
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -68,17 +68,7 @@ public record AuditContext(
     }
 
     public AuditContext withUserId(String subjectId) {
-        return new AuditContext(
-                clientId,
-                clientSessionId,
-                sessionId,
-                subjectId,
-                email,
-                ipAddress,
-                phoneNumber,
-                persistentSessionId,
-                txmaAuditEncoded,
-                metadata);
+        return withSubjectId(subjectId);
     }
 
     public AuditContext withTxmaAuditEncoded(Optional<String> txmaAuditEncoded) {
@@ -91,7 +81,7 @@ public record AuditContext(
                 ipAddress,
                 phoneNumber,
                 persistentSessionId,
-                txmaAuditEncoded,
+                txmaAuditEncoded != null ? txmaAuditEncoded : Optional.empty(),
                 metadata);
     }
 
@@ -166,6 +156,20 @@ public record AuditContext(
     }
 
     public AuditContext withSessionId(String sessionId) {
+        return new AuditContext(
+                clientId,
+                clientSessionId,
+                sessionId,
+                subjectId,
+                email,
+                ipAddress,
+                phoneNumber,
+                persistentSessionId,
+                txmaAuditEncoded,
+                metadata);
+    }
+
+    public AuditContext withPersistentSessionId(String persistentSessionId) {
         return new AuditContext(
                 clientId,
                 clientSessionId,


### PR DESCRIPTION
Adds audit event publishing for MFA method migration attempts in the MFAMethodsCreateHandler.

# authentication-api PR template picker

> [!TIP]
> Please go to the `Preview` tab and select the appropriate sub-template

## Templates

- [Auth Team](?expand=1&template=auth_template.md)
- [Orchestration Team](?expand=1&template=orch_template.md)
