### PR TITLE
ATO-1810: Consume from global logout txma queue in staging

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -142,6 +142,7 @@ Conditions:
         !Equals [production, !Ref Environment],
       ],
     ]
+  UseGlobalLogoutTxmaQueue: !Equals [staging, !Ref Environment]
 
 Mappings:
   EnvironmentConfiguration:
@@ -6021,6 +6022,36 @@ Resources:
             Action:
               - kms:Decrypt
             Resource: !GetAtt BackChannelLogoutQueueEncryptionKey.Arn
+
+  GlobalLogoutTxmaQueueConsumePolicy:
+    Condition: UseGlobalLogoutTxmaQueue
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowConsumeFromGlobalLogoutTxmaQueue
+            Effect: Allow
+            Action:
+              - sqs:ReceiveMessage
+              - sqs:DeleteMessage
+              - sqs:GetQueueAttributes
+            Resource:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                globalLogoutQueueArn,
+              ]
+          - Sid: AllowDecryptGlobalLogoutTxmaQueue
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                globalLogoutQueueKmsKeyArn,
+              ]
 
   GlobalLogoutTestQueueConsumePolicy:
     Condition: IsDevOrBuild

--- a/template.yaml
+++ b/template.yaml
@@ -2295,7 +2295,11 @@ Resources:
         - !If [
             IsDevOrBuild,
             !Ref GlobalLogoutTestQueueConsumePolicy,
-            !Ref AWS::NoValue,
+            !If [
+              UseGlobalLogoutTxmaQueue,
+              !Ref GlobalLogoutTxmaQueueConsumePolicy,
+              !Ref AWS::NoValue,
+            ],
           ]
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_117.CKV_AWS_173

--- a/template.yaml
+++ b/template.yaml
@@ -2387,6 +2387,20 @@ Resources:
             Stat: Sum
             Unit: Count
 
+  GlobalLogoutTxmaQueueEventSource:
+    Condition: UseGlobalLogoutTxmaQueue
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      EventSourceArn:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          globalLogoutQueueArn,
+        ]
+      FunctionName: !GetAtt GlobalLogoutFunction.Arn
+      FunctionResponseTypes:
+        - ReportBatchItemFailures
+
   GlobalLogoutTestQueue:
     Condition: IsDevOrBuild
     Type: AWS::SQS::Queue

--- a/template.yaml
+++ b/template.yaml
@@ -229,6 +229,8 @@ Mappings:
       spotRequestQueueKmsArn: arn:aws:kms:eu-west-2:758531536632:key/3afafd1f-59f2-4ceb-806c-f67c0c120968
       defaultProvisionedConcurrency: 3
       aisUriSecretId: 2b9a3315-50e9-4970-87e6-b354cc4a2484
+      globalLogoutQueueArn: arn:aws:sqs:eu-west-2:178023842775:self-staging-EC-SQS-Output-Queue-orchGlobalLogout
+      globalLogoutQueueKmsKeyArn: arn:aws:kms:eu-west-2:178023842775:key/7cf407f9-958e-4039-a095-c46ba0a08d82
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1


### PR DESCRIPTION
### Wider context of change

We would like to consume TXMA events from Home to do a global logout for a user. Home has now configured this event in the event catalogue, and we have configured consuming this event. We now need to configure the event source mapping and policies for this new queue.

### What’s changed

This PR adds the TXMA queue ARN and the KMS key needed to decrypt messages on the queue, to the environment config. It then uses these ARNs to configure the policy permissions for these queues, as well as the event source mapping for the GlobalLogoutHandler.

Note that this is currently feature flagged and enabled for staging only at the moment.

### Manual testing

Tested in sandpit. Deployment was ok and could complete an auth only journey

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
