### PR TITLE
ATO-1795: Add session invalidation handling ipv callback

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IpvCallbackValidationError.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IpvCallbackValidationError.java
@@ -1,0 +1,9 @@
+package uk.gov.di.authentication.ipv.entity;
+
+public record IpvCallbackValidationError(
+        String errorCode, String errorDescription, boolean isSessionInvalidation) {
+
+    public IpvCallbackValidationError(String errorCode, String errorDescription) {
+        this(errorCode, errorDescription, false);
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -293,7 +293,7 @@ public class IPVCallbackHandler
 
                 return ipvCallbackHelper.generateAuthenticationErrorResponse(
                         authRequest,
-                        new ErrorObject(ACCESS_DENIED_CODE, errorObject.get().getDescription()),
+                        new ErrorObject(ACCESS_DENIED_CODE, errorObject.get().errorDescription()),
                         false,
                         clientSessionId,
                         sessionId);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -274,6 +274,7 @@ public class IPVCallbackHandler
                             persistentId);
 
             if (errorObject.isPresent()) {
+                var destroySessionRequest = new DestroySessionsRequest(sessionId, orchSession);
                 AccountIntervention intervention =
                         segmentedFunctionCall(
                                 "AIS: getAccountIntervention",
@@ -284,11 +285,19 @@ public class IPVCallbackHandler
                 if (configurationService.isAccountInterventionServiceActionEnabled()
                         && (intervention.getBlocked() || intervention.getSuspended())) {
                     return logoutService.handleAccountInterventionLogout(
-                            new DestroySessionsRequest(sessionId, orchSession),
+                            destroySessionRequest,
                             orchSession.getInternalCommonSubjectId(),
                             input,
                             clientId,
                             intervention);
+                }
+
+                if (errorObject.get().isSessionInvalidation()) {
+                    return logoutService.handleSessionInvalidationLogout(
+                            destroySessionRequest,
+                            orchSession.getInternalCommonSubjectId(),
+                            input,
+                            clientId);
                 }
 
                 return ipvCallbackHelper.generateAuthenticationErrorResponse(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -56,6 +56,7 @@ public class IPVAuthorisationService {
     private final NowClock nowClock;
     public static final String STATE_STORAGE_PREFIX = "state:";
     private static final JWSAlgorithm SIGNING_ALGORITHM = JWSAlgorithm.ES256;
+    public static final String SESSION_INVALIDATED_ERROR_CODE = "session_invalidated";
 
     public IPVAuthorisationService(
             ConfigurationService configurationService, KmsConnectionService kmsConnectionService) {
@@ -89,6 +90,13 @@ public class IPVAuthorisationService {
                             OAuth2Error.INVALID_REQUEST_CODE, "No query parameters present"));
         }
         if (headers.containsKey("error")) {
+
+            if (SESSION_INVALIDATED_ERROR_CODE.equals(headers.get("error"))) {
+                LOG.warn("Session invalidated response from IPV");
+                return Optional.of(
+                        new IpvCallbackValidationError(headers.get("error"), null, true));
+            }
+
             LOG.warn("Error response found in IPV Authorisation response");
             return Optional.of(new IpvCallbackValidationError(headers.get("error"), null));
         }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -16,7 +16,6 @@ import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -29,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import uk.gov.di.authentication.ipv.entity.IpvCallbackValidationError;
 import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper.NowClock;
@@ -80,34 +80,35 @@ public class IPVAuthorisationService {
         this.nowClock = nowClock;
     }
 
-    public Optional<ErrorObject> validateResponse(Map<String, String> headers, String sessionId) {
+    public Optional<IpvCallbackValidationError> validateResponse(
+            Map<String, String> headers, String sessionId) {
         if (headers == null || headers.isEmpty()) {
             LOG.warn("No Query parameters in IPV Authorisation response");
             return Optional.of(
-                    new ErrorObject(
+                    new IpvCallbackValidationError(
                             OAuth2Error.INVALID_REQUEST_CODE, "No query parameters present"));
         }
         if (headers.containsKey("error")) {
             LOG.warn("Error response found in IPV Authorisation response");
-            return Optional.of(new ErrorObject(headers.get("error")));
+            return Optional.of(new IpvCallbackValidationError(headers.get("error"), null));
         }
         if (!headers.containsKey("state") || headers.get("state").isEmpty()) {
             LOG.warn("No state param in IPV Authorisation response");
             return Optional.of(
-                    new ErrorObject(
+                    new IpvCallbackValidationError(
                             OAuth2Error.INVALID_REQUEST_CODE,
                             "No state param present in Authorisation response"));
         }
         if (!isStateValid(sessionId, headers.get("state"))) {
             return Optional.of(
-                    new ErrorObject(
+                    new IpvCallbackValidationError(
                             OAuth2Error.INVALID_REQUEST_CODE,
                             "Invalid state param present in Authorisation response"));
         }
         if (!headers.containsKey("code") || headers.get("code").isEmpty()) {
             LOG.warn("No code param in IPV Authorisation response");
             return Optional.of(
-                    new ErrorObject(
+                    new IpvCallbackValidationError(
                             OAuth2Error.INVALID_REQUEST_CODE,
                             "No code param present in Authorisation response"));
         }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.IpvCallbackException;
+import uk.gov.di.authentication.ipv.entity.IpvCallbackValidationError;
 import uk.gov.di.authentication.ipv.helpers.IPVCallbackHelper;
 import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.ipv.services.IPVTokenService;
@@ -826,7 +827,8 @@ class IPVCallbackHandlerTest {
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
                 .thenReturn(
                         Optional.of(
-                                new ErrorObject(errorObject.getCode(), redirectUriErrorMessage)));
+                                new IpvCallbackValidationError(
+                                        errorObject.getCode(), redirectUriErrorMessage)));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of(COOKIE, buildCookieString()));
@@ -861,7 +863,8 @@ class IPVCallbackHandlerTest {
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
                 .thenReturn(
                         Optional.of(
-                                new ErrorObject(errorObject.getCode(), redirectUriErrorMessage)));
+                                new IpvCallbackValidationError(
+                                        errorObject.getCode(), redirectUriErrorMessage)));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of(COOKIE, buildCookieString()));
@@ -1058,7 +1061,8 @@ class IPVCallbackHandlerTest {
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
                 .thenReturn(
                         Optional.of(
-                                new ErrorObject(errorObject.getCode(), redirectUriErrorMessage)));
+                                new IpvCallbackValidationError(
+                                        errorObject.getCode(), redirectUriErrorMessage)));
         var intervention =
                 new AccountIntervention(new AccountInterventionState(true, false, false, false));
         when(accountInterventionService.getAccountIntervention(anyString(), any()))

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -167,6 +167,23 @@ class IPVAuthorisationServiceTest {
     }
 
     @Test
+    void shouldReturnSessionInvalidationErrorObjectWhenErrorCodeIsSessionInvalidated() {
+        ErrorObject errorObject =
+                new ErrorObject("session_invalidated", "Session invalidated for security reasons");
+        Map<String, String> responseHeaders = new HashMap<>();
+        responseHeaders.put("code", AUTH_CODE.getValue());
+        responseHeaders.put("state", STATE.getValue());
+        responseHeaders.put("error", errorObject.toString());
+
+        assertThat(
+                authorisationService.validateResponse(responseHeaders, SESSION_ID),
+                equalTo(
+                        Optional.of(
+                                new IpvCallbackValidationError(
+                                        errorObject.getCode(), null, true))));
+    }
+
+    @Test
     void shouldReturnErrorObjectWhenResponseContainsNoQueryParams() {
         assertThat(
                 authorisationService.validateResponse(Collections.emptyMap(), SESSION_ID),

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import uk.gov.di.authentication.ipv.entity.IpvCallbackValidationError;
 import uk.gov.di.orchestration.shared.entity.StateItem;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -162,7 +163,7 @@ class IPVAuthorisationServiceTest {
 
         assertThat(
                 authorisationService.validateResponse(responseHeaders, SESSION_ID),
-                equalTo(Optional.of(new ErrorObject(errorObject.getCode()))));
+                equalTo(Optional.of(new IpvCallbackValidationError(errorObject.getCode(), null))));
     }
 
     @Test
@@ -171,7 +172,7 @@ class IPVAuthorisationServiceTest {
                 authorisationService.validateResponse(Collections.emptyMap(), SESSION_ID),
                 equalTo(
                         Optional.of(
-                                new ErrorObject(
+                                new IpvCallbackValidationError(
                                         OAuth2Error.INVALID_REQUEST_CODE,
                                         "No query parameters present"))));
     }
@@ -185,7 +186,7 @@ class IPVAuthorisationServiceTest {
                 authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
                         Optional.of(
-                                new ErrorObject(
+                                new IpvCallbackValidationError(
                                         OAuth2Error.INVALID_REQUEST_CODE,
                                         "No state param present in Authorisation response"))));
     }
@@ -199,7 +200,7 @@ class IPVAuthorisationServiceTest {
                 authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
                         Optional.of(
-                                new ErrorObject(
+                                new IpvCallbackValidationError(
                                         OAuth2Error.INVALID_REQUEST_CODE,
                                         "No code param present in Authorisation response"))));
     }
@@ -216,7 +217,7 @@ class IPVAuthorisationServiceTest {
                 authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
                         Optional.of(
-                                new ErrorObject(
+                                new IpvCallbackValidationError(
                                         OAuth2Error.INVALID_REQUEST_CODE,
                                         "Invalid state param present in Authorisation response"))));
     }
@@ -232,7 +233,7 @@ class IPVAuthorisationServiceTest {
                 authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
                         Optional.of(
-                                new ErrorObject(
+                                new IpvCallbackValidationError(
                                         OAuth2Error.INVALID_REQUEST_CODE,
                                         "Invalid state param present in Authorisation response"))));
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -206,6 +206,23 @@ public class LogoutService {
                 Optional.of(sessionAge));
     }
 
+    public APIGatewayProxyResponseEvent handleSessionInvalidationLogout(
+            DestroySessionsRequest request,
+            String internalCommonSubjectId,
+            APIGatewayProxyRequestEvent input,
+            String clientId) {
+        LOG.info("Handling session invalidation logout");
+        destroySessions(request);
+        var auditUser = createAuditUser(input, request.getSessionId(), internalCommonSubjectId);
+        return generateLogoutResponse(
+                // ATO-1796: Create new error page on auth frontend for this scenario
+                authFrontend.defaultLogoutURI(),
+                LogoutReason.INTERVENTION,
+                auditUser,
+                Optional.of(clientId),
+                Optional.empty());
+    }
+
     private void sendAuditEvent(
             TxmaAuditUser auditUser,
             LogoutReason logoutReason,


### PR DESCRIPTION
### Wider context of change

IPV will be returning a special oAuth error to Orchestration to convey some when a user's session should be invalidated. We should respond to this error by logging a user out and sending them to a generic `You've been signed out page`

### What’s changed:
- Tweaks our validation to add a new case for this session_invalidated case
- Adds handling of this which destroys a user's session, audits the logout, and redirects them to the generic "You've been Signed Out" page
- 
### Manual testing: 
- Deployed to dev 
- Deploy this branch to ipv stub dev: https://github.com/govuk-one-login/orch-stubs/pull/322
- Run through an identity journey
- When you reach the stub, configure it to return the `session_invalidated` oAuth error
- See you are redirected to a generic "You've been signed out" page 
- Run through another authorize journey to check that you reach the sign in page with no silent login

Also did:
- Run through another ID journey without an oAuth error 
- All is as expected 

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->