### PR TITLE
WIP: OLH-2705: Add `AUTH_UPDATE_PHONE_NUMBER` audit event

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -291,7 +291,8 @@ public class MFAMethodsCreateHandler
         }
 
         Result<ErrorResponse, AuditContext> auditContextResult =
-                buildAuditContext(AUTH_MFA_METHOD_ADD_COMPLETED, input, userProfile, mfaMethodCreateRequest);
+                buildAuditContext(
+                        AUTH_MFA_METHOD_ADD_COMPLETED, input, userProfile, mfaMethodCreateRequest);
 
         if (auditContextResult.isFailure()) {
             return generateApiGatewayProxyErrorResponse(401, auditContextResult.getFailure());

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
+import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -41,6 +41,7 @@ import uk.gov.di.authentication.shared.services.mfa.MfaCreateFailureReason;
 import java.util.Map;
 import java.util.Optional;
 
+import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
@@ -316,7 +317,10 @@ public class MFAMethodsCreateHandler
                     addCompletedAuditContext.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
         }
 
-        auditService.submitAuditEvent(AUTH_MFA_METHOD_ADD_COMPLETED, auditContext);
+        auditService.submitAuditEvent(
+                AUTH_MFA_METHOD_ADD_COMPLETED,
+                addCompletedAuditContext,
+                AUDIT_EVENT_COMPONENT_ID_HOME);
 
         if (auditEventStatus.isFailure()) {
             LOG.error(auditEventStatus.getFailure());
@@ -334,7 +338,10 @@ public class MFAMethodsCreateHandler
                                             .name()
                                             .toLowerCase()));
 
-            auditService.submitAuditEvent(AUTH_UPDATE_PHONE_NUMBER, updatePhoneNumberAuditContext);
+            auditService.submitAuditEvent(
+                    AUTH_UPDATE_PHONE_NUMBER,
+                    updatePhoneNumberAuditContext,
+                    AUDIT_EVENT_COMPONENT_ID_HOME);
         }
 
         LocaleHelper.SupportedLanguage userLanguage =

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodCreateRequest;
 import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
@@ -44,7 +45,10 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.authentication.entity.Environment.PRODUCTION;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.DEFAULT_MFA_ALREADY_EXISTS;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.INVALID_OTP;
@@ -56,6 +60,7 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.getUserLanguageFromRequestHeaders;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.matchSupportedLanguage;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class MFAMethodsCreateHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -285,13 +290,52 @@ public class MFAMethodsCreateHandler
             return generateApiGatewayProxyErrorResponse(500, UNEXPECTED_ACCT_MGMT_ERROR);
         }
 
-        auditEventStatus =
-                sendAuditEvent(
-                        AUTH_MFA_METHOD_ADD_COMPLETED, input, userProfile, mfaMethodCreateRequest);
+        Result<ErrorResponse, AuditContext> auditContextResult =
+                buildAuditContext(AUTH_MFA_METHOD_ADD_COMPLETED, input, userProfile, mfaMethodCreateRequest);
+
+        if (auditContextResult.isFailure()) {
+            return generateApiGatewayProxyErrorResponse(401, auditContextResult.getFailure());
+        }
+
+        var auditContext = auditContextResult.getSuccess();
+
+        var addCompletedAuditContext =
+                auditContext.withMetadataItem(
+                        pair(
+                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                mfaMethodCreateRequest
+                                        .mfaMethod()
+                                        .method()
+                                        .mfaMethodType()
+                                        .toString()));
+
+        if (mfaMethodCreateRequest.mfaMethod().method()
+                instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
+            addCompletedAuditContext =
+                    addCompletedAuditContext.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
+        }
+
+        auditService.submitAuditEvent(AUTH_MFA_METHOD_ADD_COMPLETED, auditContext);
+
         if (auditEventStatus.isFailure()) {
             LOG.error(auditEventStatus.getFailure());
             return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
         }
+
+        if (backupMfaMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
+            var updatePhoneNumberAuditContext =
+                    auditContext.withMetadataItem(
+                            pair(
+                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                    mfaMethodCreateRequest
+                                            .mfaMethod()
+                                            .priorityIdentifier()
+                                            .name()
+                                            .toLowerCase()));
+
+            auditService.submitAuditEvent(AUTH_UPDATE_PHONE_NUMBER, updatePhoneNumberAuditContext);
+        }
+
         LocaleHelper.SupportedLanguage userLanguage =
                 matchSupportedLanguage(
                         getUserLanguageFromRequestHeaders(
@@ -326,6 +370,48 @@ public class MFAMethodsCreateHandler
             LOG.error("Failed to build successful response: ", e);
             return generateApiGatewayProxyErrorResponse(500, UNEXPECTED_ACCT_MGMT_ERROR);
         }
+    }
+
+    private Result<ErrorResponse, AuditContext> updateAuditContextForFailedMFACreation(
+            UserProfile userProfile, AuditContext auditContext) {
+        var maybeMfaMethods = mfaMethodsService.getMfaMethods(userProfile.getEmail());
+
+        if (maybeMfaMethods.isFailure()) {
+            LOG.error("No MFA methods found for user");
+            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
+        }
+
+        var mfaMethods = maybeMfaMethods.getSuccess();
+
+        var defaultMfaMethod =
+                mfaMethods.stream()
+                        .filter(
+                                method ->
+                                        method.getPriority()
+                                                .equalsIgnoreCase(
+                                                        PriorityIdentifier.DEFAULT.name()))
+                        .findFirst();
+
+        if (defaultMfaMethod.isEmpty()) {
+            LOG.error("No default MFA method found for user");
+            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
+        }
+
+        if (defaultMfaMethod.get().getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
+            auditContext = auditContext.withPhoneNumber(defaultMfaMethod.get().getDestination());
+        }
+
+        auditContext =
+                auditContext.withMetadataItem(
+                        pair(
+                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                defaultMfaMethod.get().getMfaMethodType()));
+        auditContext =
+                auditContext.withMetadataItem(
+                        pair(
+                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                PriorityIdentifier.DEFAULT.name().toLowerCase()));
+        return Result.success(auditContext);
     }
 
     private static APIGatewayProxyResponseEvent handleCreateBackupMfaFailure(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -41,7 +41,6 @@ import uk.gov.di.authentication.shared.services.mfa.MfaCreateFailureReason;
 import java.util.Map;
 import java.util.Optional;
 
-import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
@@ -291,36 +290,18 @@ public class MFAMethodsCreateHandler
             return generateApiGatewayProxyErrorResponse(500, UNEXPECTED_ACCT_MGMT_ERROR);
         }
 
