### PR TITLE
Aut 4529/auth update profile auth app

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -20,7 +20,8 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     AUTH_MFA_METHOD_SWITCH_COMPLETED,
     AUTH_CODE_VERIFIED,
     AUTH_INVALID_CODE_SENT,
-    AUTH_PHONE_CODE_SENT;
+    AUTH_PHONE_CODE_SENT,
+    AUTH_UPDATE_PROFILE_AUTH_APP;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -24,6 +24,7 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodUpdateIdentifier;
 import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodUpdateRequest;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestAuthAppMfaDetail;
 import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -48,6 +49,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_FAILED;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
 import static uk.gov.di.accountmanagement.helpers.MfaMethodResponseConverterHelper.convertMfaMethodsToMfaMethodResponse;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
@@ -172,8 +174,6 @@ public class MFAMethodsPutHandler
                             input,
                             putRequest.request.mfaMethod().method());
 
-            putRequest.request.mfaMethod();
-
             if (maybeMigrationErrorResponse.isPresent()) {
                 return maybeMigrationErrorResponse.get();
             }
@@ -249,6 +249,12 @@ public class MFAMethodsPutHandler
             return handleUpdateMfaFailureReason(maybeUpdateResult.getFailure(), input, putRequest);
         }
 
+        var auditResult = emitAuditEventForAuthAppUpdate(putRequest, input);
+
+        if (auditResult.isFailure()) {
+            return auditResult.getFailure();
+        }
+
         var updateResult = maybeUpdateResult.getSuccess();
 
         var successfulUpdateMethods = updateResult.mfaMethods();
@@ -256,7 +262,7 @@ public class MFAMethodsPutHandler
 
         if (methodsAsResponse.isFailure()) {
             LOG.error(
-                    "Error converting mfa methods to response; update may still have occurred. Error: {}",
+                    "Cannot retrieve updated method detaisl to build response; update may still have occurred. Error: {}",
                     methodsAsResponse.getFailure());
             return generateApiGatewayProxyErrorResponse(
                     500, ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR);
@@ -288,6 +294,7 @@ public class MFAMethodsPutHandler
                     return maybeAuditEventStatus.getFailure();
                 }
             }
