### PR TITLE
ATO-1751: Swap to reading state from dynamo

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -30,7 +30,6 @@ import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
 import uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler;
-import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
 import uk.gov.di.authentication.sharedtest.extensions.AccountInterventionsStubExtension;
 import uk.gov.di.orchestration.shared.domain.AccountInterventionsAuditableEvent;
 import uk.gov.di.orchestration.shared.domain.LogoutAuditableEvent;
@@ -94,6 +93,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED;
+import static uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX;
 import static uk.gov.di.authentication.testsupport.helpers.OrchAuthCodeAssertionHelper.assertOrchAuthCodeSaved;
 import static uk.gov.di.orchestration.shared.entity.VectorOfTrust.parseFromAuthRequestAttribute;
 import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
@@ -910,9 +910,10 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         private void setupMaxAgeSession() throws Json.JsonException {
             redis.addStateToRedis(
-                    AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX,
-                    ORCH_TO_AUTH_STATE,
-                    SESSION_ID);
+                    AUTHENTICATION_STATE_STORAGE_PREFIX, ORCH_TO_AUTH_STATE, SESSION_ID);
+            stateStorageExtension.storeState(
+                    AUTHENTICATION_STATE_STORAGE_PREFIX + SESSION_ID,
+                    ORCH_TO_AUTH_STATE.getValue());
             setUpClientSession();
             orchSessionExtension.addSession(
                     new OrchSessionItem(SESSION_ID)
@@ -931,9 +932,10 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                                             .getEpochSecond());
             PREVIOUS_CLIENT_SESSIONS.forEach(orchSession::addClientSession);
             redis.addStateToRedis(
-                    AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX,
-                    ORCH_TO_AUTH_STATE,
-                    SESSION_ID);
+                    AUTHENTICATION_STATE_STORAGE_PREFIX, ORCH_TO_AUTH_STATE, SESSION_ID);
+            stateStorageExtension.storeState(
+                    AUTHENTICATION_STATE_STORAGE_PREFIX + SESSION_ID,
+                    ORCH_TO_AUTH_STATE.getValue());
             setUpClientSession();
             orchSessionExtension.addSession(orchSession);
         }