-        Result<ErrorResponse, AuditContext> auditContextResult =
-                buildAuditContext(
-                        AUTH_MFA_METHOD_ADD_COMPLETED, input, userProfile, mfaMethodCreateRequest);
+        var addCompletedResult =
+                sendAuditEvent(
+                        AUTH_MFA_METHOD_ADD_COMPLETED,
+                        input,
+                        userProfile,
+                        mfaMethodCreateRequest,
+                        backupMfaMethod);
 
-        if (auditContextResult.isFailure()) {
-            return generateApiGatewayProxyErrorResponse(401, auditContextResult.getFailure());
+        if (addCompletedResult.isFailure()) {
+            LOG.error(addCompletedResult.getFailure());
+            return generateApiGatewayProxyErrorResponse(500, addCompletedResult.getFailure());
         }
-
-        var auditContext = auditContextResult.getSuccess();
-
-        var addCompletedAuditContext =
-                auditContext.withMetadataItem(
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                mfaMethodCreateRequest
-                                        .mfaMethod()
-                                        .method()
-                                        .mfaMethodType()
-                                        .toString()));
-
-        if (mfaMethodCreateRequest.mfaMethod().method()
-                instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-            addCompletedAuditContext =
-                    addCompletedAuditContext.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
-        }
-
-        auditService.submitAuditEvent(
-                AUTH_MFA_METHOD_ADD_COMPLETED,
-                addCompletedAuditContext,
-                AUDIT_EVENT_COMPONENT_ID_HOME);
 
         if (auditEventStatus.isFailure()) {
             LOG.error(auditEventStatus.getFailure());
@@ -328,20 +309,19 @@ public class MFAMethodsCreateHandler
         }
 
         if (backupMfaMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
-            var updatePhoneNumberAuditContext =
-                    auditContext.withMetadataItem(
-                            pair(
-                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                    mfaMethodCreateRequest
-                                            .mfaMethod()
-                                            .priorityIdentifier()
-                                            .name()
-                                            .toLowerCase()));
+            var updatePhoneNumberResult =
+                    sendAuditEvent(
+                            AUTH_UPDATE_PHONE_NUMBER,
+                            input,
+                            userProfile,
+                            mfaMethodCreateRequest,
+                            backupMfaMethod);
 
-            auditService.submitAuditEvent(
-                    AUTH_UPDATE_PHONE_NUMBER,
-                    updatePhoneNumberAuditContext,
-                    AUDIT_EVENT_COMPONENT_ID_HOME);
+            if (updatePhoneNumberResult.isFailure()) {
+                LOG.error(updatePhoneNumberResult.getFailure());
+                return generateApiGatewayProxyErrorResponse(
+                        500, updatePhoneNumberResult.getFailure());
+            }
         }
 
         LocaleHelper.SupportedLanguage userLanguage =
@@ -380,48 +360,6 @@ public class MFAMethodsCreateHandler
         }
     }
 
-    private Result<ErrorResponse, AuditContext> updateAuditContextForFailedMFACreation(
-            UserProfile userProfile, AuditContext auditContext) {
-        var maybeMfaMethods = mfaMethodsService.getMfaMethods(userProfile.getEmail());
-
-        if (maybeMfaMethods.isFailure()) {
-            LOG.error("No MFA methods found for user");
-            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
-        }
-
-        var mfaMethods = maybeMfaMethods.getSuccess();
-
-        var defaultMfaMethod =
-                mfaMethods.stream()
-                        .filter(
-                                method ->
-                                        method.getPriority()
-                                                .equalsIgnoreCase(
-                                                        PriorityIdentifier.DEFAULT.name()))
-                        .findFirst();
-
-        if (defaultMfaMethod.isEmpty()) {
-            LOG.error("No default MFA method found for user");
-            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
-        }
-
-        if (defaultMfaMethod.get().getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
-            auditContext = auditContext.withPhoneNumber(defaultMfaMethod.get().getDestination());
-        }
-
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                defaultMfaMethod.get().getMfaMethodType()));
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                PriorityIdentifier.DEFAULT.name().toLowerCase()));
-        return Result.success(auditContext);
-    }
-
     private static APIGatewayProxyResponseEvent handleCreateBackupMfaFailure(
             MfaCreateFailureReason failureReason) {
         return switch (failureReason) {
@@ -440,25 +378,66 @@ public class MFAMethodsCreateHandler
             AccountManagementAuditableEvent auditEvent,
             APIGatewayProxyRequestEvent input,
             UserProfile userProfile,
-            MfaMethodCreateRequest mfaMethodCreateRequest) {
-        if (auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
-            var baseContextResult =
-                    AuditHelper.buildAuditContext(
-                            configurationService, dynamoService, input, userProfile);
-            if (baseContextResult.isFailure()) {
-                return baseContextResult;
+            MfaMethodCreateRequest mfaMethodCreateRequest,
+            MFAMethod mfaMethod) {
+        try {
+            if (auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
+                var baseContextResult =
+                        AuditHelper.buildAuditContext(
+                                configurationService, dynamoService, input, userProfile);
+                if (baseContextResult.isFailure()) {
+                    return baseContextResult;
+                }
+                return AuditHelper.updateAuditContextForFailedMFACreation(
+                        userProfile, baseContextResult.getSuccess(), mfaMethodsService, LOG);
+            } else {
+                var baseContextResult =
+                        AuditHelper.buildAuditContextForMfa(
+                                auditEvent,
+                                input,
+                                userProfile,
+                                mfaMethodCreateRequest,
+                                configurationService,
+                                dynamoService,
+                                LOG);
+
+                if (baseContextResult.isFailure()) {
+                    return baseContextResult;
+                }
+
+                var context = baseContextResult.getSuccess();
+
+                if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)) {
+                    context =
+                            context.withMetadataItem(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                            mfaMethodCreateRequest
+                                                    .mfaMethod()
+                                                    .method()
+                                                    .mfaMethodType()
+                                                    .toString()));
+
+                    if (mfaMethodCreateRequest.mfaMethod().method()
+                            instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
+                        context = context.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
+                    }
+                }
+
+                if (auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER) && mfaMethod != null) {
+                    // Always set mfa-method to DEFAULT for AUTH_UPDATE_PHONE_NUMBER events
+                    context =
+                            context.withMetadataItem(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                            PriorityIdentifier.DEFAULT.name().toLowerCase()));
+                }
+
+                return Result.success(context);
             }