+
         } else {
             LOG.warn(
                     "Update operation completed successfully. Email notification could not be sent due to missing or invalid notification ID in service response.");
@@ -361,46 +368,90 @@ public class MFAMethodsPutHandler
         var publicSubjectId = input.getPathParameters().get("publicSubjectId");
         var mfaIdentifier = input.getPathParameters().get("mfaIdentifier");
 
-        if (publicSubjectId.isEmpty()) {
+        if (publicSubjectId == null || publicSubjectId.isEmpty()) {
             LOG.error("Request does not include public subject id");
             return Result.failure(
                     generateApiGatewayProxyErrorResponse(
                             400, ErrorResponse.REQUEST_MISSING_PARAMS));
         }
 
-        if (mfaIdentifier.isEmpty()) {
+        if (mfaIdentifier == null || mfaIdentifier.isEmpty()) {
             LOG.error("Request does not include mfa identifier");
             return Result.failure(
                     generateApiGatewayProxyErrorResponse(
                             400, ErrorResponse.REQUEST_MISSING_PARAMS));
         }
 
-        var maybeUserProfile =
-                authenticationService.getOptionalUserProfileFromPublicSubject(publicSubjectId);
-
-        if (maybeUserProfile.isEmpty()) {
-            LOG.error("Unknown public subject ID");
-            return Result.failure(
-                    generateApiGatewayProxyErrorResponse(404, ErrorResponse.USER_NOT_FOUND));
-        }
-
-        UserProfile userProfile = maybeUserProfile.get();
-
-        Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
-
-        if (PrincipalValidationHelper.principalIsInvalid(
-                userProfile,
-                configurationService.getInternalSectorUri(),
-                authenticationService,
-                authorizerParams)) {
-            return Result.failure(
-                    generateApiGatewayProxyErrorResponse(401, ErrorResponse.INVALID_PRINCIPAL));
-        }
-
+        // Validate request body first before database lookups
         try {
             var mfaMethodUpdateRequest =
                     serialisationService.readValue(
                             input.getBody(), MfaMethodUpdateRequest.class, true);
+
+            // Validate priority identifier
+            var priorityIdentifier = mfaMethodUpdateRequest.mfaMethod().priorityIdentifier();
+            if (priorityIdentifier == null
+                    || (!PriorityIdentifier.DEFAULT.equals(priorityIdentifier)
+                            && !PriorityIdentifier.BACKUP.equals(priorityIdentifier))) {
+                LOG.error("Invalid priority identifier");
+                return Result.failure(
+                        generateApiGatewayProxyErrorResponse(
+                                400, ErrorResponse.REQUEST_MISSING_PARAMS));
+            }
+
+            // Validate MFA method details (method can be null for switching scenarios)
+            var mfaDetail = mfaMethodUpdateRequest.mfaMethod().method();
+            if (mfaDetail != null) {
+                if (mfaDetail instanceof RequestSmsMfaDetail smsMfaDetail) {
+                    if (smsMfaDetail.mfaMethodType() == null
+                            || !MFAMethodType.SMS.equals(smsMfaDetail.mfaMethodType())
+                            || smsMfaDetail.phoneNumber() == null
+                            || smsMfaDetail.phoneNumber().trim().isEmpty()
+                            || smsMfaDetail.otp() == null
+                            || smsMfaDetail.otp().trim().isEmpty()) {
+                        LOG.error("Invalid SMS MFA request fields");
+                        return Result.failure(
+                                generateApiGatewayProxyErrorResponse(
+                                        400, ErrorResponse.REQUEST_MISSING_PARAMS));
+                    }
+                } else if (mfaDetail instanceof RequestAuthAppMfaDetail authAppDetail) {
+                    if (authAppDetail.credential() == null
+                            || authAppDetail.credential().trim().isEmpty()) {
+                        LOG.error("Invalid AUTH_APP MFA request fields");
+                        return Result.failure(
+                                generateApiGatewayProxyErrorResponse(
+                                        400, ErrorResponse.REQUEST_MISSING_PARAMS));
+                    }
+                } else {
+                    LOG.error("Invalid MFA method type");
+                    return Result.failure(
+                            generateApiGatewayProxyErrorResponse(
+                                    400, ErrorResponse.REQUEST_MISSING_PARAMS));
+                }
+            }
+
+            // Only after request validation, check user profile and principal
+            var maybeUserProfile =
+                    authenticationService.getOptionalUserProfileFromPublicSubject(publicSubjectId);
+
+            if (maybeUserProfile.isEmpty()) {
+                LOG.error("Unknown public subject ID");
+                return Result.failure(
+                        generateApiGatewayProxyErrorResponse(404, ErrorResponse.USER_NOT_FOUND));
+            }
+
+            UserProfile userProfile = maybeUserProfile.get();
+
+            Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
+
+            if (PrincipalValidationHelper.principalIsInvalid(
+                    userProfile,
+                    configurationService.getInternalSectorUri(),
+                    authenticationService,
+                    authorizerParams)) {
+                return Result.failure(
+                        generateApiGatewayProxyErrorResponse(401, ErrorResponse.INVALID_PRINCIPAL));
+            }
 
             var putRequest =
                     new ValidPutRequest(
@@ -480,6 +531,39 @@ public class MFAMethodsPutHandler
         }
 
         LOG.info("Successfully submitted audit event: {}", auditEvent.name());
+        return Result.success(null);
+    }
+
+    private Result<APIGatewayProxyResponseEvent, Void> emitAuditEventForAuthAppUpdate(
+            ValidPutRequest putRequest, APIGatewayProxyRequestEvent input) {
+        if (!(putRequest.request.mfaMethod().method() instanceof RequestAuthAppMfaDetail)) {
+            return Result.success(null);
+        }
+
+        var maybeAuditContext =
+                AuditHelper.buildAuditContext(
+                        configurationService, dynamoService, input, putRequest.userProfile);
+
+        if (maybeAuditContext.isFailure()) {
+            return Result.failure(
+                    generateApiGatewayProxyErrorResponse(401, maybeAuditContext.getFailure()));
+        }
+
+        var auditContext =
+                maybeAuditContext
+                        .getSuccess()
+                        .withMetadataItem(
+                                pair(
+                                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                        PriorityIdentifier.DEFAULT.name().toLowerCase()))
+                        .withMetadataItem(
+                                pair(
+                                        AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
+                                        JourneyType.ACCOUNT_MANAGEMENT.getValue()));
+
+        auditService.submitAuditEvent(
+                AUTH_UPDATE_PROFILE_AUTH_APP, auditContext, AUDIT_EVENT_COMPONENT_ID_HOME);
+
         return Result.success(null);
     }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.accountmanagement.services.MfaMethodsMigrationService;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
@@ -45,6 +46,7 @@ import uk.gov.di.authentication.shared.services.mfa.MfaUpdateFailure;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_COMPLETED;
@@ -203,15 +205,6 @@ public class MFAMethodsPutHandler
                             requestSmsMfaDetail.otp(),
                             NotificationType.VERIFY_PHONE_NUMBER);
             if (!isValidOtpCode) {
-                var maybeAuditContext =
-                        AuditHelper.buildAuditContext(
-                                configurationService, dynamoService, input, putRequest.userProfile);
-
-                if (maybeAuditContext.isFailure()) {
-                    return generateApiGatewayProxyErrorResponse(
-                            401, maybeAuditContext.getFailure());
-                }
-
                 var maybeAuditEventStatus =
                         sendAuditEvent(
                                 AUTH_INVALID_CODE_SENT,
@@ -262,7 +255,7 @@ public class MFAMethodsPutHandler
 
         if (methodsAsResponse.isFailure()) {
             LOG.error(
-                    "Cannot retrieve updated method detaisl to build response; update may still have occurred. Error: {}",
+                    "Cannot retrieve updated method details to build response; update may still have occurred. Error: {}",
                     methodsAsResponse.getFailure());
             return generateApiGatewayProxyErrorResponse(
                     500, ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -201,7 +201,12 @@ class MFAMethodsPutHandlerTest {
         verify(authenticationService).getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT);
         verify(codeStorageService)
                 .isValidOtpCode(EMAIL, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER);
-        verify(mfaMethodsService).updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest);
+        verify(mfaMethodsService)
+                .updateMfaMethod(
+                        eq(EMAIL),
+                        eq(DEFAULT_SMS_METHOD),
+                        eq(List.of(DEFAULT_SMS_METHOD)),
+                        eq(updateRequest));
     }
 
     @Test
@@ -276,7 +281,12 @@ class MFAMethodsPutHandlerTest {
         verify(authenticationService).getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT);
         verify(codeStorageService)
                 .isValidOtpCode(nonMigratedEmail, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER);
-        verify(mfaMethodsService).updateMfaMethod(nonMigratedEmail, MFA_IDENTIFIER, updateRequest);
+        verify(mfaMethodsService)
+                .updateMfaMethod(
+                        eq(nonMigratedEmail),
+                        eq(DEFAULT_SMS_METHOD),
+                        eq(List.of(DEFAULT_SMS_METHOD)),
+                        eq(updateRequest));
         verify(mfaMethodsMigrationService)
                 .migrateMfaCredentialsForUserIfRequired(any(), any(), any(), any());
     }
@@ -359,7 +369,12 @@ class MFAMethodsPutHandlerTest {
         verify(authenticationService).getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT);
         verify(codeStorageService)
                 .isValidOtpCode(EMAIL, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER);
-        verify(mfaMethodsService).updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest);
+        verify(mfaMethodsService)
+                .updateMfaMethod(
+                        eq(EMAIL),
+                        eq(DEFAULT_SMS_METHOD),
+                        eq(List.of(DEFAULT_SMS_METHOD)),
+                        eq(updateRequest));
     }
 
     @CsvSource({"500", "404", "200"})
@@ -1079,7 +1094,12 @@ class MFAMethodsPutHandlerTest {
         var switchedMfaMethod =
                 MFAMethod.authAppMfaMethod(
                         "test-credential", true, true, PriorityIdentifier.DEFAULT, MFA_IDENTIFIER);
-        when(mfaMethodsService.updateMfaMethod(eq(EMAIL), eq(MFA_IDENTIFIER), any()))
+        when(mfaMethodsService.getMfaMethod(EMAIL, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
+        when(mfaMethodsService.updateMfaMethod(any(), any(), any(), any()))
                 .thenReturn(
                         Result.success(
                                 new MFAMethodsService.MfaUpdateResponse(
@@ -1091,7 +1111,9 @@ class MFAMethodsPutHandlerTest {
         assertEquals(200, result.getStatusCode());
 
         verify(authenticationService).getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT);
-        verify(mfaMethodsService).updateMfaMethod(eq(EMAIL), eq(MFA_IDENTIFIER), any());
+        verify(mfaMethodsService)
+                .updateMfaMethod(
+                        eq(EMAIL), eq(DEFAULT_SMS_METHOD), eq(List.of(DEFAULT_SMS_METHOD)), any());
         verify(sqsClient).send(any());
     }
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
@@ -176,7 +176,6 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @Nested
     class ChangingDefaultMethod {
-
         public static final String DEFAULT_AUTH_APP_RESPONSE_TEMPLATE =
                 """
                 [
@@ -191,7 +190,6 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                     }
                 ]
                 """;
-
         public static final String SMS_RESPONSE_TEMPLATE =
                 """
                 {
@@ -594,14 +592,14 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             addInvalidCodeSentAttributes.put(EXTENSIONS_MFA_METHOD, DEFAULT.name().toLowerCase());
             addInvalidCodeSentAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             eventExpectations.put(AUTH_INVALID_CODE_SENT.name(), addInvalidCodeSentAttributes);
-
             verifyAuditEvents(expectedEvents, eventExpectations);
+
+            assertNoNotificationsReceived(notificationsQueue);
         }
     }
 
     @Nested
     class SwitchingMethods {
-
         private void assertRetrievedMethodHasSameFieldsWithUpdatedPriority(
                 MFAMethod expected, MFAMethod retrieved, PriorityIdentifier expectedPriority) {
             assertAll(
@@ -640,7 +638,6 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                      }
                  }
                 """;
-
         public static final String SWITCH_REQUEST =
                 """
                 {
@@ -791,7 +788,6 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @Nested
     class UserMigration {
-
         private void createUnMigratedUserWithIntermediateMfaIdentifier(String mfaIdentifier) {
             userStore.setPhoneNumberAndVerificationStatus(
                     TEST_EMAIL, TEST_PHONE_NUMBER, true, true);
@@ -893,7 +889,6 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @Nested
     class Idempotence {
-
         @Test
         void duplicateUpdatesShouldBeIdempotentForUpdatesToDefaultMethod() {
             userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, defaultAuthApp);
@@ -1029,12 +1024,11 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @Nested
     class Validations {
-
         @Test
         void shouldReturn401WhenPrincipalIsInvalid() {
             var response =
                     makeRequest(
-                            Optional.empty(),
+                            Optional.of(ChangingBackupMethod.buildUpdateRequestWithOtp()),
                             TEST_HEADERS,
                             Collections.emptyMap(),
                             Map.ofEntries(
@@ -1044,7 +1038,6 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
             assertEquals(401, response.getStatusCode());
             assertThat(response, hasJsonBody(ErrorResponse.INVALID_PRINCIPAL));
-
             assertNoNotificationsReceived(notificationsQueue);
 
             assertNoTxmaAuditEventsReceived(txmaAuditQueue);
@@ -1054,7 +1047,7 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
         void shouldReturn404WhenUserProfileIsNotFoundForPublicSubject() {
             var response =
                     makeRequest(
-                            Optional.empty(),
+                            Optional.of(ChangingBackupMethod.buildUpdateRequestWithOtp()),
                             TEST_HEADERS,
                             Collections.emptyMap(),
                             Map.ofEntries(


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->
Add AUTH_UPDATE_PROFILE_AUTH_APP event.

Branched off AUT-4245 which needs to be on main before this change can be merged.

## How to review

1. Code Review
2. Deploy to dev and run acceptance tests
<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
