### PR TITLE
INC0014820: Add audit queue rights to the mfa_methods_delete lambda

### DIFF
--- a/ci/terraform/account-management/mfa-methods-delete.tf
+++ b/ci/terraform/account-management/mfa-methods-delete.tf
@@ -7,6 +7,8 @@ module "account_management_api_mfa_methods_delete_role" {
   policies_to_attach = [
     aws_iam_policy.dynamo_am_user_read_access_policy.arn,
     aws_iam_policy.dynamo_am_user_write_access_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    module.account_management_txma_audit.access_policy_arn,
   ]
   extra_tags = {
     Service = "mfa-methods-delete"


### PR DESCRIPTION


## What

Add audit queue rights to the mfa_methods_delete lambda

Fixes an issue where audit events cannot be posted to the audit queue as the lambda does not have the rights to do so.

'/production-mfa-methods-delete-lambda is not authorized to perform: sqs:sendmessage on resource:'

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review

Lambda deployed to authdev1 and regression tested.  Checked the SQS queue to see that the event had been posted successfully.

{"timestamp":1752055127,"event_timestamp_ms":1752055127529,"event_name":"AUTH_MFA_METHOD_DELETE_COMPLETED","client_id":"","component_id":"AUTH","user":{"user_id":"urn:fdc:gov.uk:2022:","transaction_id":null,"email":"email","phone":"","ip_address":"127.0.0.1","session_id":"","persistent_session_id":"unknown","govuk_signin_journey_id":"unknown"},"platform":null,"restricted":null,"extensions":{"journey-type":"ACCOUNT_MANAGEMENT","mfa-type":"AUTH_APP"}}

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration.