-            return AuditHelper.updateAuditContextForFailedMFACreation(
-                    userProfile, baseContextResult.getSuccess(), mfaMethodsService, LOG);
-        } else {
-            return AuditHelper.buildAuditContextForMfa(
-                    auditEvent,
-                    input,
-                    userProfile,
-                    mfaMethodCreateRequest,
-                    configurationService,
-                    dynamoService,
-                    LOG);
+        } catch (Exception e) {
+            LOG.error("Error building audit context", e);
+            return Result.failure(ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR);
         }
     }
 
@@ -467,8 +446,18 @@ public class MFAMethodsCreateHandler
             APIGatewayProxyRequestEvent input,
             UserProfile userProfile,
             MfaMethodCreateRequest mfaMethodCreateRequest) {
+        return sendAuditEvent(auditEvent, input, userProfile, mfaMethodCreateRequest, null);
+    }
+
+    private Result<ErrorResponse, Void> sendAuditEvent(
+            AccountManagementAuditableEvent auditEvent,
+            APIGatewayProxyRequestEvent input,
+            UserProfile userProfile,
+            MfaMethodCreateRequest mfaMethodCreateRequest,
+            MFAMethod mfaMethod) {
         var maybeAuditContext =
-                buildAuditContext(auditEvent, input, userProfile, mfaMethodCreateRequest);
+                buildAuditContext(
+                        auditEvent, input, userProfile, mfaMethodCreateRequest, mfaMethod);
         if (maybeAuditContext.isFailure()) {
             LOG.error(
                     "Error when building audit context for {} audit event with error code {}. No event raised",
@@ -477,8 +466,16 @@ public class MFAMethodsCreateHandler
             return Result.failure(ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT);
         }
 
-        return AuditHelper.sendAuditEvent(
-                auditEvent, maybeAuditContext.getSuccess(), auditService, LOG);
+        var result =
+                AuditHelper.sendAuditEvent(
+                        auditEvent, maybeAuditContext.getSuccess(), auditService, LOG);
+
+        if (result.isFailure()) {
+            return Result.failure(result.getFailure());
+        }
+
+        LOG.info("Successfully submitted audit event: {}", auditEvent.name());
+        return Result.success(null);
     }
 
     private void addSessionIdToLogs(APIGatewayProxyRequestEvent input) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
-import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -52,6 +52,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.helpers.MfaMethodResponseConverterHelper.convertMfaMethodsToMfaMethodResponse;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
@@ -269,23 +270,15 @@ public class MFAMethodsPutHandler
             sendEmailNotification(
                     emailNotificationType, putRequest.userProfile.getEmail(), userLanguage);
 
-            var postUpdateDefaultMfaMethod =
-                    successfulUpdateMethods.stream()
-                            .filter(mfaMethod -> DEFAULT.name().equals(mfaMethod.getPriority()))
-                            .findFirst()
-                            .orElseThrow();
+            var maybeAuditEventsStatus =
+                    sendSuccessAuditEvents(
+                            updateTypeIdentifier,
+                            input,
+                            putRequest,
+                            successfulUpdateMethods);
 
-            if (updateTypeIdentifier == MFAMethodUpdateIdentifier.SWITCHED_MFA_METHODS) {
-                var maybeAuditEventStatus =
-                        sendAuditEvent(
-                                AUTH_MFA_METHOD_SWITCH_COMPLETED,
-                                input,
-                                putRequest,
-                                postUpdateDefaultMfaMethod);
-
-                if (maybeAuditEventStatus.isFailure()) {
-                    return maybeAuditEventStatus.getFailure();
-                }
+            if (maybeAuditEventsStatus.isFailure()) {
+                return maybeAuditEventsStatus.getFailure();
             }
 
         } else {
@@ -503,6 +496,83 @@ public class MFAMethodsPutHandler
                 notificationType.name());
     }
 
+    private Result<APIGatewayProxyResponseEvent, Void> sendSuccessAuditEvents(
+            MFAMethodUpdateIdentifier updateTypeIdentifier,
+            APIGatewayProxyRequestEvent input,
+            UserProfile userProfile,
+            List<MFAMethod> updatedMfaMethods) {
+        var postUpdateDefaultMfaMethod =
+                updatedMfaMethods.stream()
+                        .filter(mfaMethod -> DEFAULT.name().equals(mfaMethod.getPriority()))
+                        .findFirst()
+                        .orElseThrow();
+
+        return switch (updateTypeIdentifier) {
+            case SWITCHED_MFA_METHODS -> handleSwitchedMfaMethodsAuditEvents(
+                    input, userProfile, updatedMfaMethods);
+            case CHANGED_SMS -> sendAuditEvent(
+                    AUTH_UPDATE_PHONE_NUMBER, input, userProfile, postUpdateDefaultMfaMethod);
+            case CHANGED_DEFAULT_MFA -> {
+                var isDefaultMfaMethodSMS =
+                        postUpdateDefaultMfaMethod
+                                .getMfaMethodType()
+                                .equals(MFAMethodType.SMS.getValue());
+                if (isDefaultMfaMethodSMS) {
+                    yield sendAuditEvent(
+                            AUTH_UPDATE_PHONE_NUMBER,
+                            input,
+                            userProfile,
+                            postUpdateDefaultMfaMethod);
+                }
+
+                yield Result.success(null);
+            }
+            default -> Result.success(null);
+        };
+    }
+
+    private Result<APIGatewayProxyResponseEvent, Void> handleSwitchedMfaMethodsAuditEvents(
+            APIGatewayProxyRequestEvent input,
+            UserProfile userProfile,
+            List<MFAMethod> updatedMfaMethods) {
+        var postUpdateDefaultMfaMethod =
+                updatedMfaMethods.stream()
+                        .filter(mfaMethod -> DEFAULT.name().equals(mfaMethod.getPriority()))
+                        .findFirst()
+                        .orElseThrow();
+
+        var maybeCompletedAuditEvent =
+                sendAuditEvent(
+                        AUTH_MFA_METHOD_SWITCH_COMPLETED,
+                        input,
+                        userProfile,
+                        postUpdateDefaultMfaMethod);
+
+        if (maybeCompletedAuditEvent.isFailure()) {
+            return maybeCompletedAuditEvent;
+        }
+
+        var allSmsMfaMethods =
+                updatedMfaMethods.stream()
+                        .filter(
+                                mfaMethod ->
+                                        MFAMethodType.SMS
+                                                .getValue()
+                                                .equals(mfaMethod.getMfaMethodType()))
+                        .toList();
+
+        for (var smsMfaMethod : allSmsMfaMethods) {
+            var maybeUpdatedPhoneNumberAuditEvent =
+                    sendAuditEvent(AUTH_UPDATE_PHONE_NUMBER, input, userProfile, smsMfaMethod);
+
+            if (maybeUpdatedPhoneNumberAuditEvent.isFailure()) {
+                return maybeUpdatedPhoneNumberAuditEvent;
+            }
+        }
+
+        return Result.success(null);
+    }
+
     private Result<APIGatewayProxyResponseEvent, Void> sendAuditEvent(
             AccountManagementAuditableEvent auditEvent,
             APIGatewayProxyRequestEvent input,
@@ -576,7 +646,6 @@ public class MFAMethodsPutHandler
                         pair(
                                 AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
                                 JourneyType.ACCOUNT_MANAGEMENT.getValue()),
-                        pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType())
                     };
 
             var context =
