### PR TITLE
AUT-4533: Function specific CodeDeployServiceRole

### DIFF
--- a/ci/cloudformation/auth/function/account-interventions.yaml
+++ b/ci/cloudformation/auth/function/account-interventions.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleA.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.AccountInterventionsHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/account-recovery.yaml
+++ b/ci/cloudformation/auth/function/account-recovery.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleA.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.AccountRecoveryHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/auth-token.yaml
+++ b/ci/cloudformation/auth/function/auth-token.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./auth-external-api/build/distributions/auth-external-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleA.Arn
       Handler: uk.gov.di.authentication.external.lambda.TokenHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/auth-userinfo.yaml
+++ b/ci/cloudformation/auth/function/auth-userinfo.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./auth-external-api/build/distributions/auth-external-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleA.Arn
       Handler: uk.gov.di.authentication.external.lambda.UserInfoHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/check-email-fraud-block.yaml
+++ b/ci/cloudformation/auth/function/check-email-fraud-block.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleA.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.CheckEmailFraudBlockHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/check-reauth-user.yaml
+++ b/ci/cloudformation/auth/function/check-reauth-user.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleA.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.CheckReAuthUserHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/email-notification-sqs.yaml
+++ b/ci/cloudformation/auth/function/email-notification-sqs.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleA.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.NotificationHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/login.yaml
+++ b/ci/cloudformation/auth/function/login.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleA.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.LoginHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/mfa-reset-authorize.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-authorize.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleB.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.MfaResetAuthorizeHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/mfa-reset-jar-jwk.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-jar-jwk.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleB.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.MfaResetJarJwkHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/mfa-reset-storage-token-jwk.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-storage-token-jwk.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleB.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.MfaResetStorageTokenJwkHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/mfa.yaml
+++ b/ci/cloudformation/auth/function/mfa.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleB.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.MfaHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/orch-auth-code.yaml
+++ b/ci/cloudformation/auth/function/orch-auth-code.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleB.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/reset-password-request.yaml
+++ b/ci/cloudformation/auth/function/reset-password-request.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleB.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.ResetPasswordRequestHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/reset-password.yaml
+++ b/ci/cloudformation/auth/function/reset-password.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleB.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.ResetPasswordHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/reverification-result.yaml
+++ b/ci/cloudformation/auth/function/reverification-result.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleB.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.ReverificationResultHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/send-notification.yaml
+++ b/ci/cloudformation/auth/function/send-notification.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleC.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/signup.yaml
+++ b/ci/cloudformation/auth/function/signup.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleC.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.SignUpHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/start.yaml
+++ b/ci/cloudformation/auth/function/start.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleC.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.StartHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/ticf-cri.yaml
+++ b/ci/cloudformation/auth/function/ticf-cri.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleC.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.TicfCriHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/update-profile.yaml
+++ b/ci/cloudformation/auth/function/update-profile.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleC.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.UpdateProfileHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/user-exists.yaml
+++ b/ci/cloudformation/auth/function/user-exists.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleC.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/verify-code.yaml
+++ b/ci/cloudformation/auth/function/verify-code.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleC.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/function/verify-mfa-code.yaml
+++ b/ci/cloudformation/auth/function/verify-mfa-code.yaml
@@ -8,9 +8,6 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AutoPublishAlias: active
       CodeUri: ./frontend-api/build/distributions/frontend-api.zip
-      DeploymentPreference:
-        Type: !Ref LambdaDeploymentPreference
-        Role: !GetAtt CodeDeployServiceRoleC.Arn
       Handler: uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler::handleRequest
       Environment:
         Variables:

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -373,6 +373,9 @@ Globals:
       - UseCodeSigning
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
+    DeploymentPreference:
+      Type: !Ref LambdaDeploymentPreference
+      Role: !GetAtt CodeDeployServiceRole.Arn
     Environment:
       Variables:
         ENVIRONMENT:
@@ -451,49 +454,7 @@ Globals:
     Timeout: 30
 
 Resources:
-  CodeDeployServiceRoleA:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Action:
-              - sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - codedeploy.amazonaws.com
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda
-      PermissionsBoundary:
-        !If [
-          UsePermissionsBoundary,
-          !Ref PermissionsBoundary,
-          !Ref AWS::NoValue,
-        ]
-
-  CodeDeployServiceRoleB:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Action:
-              - sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - codedeploy.amazonaws.com
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda
-      PermissionsBoundary:
-        !If [
-          UsePermissionsBoundary,
-          !Ref PermissionsBoundary,
-          !Ref AWS::NoValue,
-        ]
-
-  CodeDeployServiceRoleC:
+  CodeDeployServiceRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:


### PR DESCRIPTION
## What

Each Lambda function gets its own CodeDeployServiceRole. This is to overcome the non-increasable quota on Lambda API calls per second.

## How to review

Deploy to dev environment.