@@ -1160,10 +1162,9 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     }
 
     private void setupSession() throws Json.JsonException {
-        redis.addStateToRedis(
-                AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX,
-                ORCH_TO_AUTH_STATE,
-                SESSION_ID);
+        redis.addStateToRedis(AUTHENTICATION_STATE_STORAGE_PREFIX, ORCH_TO_AUTH_STATE, SESSION_ID);
+        stateStorageExtension.storeState(
+                AUTHENTICATION_STATE_STORAGE_PREFIX + SESSION_ID, ORCH_TO_AUTH_STATE.getValue());
         setUpClientSession();
         orchSessionExtension.addSession(new OrchSessionItem(SESSION_ID));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -38,6 +38,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.OrchAuthCodeExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 
 import java.net.URI;
@@ -103,6 +104,9 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
     @RegisterExtension
     public static final OrchAuthCodeExtension orchAuthCodeExtension = new OrchAuthCodeExtension();
+
+    @RegisterExtension
+    public static final StateStorageExtension stateStorageExtension = new StateStorageExtension();
 
     protected static final ConfigurationService configurationService =
             new DocAppCallbackHandlerIntegrationTest.TestConfigurationService(
@@ -376,6 +380,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         orchClientSession.setDocAppSubjectId(docAppSubjectId.getValue());
         orchClientSessionExtension.storeClientSession(orchClientSession);
         redis.addStateToRedis(DOC_APP_STATE, SESSION_ID);
+        stateStorageExtension.storeState("state:" + SESSION_ID, DOC_APP_STATE.getValue());
         orchSessionExtension.addSession(
                 new OrchSessionItem(SESSION_ID)
                         .withAccountState(OrchSessionItem.AccountState.EXISTING_DOC_APP_JOURNEY));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -50,6 +50,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 
 import java.net.URI;
@@ -104,6 +105,9 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
     @RegisterExtension
     public static final OrchAuthCodeExtension orchAuthCodeExtension = new OrchAuthCodeExtension();
+
+    @RegisterExtension
+    public static final StateStorageExtension stateStorageExtension = new StateStorageExtension();
 
     protected static final ConfigurationService configurationService =
             new IPVCallbackHandlerIntegrationTest.TestConfigurationService(
@@ -179,6 +183,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 CLIENT_NAME)
                         .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
+        stateStorageExtension.storeState("state:" + SESSION_ID, ORCHESTRATION_STATE.getValue());
 
         var response =
                 makeRequest(
@@ -310,6 +315,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 CLIENT_NAME)
                         .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
+        stateStorageExtension.storeState("state:" + SESSION_ID, ORCHESTRATION_STATE.getValue());
 
         makeRequest(
                 Optional.empty(),
@@ -469,6 +475,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 CLIENT_NAME)
                         .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
+        stateStorageExtension.storeState("state:" + SESSION_ID, ORCHESTRATION_STATE.getValue());
 
         var response =
                 makeRequest(
@@ -560,6 +567,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 CLIENT_NAME)
                         .withRpPairwiseId(rpPairwiseId));
         redis.addStateToRedis(ORCHESTRATION_STATE, SESSION_ID);
+        stateStorageExtension.storeState("state:" + SESSION_ID, ORCHESTRATION_STATE.getValue());
 
         var response =
                 makeRequest(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -141,31 +141,16 @@ public class IPVAuthorisationService {
     }
 
     private boolean isStateValid(String sessionId, String responseState) {
-        var prefixedSessionId = STATE_STORAGE_PREFIX + sessionId;
-        var valueFromRedis =
-                Optional.ofNullable(redisConnectionService.getValue(prefixedSessionId));
-        if (valueFromRedis.isEmpty()) {
-            LOG.info("No state found in Redis");
-            return false;
-        }
-
-        State storedState;
-        try {
-            storedState = objectMapper.readValue(valueFromRedis.get(), State.class);
-        } catch (JsonException e) {
-            LOG.info("Error when deserializing state from redis");
-            return false;
-        }
-
-        // Here we have to deserialise the state and get the value before we can compare the state
-        // values, as the serialised state value is surrounded by double quotes
         var valueFromDynamo =
-                stateStorageService.getState(prefixedSessionId).map(StateItem::getState);
-        LOG.info(
-                "Is state from redis equal to state from dynamo? {}",
-                valueFromDynamo.isPresent()
-                        && storedState.getValue().equals(valueFromDynamo.get()));
+                stateStorageService
+                        .getState(STATE_STORAGE_PREFIX + sessionId)
+                        .map(StateItem::getState);
+        if (valueFromDynamo.isEmpty()) {
+            LOG.info("No state found in Dynamo");
+            return false;
+        }
 
+        State storedState = new State(valueFromDynamo.get());
         LOG.info(
                 "Response state: {} and Stored state: {}. Are equal: {}",
                 responseState,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -39,6 +39,7 @@ import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
@@ -209,6 +210,23 @@ class IPVAuthorisationServiceTest {
                                 new ErrorObject(
                                         OAuth2Error.INVALID_REQUEST_CODE,
                                         "No code param present in Authorisation response"))));
+    }
+
+    @Test
+    void shouldReturnErrorObjectWhenNoStateFoundInDynamo() {
+        when(stateStorageService.getState(
+                        DocAppAuthorisationService.STATE_STORAGE_PREFIX + SESSION_ID))
+                .thenReturn(Optional.empty());
+        Map<String, String> responseHeaders = new HashMap<>();
+        responseHeaders.put("state", STATE.getValue());
+
+        assertThat(
+                authorisationService.validateResponse(responseHeaders, SESSION_ID),
+                equalTo(
+                        Optional.of(
+                                new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE,
+                                        "Invalid state param present in Authorisation response"))));
     }
 
     @Test

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -127,8 +127,7 @@ public class AuthenticationCallbackHandler
         var stateStorageService = new StateStorageService(configurationService);
         var oidcApi = new OidcAPI(configurationService);
         this.configurationService = configurationService;
