### PR TITLE
OLH-2696: Add `AUTH_MFA_METHOD_SWITCH_FAILED` audit event

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -14,6 +14,7 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     AUTH_EMAIL_FRAUD_CHECK_BYPASSED,
     AUTH_MFA_METHOD_ADD_FAILED,
     AUTH_MFA_METHOD_ADD_COMPLETED,
+    AUTH_MFA_METHOD_SWITCH_FAILED,
     AUTH_MFA_METHOD_SWITCH_COMPLETED;
 
     public AuditableEvent parseFromName(String name) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -39,7 +39,7 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
-import uk.gov.di.authentication.shared.services.mfa.MfaUpdateFailureReason;
+import uk.gov.di.authentication.shared.services.mfa.MfaUpdateFailure;
 
 import java.util.List;
 import java.util.Map;
@@ -228,7 +228,8 @@ public class MFAMethodsPutHandler
     }
 
     private static APIGatewayProxyResponseEvent handleUpdateMfaFailureReason(
-            MfaUpdateFailureReason failureReason) {
+            MfaUpdateFailure failure) {
+        var failureReason = failure.failureReason();
         var response =
                 switch (failureReason) {
                     case CANNOT_CHANGE_TYPE_OF_MFA_METHOD -> generateApiGatewayProxyErrorResponse(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -33,6 +33,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaMigrationFailureReason;
+import uk.gov.di.authentication.shared.services.mfa.MfaUpdateFailure;
 import uk.gov.di.authentication.shared.services.mfa.MfaUpdateFailureReason;
 
 import java.util.HashMap;
@@ -487,7 +488,7 @@ class MFAMethodsPutHandlerTest {
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
         var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber, TEST_OTP));
         when(mfaMethodsService.updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest))
-                .thenReturn(Result.failure(failureReason));
+                .thenReturn(Result.failure(new MfaUpdateFailure(failureReason)));
         var result = handler.handleRequest(eventWithUpdateRequest, context);
 
         assertThat(result, hasStatus(expectedStatus));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
@@ -852,7 +852,9 @@ class MFAMethodsServiceIntegrationTest {
 
             var result = mfaMethodsService.updateMfaMethod(EMAIL, "some-other-identifier", request);
 
-            assertEquals(MfaUpdateFailureReason.UNKOWN_MFA_IDENTIFIER, result.getFailure());
+            assertEquals(
+                    MfaUpdateFailureReason.UNKOWN_MFA_IDENTIFIER,
+                    result.getFailure().failureReason());
 
             var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
             assertEquals(List.of(defaultPriorityAuthApp), remainingMfaMethods);
@@ -974,7 +976,7 @@ class MFAMethodsServiceIntegrationTest {
 
                 assertEquals(
                         MfaUpdateFailureReason.ATTEMPT_TO_UPDATE_PHONE_NUMBER_WITH_BACKUP_NUMBER,
-                        result.getFailure());
+                        result.getFailure().failureReason());
 
                 var methodsInDatabase =
                         mfaMethodsService.getMfaMethods(EMAIL).getSuccess().stream()
@@ -1064,7 +1066,9 @@ class MFAMethodsServiceIntegrationTest {
                         mfaMethodsService.updateMfaMethod(
                                 EMAIL, defaultPrioritySms.getMfaIdentifier(), request);
 
-                assertEquals(MfaUpdateFailureReason.INVALID_PHONE_NUMBER, result.getFailure());
+                assertEquals(
+                        MfaUpdateFailureReason.INVALID_PHONE_NUMBER,
+                        result.getFailure().failureReason());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(defaultPrioritySms), remainingMfaMethods);
@@ -1081,7 +1085,7 @@ class MFAMethodsServiceIntegrationTest {
 
                 assertEquals(
                         MfaUpdateFailureReason.CANNOT_CHANGE_PRIORITY_OF_DEFAULT_METHOD,
-                        result.getFailure());
+                        result.getFailure().failureReason());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(defaultPriorityAuthApp), remainingMfaMethods);
@@ -1108,7 +1112,7 @@ class MFAMethodsServiceIntegrationTest {
 
                 assertEquals(
                         MfaUpdateFailureReason.REQUEST_TO_UPDATE_MFA_METHOD_WITH_NO_CHANGE,
-                        result.getFailure());
+                        result.getFailure().failureReason());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(existingMethod), remainingMfaMethods);
@@ -1177,7 +1181,8 @@ class MFAMethodsServiceIntegrationTest {
                                 EMAIL, existingMethod.getMfaIdentifier(), request);
 
                 assertEquals(
-                        MfaUpdateFailureReason.CANNOT_EDIT_MFA_BACKUP_METHOD, result.getFailure());
+                        MfaUpdateFailureReason.CANNOT_EDIT_MFA_BACKUP_METHOD,
+                        result.getFailure().failureReason());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
                 assertEquals(List.of(existingMethod), remainingMfaMethods);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MFAMethodsService.java
@@ -394,7 +394,8 @@ public class MFAMethodsService {
                 .mapFailure(
                         errorString -> {
                             LOG.error(errorString);
-                            return new MfaUpdateFailure(MfaUpdateFailureReason.UNEXPECTED_ERROR);
+                            return new MfaUpdateFailure(
+                                    MfaUpdateFailureReason.UNEXPECTED_ERROR, updateTypeIdentifier);
                         });
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaUpdateFailure.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaUpdateFailure.java
@@ -1,3 +1,10 @@
 package uk.gov.di.authentication.shared.services.mfa;
 
-public record MfaUpdateFailure(MfaUpdateFailureReason failureReason) {}
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodUpdateIdentifier;
+
+public record MfaUpdateFailure(
+        MfaUpdateFailureReason failureReason, MFAMethodUpdateIdentifier updateTypeIdentifier) {
+    public MfaUpdateFailure(MfaUpdateFailureReason failureReason) {
+        this(failureReason, null);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaUpdateFailure.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaUpdateFailure.java
@@ -1,0 +1,3 @@
+package uk.gov.di.authentication.shared.services.mfa;
+
+public record MfaUpdateFailure(MfaUpdateFailureReason failureReason) {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaUpdateFailure.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaUpdateFailure.java
@@ -1,10 +1,13 @@
 package uk.gov.di.authentication.shared.services.mfa;
 
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodUpdateIdentifier;
 
 public record MfaUpdateFailure(
-        MfaUpdateFailureReason failureReason, MFAMethodUpdateIdentifier updateTypeIdentifier) {
+        MfaUpdateFailureReason failureReason,
+        MFAMethodUpdateIdentifier updateTypeIdentifier,
+        MFAMethod mfaMethodToUpdate) {
     public MfaUpdateFailure(MfaUpdateFailureReason failureReason) {
-        this(failureReason, null);
+        this(failureReason, null, null);
     }
 }


### PR DESCRIPTION
## What

Introduces a new `AUTH_MFA_METHOD_SWITCH_FAILED` audit event which is triggered when a user's attempt to switch their backup method for their default fails unexpectedly.

To support this `MfaUpdateFailure` has been created. This class now includes the reason for the failure and the MFA method that was being updated, providing essential context for the new audit event.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.


## Related PRs

- This extends work from https://github.com/govuk-one-login/authentication-api/pull/6778
