### PR TITLE
BAU: Add a test for enum removal

### DIFF
--- a/shared/src/test/java/uk/gov/di/authentication/entity/CodeRequestTypeTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/entity/CodeRequestTypeTest.java
@@ -1,0 +1,39 @@
+package uk.gov.di.authentication.entity;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CodeRequestTypeTest {
+
+    @Test
+    void testForZddDeployment() {
+        var codeDefinedEnumValues =
+                Arrays.stream(CodeRequestType.values())
+                        .map(Enum::name)
+                        .collect(Collectors.joining());
+        var staticDefinedEnumValues =
+                List.of(
+                        "EMAIL_REGISTRATION",
+                        "EMAIL_ACCOUNT_RECOVERY",
+                        "EMAIL_PASSWORD_RESET",
+                        "MFA_ACCOUNT_RECOVERY",
+                        "MFA_PW_RESET_MFA",
+                        "MFA_REGISTRATION",
+                        "MFA_SIGN_IN",
+                        "MFA_REAUTHENTICATION");
+
+        staticDefinedEnumValues.forEach(
+                v ->
+                        assertTrue(
+                                codeDefinedEnumValues.contains(v),
+                                String.format(
+                                        "%s removed from CodeRequestType. Ensure this change is ZDD compatible",
+                                        v)));
+    }
+}


### PR DESCRIPTION
## What

Adds a small test which contains a static list of existing enum values, which is seperate from the values defined on the enum class. This test has a small warning about ensuring the deployment is ZDD compatible as removing an enum value whilst it is still serialized in existing sessions will throw an error and kill existing sessions


## How to review: 
- Pull the branch and delete a value from the CodeRequestType enum
- Run the test and see it fail

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