-        this.authorisationService =
-                new AuthenticationAuthorizationService(redisConnectionService, stateStorageService);
+        this.authorisationService = new AuthenticationAuthorizationService(stateStorageService);
         this.tokenService =
                 new AuthenticationTokenService(configurationService, kmsConnectionService);
         this.orchSessionService = new OrchSessionService(configurationService);
@@ -169,8 +168,7 @@ public class AuthenticationCallbackHandler
         var stateStorageService = new StateStorageService(configurationService);
         var kmsConnectionService = new KmsConnectionService(configurationService);
         this.configurationService = configurationService;
-        this.authorisationService =
-                new AuthenticationAuthorizationService(redisConnectionService, stateStorageService);
+        this.authorisationService = new AuthenticationAuthorizationService(stateStorageService);
         this.tokenService =
                 new AuthenticationTokenService(configurationService, kmsConnectionService);
         this.orchSessionService = new OrchSessionService(configurationService);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
@@ -135,6 +135,23 @@ class AuthenticationAuthorizationServiceTest {
     }
 
     @Test
+    void shouldThrowWhenNoStateFoundInDynamo() {
+        when(stateStorageService.getState(AUTHENTICATION_STATE_STORAGE_PREFIX + SESSION_ID))
+                .thenReturn(Optional.empty());
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("state", new State().getValue());
+        queryParams.put("code", EXAMPLE_AUTH_CODE);
+
+        var exception =
+                assertThrows(
+                        AuthenticationCallbackValidationException.class,
+                        () -> authService.validateRequest(queryParams, SESSION_ID));
+        assertThat(exception.getError(), is((equalTo(OAuth2Error.SERVER_ERROR))));
+        assertThat(exception.getLogoutRequired(), is((equalTo(false))));
+        verify(stateStorageService).getState(AUTHENTICATION_STATE_STORAGE_PREFIX + SESSION_ID);
+    }
+
+    @Test
     void shouldThrowWhenNoCodeParamPresent() {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put("state", new State().getValue());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
@@ -10,11 +10,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.oidc.exceptions.AuthenticationCallbackValidationException;
-import uk.gov.di.orchestration.shared.services.RedisConnectionService;
+import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.services.StateStorageService;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,35 +28,33 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX;
 
 class AuthenticationAuthorizationServiceTest {
-    private final RedisConnectionService redisConnectionService =
-            mock(RedisConnectionService.class);
     private final StateStorageService stateStorageService = mock(StateStorageService.class);
     private AuthenticationAuthorizationService authService;
-    private static final State REDIS_STORED_STATE = new State();
+    private static final State STORED_STATE = new State();
     private static final String SESSION_ID = "a-session-id";
     private static final String EXAMPLE_AUTH_CODE = "any-text-will-do";
 
     @BeforeEach
     void setUp() {
-        when(redisConnectionService.getValue(anyString()))
-                .thenReturn(REDIS_STORED_STATE.getValue());
-        authService =
-                new AuthenticationAuthorizationService(redisConnectionService, stateStorageService);
+        when(stateStorageService.getState(anyString()))
+                .thenReturn(
+                        Optional.of(
+                                new StateItem(AUTHENTICATION_STATE_STORAGE_PREFIX + SESSION_ID)
+                                        .withState(STORED_STATE.getValue())));
+        authService = new AuthenticationAuthorizationService(stateStorageService);
     }
 
     @Test
     void shouldValidateRequestWithValidParams() {
         Map<String, String> queryParams = new HashMap<>();
-        queryParams.put("state", REDIS_STORED_STATE.getValue());
+        queryParams.put("state", STORED_STATE.getValue());
         queryParams.put("code", EXAMPLE_AUTH_CODE);
 
         assertDoesNotThrow(() -> authService.validateRequest(queryParams, SESSION_ID));
-        verify(redisConnectionService)
-                .getValue(
-                        AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX
-                                + SESSION_ID);
+        verify(stateStorageService).getState(AUTHENTICATION_STATE_STORAGE_PREFIX + SESSION_ID);
     }
 
     @Test
@@ -68,7 +67,7 @@ class AuthenticationAuthorizationServiceTest {
                         () -> authService.validateRequest(queryParams, SESSION_ID));
         assertThat(exception.getError(), is((equalTo(OAuth2Error.SERVER_ERROR))));
         assertThat(exception.getLogoutRequired(), is((equalTo(false))));
-        verify(redisConnectionService, never()).getValue(anyString());
+        verify(stateStorageService, never()).getState(anyString());
     }
 
     @Test
@@ -82,7 +81,7 @@ class AuthenticationAuthorizationServiceTest {
                         () -> authService.validateRequest(queryParams, SESSION_ID));
         assertThat(exception.getError(), is((equalTo(OAuth2Error.SERVER_ERROR))));
         assertThat(exception.getLogoutRequired(), is((equalTo(false))));
-        verify(redisConnectionService, never()).getValue(anyString());
+        verify(stateStorageService, never()).getState(anyString());
     }
 
     @ParameterizedTest
