### PR TITLE
ATO-1782: add metric for rate limit exceeded

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -183,6 +183,8 @@ public class AuthorisationHandler
         var kmsConnectionService = new KmsConnectionService(configurationService);
         var jwksService = new JwksService(configurationService, kmsConnectionService);
         var stateStorageService = new StateStorageService(configurationService);
+        var cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
+
         this.orchSessionService = new OrchSessionService(configurationService);
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService);
@@ -206,16 +208,18 @@ public class AuthorisationHandler
                         kmsConnectionService,
                         jwksService,
                         stateStorageService);
-        this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.tokenValidationService = new TokenValidationService(jwksService, configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
         this.authorisationService = new AuthorisationService(configurationService);
-        this.rateLimitService = new RateLimitService(noOpRateLimitAlgorithm);
+        this.rateLimitService =
+                new RateLimitService(noOpRateLimitAlgorithm, cloudwatchMetricsService);
     }
 
     public AuthorisationHandler(
             ConfigurationService configurationService, RedisConnectionService redis) {
         this.configurationService = configurationService;
+        var cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
         this.orchestrationAuthorizationService =
@@ -236,13 +240,14 @@ public class AuthorisationHandler
                         kmsConnectionService,
                         jwksService,
                         stateStorageService);
-        this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService, redis);
         this.tokenValidationService = new TokenValidationService(jwksService, configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
         this.authorisationService = new AuthorisationService(configurationService);
-        this.rateLimitService = new RateLimitService(noOpRateLimitAlgorithm);
+        this.rateLimitService =
+                new RateLimitService(noOpRateLimitAlgorithm, cloudwatchMetricsService);
     }
 
     public AuthorisationHandler() {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RateLimitService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RateLimitService.java
@@ -1,15 +1,25 @@
 package uk.gov.di.authentication.oidc.services;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.ClientRequestInfo;
 import uk.gov.di.authentication.oidc.entity.RateLimitAlgorithm;
 import uk.gov.di.authentication.oidc.entity.RateLimitDecision;
+import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
+
+import java.util.Map;
 
 public class RateLimitService {
 
     private final RateLimitAlgorithm rateLimitAlgorithm;
+    private final CloudwatchMetricsService cloudwatchMetricsService;
+    private static final Logger LOG = LogManager.getLogger(RateLimitService.class);
 
-    public RateLimitService(RateLimitAlgorithm rateLimitAlgorithm) {
+    public RateLimitService(
+            RateLimitAlgorithm rateLimitAlgorithm,
+            CloudwatchMetricsService cloudwatchMetricsService) {
         this.rateLimitAlgorithm = rateLimitAlgorithm;
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
     }
 
     public RateLimitDecision getClientRateLimitDecision(ClientRequestInfo clientRequestInfo) {
@@ -17,6 +27,27 @@ public class RateLimitService {
             return RateLimitDecision.UNDER_LIMIT_NO_ACTION;
         }
 
-        return rateLimitAlgorithm.getClientRateLimitDecision(clientRequestInfo);
+        var decision = rateLimitAlgorithm.getClientRateLimitDecision(clientRequestInfo);
+
+        if (decision.hasExceededRateLimit()) {
+            emitRateLimitExceededMetric(decision, clientRequestInfo.clientID());
+            LOG.info("Client has exceeded rate limit, action: {}", decision.getAction().toString());
+        }
+
+        return decision;
+    }
+
+    private void emitRateLimitExceededMetric(RateLimitDecision rateLimitDecision, String clientId) {
+        try {
+            cloudwatchMetricsService.incrementCounter(
+                    "RpRateLimitExceeded",
+                    Map.of(
+                            "clientId",
+                            clientId,
+                            "action",
+                            rateLimitDecision.getAction().toString()));
+        } catch (Exception e) {
+            LOG.warn("Error incrementing RpRateLimitExceeded metric", e);
+        }
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RateLimitServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RateLimitServiceTest.java
@@ -7,12 +7,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.oidc.entity.ClientRequestInfo;
 import uk.gov.di.authentication.oidc.entity.RateLimitAlgorithm;
 import uk.gov.di.authentication.oidc.entity.RateLimitDecision;
+import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.sharedtest.helper.Constants;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 class RateLimitServiceTest {
 
@@ -21,25 +26,49 @@ class RateLimitServiceTest {
     private static final RateLimitAlgorithm alwaysReturnToRpAction =
             (client) -> RateLimitDecision.OVER_LIMIT_RETURN_TO_RP;
 
+    private final CloudwatchMetricsService cloudwatchMetricsService =
+            mock(CloudwatchMetricsService.class);
+
     @Test
     void itReturnsNoActionDecisionWhenTheClientHasNoRateLimit() {
-        var rateLimitService = new RateLimitService(alwaysReturnToRpAction);
+        var rateLimitService =
+                new RateLimitService(alwaysReturnToRpAction, cloudwatchMetricsService);
         var rateLimitDecision =
                 rateLimitService.getClientRateLimitDecision(
                         new ClientRequestInfo(Constants.TEST_CLIENT_ID, null));
         assertFalse(rateLimitDecision.hasExceededRateLimit());
         assertEquals(RateLimitDecision.RateLimitAction.NONE, rateLimitDecision.getAction());
+
+        verify(cloudwatchMetricsService, never())
+                .incrementCounter(
+                        "RpRateLimitExceeded",
+                        Map.of(
+                                "clientId",
+                                Constants.TEST_CLIENT_ID,
+                                "action",
+                                RateLimitDecision.RateLimitAction.NONE.toString()));
     }
 
     @ParameterizedTest
     @MethodSource("rateLimitAlgosAndOutcomes")
     void itDelegatesToTheRateLimitAlgoWhenClientHasARateLimitConfigured(
             RateLimitAlgorithm algorithm, RateLimitDecision outcome) {
-        var rateLimitService = new RateLimitService(algorithm);
+        var rateLimitService = new RateLimitService(algorithm, cloudwatchMetricsService);
         var rateLimitDecision =
                 rateLimitService.getClientRateLimitDecision(
                         new ClientRequestInfo(Constants.TEST_CLIENT_ID, 400));
         assertEquals(outcome, rateLimitDecision);
+
+        if (outcome.hasExceededRateLimit()) {
+            verify(cloudwatchMetricsService)
+                    .incrementCounter(
+                            "RpRateLimitExceeded",
+                            Map.of(
+                                    "clientId",
+                                    Constants.TEST_CLIENT_ID,
+                                    "action",
+                                    outcome.getAction().toString()));
+        }
     }
 
     private static Stream<Arguments> rateLimitAlgosAndOutcomes() {


### PR DESCRIPTION
### Wider context of change:

We are planning to implement RP rate limiting. As part of this we will implement a metric which will track when an RP has exceeded their rate limit.

### What’s changed:
- Adds new metric emission 

### Manual testing: 
- N/A this code is not hit yet
### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->