@@ -599,6 +668,15 @@ public class MFAMethodsPutHandler
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
                             AuditHelper.getTxmaAuditEncoded(input.getHeaders()),
                             List.of(initialMetadataPairs));
+
+
+            if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
+                context =
+                        context.withMetadataItem(
+                                pair(
+                                        AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                        mfaMethod.getMfaMethodType()));
+            }
 
             if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
                     || auditEvent.equals(AUTH_INVALID_CODE_SENT)) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -272,10 +272,7 @@ public class MFAMethodsPutHandler
 
             var maybeAuditEventsStatus =
                     sendSuccessAuditEvents(
-                            updateTypeIdentifier,
-                            input,
-                            putRequest,
-                            successfulUpdateMethods);
+                            updateTypeIdentifier, input, putRequest, successfulUpdateMethods);
 
             if (maybeAuditEventsStatus.isFailure()) {
                 return maybeAuditEventsStatus.getFailure();
@@ -499,7 +496,7 @@ public class MFAMethodsPutHandler
     private Result<APIGatewayProxyResponseEvent, Void> sendSuccessAuditEvents(
             MFAMethodUpdateIdentifier updateTypeIdentifier,
             APIGatewayProxyRequestEvent input,
-            UserProfile userProfile,
+            ValidPutRequest putRequest,
             List<MFAMethod> updatedMfaMethods) {
         var postUpdateDefaultMfaMethod =
                 updatedMfaMethods.stream()
@@ -509,9 +506,9 @@ public class MFAMethodsPutHandler
 
         return switch (updateTypeIdentifier) {
             case SWITCHED_MFA_METHODS -> handleSwitchedMfaMethodsAuditEvents(
-                    input, userProfile, updatedMfaMethods);
+                    input, putRequest, updatedMfaMethods);
             case CHANGED_SMS -> sendAuditEvent(
-                    AUTH_UPDATE_PHONE_NUMBER, input, userProfile, postUpdateDefaultMfaMethod);
+                    AUTH_UPDATE_PHONE_NUMBER, input, putRequest, postUpdateDefaultMfaMethod);
             case CHANGED_DEFAULT_MFA -> {
                 var isDefaultMfaMethodSMS =
                         postUpdateDefaultMfaMethod
@@ -521,7 +518,7 @@ public class MFAMethodsPutHandler
                     yield sendAuditEvent(
                             AUTH_UPDATE_PHONE_NUMBER,
                             input,
-                            userProfile,
+                            putRequest,
                             postUpdateDefaultMfaMethod);
                 }
 
@@ -533,7 +530,7 @@ public class MFAMethodsPutHandler
 
     private Result<APIGatewayProxyResponseEvent, Void> handleSwitchedMfaMethodsAuditEvents(
             APIGatewayProxyRequestEvent input,
-            UserProfile userProfile,
+            ValidPutRequest putRequest,
             List<MFAMethod> updatedMfaMethods) {
         var postUpdateDefaultMfaMethod =
                 updatedMfaMethods.stream()
@@ -545,7 +542,7 @@ public class MFAMethodsPutHandler
                 sendAuditEvent(
                         AUTH_MFA_METHOD_SWITCH_COMPLETED,
                         input,
-                        userProfile,
+                        putRequest,
                         postUpdateDefaultMfaMethod);
 
         if (maybeCompletedAuditEvent.isFailure()) {
@@ -563,7 +560,7 @@ public class MFAMethodsPutHandler
 
         for (var smsMfaMethod : allSmsMfaMethods) {
             var maybeUpdatedPhoneNumberAuditEvent =
-                    sendAuditEvent(AUTH_UPDATE_PHONE_NUMBER, input, userProfile, smsMfaMethod);
+                    sendAuditEvent(AUTH_UPDATE_PHONE_NUMBER, input, putRequest, smsMfaMethod);
 
             if (maybeUpdatedPhoneNumberAuditEvent.isFailure()) {
                 return maybeUpdatedPhoneNumberAuditEvent;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -669,7 +669,6 @@ public class MFAMethodsPutHandler
                             AuditHelper.getTxmaAuditEncoded(input.getHeaders()),
                             List.of(initialMetadataPairs));
 
-
             if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
                 context =
                         context.withMetadataItem(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -51,8 +51,8 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_FAILED;
-import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
 import static uk.gov.di.accountmanagement.helpers.MfaMethodResponseConverterHelper.convertMfaMethodsToMfaMethodResponse;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
@@ -675,7 +675,8 @@ public class MFAMethodsPutHandler
             }
 
             if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
-                    || auditEvent.equals(AUTH_INVALID_CODE_SENT)) {
+                    || auditEvent.equals(AUTH_INVALID_CODE_SENT)
+                    || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
                 context =
                         context.withMetadataItem(
                                 pair(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.accountmanagement.services.MfaMethodsMigrationService;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
@@ -45,6 +46,7 @@ import uk.gov.di.authentication.shared.services.mfa.MfaUpdateFailure;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_COMPLETED;
@@ -203,15 +205,6 @@ public class MFAMethodsPutHandler
                             requestSmsMfaDetail.otp(),
                             NotificationType.VERIFY_PHONE_NUMBER);
             if (!isValidOtpCode) {
-                var maybeAuditContext =
-                        AuditHelper.buildAuditContext(
-                                configurationService, dynamoService, input, putRequest.userProfile);
-
-                if (maybeAuditContext.isFailure()) {
-                    return generateApiGatewayProxyErrorResponse(
-                            401, maybeAuditContext.getFailure());
-                }
-
                 var maybeAuditEventStatus =
                         sendAuditEvent(
                                 AUTH_INVALID_CODE_SENT,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -19,7 +19,7 @@ import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.entity.PendingEmailCheckRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
@@ -56,8 +56,8 @@ import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSI
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.INVALID_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.NEW_PHONE_NUMBER_ALREADY_IN_USE;
-import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.REQUEST_MISSING_PARAMS;
+import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -19,7 +19,7 @@ import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.entity.PendingEmailCheckRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
@@ -56,6 +56,7 @@ import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSI
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.INVALID_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.NEW_PHONE_NUMBER_ALREADY_IN_USE;
+import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.REQUEST_MISSING_PARAMS;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -226,7 +227,7 @@ public class SendOtpNotificationHandler
 
         incrementUserSubmittedCredentialIfNotificationSetupJourney(
                 cloudwatchMetricsService,
-                JourneyType.ACCOUNT_MANAGEMENT,
+                ACCOUNT_MANAGEMENT,
                 sendNotificationRequest.getNotificationType().name(),
                 configurationService.getEnvironment());
 
@@ -344,7 +345,7 @@ public class SendOtpNotificationHandler
                                         clientSessionId,
                                         persistentSessionId,
                                         IpAddressHelper.extractIpAddress(input),
-                                        JourneyType.ACCOUNT_MANAGEMENT,
+                                        ACCOUNT_MANAGEMENT,
                                         timeOfInitialRequest,
                                         isTestUserRequest)));
                 LOG.info(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -293,6 +293,58 @@ class AuthenticateHandlerTest {
     }
 
     @Test
+    void shouldReturn204IfIfAisCallEnabledAndUserIsSuspendedWithReproveIdentity()
+            throws UnsuccessfulAccountInterventionsResponseException {
+        when(configurationService.isAccountInterventionServiceCallInAuthenticateEnabled())
+                .thenReturn(true);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(USER_PROFILE));
+        when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(true);
+        when(authenticationService.getPhoneNumber(EMAIL)).thenReturn(Optional.of(PHONE_NUMBER));
+
+        when(accountInterventionsService.sendAccountInterventionsOutboundRequest(clientSubjectId))
+                .thenReturn(
+                        new AccountInterventionsInboundResponse(
+                                new Intervention(1L), new State(false, true, true, false)));
+
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(204));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        AUTH_ACCOUNT_MANAGEMENT_AUTHENTICATE,
+                        auditContext.withSubjectId(clientSubjectId),
+                        AUDIT_EVENT_COMPONENT_ID_AUTH);
+    }
+
+    @Test
+    void shouldReturn204IfIfAisCallEnabledAndUserIsSuspendedWithResetPasswordAndReproveIdentity()
+            throws UnsuccessfulAccountInterventionsResponseException {
+        when(configurationService.isAccountInterventionServiceCallInAuthenticateEnabled())
+                .thenReturn(true);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(USER_PROFILE));
+        when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(true);
+        when(authenticationService.getPhoneNumber(EMAIL)).thenReturn(Optional.of(PHONE_NUMBER));
+
+        when(accountInterventionsService.sendAccountInterventionsOutboundRequest(clientSubjectId))
+                .thenReturn(
+                        new AccountInterventionsInboundResponse(
+                                new Intervention(1L), new State(false, true, true, true)));
+
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(204));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        AUTH_ACCOUNT_MANAGEMENT_AUTHENTICATE,
+                        auditContext.withSubjectId(clientSubjectId),
+                        AUDIT_EVENT_COMPONENT_ID_AUTH);
+    }
+
+    @Test
     void shouldReturn500IfIfAisCallEnabledTheCallFails()
             throws UnsuccessfulAccountInterventionsResponseException {
         when(configurationService.isAccountInterventionServiceCallInAuthenticateEnabled())

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -293,58 +293,6 @@ class AuthenticateHandlerTest {
     }
 
     @Test
-    void shouldReturn204IfIfAisCallEnabledAndUserIsSuspendedWithReproveIdentity()
-            throws UnsuccessfulAccountInterventionsResponseException {
-        when(configurationService.isAccountInterventionServiceCallInAuthenticateEnabled())
-                .thenReturn(true);
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                .thenReturn(Optional.of(USER_PROFILE));
-        when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(true);
-        when(authenticationService.getPhoneNumber(EMAIL)).thenReturn(Optional.of(PHONE_NUMBER));
-
-        when(accountInterventionsService.sendAccountInterventionsOutboundRequest(clientSubjectId))
-                .thenReturn(
-                        new AccountInterventionsInboundResponse(
-                                new Intervention(1L), new State(false, true, true, false)));
-
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
-
-        assertThat(result, hasStatus(204));
-
-        verify(auditService)
-                .submitAuditEvent(
-                        AUTH_ACCOUNT_MANAGEMENT_AUTHENTICATE,
-                        auditContext.withSubjectId(clientSubjectId),
-                        AUDIT_EVENT_COMPONENT_ID_AUTH);
-    }
-
-    @Test
-    void shouldReturn204IfIfAisCallEnabledAndUserIsSuspendedWithResetPasswordAndReproveIdentity()
-            throws UnsuccessfulAccountInterventionsResponseException {
-        when(configurationService.isAccountInterventionServiceCallInAuthenticateEnabled())
-                .thenReturn(true);
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                .thenReturn(Optional.of(USER_PROFILE));
-        when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(true);
-        when(authenticationService.getPhoneNumber(EMAIL)).thenReturn(Optional.of(PHONE_NUMBER));
-
-        when(accountInterventionsService.sendAccountInterventionsOutboundRequest(clientSubjectId))
-                .thenReturn(
-                        new AccountInterventionsInboundResponse(
-                                new Intervention(1L), new State(false, true, true, true)));
-
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
-
-        assertThat(result, hasStatus(204));
-
-        verify(auditService)
-                .submitAuditEvent(
-                        AUTH_ACCOUNT_MANAGEMENT_AUTHENTICATE,
-                        auditContext.withSubjectId(clientSubjectId),
-                        AUDIT_EVENT_COMPONENT_ID_AUTH);
-    }
-
-    @Test
     void shouldReturn500IfIfAisCallEnabledTheCallFails()
             throws UnsuccessfulAccountInterventionsResponseException {
         when(configurationService.isAccountInterventionServiceCallInAuthenticateEnabled())

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/CommonTestAuditHelpers.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/CommonTestAuditHelpers.java
@@ -1,0 +1,24 @@
+package uk.gov.di.accountmanagement.lambda;
+
+import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.shared.services.AuditService;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CommonTestAuditHelpers {
+    public static void containsMetadataPair(
+            AuditContext capturedObject, String field, String value) {
+        Optional<AuditService.MetadataPair> metadataItem =
+                capturedObject.getMetadataItemByKey(field);
+        assertTrue(
+                metadataItem.isPresent(),
+                "Metadata field '" + field + "' not found in audit context");
+        assertEquals(
+                AuditService.MetadataPair.pair(field, value),
+                metadataItem.get(),
+                "Metadata field '" + field + "' has incorrect value");
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
@@ -55,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -264,29 +266,80 @@ class MFAMethodsCreateHandlerTest {
                     JsonParser.parseString(expectedResponse).getAsJsonObject().toString();
             assertEquals(expectedResponseParsedToString, result.getBody());
 
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+            InOrder inOrder = inOrder(auditService);
 
-            verify(auditService)
+            ArgumentCaptor<AuditContext> auditContextCaptor =
+                    ArgumentCaptor.forClass(AuditContext.class);
+
+            inOrder.verify(auditService)
+                    .submitAuditEvent(
+                            eq(AUTH_CODE_VERIFIED),
+                            auditContextCaptor.capture(),
+                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
+
+            AuditContext capturedCodeVerifiedContext = auditContextCaptor.getValue();
+            containsMetadataPair(
+                    capturedCodeVerifiedContext,
+                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
+                    ACCOUNT_MANAGEMENT.name());
+            containsMetadataPair(
+                    capturedCodeVerifiedContext,
+                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                    MFAMethodType.SMS.name());
+            containsMetadataPair(
+                    capturedCodeVerifiedContext,
+                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                    PriorityIdentifier.BACKUP.name().toLowerCase());
+            containsMetadataPair(
+                    capturedCodeVerifiedContext, AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false");
+            containsMetadataPair(
+                    capturedCodeVerifiedContext, AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, TEST_OTP);
+            containsMetadataPair(
+                    capturedCodeVerifiedContext,
+                    AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
+                    MFA_SMS.name());
+            containsMetadataPair(
+                    capturedCodeVerifiedContext,
+                    AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
+                    "44");
+
+            ArgumentCaptor<AuditContext> addCompletedCaptor =
+                    ArgumentCaptor.forClass(AuditContext.class);
+            inOrder.verify(auditService)
                     .submitAuditEvent(
                             eq(AUTH_MFA_METHOD_ADD_COMPLETED),
-                            captor.capture(),
+                            addCompletedCaptor.capture(),
                             eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-            AuditContext capturedObject = captor.getValue();
 
+            AuditContext capturedAddCompletedContext = addCompletedCaptor.getValue();
             containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
+                    capturedAddCompletedContext,
+                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
+                    ACCOUNT_MANAGEMENT.name());
             containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.name());
+                    capturedAddCompletedContext,
+                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                    MFAMethodType.SMS.name());
             containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE, "44");
+                    capturedAddCompletedContext,
+                    AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
+                    "44");
 
-            verify(auditService).submitAuditEvent(eq(AUTH_UPDATE_PHONE_NUMBER), captor.capture());
-            capturedObject = captor.getValue();
+            ArgumentCaptor<AuditContext> updatePhoneCaptor =
+                    ArgumentCaptor.forClass(AuditContext.class);
+            inOrder.verify(auditService)
+                    .submitAuditEvent(
+                            eq(AUTH_UPDATE_PHONE_NUMBER),
+                            updatePhoneCaptor.capture(),
+                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
 
+            AuditContext capturedUpdatePhoneContext = updatePhoneCaptor.getValue();
             containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
+                    capturedUpdatePhoneContext,
+                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
+                    ACCOUNT_MANAGEMENT.name());
             containsMetadataPair(
-                    capturedObject,
+                    capturedUpdatePhoneContext,
                     AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
                     backupMfa.getPriority().toLowerCase());
         }
@@ -353,22 +406,53 @@ class MFAMethodsCreateHandlerTest {
                                             NotificationType.BACKUP_METHOD_ADDED,
                                             LocaleHelper.SupportedLanguage.EN)));
 
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+            verify(auditService, never())
+                    .submitAuditEvent(eq(AUTH_UPDATE_PHONE_NUMBER), any(), any());
+
+            InOrder inOrder = inOrder(auditService);
+
+            ArgumentCaptor<AuditContext> auditContextCaptor =
+                    ArgumentCaptor.forClass(AuditContext.class);
+
+            inOrder.verify(auditService)
+                    .submitAuditEvent(
+                            eq(AUTH_CODE_VERIFIED),
+                            auditContextCaptor.capture(),
+                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
+
+            AuditContext capturedCodeVerifiedContext = auditContextCaptor.getValue();
+            containsMetadataPair(
+                    capturedCodeVerifiedContext,
+                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
+                    ACCOUNT_MANAGEMENT.name());
+            containsMetadataPair(
+                    capturedCodeVerifiedContext,
+                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                    MFAMethodType.AUTH_APP.name());
+            containsMetadataPair(
+                    capturedCodeVerifiedContext,
+                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                    PriorityIdentifier.BACKUP.name().toLowerCase());
+            containsMetadataPair(
+                    capturedCodeVerifiedContext, AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false");
+
+            ArgumentCaptor<AuditContext> addCompletedCaptor =
+                    ArgumentCaptor.forClass(AuditContext.class);
             verify(auditService)
                     .submitAuditEvent(
                             eq(AUTH_MFA_METHOD_ADD_COMPLETED),
-                            captor.capture(),
+                            addCompletedCaptor.capture(),
                             eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-            AuditContext capturedObject = captor.getValue();
 
+            AuditContext capturedAddCompletedContext = addCompletedCaptor.getValue();
             containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
+                    capturedAddCompletedContext,
+                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
+                    ACCOUNT_MANAGEMENT.name());
             containsMetadataPair(
-                    capturedObject,
+                    capturedAddCompletedContext,
                     AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                    MFAMethodType.AUTH_APP.toString());
-
-            verify(auditService, never()).submitAuditEvent(eq(AUTH_UPDATE_PHONE_NUMBER), any());
+                    MFAMethodType.AUTH_APP.name());
         }
 
         @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -56,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -65,6 +66,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