@@ -97,7 +96,7 @@ class AuthenticationAuthorizationServiceTest {
                         () -> authService.validateRequest(queryParams, SESSION_ID));
         assertThat(exception.getError(), is((equalTo(expectedErrorObject))));
         assertThat(exception.getLogoutRequired(), is((equalTo(true))));
-        verify(redisConnectionService, never()).getValue(anyString());
+        verify(stateStorageService, never()).getState(anyString());
     }
 
     static Stream<Arguments> reauthErrorCases() {
@@ -117,7 +116,7 @@ class AuthenticationAuthorizationServiceTest {
                         () -> authService.validateRequest(queryParams, SESSION_ID));
         assertThat(exception.getError(), is((equalTo(OAuth2Error.SERVER_ERROR))));
         assertThat(exception.getLogoutRequired(), is((equalTo(false))));
-        verify(redisConnectionService, never()).getValue(anyString());
+        verify(stateStorageService, never()).getState(anyString());
     }
 
     @Test
@@ -132,10 +131,7 @@ class AuthenticationAuthorizationServiceTest {
                         () -> authService.validateRequest(queryParams, SESSION_ID));
         assertThat(exception.getError(), is((equalTo(OAuth2Error.SERVER_ERROR))));
         assertThat(exception.getLogoutRequired(), is((equalTo(false))));
