### PR TITLE
ATO-1744: write to new docapp credential table

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.app.domain.DocAppAuditableEvent;
 import uk.gov.di.authentication.app.exception.DocAppCallbackException;
 import uk.gov.di.authentication.app.services.DocAppCriService;
+import uk.gov.di.authentication.app.services.DynamoDocAppCriService;
 import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.api.AuthFrontend;
@@ -72,6 +73,7 @@ public class DocAppCallbackHandler
     private final OrchClientSessionService orchClientSessionService;
     private final AuditService auditService;
     private final DynamoDocAppService dynamoDocAppService;
+    private final DynamoDocAppCriService dynamoDocAppCriService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final NoSessionOrchestrationService noSessionOrchestrationService;
     private final OrchAuthCodeService orchAuthCodeService;
@@ -91,6 +93,7 @@ public class DocAppCallbackHandler
             OrchClientSessionService orchClientSessionService,
             AuditService auditService,
             DynamoDocAppService dynamoDocAppService,
+            DynamoDocAppCriService dynamoDocAppCriService,
             OrchAuthCodeService orchAuthCodeService,
             CloudwatchMetricsService cloudwatchMetricsService,
             NoSessionOrchestrationService noSessionOrchestrationService,
@@ -103,6 +106,7 @@ public class DocAppCallbackHandler
         this.orchClientSessionService = orchClientSessionService;
         this.auditService = auditService;
         this.dynamoDocAppService = dynamoDocAppService;
+        this.dynamoDocAppCriService = dynamoDocAppCriService;
         this.orchAuthCodeService = orchAuthCodeService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.noSessionOrchestrationService = noSessionOrchestrationService;
@@ -127,6 +131,7 @@ public class DocAppCallbackHandler
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.dynamoDocAppService = new DynamoDocAppService(configurationService);
+        this.dynamoDocAppCriService = new DynamoDocAppCriService(configurationService);
         this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.noSessionOrchestrationService =
@@ -152,6 +157,7 @@ public class DocAppCallbackHandler
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.dynamoDocAppService = new DynamoDocAppService(configurationService);
+        this.dynamoDocAppCriService = new DynamoDocAppCriService(configurationService);
         this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.noSessionOrchestrationService =
@@ -286,6 +292,8 @@ public class DocAppCallbackHandler
                         user);
                 LOG.info("Adding DocAppCredential to dynamo");
                 dynamoDocAppService.addDocAppCredential(
+                        orchClientSession.getDocAppSubjectId(), credential);
+                dynamoDocAppCriService.addDocAppCredential(
                         orchClientSession.getDocAppSubjectId(), credential);
 
                 LOG.info("Redirecting to frontend");

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppCriService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppCriService.java
@@ -1,0 +1,32 @@
+package uk.gov.di.authentication.app.services;
+
+import uk.gov.di.authentication.app.entity.DocAppCredential;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.BaseDynamoService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+public class DynamoDocAppCriService extends BaseDynamoService<DocAppCredential> {
+
+    private final long timeToExist;
+
+    public DynamoDocAppCriService(ConfigurationService configurationService) {
+        super(DocAppCredential.class, "Orch-Doc-App-Credential", configurationService, true);
+        this.timeToExist = configurationService.getAccessTokenExpiry();
+    }
+
+    public void addDocAppCredential(String subjectID, List<String> credential) {
+        var docAppCredential =
+                new DocAppCredential()
+                        .withSubjectID(subjectID)
+                        .withCredential(credential)
+                        .withTimeToExist(
+                                NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond());
+
+        put(docAppCredential);
+    }
+}

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 import uk.gov.di.authentication.app.domain.DocAppAuditableEvent;
 import uk.gov.di.authentication.app.services.DocAppCriService;
+import uk.gov.di.authentication.app.services.DynamoDocAppCriService;
 import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.api.AuthFrontend;
@@ -90,6 +91,8 @@ class DocAppCallbackHandlerTest {
             mock(OrchClientSessionService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final DynamoDocAppService dynamoDocAppService = mock(DynamoDocAppService.class);
+    private final DynamoDocAppCriService dynamoDocAppCriService =
+            mock(DynamoDocAppCriService.class);
     private final NoSessionOrchestrationService noSessionOrchestrationService =
             mock(NoSessionOrchestrationService.class);
     private static final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
@@ -154,6 +157,7 @@ class DocAppCallbackHandlerTest {
                         orchClientSessionService,
                         auditService,
                         dynamoDocAppService,
+                        dynamoDocAppCriService,
                         orchAuthCodeService,
                         cloudwatchMetricsService,
                         noSessionOrchestrationService,
@@ -213,6 +217,9 @@ class DocAppCallbackHandlerTest {
 
         verifyNoMoreInteractions(auditService);
         verify(dynamoDocAppService)
+                .addDocAppCredential(
+                        PAIRWISE_SUBJECT_ID.getValue(), List.of("a-verifiable-credential"));
+        verify(dynamoDocAppCriService)
                 .addDocAppCredential(
                         PAIRWISE_SUBJECT_ID.getValue(), List.of("a-verifiable-credential"));
         verify(cloudwatchMetricsService)

--- a/template.yaml
+++ b/template.yaml
@@ -1677,6 +1677,8 @@ Resources:
       Policies:
         - !Ref DocAppCredentialTableReadAccessPolicy
         - !Ref DocAppCredentialTableWriteAccessPolicy
+        - !Ref OrchDocAppCredentialTableReadAccessPolicy
+        - !Ref OrchDocAppCredentialTableWriteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref RedisParametersAccessPolicy
         - !Ref DocAppSigningKmsAccessPolicy
@@ -5588,6 +5590,56 @@ Resources:
                 !Ref Environment,
                 docAppCredentialTableKeyArn,
               ]
+
+  OrchDocAppCredentialTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowOrchDocAppCredentialTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:BatchGetItem
+              - dynamodb:DescribeTable
+              - dynamodb:DescribeStream
+              - dynamodb:Get*
+              - dynamodb:Query
+              - dynamodb:Scan
+            Resource: !GetAtt DocAppCredentialTable.Arn
+          - Sid: AllowOrchDocAppCredentialTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: !GetAtt DocAppCredentialTableEncryptionKey.Arn
+
+  OrchDocAppCredentialTableWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowOrchDocAppCredentialTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:UpdateItem
+              - dynamodb:PutItem
+            Resource: !GetAtt DocAppCredentialTable.Arn
+          - Sid: AllowOrchDocAppCredentialTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: !GetAtt DocAppCredentialTableEncryptionKey.Arn
 
   UserProfileTableReadAccessPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
### Wider context of change

Migrating the doc App credential table from the auth account to the orch account

### What’s changed

Added new service and method to add to the new table
Added permissions in docAppcallback lambda

### Manual testing

deployed and ran through doc app journey in dev