@@ -263,6 +265,7 @@ class MFAMethodsCreateHandlerTest {
             assertEquals(expectedResponseParsedToString, result.getBody());
 
             ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+
             verify(auditService)
                     .submitAuditEvent(
                             eq(AUTH_MFA_METHOD_ADD_COMPLETED),
@@ -276,6 +279,16 @@ class MFAMethodsCreateHandlerTest {
                     capturedObject, AUDIT_EVENT_EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.name());
             containsMetadataPair(
                     capturedObject, AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE, "44");
+
+            verify(auditService).submitAuditEvent(eq(AUTH_UPDATE_PHONE_NUMBER), captor.capture());
+            capturedObject = captor.getValue();
+
+            containsMetadataPair(
+                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
+            containsMetadataPair(
+                    capturedObject,
+                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                    backupMfa.getPriority().toLowerCase());
         }
 
         @Test
@@ -354,6 +367,8 @@ class MFAMethodsCreateHandlerTest {
                     capturedObject,
                     AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
                     MFAMethodType.AUTH_APP.toString());
+
+            verify(auditService, never()).submitAuditEvent(eq(AUTH_UPDATE_PHONE_NUMBER), any());
         }
 
         @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -201,7 +201,12 @@ class MFAMethodsPutHandlerTest {
         verify(authenticationService).getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT);
         verify(codeStorageService)
                 .isValidOtpCode(EMAIL, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER);
-        verify(mfaMethodsService).updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest);
+        verify(mfaMethodsService)
+                .updateMfaMethod(
+                        eq(EMAIL),
+                        eq(DEFAULT_SMS_METHOD),
+                        eq(List.of(DEFAULT_SMS_METHOD)),
+                        eq(updateRequest));
     }
 
     @Test
