### PR TITLE
AUT-4449: Redis non-prod scream test

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -25,7 +25,7 @@ module "authenticate" {
     ENVIRONMENT                                               = var.environment
     INTERNAl_SECTOR_URI                                       = var.internal_sector_uri
     TXMA_AUDIT_QUEUE_URL                                      = module.account_management_txma_audit.queue_url
-    REDIS_KEY                                                 = local.redis_key
+    REDIS_KEY                                                 = var.environment == "production" ? local.redis_key : null
     ACCOUNT_INTERVENTION_SERVICE_URI                          = var.account_intervention_service_uri
     ACCOUNT_INTERVENTION_SERVICE_CALL_IN_AUTHENTICATE_ENABLED = var.ais_call_in_authenticate_enabled
   }

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -46,10 +46,10 @@ module "authenticate" {
   lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.allow_aws_service_access_security_group_id,
-    aws_security_group.allow_access_to_am_redis.id,
-  ]
+  ], var.environment == "production" ? [aws_security_group.allow_access_to_am_redis.id] : [])
+
   subnet_id                              = local.private_subnet_ids
   environment                            = var.environment
   lambda_role_arn                        = module.account_management_api_authenticate_role.arn

--- a/ci/terraform/account-management/mfa-methods-delete.tf
+++ b/ci/terraform/account-management/mfa-methods-delete.tf
@@ -21,7 +21,7 @@ module "mfa-methods-delete" {
   endpoint_name = "mfa-methods-delete"
   handler_environment_variables = {
     ENVIRONMENT                       = var.environment
-    REDIS_KEY                         = local.redis_key
+    REDIS_KEY                         = var.environment == "production" ? local.redis_key : null
     EMAIL_QUEUE_URL                   = aws_sqs_queue.email_queue.id
     TXMA_AUDIT_QUEUE_URL              = module.account_management_txma_audit.queue_url
     INTERNAl_SECTOR_URI               = var.internal_sector_uri

--- a/ci/terraform/account-management/mfa-methods-delete.tf
+++ b/ci/terraform/account-management/mfa-methods-delete.tf
@@ -39,10 +39,10 @@ module "mfa-methods-delete" {
   lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.allow_aws_service_access_security_group_id,
-    aws_security_group.allow_access_to_am_redis.id,
-  ]
+  ], var.environment == "production" ? [aws_security_group.allow_access_to_am_redis.id] : [])
+
   subnet_id                              = local.private_subnet_ids
   environment                            = var.environment
   lambda_role_arn                        = module.account_management_api_mfa_methods_delete_role.arn

