### PR TITLE
AUT-4512: doc change to trigger an api deployment

### DIFF
--- a/ci/terraform/account-management/openapi_v2.yaml
+++ b/ci/terraform/account-management/openapi_v2.yaml
@@ -323,7 +323,7 @@ paths:
                 post-when-default-method-already-exists-new-one-cannot-be-created:
                   value:
                     code: 1080
-                    message: "Default method already exists, new one cannot be created."
+                    message: "Default method already exists, new one cannot be created"
                 post-when-invalid-otp-code:
                   value:
                     code: 1020


### PR DESCRIPTION
## What

Doc change to trigger an api deployment

Testing to make sure that changes to the api spec trigger and api deployment in integration.  Switch changes appear not to have triggered a deployment.

## How to review

1. Code Review

## Related PRs

#6698 