@@ -276,7 +281,12 @@ class MFAMethodsPutHandlerTest {
         verify(authenticationService).getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT);
         verify(codeStorageService)
                 .isValidOtpCode(nonMigratedEmail, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER);
-        verify(mfaMethodsService).updateMfaMethod(nonMigratedEmail, MFA_IDENTIFIER, updateRequest);
+        verify(mfaMethodsService)
+                .updateMfaMethod(
+                        eq(nonMigratedEmail),
+                        eq(DEFAULT_SMS_METHOD),
+                        eq(List.of(DEFAULT_SMS_METHOD)),
+                        eq(updateRequest));
         verify(mfaMethodsMigrationService)
                 .migrateMfaCredentialsForUserIfRequired(any(), any(), any(), any());
     }
@@ -359,7 +369,12 @@ class MFAMethodsPutHandlerTest {
         verify(authenticationService).getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT);
         verify(codeStorageService)
                 .isValidOtpCode(EMAIL, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER);
-        verify(mfaMethodsService).updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest);
+        verify(mfaMethodsService)
+                .updateMfaMethod(
+                        eq(EMAIL),
+                        eq(DEFAULT_SMS_METHOD),
+                        eq(List.of(DEFAULT_SMS_METHOD)),
+                        eq(updateRequest));
     }
 
     @CsvSource({"500", "404", "200"})