-        verify(redisConnectionService)
-                .getValue(
-                        AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX
-                                + SESSION_ID);
+        verify(stateStorageService).getState(AUTHENTICATION_STATE_STORAGE_PREFIX + SESSION_ID);
     }
 
     @Test

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
@@ -125,31 +125,16 @@ public class DocAppAuthorisationService {
     }
 
     private boolean isStateValid(String sessionId, String responseState) {
-        var prefixedSessionId = STATE_STORAGE_PREFIX + sessionId;
-        var valueFromRedis =
-                Optional.ofNullable(redisConnectionService.getValue(prefixedSessionId));
-        if (valueFromRedis.isEmpty()) {
-            LOG.info("No Doc Checking App state found in Redis");
-            return false;
-        }
-
-        State storedState;
-        try {
-            storedState = objectMapper.readValue(valueFromRedis.get(), State.class);
-        } catch (JsonException e) {
-            LOG.info("Error when deserializing state from redis");
-            return false;
-        }
-
-        // Here we have to deserialise the state and get the value before we can compare the state
-        // values, as the serialised state value is surrounded by double quotes
         var valueFromDynamo =
-                stateStorageService.getState(prefixedSessionId).map(StateItem::getState);
-        LOG.info(
-                "Is state from redis equal to state from dynamo? {}",
-                valueFromDynamo.isPresent()
-                        && storedState.getValue().equals(valueFromDynamo.get()));
+                stateStorageService
+                        .getState(STATE_STORAGE_PREFIX + sessionId)
+                        .map(StateItem::getState);
+        if (valueFromDynamo.isEmpty()) {
+            LOG.info("No Doc Checking App state found in Dynamo");
+            return false;
+        }
 
+        State storedState = new State(valueFromDynamo.get());
         LOG.info(
                 "Response state: {} and Stored state: {}. Are equal: {}",
                 responseState,

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
@@ -191,6 +191,22 @@ class DocAppAuthorisationServiceTest {
     }
 
     @Test
+    void shouldReturnErrorObjectWhenNoStateFoundInDynamo() {
+        when(stateStorageService.getState(STATE_STORAGE_PREFIX + SESSION_ID))
+                .thenReturn(Optional.empty());
+        Map<String, String> responseHeaders = new HashMap<>();
+        responseHeaders.put("state", STATE.getValue());
+
+        assertThat(
+                authorisationService.validateResponse(responseHeaders, SESSION_ID),
+                equalTo(
+                        Optional.of(
+                                new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE,
+                                        "Invalid state param present in Authorisation response"))));
+    }
+
+    @Test
     void shouldReturnErrorObjectWhenStateInResponseIsDifferentToStoredState() {
         State differentState = new State();
         Map<String, String> responseHeaders = new HashMap<>();

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 
@@ -101,8 +102,11 @@ class DocAppAuthorisationServiceTest {
     void setUp() throws Json.JsonException, MalformedURLException, KeySourceException {
         when(configurationService.getDocAppJwksURI()).thenReturn(JWKS_URL);
         when(configurationService.getSessionExpiry()).thenReturn(SESSION_EXPIRY);
-        when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + SESSION_ID))
-                .thenReturn(objectMapper.writeValueAsString(STATE));
+        when(stateStorageService.getState(STATE_STORAGE_PREFIX + SESSION_ID))
+                .thenReturn(
+                        Optional.of(
+                                new StateItem(STATE_STORAGE_PREFIX + SESSION_ID)
+                                        .withState(STATE.getValue())));
         when(configurationService.getDocAppAuthorisationClientId()).thenReturn(DOC_APP_CLIENT_ID);
         when(configurationService.getDocAppAuthorisationCallbackURI())
                 .thenReturn(DOC_APP_CALLBACK_URI);
@@ -187,11 +191,8 @@ class DocAppAuthorisationServiceTest {
     }
 
     @Test
-    void shouldReturnErrorObjectWhenStateInResponseIsDifferentToStoredState()
-            throws Json.JsonException {
+    void shouldReturnErrorObjectWhenStateInResponseIsDifferentToStoredState() {
         State differentState = new State();
-        when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + SESSION_ID))
-                .thenReturn(objectMapper.writeValueAsString(STATE));
         Map<String, String> responseHeaders = new HashMap<>();
         responseHeaders.put("state", differentState.getValue());
         responseHeaders.put("code", AUTH_CODE.getValue());


### PR DESCRIPTION
### Wider context of change

We would like to store state in a dynamo table in orch instead of storing state in redis. By now we should be confident that the dynamo state is always the same as the redis state. We can now safely swap to using the dynamo state instead of the redis state.

### What’s changed

This PR swaps to using the dynamo state for state-related operations instead of using the redis state. Now the redis state will not be read, and we can remove the writing of this state in the next PR

### Manual testing

Tested in sandpit. Performed the following journeys:
- Auth only
- Doc app
- Identity

All 3 journeys completed successfully.

Have checked the logs over the weekend and they are all in sync (1 was out of sync but we suspect that is a dynamo read consistency issue) 

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