--- a/ci/terraform/account-management/mfa-methods-retrieve.tf
+++ b/ci/terraform/account-management/mfa-methods-retrieve.tf
@@ -19,7 +19,7 @@ module "mfa-methods-retrieve" {
   endpoint_name = "mfa-methods-retrieve"
   handler_environment_variables = {
     ENVIRONMENT                       = var.environment
-    REDIS_KEY                         = local.redis_key
+    REDIS_KEY                         = var.environment == "production" ? local.redis_key : null
     TXMA_AUDIT_QUEUE_URL              = module.account_management_txma_audit.queue_url
     INTERNAl_SECTOR_URI               = var.internal_sector_uri
     MFA_METHOD_MANAGEMENT_API_ENABLED = var.mfa_method_management_api_enabled

--- a/ci/terraform/account-management/mfa-methods-retrieve.tf
+++ b/ci/terraform/account-management/mfa-methods-retrieve.tf
@@ -36,10 +36,10 @@ module "mfa-methods-retrieve" {
   lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.allow_aws_service_access_security_group_id,
-    aws_security_group.allow_access_to_am_redis.id,
-  ]
+  ], var.environment == "production" ? [aws_security_group.allow_access_to_am_redis.id] : [])
+
   subnet_id                              = local.private_subnet_ids
   environment                            = var.environment
   lambda_role_arn                        = module.account_management_api_mfa_methods_retrieve_role.arn

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -4,7 +4,7 @@ module "auth_userinfo_role" {
   role_name   = "auth-ext-userinfo-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     module.auth_ext_txma_audit.access_policy_arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
@@ -12,11 +12,11 @@ module "auth_userinfo_role" {
     aws_iam_policy.dynamo_access_token_store_read_access_policy.arn,
     aws_iam_policy.dynamo_access_token_store_write_access_policy.arn,
     aws_iam_policy.access_token_store_signing_key_kms_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     local.user_credentials_encryption_policy_arn,
     aws_iam_policy.dynamo_auth_session_write_policy.arn,
     aws_iam_policy.dynamo_auth_session_read_policy.arn
-  ]
+  ])
   extra_tags = {
     Service = "auth-userinfo"
   }

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -33,7 +33,7 @@ module "auth_userinfo" {
   handler_environment_variables = {
     ENVIRONMENT          = var.environment
     TXMA_AUDIT_QUEUE_URL = module.auth_ext_txma_audit.queue_url
-    REDIS_KEY            = local.redis_key
+    REDIS_KEY            = var.environment == "production" ? local.redis_key : null
     INTERNAl_SECTOR_URI  = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.external.lambda.UserInfoHandler::handleRequest"

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -55,10 +55,10 @@ module "auth_userinfo" {
   lambda_zip_file_version = aws_s3_object.auth_ext_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.auth_userinfo_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -11,7 +11,7 @@ module "frontend_api_account_interventions_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     module.oidc_txma_audit.access_policy_arn,
     ], local.deploy_ticf_cri_count == 1 ? [
     aws_iam_policy.ticf_cri_lambda_invocation_policy[0].arn,

--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -63,10 +63,11 @@ module "account_interventions" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_account_interventions_role[count.index].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -37,7 +37,7 @@ module "account_interventions" {
     ENVIRONMENT                                 = var.environment
     TXMA_AUDIT_QUEUE_URL                        = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI                         = var.internal_sector_uri
-    REDIS_KEY                                   = local.redis_key
+    REDIS_KEY                                   = var.environment == "production" ? local.redis_key : null
     ACCOUNT_INTERVENTION_SERVICE_URI            = var.account_intervention_service_uri
     ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR = var.account_intervention_service_abort_on_error
     ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -35,7 +35,7 @@ module "account_recovery" {
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
-    REDIS_KEY                = local.redis_key
+    REDIS_KEY                = var.environment == "production" ? local.redis_key : null
     HEADERS_CASE_INSENSITIVE = "false"
     INTERNAl_SECTOR_URI      = var.internal_sector_uri
   }

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -4,20 +4,20 @@ module "frontend_api_account_recovery_role" {
   role_name   = "frontend-api-account-recovery-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     aws_iam_policy.dynamo_auth_session_read_policy.arn
-  ]
+  ])
   extra_tags = {
     Service = "account-recovery"
   }

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -56,10 +56,10 @@ module "account_recovery" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_account_recovery_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -4,17 +4,17 @@ module "oidc_auth_code_role" {
   role_name   = "oidc-auth-code-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     local.user_profile_encryption_policy_arn
-  ]
+  ])
   extra_tags = {
     Service = "auth-code"
   }

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -47,10 +47,10 @@ module "auth-code" {
   lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_auth_code_role.arn
   environment                            = var.environment

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -29,7 +29,7 @@ module "auth-code" {
 
   handler_environment_variables = {
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
-    REDIS_KEY                = local.redis_key
+    REDIS_KEY                = var.environment == "production" ? local.redis_key : null
     ENVIRONMENT              = var.environment
     HEADERS_CASE_INSENSITIVE = "false"
     INTERNAl_SECTOR_URI      = var.internal_sector_uri

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -39,7 +39,7 @@ module "orch_auth_code" {
     ENVIRONMENT                    = var.environment
     TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI            = var.internal_sector_uri
-    REDIS_KEY                      = local.redis_key
+    REDIS_KEY                      = var.environment == "production" ? local.redis_key : null
     SUPPORT_REAUTH_SIGNOUT_ENABLED = var.support_reauth_signout_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler::handleRequest"

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -58,10 +58,10 @@ module "orch_auth_code" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_orch_auth_code_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -4,14 +4,14 @@ module "frontend_api_orch_auth_code_role" {
   role_name   = "frontend-api-orch-auth-code-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_auth_code_store_write_access_policy.arn,
     aws_iam_policy.dynamo_auth_code_store_read_access_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     aws_iam_policy.auth_code_dynamo_encryption_key_kms_policy.arn,
     aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
@@ -21,7 +21,7 @@ module "frontend_api_orch_auth_code_role" {
     local.email_check_results_encryption_policy_arn,
     aws_iam_policy.dynamo_auth_session_read_policy.arn,
     aws_iam_policy.dynamo_auth_session_write_policy.arn
-  ]
+  ])
   extra_tags = {
     Service = "orch-auth-code"
   }

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -57,10 +57,10 @@ module "check_email_fraud_block" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_check_email_fraud_block_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -34,7 +34,7 @@ module "check_email_fraud_block" {
     ENVIRONMENT                   = var.environment
     TXMA_AUDIT_QUEUE_URL          = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI           = var.internal_sector_uri
-    REDIS_KEY                     = local.redis_key
+    REDIS_KEY                     = var.environment == "production" ? local.redis_key : null
     LOCKOUT_DURATION              = var.lockout_duration
     LOCKOUT_COUNT_TTL             = var.lockout_count_ttl
     SUPPORT_EMAIL_CHECK_ENABLED   = var.support_email_check_enabled

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -5,17 +5,17 @@ module "frontend_api_check_email_fraud_block_role" {
   role_name   = "frontend-api-check-email-fraud-block-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     module.oidc_txma_audit.access_policy_arn,
     local.email_check_results_encryption_policy_arn,
     aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
     local.client_registry_encryption_policy_arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_auth_session_read_policy.arn
-  ]
+  ])
   extra_tags = {
     Service = "check-email-fraud-block"
   }

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -61,10 +61,10 @@ module "check_reauth_user" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_check_reauth_user_role[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -5,10 +5,10 @@ module "frontend_api_check_reauth_user_role" {
   role_name   = "frontend-api-check-reauth-user-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
@@ -17,7 +17,7 @@ module "frontend_api_check_reauth_user_role" {
     aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn,
     aws_iam_policy.dynamo_auth_session_read_policy.arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn
-  ]
+  ])
   extra_tags = {
     Service = "check-reauth-user"
   }

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -36,7 +36,7 @@ module "check_reauth_user" {
     ENVIRONMENT                             = var.environment
     TXMA_AUDIT_QUEUE_URL                    = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI                     = var.internal_sector_uri
-    REDIS_KEY                               = local.redis_key
+    REDIS_KEY                               = var.environment == "production" ? local.redis_key : null
     LOCKOUT_DURATION                        = var.lockout_duration
     LOCKOUT_COUNT_TTL                       = var.lockout_count_ttl
     SUPPORT_REAUTH_SIGNOUT_ENABLED          = var.support_reauth_signout_enabled

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -31,7 +31,7 @@ module "identity_progress" {
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     ENVIRONMENT              = var.environment
     HEADERS_CASE_INSENSITIVE = "false"
-    REDIS_KEY                = local.redis_key
+    REDIS_KEY                = var.environment == "production" ? local.redis_key : null
     OIDC_API_BASE_URL        = local.api_base_url,
     ORCH_DYNAMO_ARN_PREFIX   = "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-"
   }

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -51,10 +51,11 @@ module "identity_progress" {
   lambda_zip_file_version = aws_s3_object.ipv_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.identity_progress_role_2.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -6,7 +6,7 @@ module "identity_progress_role_2" {
 
   policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     module.oidc_txma_audit.access_policy_arn,
     ], var.is_orch_stubbed ? [] : [
     aws_iam_policy.dynamo_orch_session_cross_account_read_access_policy[0].arn,

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -26,7 +26,7 @@ module "ipv-capacity" {
   handler_environment_variables = {
     ENVIRONMENT                    = var.environment
     TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
-    REDIS_KEY                      = local.redis_key
+    REDIS_KEY                      = var.environment == "production" ? local.redis_key : null
     IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -49,10 +49,10 @@ module "ipv-capacity" {
   lambda_zip_file_version = aws_s3_object.ipv_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.ipv_capacity_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -52,10 +52,10 @@ module "logout" {
   lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_logout_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -31,7 +31,7 @@ module "logout" {
 
   handler_environment_variables = {
     TXMA_AUDIT_QUEUE_URL                 = module.oidc_txma_audit.queue_url
-    REDIS_KEY                            = local.redis_key
+    REDIS_KEY                            = var.environment == "production" ? local.redis_key : null
     ENVIRONMENT                          = var.environment
     EXTERNAL_TOKEN_SIGNING_KEY_ALIAS     = local.id_token_signing_key_alias_name
     EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS = aws_kms_alias.id_token_signing_key_alias.name

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -4,18 +4,18 @@ module "oidc_logout_role" {
   role_name   = "oidc-logout-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     module.oidc_txma_audit.access_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     aws_iam_policy.back_channel_logout_queue_write_access_policy.arn
-  ]
+  ])
   extra_tags = {
     Service = "logout"
   }

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -87,10 +87,10 @@ module "processing-identity" {
   lambda_zip_file_version = aws_s3_object.ipv_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = var.is_orch_stubbed ? module.ipv_processing_identity_role_2.arn : module.ipv_processing_identity_role_with_orch_session_table_read_write_delete_access_2[0].arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -4,18 +4,18 @@ module "ipv_processing_identity_role_2" {
   role_name   = "ipv-processing-identity-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.pepper_parameter_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn
-  ]
+    local.user_credentials_encryption_policy_arn]
+  )
   extra_tags = {
     Service = "processing-identity"
   }
@@ -29,13 +29,13 @@ module "ipv_processing_identity_role_with_orch_session_table_read_write_delete_a
   role_name   = "ipv-processing-identity-role-with-orch-session-combined-access"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.pepper_parameter_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
@@ -45,7 +45,7 @@ module "ipv_processing_identity_role_with_orch_session_table_read_write_delete_a
     aws_iam_policy.dynamo_orch_client_session_encryption_key_cross_account_decrypt_policy[0].arn,
     aws_iam_policy.dynamo_orch_client_session_cross_account_read_and_delete_access_policy[0].arn,
     aws_iam_policy.dynamo_orch_identity_credentials_cross_account_read_access_policy[0].arn
-  ]
+  ])
 }
 
 module "processing-identity" {

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -59,8 +59,7 @@ module "processing-identity" {
   handler_environment_variables = {
     TXMA_AUDIT_QUEUE_URL                        = module.oidc_txma_audit.queue_url
     ENVIRONMENT                                 = var.environment
-    HEADERS_CASE_INSENSITIVE                    = "false"
-    REDIS_KEY                                   = local.redis_key
+    REDIS_KEY                                   = var.environment == "production" ? local.redis_key : null
     INTERNAl_SECTOR_URI                         = var.internal_sector_uri
     ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED = var.account_intervention_service_action_enabled
     ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -4,16 +4,16 @@ module "reverification_result_role" {
   role_name   = "reverification-result_role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.ipv_reverification_request_signing_key_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
     aws_iam_policy.dynamo_auth_session_read_policy.arn,
     aws_iam_policy.dynamo_id_reverification_state_read_policy.arn
-  ]
+  ])
   extra_tags = {
     Service = "reverification-result"
   }

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -57,10 +57,10 @@ module "reverification_result" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_egress_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.reverification_result_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -30,7 +30,7 @@ module "reverification_result" {
   handler_environment_variables = {
     TXMA_AUDIT_QUEUE_URL                          = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI                           = var.internal_sector_uri
-    REDIS_KEY                                     = local.redis_key
+    REDIS_KEY                                     = var.environment == "production" ? local.redis_key : null
     IPV_AUDIENCE                                  = var.ipv_audience
     IPV_AUTHORISATION_CALLBACK_URI                = var.ipv_auth_authorize_callback_uri
     IPV_AUTHORISATION_CLIENT_ID                   = var.ipv_auth_authorize_client_id

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -57,10 +57,10 @@ module "signup" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_signup_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -4,13 +4,13 @@ module "frontend_api_signup_role" {
   role_name   = "frontend-api-signup-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
     aws_iam_policy.dynamo_auth_session_read_policy.arn,
     aws_iam_policy.dynamo_auth_session_write_policy.arn,
@@ -19,7 +19,7 @@ module "frontend_api_signup_role" {
     local.common_passwords_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn
-  ]
+  ])
   extra_tags = {
     Service = "signup"
   }

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -36,7 +36,7 @@ module "signup" {
   handler_environment_variables = {
     ENVIRONMENT                   = var.environment
     TXMA_AUDIT_QUEUE_URL          = module.oidc_txma_audit.queue_url
-    REDIS_KEY                     = local.redis_key
+    REDIS_KEY                     = var.environment == "production" ? local.redis_key : null
     TERMS_CONDITIONS_VERSION      = var.terms_and_conditions
     INTERNAl_SECTOR_URI           = var.internal_sector_uri
     USE_STRONGLY_CONSISTENT_READS = var.use_strongly_consistent_reads

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -4,11 +4,11 @@ module "frontend_api_start_role" {
   role_name   = "frontend-api-start-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_authentication_attempt_read_policy.arn,
     aws_iam_policy.dynamo_auth_session_read_policy.arn,
@@ -18,7 +18,7 @@ module "frontend_api_start_role" {
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     local.user_profile_encryption_policy_arn
-  ]
+  ])
   extra_tags = {
     Service = "start"
   }

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -60,10 +60,10 @@ module "start" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_start_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -36,7 +36,7 @@ module "start" {
     TXMA_AUDIT_QUEUE_URL                    = module.oidc_txma_audit.queue_url
     CUSTOM_DOC_APP_CLAIM_ENABLED            = var.custom_doc_app_claim_enabled
     DOC_APP_DOMAIN                          = var.doc_app_domain
-    REDIS_KEY                               = local.redis_key
+    REDIS_KEY                               = var.environment == "production" ? local.redis_key : null
     ENVIRONMENT                             = var.environment
     HEADERS_CASE_INSENSITIVE                = "false"
     IDENTITY_ENABLED                        = var.ipv_api_enabled

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -4,19 +4,19 @@ module "frontend_api_update_profile_role" {
   role_name   = "frontend-api-update-profile-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = concat([
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
+    ], var.environment == "production" ? [aws_iam_policy.redis_parameter_policy.arn] : [], [
     module.oidc_txma_audit.access_policy_arn,
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
     aws_iam_policy.dynamo_auth_session_read_policy.arn
-  ]
+  ])
   extra_tags = {
     Service = "update-profile"
   }

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -55,10 +55,10 @@ module "update_profile" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = [
+  security_group_ids = concat([
     local.authentication_security_group_id,
-    local.authentication_oidc_redis_security_group_id,
-  ]
+  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_update_profile_role.arn
   logging_endpoint_arns                  = var.logging_endpoint_arns

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -33,7 +33,7 @@ module "update_profile" {
   handler_environment_variables = {
     ENVIRONMENT                   = var.environment
     TXMA_AUDIT_QUEUE_URL          = module.oidc_txma_audit.queue_url
-    REDIS_KEY                     = local.redis_key
+    REDIS_KEY                     = var.environment == "production" ? local.redis_key : null
     TERMS_CONDITIONS_VERSION      = var.terms_and_conditions
     HEADERS_CASE_INSENSITIVE      = "false"
     INTERNAl_SECTOR_URI           = var.internal_sector_uri


### PR DESCRIPTION
## What

TL;DR: remove redis configuration from lambdas that no longer use redis (in theory).

- **AUT-4449: Remove REDIS_KEY envar in non-prod envs**
- **AUT-4449: Remove redis policies in non-prod envs**
- **AUT-4449: Remove redis sg from non-prod envs**

In future, we'll enable snapstart on these lambdas, but we can only do that if they definitely don't use redis.

Removing access to redis is a nice way to test if it's needed (via ATs).

This is all ternary'd to prevent the changes from hitting production.

## How to review

- check the methodology is sound
- check that the ternaries are:
  - correct
  - actually in place
- check I've done nothing dumb