@@ -1079,7 +1094,12 @@ class MFAMethodsPutHandlerTest {
         var switchedMfaMethod =
                 MFAMethod.authAppMfaMethod(
                         "test-credential", true, true, PriorityIdentifier.DEFAULT, MFA_IDENTIFIER);
-        when(mfaMethodsService.updateMfaMethod(eq(EMAIL), eq(MFA_IDENTIFIER), any()))
+        when(mfaMethodsService.getMfaMethod(EMAIL, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
+        when(mfaMethodsService.updateMfaMethod(any(), any(), any(), any()))
                 .thenReturn(
                         Result.success(
                                 new MFAMethodsService.MfaUpdateResponse(
@@ -1091,7 +1111,9 @@ class MFAMethodsPutHandlerTest {
         assertEquals(200, result.getStatusCode());
 
         verify(authenticationService).getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT);
-        verify(mfaMethodsService).updateMfaMethod(eq(EMAIL), eq(MFA_IDENTIFIER), any());
+        verify(mfaMethodsService)
+                .updateMfaMethod(
+                        eq(EMAIL), eq(DEFAULT_SMS_METHOD), eq(List.of(DEFAULT_SMS_METHOD)), any());
         verify(sqsClient).send(any());
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -60,7 +60,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
-import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_FAILED;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -60,6 +60,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
+import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_FAILED;

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -43,8 +43,8 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
-import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_MIGRATION_ATTEMPTED;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.entity.NotificationType.BACKUP_METHOD_ADDED;
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_MFA_METHOD;
@@ -169,11 +169,6 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
             assertEquals(expectedResponse, response.getBody());
 
-            // Verify audit event was emitted
-            var receivedEvents =
-                    assertTxmaAuditEventsReceived(
-                            txmaAuditQueue, List.of(AUTH_MFA_METHOD_ADD_COMPLETED));
-
             assertNotificationsReceived(
                     notificationsQueue,
                     List.of(
@@ -285,8 +280,10 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             assertEquals(expectedResponse, response.getBody());
 
             List<AuditableEvent> expectedEvents =
-
-                            List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PHONE_NUMBER, AUTH_MFA_METHOD_ADD_COMPLETED);
+                    List.of(
+                            AUTH_CODE_VERIFIED,
+                            AUTH_UPDATE_PHONE_NUMBER,
+                            AUTH_MFA_METHOD_ADD_COMPLETED);
 
             Map<String, String> codeVerifiedAttributes = new HashMap<>();
             codeVerifiedAttributes.put(EXTENSIONS_MFA_CODE_ENTERED, otp);

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -43,6 +43,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_MIGRATION_ATTEMPTED;
 import static uk.gov.di.accountmanagement.entity.NotificationType.BACKUP_METHOD_ADDED;
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_JOURNEY_TYPE;
@@ -277,9 +278,8 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
             assertEquals(expectedResponse, response.getBody());
 
-            // Check audit event
             List<AuditableEvent> expectedEvents =
-                    List.of(AUTH_CODE_VERIFIED, AUTH_MFA_METHOD_ADD_COMPLETED);
+                    List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PHONE_NUMBER, AUTH_MFA_METHOD_ADD_COMPLETED);
 
             Map<String, String> codeVerifiedAttributes = new HashMap<>();
             codeVerifiedAttributes.put(EXTENSIONS_MFA_CODE_ENTERED, otp);

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -169,6 +169,11 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
             assertEquals(expectedResponse, response.getBody());
 
+            // Verify audit event was emitted
+            var receivedEvents =
+                    assertTxmaAuditEventsReceived(
+                            txmaAuditQueue, List.of(AUTH_MFA_METHOD_ADD_COMPLETED));
+
             assertNotificationsReceived(
                     notificationsQueue,
                     List.of(
@@ -180,6 +185,7 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             // Check audit events
             List<AuditableEvent> expectedEvents =
                     List.of(
+                            AUTH_UPDATE_PHONE_NUMBER,
                             AUTH_CODE_VERIFIED,
                             AUTH_MFA_METHOD_MIGRATION_ATTEMPTED,
                             AUTH_MFA_METHOD_ADD_COMPLETED);
@@ -279,7 +285,8 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             assertEquals(expectedResponse, response.getBody());
 
             List<AuditableEvent> expectedEvents =
-                    List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PHONE_NUMBER, AUTH_MFA_METHOD_ADD_COMPLETED);
+
+                            List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PHONE_NUMBER, AUTH_MFA_METHOD_ADD_COMPLETED);
 
             Map<String, String> codeVerifiedAttributes = new HashMap<>();
             codeVerifiedAttributes.put(EXTENSIONS_MFA_CODE_ENTERED, otp);

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
@@ -36,6 +36,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_MIGRATION_ATTEMPTED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_COMPLETED;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
 import static uk.gov.di.accountmanagement.entity.NotificationType.CHANGED_AUTHENTICATOR_APP;
 import static uk.gov.di.accountmanagement.entity.NotificationType.CHANGED_DEFAULT_MFA;
@@ -342,7 +343,8 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                                     PHONE_NUMBER_UPDATED,
                                     LocaleHelper.SupportedLanguage.EN)));
 
-            List<AuditableEvent> expectedEvents = List.of(AUTH_CODE_VERIFIED);
+            List<AuditableEvent> expectedEvents =
+                    List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PHONE_NUMBER);
 
             Map<String, Map<String, String>> eventExpectations = new HashMap<>();
 
@@ -430,7 +432,8 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                                     CHANGED_DEFAULT_MFA,
                                     LocaleHelper.SupportedLanguage.EN)));
 
