### PR TITLE
BAU: Error level changes for NotifyCallbackHandler and CheckReAuthUserHandler

### DIFF
--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -216,7 +216,7 @@ public class NotifyCallbackHandler
                 .map(DeliveryReceiptsNotificationType::getTemplateAlias)
                 .orElseThrow(
                         () -> {
-                            LOG.warn("No template found with template ID: {}", templateID);
+                            LOG.error("No template found with template ID: {}", templateID);
                             throw new RuntimeException("No template found with template ID");
                         });
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -146,7 +146,7 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
                                             request.email(),
                                             maybeUserProfileOfUserSuppliedEmail));
         } catch (AccountLockedException e) {
-            LOG.error("Account is unable to reauth due to too many failed attempts.");
+            LOG.warn("Account is unable to reauth due to too many failed attempts.");
             return generateApiGatewayProxyErrorResponse(400, e.getErrorResponse());
         }
     }


### PR DESCRIPTION
## What

Error level changes for NotifyCallbackHandler and CheckReAuthUserHandler

- Fixes an issue where "Account is unable to reauth due to too many failed attempts" is logged as an error when it is actually a valid alternative scenario and not a failure.  This is causing unecessary alerts: https://gds.slack.com/archives/C02HCLREVV5/p1752004116511279

- Fixes an issue with NotifyCallbackHandler where 'No template found with template ID' errors were logged as 'warn', making the issue more difficult to detect and diagnose.

## How to review

1. Code Review

## Related

#6804 