-            List<AuditableEvent> expectedEvents = List.of(AUTH_CODE_VERIFIED);
+            List<AuditableEvent> expectedEvents =
+                    List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PHONE_NUMBER);
 
             Map<String, Map<String, String>> eventExpectations = new HashMap<>();
 
@@ -718,7 +721,11 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                                     SWITCHED_MFA_METHODS,
                                     LocaleHelper.SupportedLanguage.EN)));
 
-            List<AuditableEvent> expectedEvents = List.of(AUTH_MFA_METHOD_SWITCH_COMPLETED);
+            List<AuditableEvent> expectedEvents =
+                    List.of(
+                            AUTH_UPDATE_PHONE_NUMBER,
+                            AUTH_UPDATE_PHONE_NUMBER,
+                            AUTH_MFA_METHOD_SWITCH_COMPLETED);
 
             Map<String, Map<String, String>> eventExpectations = new HashMap<>();
 
@@ -787,7 +794,8 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                                     SWITCHED_MFA_METHODS,
                                     LocaleHelper.SupportedLanguage.EN)));
 
-            List<AuditableEvent> expectedEvents = List.of(AUTH_MFA_METHOD_SWITCH_COMPLETED);
+            List<AuditableEvent> expectedEvents =
+                    List.of(AUTH_UPDATE_PHONE_NUMBER, AUTH_MFA_METHOD_SWITCH_COMPLETED);
 
             Map<String, Map<String, String>> eventExpectations = new HashMap<>();
 
@@ -876,7 +884,10 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                     () -> assertEquals(secondPhoneNumber, retrievedMethod.getDestination()));
 
             List<AuditableEvent> expectedEvents =
-                    List.of(AUTH_MFA_METHOD_MIGRATION_ATTEMPTED, AUTH_CODE_VERIFIED);
+                    List.of(
+                            AUTH_MFA_METHOD_MIGRATION_ATTEMPTED,
+                            AUTH_CODE_VERIFIED,
+                            AUTH_UPDATE_PHONE_NUMBER);
 
             Map<String, Map<String, String>> eventExpectations = new HashMap<>();
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -34,8 +34,6 @@ import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSI
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_TEST_USER;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER;

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -34,6 +34,8 @@ import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSI
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_TEST_USER;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER;
@@ -171,7 +173,8 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                                         SupportedLanguage.EN)));
 
                 List<String> receivedEvents =
-                        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_SEND_OTP, AUTH_PHONE_CODE_SENT));
+                        assertTxmaAuditEventsReceived(
+                                txmaAuditQueue, List.of(AUTH_SEND_OTP, AUTH_PHONE_CODE_SENT));
 
                 AuditEventExpectation sendOtpExpectation =
                         new AuditEventExpectation(AUTH_SEND_OTP.name());

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -152,7 +152,9 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                         makeRequest(
                                 Optional.of(
                                         new SendNotificationRequest(
-                                                TEST_EMAIL, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER)),
+                                                TEST_EMAIL,
+                                                VERIFY_PHONE_NUMBER,
+                                                TEST_PHONE_NUMBER)),
                                 headers,
                                 Collections.emptyMap(),
                                 Collections.emptyMap(),
@@ -169,8 +171,8 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                                         SupportedLanguage.EN)));
 
                 List<String> receivedEvents =
-                        assertTxmaAuditEventsReceived(
-                                txmaAuditQueue, List.of(AUTH_SEND_OTP, AUTH_PHONE_CODE_SENT));
+                        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_SEND_OTP, AUTH_PHONE_CODE_SENT));
+
                 AuditEventExpectation sendOtpExpectation =
                         new AuditEventExpectation(AUTH_SEND_OTP.name());
                 sendOtpExpectation.withAttribute(

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -34,6 +34,8 @@ import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSI
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_TEST_USER;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER;

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -152,9 +152,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                         makeRequest(
                                 Optional.of(
                                         new SendNotificationRequest(
-                                                TEST_EMAIL,
-                                                VERIFY_PHONE_NUMBER,
-                                                TEST_PHONE_NUMBER)),
+                                                TEST_EMAIL, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER)),
                                 headers,
                                 Collections.emptyMap(),
                                 Collections.emptyMap(),


### PR DESCRIPTION
Note.  The commit history needs an edit which can be done after AUT-4529 is merged.

## What

<!-- Describe what you have changed and why -->

Introduces a new `AUTH_UPDATE_PHONE_NUMBER` audit event in the new account management API which is triggered when a user performs an operation that either adds or changes an SMS MFA method on their account. This covers several scenarios:

- Adding a new SMS MFA method to the account (a new number is being added)
- Switching MFA methods - emitted for each SMS method on the account
  - Note that the priority changes in these cases (e.g., swapping SMS1 and SMS2 results in the priority identifiers swapping too, which is one of the audit event extensions)
- Changing SMS method
- Changing default MFA method when the new default method type is SMS

### Notes around existing `UpdatePhoneNumberHandler`

Note that this handler will be deprecated after method management is enabled in production. Changes have therefore only been made to the MFA API instead.

Slack thread discussing this for reference: https://gds.slack.com/archives/C02KUCT0ZAS/p1751296990016759?thread_ts=1751293017.525419&cid=C02KUCT0ZAS

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review commit-by-commit
1. Deploy to dev and run through the scenarios above to try and trigger the event. Requests should succeed and emit a new message to the `*-account-mgmt-txma-audit-queue` SQS queue with the relevant audit context (containing the `journey-type` and `mfa-method` extensions with the expected values.

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
4. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- N/A - only emits an audit event for requests to the lambda**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**
