### PR TITLE
AUT-4526: Raise AUTH_CODE_VERIFIED in account management

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -18,6 +18,7 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     AUTH_MFA_METHOD_MIGRATION_ATTEMPTED,
     AUTH_MFA_METHOD_SWITCH_FAILED,
     AUTH_MFA_METHOD_SWITCH_COMPLETED,
+    AUTH_CODE_VERIFIED,
     AUTH_INVALID_CODE_SENT;
 
     public AuditableEvent parseFromName(String name) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.mfa.response.MfaMethodResponse;
@@ -24,7 +25,12 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodCreateRequest;
 import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
+import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
@@ -35,14 +41,18 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaCreateFailureReason;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
+import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
+import static uk.gov.di.authentication.shared.entity.AuthSessionItem.ATTRIBUTE_CLIENT_ID;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.DEFAULT_MFA_ALREADY_EXISTS;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.INVALID_OTP;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.REQUEST_MISSING_PARAMS;
@@ -160,7 +170,7 @@ public class MFAMethodsCreateHandler
     }
 
     private Result<ErrorResponse, MfaMethodCreateRequest> validateRequest(
-            APIGatewayProxyRequestEvent input, UserProfile userProfile, AuditContext auditContext) {
+            APIGatewayProxyRequestEvent input, UserProfile userProfile) {
         MfaMethodCreateRequest mfaMethodCreateRequest = null;
 
         try {
@@ -184,12 +194,13 @@ public class MFAMethodsCreateHandler
                             NotificationType.VERIFY_PHONE_NUMBER);
             if (!isValidOtpCode) {
                 LOG.info("Invalid OTP presented.");
-                auditContext =
-                        auditContext.withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                        PriorityIdentifier.BACKUP.name().toLowerCase()));
-                auditService.submitAuditEvent(AUTH_INVALID_CODE_SENT, auditContext);
+                var auditEventStatus =
+                        sendAuditEvent(
+                                AUTH_INVALID_CODE_SENT, input, userProfile, mfaMethodCreateRequest);
+                if (auditEventStatus.isFailure()) {
+                    LOG.error(auditEventStatus.getFailure());
+                    return Result.failure(auditEventStatus.getFailure());
+                }
                 return Result.failure(INVALID_OTP);
             }
         }
@@ -210,17 +221,7 @@ public class MFAMethodsCreateHandler
 
         var userProfile = maybePassedGuardConditions.getSuccess();
 
-        Result<ErrorResponse, AuditContext> auditContextResult =
-                AuditHelper.buildAuditContext(
-                        configurationService, dynamoService, input, userProfile);
-
-        if (auditContextResult.isFailure()) {
-            return generateApiGatewayProxyErrorResponse(401, auditContextResult.getFailure());
-        }
-
-        var auditContext = auditContextResult.getSuccess();
-
-        var maybeValidRequest = validateRequest(input, userProfile, auditContext);
+        var maybeValidRequest = validateRequest(input, userProfile);
 
         if (maybeValidRequest.isFailure()) {
             return generateApiGatewayProxyErrorResponse(400, maybeValidRequest.getFailure());
@@ -241,13 +242,14 @@ public class MFAMethodsCreateHandler
                         userProfile.getEmail(), mfaMethodCreateRequest.mfaMethod());
 
         if (addBackupMfaResult.isFailure()) {
-            var maybeAuditContext =
-                    updateAuditContextForFailedMFACreation(userProfile, auditContext);
-            if (maybeAuditContext.isFailure()) {
-                return generateApiGatewayProxyErrorResponse(500, maybeAuditContext.getFailure());
+            LOG.error(addBackupMfaResult.getFailure());
+            var auditEventStatus =
+                    sendAuditEvent(
+                            AUTH_MFA_METHOD_ADD_FAILED, input, userProfile, mfaMethodCreateRequest);
+            if (auditEventStatus.isFailure()) {
+                LOG.error(auditEventStatus.getFailure());
+                return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
             }
-            auditService.submitAuditEvent(
-                    AUTH_MFA_METHOD_ADD_FAILED, maybeAuditContext.getSuccess());
             return handleCreateBackupMfaFailure(addBackupMfaResult.getFailure());
         }
 
@@ -256,33 +258,23 @@ public class MFAMethodsCreateHandler
 
         if (backupMfaMethodAsResponse.isFailure()) {
             LOG.error(backupMfaMethodAsResponse.getFailure());
-
-            var maybeAuditContext =
-                    updateAuditContextForFailedMFACreation(userProfile, auditContext);
-            if (maybeAuditContext.isFailure()) {
-                return generateApiGatewayProxyErrorResponse(500, maybeAuditContext.getFailure());
+            var auditEventStatus =
+                    sendAuditEvent(
+                            AUTH_MFA_METHOD_ADD_FAILED, input, userProfile, mfaMethodCreateRequest);
+            if (auditEventStatus.isFailure()) {
+                LOG.error(auditEventStatus.getFailure());
+                return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
             }
-            auditService.submitAuditEvent(
-                    AUTH_MFA_METHOD_ADD_FAILED, maybeAuditContext.getSuccess());
             return generateApiGatewayProxyErrorResponse(500, UNEXPECTED_ACCT_MGMT_ERROR);
         }
 
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                mfaMethodCreateRequest
-                                        .mfaMethod()
-                                        .method()
-                                        .mfaMethodType()
-                                        .toString()));
-
-        if (mfaMethodCreateRequest.mfaMethod().method()
-                instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-            auditContext = auditContext.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
+        var auditEventStatus =
+                sendAuditEvent(
+                        AUTH_MFA_METHOD_ADD_COMPLETED, input, userProfile, mfaMethodCreateRequest);
+        if (auditEventStatus.isFailure()) {
+            LOG.error(auditEventStatus.getFailure());
+            return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
         }
-
-        auditService.submitAuditEvent(AUTH_MFA_METHOD_ADD_COMPLETED, auditContext);
 
         LocaleHelper.SupportedLanguage userLanguage =
                 matchSupportedLanguage(
@@ -320,48 +312,6 @@ public class MFAMethodsCreateHandler
         }
     }
 
-    private Result<ErrorResponse, AuditContext> updateAuditContextForFailedMFACreation(
-            UserProfile userProfile, AuditContext auditContext) {
-        var maybeMfaMethods = mfaMethodsService.getMfaMethods(userProfile.getEmail());
-
-        if (maybeMfaMethods.isFailure()) {
-            LOG.error("No MFA methods found for user");
-            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
-        }
-
-        var mfaMethods = maybeMfaMethods.getSuccess();
-
-        var defaultMfaMethod =
-                mfaMethods.stream()
-                        .filter(
-                                method ->
-                                        method.getPriority()
-                                                .equalsIgnoreCase(
-                                                        PriorityIdentifier.DEFAULT.name()))
-                        .findFirst();
-
-        if (defaultMfaMethod.isEmpty()) {
-            LOG.error("No default MFA method found for user");
-            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
-        }
-
-        if (defaultMfaMethod.get().getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
-            auditContext = auditContext.withPhoneNumber(defaultMfaMethod.get().getDestination());
-        }
-
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                defaultMfaMethod.get().getMfaMethodType()));
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                PriorityIdentifier.DEFAULT.name().toLowerCase()));
-        return Result.success(auditContext);
-    }
-
     private static APIGatewayProxyResponseEvent handleCreateBackupMfaFailure(
             MfaCreateFailureReason failureReason) {
         return switch (failureReason) {
@@ -374,6 +324,132 @@ public class MFAMethodsCreateHandler
             case INVALID_PHONE_NUMBER -> generateApiGatewayProxyErrorResponse(
                     400, ErrorResponse.INVALID_PHONE_NUMBER);
         };
+    }
+
+    private Result<ErrorResponse, AuditContext> buildAuditContext(
+            AccountManagementAuditableEvent auditEvent,
+            APIGatewayProxyRequestEvent input,
+            UserProfile userProfile,
+            MfaMethodCreateRequest mfaMethodCreateRequest) {
+        try {
+            var initialMetadataPairs =
+                    new AuditService.MetadataPair[] {
+                        pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.getValue())
+                    };
+
+            var context =
+                    new AuditContext(
+                            input.getRequestContext()
+                                    .getAuthorizer()
+                                    .getOrDefault(ATTRIBUTE_CLIENT_ID, AuditService.UNKNOWN)
+                                    .toString(),
+                            ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
+                            RequestHeaderHelper.getHeaderValueOrElse(
+                                    input.getHeaders(), SESSION_ID_HEADER, ""),
+                            ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                                            userProfile,
+                                            configurationService.getInternalSectorUri(),
+                                            dynamoService)
+                                    .getValue(),
+                            userProfile.getEmail(),
+                            IpAddressHelper.extractIpAddress(input),
+                            null,
+                            PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                            AuditHelper.getTxmaAuditEncoded(input.getHeaders()),
+                            List.of(initialMetadataPairs));
+
+            if (auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
+                var maybeMfaMethods = mfaMethodsService.getMfaMethods(userProfile.getEmail());
+
+                if (maybeMfaMethods.isFailure()) {
+                    LOG.error("No MFA methods found for user");
+                    return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
+                }
+
+                var mfaMethods = maybeMfaMethods.getSuccess();
+
+                var defaultMfaMethod =
+                        mfaMethods.stream()
+                                .filter(
+                                        method ->
+                                                method.getPriority()
+                                                        .equalsIgnoreCase(
+                                                                PriorityIdentifier.DEFAULT.name()))
+                                .findFirst();
+
+                if (defaultMfaMethod.isEmpty()) {
+                    LOG.error("No default MFA method found for user");
+                    return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
+                }
+
+                if (defaultMfaMethod
+                        .get()
+                        .getMfaMethodType()
+                        .equalsIgnoreCase(MFAMethodType.SMS.name())) {
+                    context = context.withPhoneNumber(defaultMfaMethod.get().getDestination());
+                }
+
+                context =
+                        context.withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                                defaultMfaMethod.get().getMfaMethodType()))
+                                .withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                                PriorityIdentifier.DEFAULT.name().toLowerCase()));
+
+            } else {
+                context =
+                        context.withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                                mfaMethodCreateRequest
+                                                        .mfaMethod()
+                                                        .method()
+                                                        .mfaMethodType()
+                                                        .toString()))
+                                .withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                                PriorityIdentifier.BACKUP.name().toLowerCase()));
+
+                if (mfaMethodCreateRequest.mfaMethod().method()
+                        instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
+                    context = context.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
+                }
+            }
+
+            return Result.success(context);
+        } catch (Exception e) {
+            LOG.error("Error building audit context", e);
+            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
+        }
+    }
+
+    private Result<ErrorResponse, Void> sendAuditEvent(
+            AccountManagementAuditableEvent auditEvent,
+            APIGatewayProxyRequestEvent input,
+            UserProfile userProfile,
+            MfaMethodCreateRequest mfaMethodCreateRequest) {
+        var maybeAuditContext =
+                buildAuditContext(auditEvent, input, userProfile, mfaMethodCreateRequest);
+        if (maybeAuditContext.isFailure()) {
+            LOG.error(
+                    "Error when building audit context for {} audit event with error code {}. No event raised",
+                    auditEvent,
+                    maybeAuditContext.getFailure());
+            return Result.failure(ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT);
+        }
+
+        try {
+            auditService.submitAuditEvent(auditEvent, maybeAuditContext.getSuccess());
+        } catch (Exception e) {
+            LOG.error("Error submitting audit event", e);
+            return Result.failure(ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT);
+        }
+
+        return Result.success(null);
     }
 
     private MfaMethodCreateRequest readMfaMethodCreateRequest(APIGatewayProxyRequestEvent input)

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -528,8 +528,8 @@ public class MFAMethodsPutHandler
             }
 
             if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
-                if (putRequest.request.mfaMethod().method()
-                                instanceof RequestSmsMfaDetail requestSmsMfaDetail
+                MfaMethodUpdateRequest.MfaMethod requestedMethod = putRequest.request.mfaMethod();
+                if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail
                         && requestSmsMfaDetail.otp() != null) {
                     context =
                             context.withMetadataItem(
@@ -551,11 +551,14 @@ public class MFAMethodsPutHandler
                                 .withMetadataItem(
                                         pair(
                                                 AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                                mfaMethod.getPriority().toLowerCase()))
+                                                requestedMethod
+                                                        .priorityIdentifier()
+                                                        .name()
+                                                        .toLowerCase()))
                                 .withMetadataItem(
                                         pair(
                                                 AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                                mfaMethod.getMfaMethodType()));
+                                                requestedMethod.method().mfaMethodType()));
             }
 
             return Result.success(context);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
@@ -106,6 +106,8 @@ public class MFAMethodsRetrieveHandler
                         500, ErrorResponse.AUTH_APP_MFA_ID_ERROR);
                 case USER_DOES_NOT_HAVE_ACCOUNT -> generateApiGatewayProxyErrorResponse(
                         500, ErrorResponse.ACCT_DOES_NOT_EXIST);
+                case UNKNOWN_MFA_IDENTIFIER -> generateApiGatewayProxyErrorResponse(
+                        500, ErrorResponse.MFA_METHOD_NOT_FOUND);
             };
         }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -55,7 +55,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -49,6 +49,7 @@ import java.util.stream.Stream;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -57,14 +58,18 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_FAILED;
 import static uk.gov.di.accountmanagement.entity.NotificationType.CHANGED_DEFAULT_MFA;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.VALID_HEADERS;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.BACKUP_SMS_METHOD;
@@ -103,6 +108,7 @@ class MFAMethodsPutHandlerTest {
                     TEST_PUBLIC_SUBJECT, "test.account.gov.uk", TEST_SALT);
     private static final String MFA_IDENTIFIER = "some-mfa-identifier";
     public static final String TEST_OTP = "123456";
+    public static final String INCORRECT_OTP = "111111";
 
     private MFAMethodsPutHandler handler;
 
@@ -398,6 +404,86 @@ class MFAMethodsPutHandlerTest {
                 defaultMfaMethod.getMfaMethodType());
     }
 
+    @Test
+    void shouldRaiseAuthCodeVerifiedAuditEvent() {
+        var updateRequest =
+                MfaMethodUpdateRequest.from(
+                        PriorityIdentifier.DEFAULT,
+                        new RequestSmsMfaDetail(DEFAULT_SMS_METHOD.getDestination(), TEST_OTP));
+        var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
+        var eventWithUpdateRequest =
+                event.withBody(updateSmsRequest(DEFAULT_SMS_METHOD.getDestination(), TEST_OTP));
+        when(codeStorageService.isValidOtpCode(
+                        EMAIL, TEST_OTP, NotificationType.VERIFY_PHONE_NUMBER))
+                .thenReturn(true);
+        when(authenticationService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
+                .thenReturn(Optional.of(userProfile));
+        when(mfaMethodsService.getMfaMethod(EMAIL, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
+        when(mfaMethodsService.updateMfaMethod(eq(EMAIL), any(), any(), eq(updateRequest)))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.MfaUpdateResponse(
+                                        List.of(DEFAULT_SMS_METHOD),
+                                        MFAMethodUpdateIdentifier.CHANGED_DEFAULT_MFA)));
+
+        handler.handleRequest(eventWithUpdateRequest, context);
+
+        ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+        verify(auditService).submitAuditEvent(eq(AUTH_CODE_VERIFIED), captor.capture());
+        AuditContext capturedObject = captor.getValue();
+
+        containsMetadataPair(capturedObject, AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, TEST_OTP);
+        containsMetadataPair(capturedObject, AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false");
+        containsMetadataPair(
+                capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
+        containsMetadataPair(
+                capturedObject,
+                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                DEFAULT_SMS_METHOD.getPriority().toLowerCase());
+        containsMetadataPair(
+                capturedObject,
+                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                DEFAULT_SMS_METHOD.getMfaMethodType());
+        containsMetadataPair(capturedObject, AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, "MFA_SMS");
+    }
+
+    @Test
+    void shouldNotRaiseAuthCodeVerifiedAuditEvent() {
+        var updateRequest =
+                MfaMethodUpdateRequest.from(
+                        PriorityIdentifier.DEFAULT,
+                        new RequestSmsMfaDetail(
+                                DEFAULT_SMS_METHOD.getDestination(), INCORRECT_OTP));
+        var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
+        var eventWithUpdateRequest =
+                event.withBody(
+                        updateSmsRequest(DEFAULT_SMS_METHOD.getDestination(), INCORRECT_OTP));
+        when(codeStorageService.isValidOtpCode(
+                        EMAIL, INCORRECT_OTP, NotificationType.VERIFY_PHONE_NUMBER))
+                .thenReturn(false);
+        when(authenticationService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
+                .thenReturn(Optional.of(userProfile));
+        when(mfaMethodsService.getMfaMethod(EMAIL, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
+        when(mfaMethodsService.updateMfaMethod(eq(EMAIL), any(), any(), eq(updateRequest)))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.MfaUpdateResponse(
+                                        List.of(DEFAULT_SMS_METHOD),
+                                        MFAMethodUpdateIdentifier.CHANGED_DEFAULT_MFA)));
+
+        handler.handleRequest(eventWithUpdateRequest, context);
+
+        verify(auditService, never()).submitAuditEvent(eq(AUTH_CODE_VERIFIED), any());
+    }
+
     private static Stream<Arguments> migrationFailureReasonsToExpectedStatusCodes() {
         return Stream.of(
                 Arguments.of(MfaMigrationFailureReason.UNEXPECTED_ERROR_RETRIEVING_METHODS, 500),
@@ -493,7 +579,9 @@ class MFAMethodsPutHandlerTest {
             verify(sqsClient, never()).send(any());
         }
 
-        verifyNoInteractions(auditService);
+        verify(auditService, never())
+                .submitAuditEvent(
+                        not(eq(AUTH_CODE_VERIFIED)), any(), any(AuditService.MetadataPair[].class));
     }
 
     private static Stream<Arguments> updateFailureReasonsToExpectedResponses() {
@@ -565,7 +653,9 @@ class MFAMethodsPutHandlerTest {
                 expectedError -> assertThat(result, hasJsonBody(expectedError)));
 
         verify(sqsClient, never()).send(any());
-        verifyNoInteractions(auditService);
+        verify(auditService, never())
+                .submitAuditEvent(
+                        not(eq(AUTH_CODE_VERIFIED)), any(), any(AuditService.MetadataPair[].class));
     }
 
     @Test
@@ -641,7 +731,9 @@ class MFAMethodsPutHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR));
 
         verify(sqsClient, never()).send(any());
-        verifyNoInteractions(auditService);
+        verify(auditService, never())
+                .submitAuditEvent(
+                        not(eq(AUTH_CODE_VERIFIED)), any(), any(AuditService.MetadataPair[].class));
     }
 
     @Test
@@ -753,6 +845,11 @@ class MFAMethodsPutHandlerTest {
                 .thenReturn(false);
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
         when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(TEST_SALT);
+        when(mfaMethodsService.getMfaMethod(EMAIL, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
 
         var phoneNumber = "123456789";
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -68,6 +68,7 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.BACKUP_SMS_METHOD;
+import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.DEFAULT_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.containsMetadataPair;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.identityWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
@@ -148,7 +149,12 @@ class MFAMethodsPutHandlerTest {
         var updatedMfaMethod =
                 MFAMethod.smsMfaMethod(
                         true, true, phoneNumber, PriorityIdentifier.DEFAULT, MFA_IDENTIFIER);
-        when(mfaMethodsService.updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest))
+        when(mfaMethodsService.getMfaMethod(EMAIL, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
+        when(mfaMethodsService.updateMfaMethod(eq(EMAIL), any(), any(), eq(updateRequest)))
                 .thenReturn(
                         Result.success(
                                 new MFAMethodsService.MfaUpdateResponse(
@@ -211,7 +217,13 @@ class MFAMethodsPutHandlerTest {
         var updatedMfaMethod =
                 MFAMethod.smsMfaMethod(
                         true, true, phoneNumber, PriorityIdentifier.DEFAULT, MFA_IDENTIFIER);
-        when(mfaMethodsService.updateMfaMethod(nonMigratedEmail, MFA_IDENTIFIER, updateRequest))
+        when(mfaMethodsService.getMfaMethod(nonMigratedEmail, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
+        when(mfaMethodsService.updateMfaMethod(
+                        eq(nonMigratedEmail), any(), any(), eq(updateRequest)))
                 .thenReturn(
                         Result.success(
                                 new MFAMethodsService.MfaUpdateResponse(
@@ -286,7 +298,12 @@ class MFAMethodsPutHandlerTest {
         var updatedMfaMethod =
                 MFAMethod.smsMfaMethod(
                         true, true, phoneNumber, PriorityIdentifier.DEFAULT, MFA_IDENTIFIER);
-        when(mfaMethodsService.updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest))
+        when(mfaMethodsService.getMfaMethod(EMAIL, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
+        when(mfaMethodsService.updateMfaMethod(eq(EMAIL), any(), any(), eq(updateRequest)))
                 .thenReturn(
                         Result.success(
                                 new MFAMethodsService.MfaUpdateResponse(
@@ -351,7 +368,13 @@ class MFAMethodsPutHandlerTest {
                         "auth-app-identifier-1");
         var postUpdateMfaMethods = List.of(defaultMfaMethod, backupMfaMethod);
 
-        when(mfaMethodsService.updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest))
+        when(mfaMethodsService.getMfaMethod(EMAIL, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        defaultMfaMethod, postUpdateMfaMethods)));
+
+        when(mfaMethodsService.updateMfaMethod(eq(EMAIL), any(), any(), eq(updateRequest)))
                 .thenReturn(
                         Result.success(
                                 new MFAMethodsService.MfaUpdateResponse(
@@ -407,10 +430,17 @@ class MFAMethodsPutHandlerTest {
         when(authenticationService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(nonMigratedUser));
 
+        when(mfaMethodsService.getMfaMethod(nonMigratedEmail, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
+
         var updatedMfaMethod =
                 MFAMethod.smsMfaMethod(
                         true, true, phoneNumber, PriorityIdentifier.DEFAULT, MFA_IDENTIFIER);
-        when(mfaMethodsService.updateMfaMethod(nonMigratedEmail, MFA_IDENTIFIER, updateRequest))
+        when(mfaMethodsService.updateMfaMethod(
+                        eq(nonMigratedEmail), any(), any(), eq(updateRequest)))
                 .thenReturn(
                         Result.success(
                                 new MFAMethodsService.MfaUpdateResponse(
@@ -521,8 +551,13 @@ class MFAMethodsPutHandlerTest {
 
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
         var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber, TEST_OTP));
-        when(mfaMethodsService.updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest))
+        when(mfaMethodsService.updateMfaMethod(eq(EMAIL), any(), any(), eq(updateRequest)))
                 .thenReturn(Result.failure(new MfaUpdateFailure(failureReason)));
+        when(mfaMethodsService.getMfaMethod(EMAIL, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
         var result = handler.handleRequest(eventWithUpdateRequest, context);
 
         assertThat(result, hasStatus(expectedStatus));
@@ -547,7 +582,12 @@ class MFAMethodsPutHandlerTest {
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
         var eventWithUpdateRequest = event.withBody(updateSmsRequest(phoneNumber, TEST_OTP));
 
-        when(mfaMethodsService.updateMfaMethod(EMAIL, MFA_IDENTIFIER, updateRequest))
+        when(mfaMethodsService.getMfaMethod(EMAIL, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
+        when(mfaMethodsService.updateMfaMethod(eq(EMAIL), any(), any(), eq(updateRequest)))
                 .thenReturn(
                         Result.failure(
                                 new MfaUpdateFailure(
@@ -581,7 +621,12 @@ class MFAMethodsPutHandlerTest {
         var mfaWithInvalidType =
                 new MFAMethod("invalid method type", credential, true, true, "updatedString");
 
-        when(mfaMethodsService.updateMfaMethod(eq(EMAIL), eq(MFA_IDENTIFIER), any()))
+        when(mfaMethodsService.getMfaMethod(EMAIL, MFA_IDENTIFIER))
+                .thenReturn(
+                        Result.success(
+                                new MFAMethodsService.GetMfaResult(
+                                        DEFAULT_SMS_METHOD, List.of(DEFAULT_SMS_METHOD))));
+        when(mfaMethodsService.updateMfaMethod(eq(EMAIL), any(), any(), any()))
                 .thenReturn(
                         Result.success(
                                 new MFAMethodsService.MfaUpdateResponse(

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
@@ -442,7 +442,7 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             codeVerifiedAttributes.put(EXTENSIONS_ACCOUNT_RECOVERY, "false");
             codeVerifiedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             codeVerifiedAttributes.put(EXTENSIONS_MFA_METHOD, DEFAULT.name().toLowerCase());
-            codeVerifiedAttributes.put(EXTENSIONS_MFA_TYPE, AUTH_APP.name());
+            codeVerifiedAttributes.put(EXTENSIONS_MFA_TYPE, SMS.name());
             codeVerifiedAttributes.put(EXTENSIONS_MFA_CODE_ENTERED, otp);
             codeVerifiedAttributes.put(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name());
             eventExpectations.put(AUTH_CODE_VERIFIED.name(), codeVerifiedAttributes);
@@ -522,7 +522,7 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             codeVerifiedAttributes.put(EXTENSIONS_ACCOUNT_RECOVERY, "false");
             codeVerifiedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             codeVerifiedAttributes.put(EXTENSIONS_MFA_METHOD, DEFAULT.name().toLowerCase());
-            codeVerifiedAttributes.put(EXTENSIONS_MFA_TYPE, SMS.name());
+            codeVerifiedAttributes.put(EXTENSIONS_MFA_TYPE, AUTH_APP.name());
             eventExpectations.put(AUTH_CODE_VERIFIED.name(), codeVerifiedAttributes);
 
             verifyAuditEvents(expectedEvents, eventExpectations);
@@ -561,7 +561,7 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             codeVerifiedAttributes.put(EXTENSIONS_ACCOUNT_RECOVERY, "false");
             codeVerifiedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             codeVerifiedAttributes.put(EXTENSIONS_MFA_METHOD, DEFAULT.name().toLowerCase());
-            codeVerifiedAttributes.put(EXTENSIONS_MFA_TYPE, SMS.name());
+            codeVerifiedAttributes.put(EXTENSIONS_MFA_TYPE, AUTH_APP.name());
             eventExpectations.put(AUTH_CODE_VERIFIED.name(), codeVerifiedAttributes);
 
             verifyAuditEvents(expectedEvents, eventExpectations);

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
@@ -64,11 +64,24 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 
 class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String INTERNAL_SECTOR_HOST = "test.account.gov.uk";
-    public static final String UPDATE_SMS_METHOD_REQUEST_TEMPLATE =
+    public static final String UPDATE_DEFAULT_SMS_METHOD_REQUEST_TEMPLATE =
             """
             {
               "mfaMethod": {
                 "priorityIdentifier": "DEFAULT",
+                "method": {
+                    "mfaMethodType": "SMS",
+                    "phoneNumber": "%s",
+                    "otp": "%s"
+                }
+              }
+            }
+            """;
+    public static final String UPDATE_BACKUP_SMS_METHOD_REQUEST_TEMPLATE =
+            """
+            {
+              "mfaMethod": {
+                "priorityIdentifier": "BACKUP",
                 "method": {
                     "mfaMethodType": "SMS",
                     "phoneNumber": "%s",
@@ -269,7 +282,8 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             var mfaIdentifier = defaultSms.getMfaIdentifier();
             var updatedPhoneNumber = "07900000123";
             var updatedPhoneNumberWithCountryCode = "+447900000123";
-            var updateRequest = format(UPDATE_SMS_METHOD_REQUEST_TEMPLATE, updatedPhoneNumber, otp);
+            var updateRequest =
+                    format(UPDATE_DEFAULT_SMS_METHOD_REQUEST_TEMPLATE, updatedPhoneNumber, otp);
 
             var response =
                     makeRequest(
@@ -355,7 +369,8 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             userStore.setMfaMethodsMigrated(TEST_EMAIL, true);
 
             var otp = redis.generateAndSavePhoneNumberCode(TEST_EMAIL, 9000);
-            var updateRequest = format(UPDATE_SMS_METHOD_REQUEST_TEMPLATE, "+447900000123", otp);
+            var updateRequest =
+                    format(UPDATE_DEFAULT_SMS_METHOD_REQUEST_TEMPLATE, "+447900000123", otp);
             var mfaIdentifier = defaultAuthApp.getMfaIdentifier();
 
             var response =
@@ -563,7 +578,10 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             var mfaIdentifier = defaultSms.getMfaIdentifier();
             var updatedPhoneNumber = "07900000123";
             var updateRequest =
-                    format(UPDATE_SMS_METHOD_REQUEST_TEMPLATE, updatedPhoneNumber, invalidOtp);
+                    format(
+                            UPDATE_DEFAULT_SMS_METHOD_REQUEST_TEMPLATE,
+                            updatedPhoneNumber,
+                            invalidOtp);
 
             var response =
                     makeRequest(
@@ -799,7 +817,8 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             var secondPhoneNumber = "+447900000100";
             var otp = redis.generateAndSavePhoneNumberCode(TEST_EMAIL, 9000);
 
-            var updateRequest = format(UPDATE_SMS_METHOD_REQUEST_TEMPLATE, secondPhoneNumber, otp);
+            var updateRequest =
+                    format(UPDATE_DEFAULT_SMS_METHOD_REQUEST_TEMPLATE, secondPhoneNumber, otp);
 
             var response =
                     makeRequest(
@@ -969,7 +988,10 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
             var mfaIdentifierOfBackup = backupSms.getMfaIdentifier();
             var otp = redis.generateAndSavePhoneNumberCode(TEST_EMAIL, 9000);
             var updateRequest =
-                    format(UPDATE_SMS_METHOD_REQUEST_TEMPLATE, backupSms.getDestination(), otp);
+                    format(
+                            UPDATE_BACKUP_SMS_METHOD_REQUEST_TEMPLATE,
+                            backupSms.getDestination(),
+                            otp);
 
             var requestPathParams =
                     Map.ofEntries(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -357,6 +357,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         500, ErrorResponse.AUTH_APP_MFA_ID_ERROR);
                 case USER_DOES_NOT_HAVE_ACCOUNT -> generateApiGatewayProxyErrorResponse(
                         500, ErrorResponse.ACCT_DOES_NOT_EXIST);
+                case UNKNOWN_MFA_IDENTIFIER -> generateApiGatewayProxyErrorResponse(
+                        500, ErrorResponse.INVALID_MFA_METHOD);
             };
         }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -273,6 +273,10 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                     LOG.error("Could not find user profile for reset password request");
                     yield generateApiGatewayProxyErrorResponse(404, ErrorResponse.USER_NOT_FOUND);
                 }
+                case UNKNOWN_MFA_IDENTIFIER -> {
+                    yield generateApiGatewayProxyErrorResponse(
+                            500, ErrorResponse.INVALID_MFA_METHOD);
+                }
             };
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/MFAMethodsServiceIntegrationTest.java
@@ -38,55 +38,41 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.BACKUP_AUTH_APP_METHOD;
+import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.BACKUP_SMS_METHOD;
+import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.DEFAULT_AUTH_APP_METHOD;
+import static uk.gov.di.authentication.shared.helpers.CommonTestVariables.DEFAULT_SMS_METHOD;
 import static uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT;
 
 class MFAMethodsServiceIntegrationTest {
 
     private static final String EMAIL = "joe.bloggs@example.com";
-    private static final String PHONE_NUMBER_WITHOUT_COUNTRY_CODE = "07900000000";
-    private static final String PHONE_NUMBER_WITH_COUNTRY_CODE = "+447900000000";
-    private static final String PHONE_NUMBER_TWO_WITH_COUNTRY_CODE = "+447900000100";
+    private static final String PHONE_NUMBER_WITH_COUNTRY_CODE =
+            DEFAULT_SMS_METHOD.getDestination();
+    private static final String PHONE_NUMBER_WITHOUT_COUNTRY_CODE =
+            "0" + PHONE_NUMBER_WITH_COUNTRY_CODE.substring(3);
     private static final String AUTH_APP_CREDENTIAL = "some-credential";
-    private static final String SMS_MFA_IDENTIFIER_1 = "ea83592f-b9bf-436f-b4f4-ee33f610ee05";
-    private static final String SMS_MFA_IDENTIFIER_2 = "3634a5e3-dac8-4804-8d40-181722b48ae1";
-    private static final String APP_MFA_IDENTIFIER_1 = "a87e57e5-6175-4be7-af7d-547a390b36c1";
-    private static final String APP_MFA_IDENTIFIER_2 = "898a7e13-c354-430a-a3ca-8cc6c6391057";
-    private static final MFAMethod defaultPriorityAuthApp =
-            MFAMethod.authAppMfaMethod(
-                    AUTH_APP_CREDENTIAL,
-                    true,
-                    true,
-                    PriorityIdentifier.DEFAULT,
-                    APP_MFA_IDENTIFIER_1);
     private static final String AUTH_APP_CREDENTIAL_TWO = "another-credential";
-    private static final MFAMethod backupPriorityAuthApp =
-            MFAMethod.authAppMfaMethod(
-                    AUTH_APP_CREDENTIAL_TWO,
-                    true,
-                    true,
-                    PriorityIdentifier.BACKUP,
-                    APP_MFA_IDENTIFIER_2);
-    private static final MFAMethod defaultPrioritySms =
-            MFAMethod.smsMfaMethod(
-                    true,
-                    true,
-                    PHONE_NUMBER_WITH_COUNTRY_CODE,
-                    PriorityIdentifier.DEFAULT,
-                    SMS_MFA_IDENTIFIER_1);
-    private static final MFAMethod backupPrioritySms =
-            MFAMethod.smsMfaMethod(
-                    true,
-                    true,
-                    PHONE_NUMBER_TWO_WITH_COUNTRY_CODE,
-                    PriorityIdentifier.BACKUP,
-                    SMS_MFA_IDENTIFIER_2);
+    private static MFAMethod defaultPriorityAuthApp;
+    private static MFAMethod backupPriorityAuthApp;
+    private static MFAMethod defaultPrioritySms;
+    private static MFAMethod backupPrioritySms;
     MFAMethodsService mfaMethodsService = new MFAMethodsService(ConfigurationService.getInstance());
     private UserProfile userProfile;
 
     @RegisterExtension static UserStoreExtension userStoreExtension = new UserStoreExtension();
+
+    @BeforeEach
+    void setUp() {
+        defaultPriorityAuthApp = new MFAMethod(DEFAULT_AUTH_APP_METHOD);
+        backupPriorityAuthApp = new MFAMethod(BACKUP_AUTH_APP_METHOD);
+        defaultPrioritySms = new MFAMethod(DEFAULT_SMS_METHOD);
+        backupPrioritySms = new MFAMethod(BACKUP_SMS_METHOD);
+    }
 
     @Nested
     class CheckIfPhoneNumberInUse {
@@ -223,7 +209,7 @@ class MFAMethodsServiceIntegrationTest {
                             PHONE_NUMBER_WITH_COUNTRY_CODE,
                             PriorityIdentifier.DEFAULT,
                             mfaIdentifier);
-            assertEquals(List.of(expectedData), result);
+            assertIterableEquals(List.of(expectedData), result);
         }
 
         @ParameterizedTest
@@ -244,7 +230,7 @@ class MFAMethodsServiceIntegrationTest {
                             PHONE_NUMBER_WITH_COUNTRY_CODE,
                             PriorityIdentifier.DEFAULT,
                             mfaIdentifier);
-            assertEquals(List.of(expectedData), result);
+            assertIterableEquals(List.of(expectedData), result);
         }
 
         @ParameterizedTest
@@ -333,7 +319,7 @@ class MFAMethodsServiceIntegrationTest {
 
             var result = mfaMethodsService.getMfaMethods(email).getSuccess();
 
-            assertEquals(List.of(), result);
+            assertIterableEquals(List.of(), result);
         }
 
         @ParameterizedTest
@@ -559,7 +545,7 @@ class MFAMethodsServiceIntegrationTest {
 
             var result = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
-            assertEquals(List.of(defaultPrioritySms), result);
+            assertIterableEquals(List.of(defaultPrioritySms), result);
         }
 
         @Test
@@ -568,7 +554,7 @@ class MFAMethodsServiceIntegrationTest {
 
             var result = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
-            assertEquals(List.of(defaultPriorityAuthApp), result);
+            assertIterableEquals(List.of(defaultPriorityAuthApp), result);
         }
 
         private static Stream<List<MFAMethod>> mfaMethodsCombinations() {
@@ -1071,7 +1057,7 @@ class MFAMethodsServiceIntegrationTest {
                         result.getFailure().failureReason());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
-                assertEquals(List.of(defaultPrioritySms), remainingMfaMethods);
+                assertIterableEquals(List.of(defaultPrioritySms), remainingMfaMethods);
             }
 
             @Test
@@ -1115,7 +1101,7 @@ class MFAMethodsServiceIntegrationTest {
                         result.getFailure().failureReason());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
-                assertEquals(List.of(existingMethod), remainingMfaMethods);
+                assertIterableEquals(List.of(existingMethod), remainingMfaMethods);
             }
         }
 
@@ -1185,7 +1171,7 @@ class MFAMethodsServiceIntegrationTest {
                         result.getFailure().failureReason());
 
                 var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
-                assertEquals(List.of(existingMethod), remainingMfaMethods);
+                assertIterableEquals(List.of(existingMethod), remainingMfaMethods);
             }
         }
     }
@@ -1212,7 +1198,7 @@ class MFAMethodsServiceIntegrationTest {
 
             var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
-            assertEquals(List.of(defaultPrioritySms), remainingMfaMethods);
+            assertIterableEquals(List.of(defaultPrioritySms), remainingMfaMethods);
         }
 
         @Test
@@ -1230,7 +1216,7 @@ class MFAMethodsServiceIntegrationTest {
 
             var remainingMfaMethods = mfaMethodsService.getMfaMethods(EMAIL).getSuccess();
 
-            assertEquals(List.of(defaultPriorityAuthApp), remainingMfaMethods);
+            assertIterableEquals(List.of(defaultPriorityAuthApp), remainingMfaMethods);
         }
 
         @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.asJson;
 
 public class AuditAssertionsHelper {
@@ -138,10 +139,11 @@ public class AuditAssertionsHelper {
             AuditContext capturedObject, String field, String value) {
         capturedObject
                 .getMetadataItemByKey(field)
-                .ifPresent(
+                .ifPresentOrElse(
                         actualMetadataPairForMfaMethod ->
                                 assertEquals(
                                         AuditService.MetadataPair.pair(field, value),
-                                        actualMetadataPairForMfaMethod));
+                                        actualMetadataPairForMfaMethod),
+                        () -> fail("Missing metadata key: " + field));
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditEventExpectation.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditEventExpectation.java
@@ -52,7 +52,10 @@ public class AuditEventExpectation {
                             return jsonObj.get("event_name").getAsString().equalsIgnoreCase(name);
                         })
                 .findFirst()
-                .orElseThrow(() -> new AssertionFailedError("Missing " + name + " audit event."));
+                .orElseThrow(
+                        () ->
+                                new AssertionFailedError(
+                                        "Missing " + name + " audit event " + eventName));
     }
 
     private JsonElement getJsonElementByPath(JsonObject json, String path) {
@@ -63,10 +66,12 @@ public class AuditEventExpectation {
             if (current.isJsonObject()) {
                 current = current.getAsJsonObject().get(part);
                 if (current == null) {
-                    throw new AssertionFailedError("Path " + path + " not found in event");
+                    throw new AssertionFailedError(
+                            "Path " + path + " not found in event " + eventName);
                 }
             } else {
-                throw new AssertionFailedError("Cannot navigate path " + path + " in event");
+                throw new AssertionFailedError(
+                        "Cannot navigate path " + path + " in event " + eventName);
             }
         }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
@@ -9,6 +9,8 @@ public interface AuditableEvent {
     String AUDIT_EVENT_EXTENSIONS_MIGRATION_SUCCEEDED = "migration-succeeded";
     String AUDIT_EVENT_EXTENSIONS_HAD_PARTIAL = "had-partial";
     String AUDIT_EVENT_EXTENSIONS_ATTEMPT_NO_FAILED_AT = "attemptNoFailedAt";
+    String AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE = "notification-type";
+    String AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED = "MFACodeEntered";
 
     AuditableEvent parseFromName(String name);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -109,7 +109,8 @@ public enum ErrorResponse {
     ACCT_SUSPENDED(1083, "User's account is suspended"),
     ACCT_BLOCKED(1084, "User's account is blocked"),
     NO_USER_PROFILE_FOR_EMAIL(1085, "Email from request does not have a user profile"),
-    USER_DOES_NOT_HAVE_ACCOUNT(1086, "Email from request does not have any user credentials");
+    USER_DOES_NOT_HAVE_ACCOUNT(1086, "Email from request does not have any user credentials"),
+    FAILED_TO_RAISE_AUDIT_EVENT(1087, "Failed to raise an audit event");
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/MFAMethod.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/mfa/MFAMethod.java
@@ -44,6 +44,18 @@ public class MFAMethod implements Comparable<MFAMethod> {
         this.updated = updated;
     }
 
+    public MFAMethod(MFAMethod source) {
+        if (source == null) throw new IllegalArgumentException("MFAMethod is required to copy");
+        this.mfaMethodType = source.getMfaMethodType();
+        this.credentialValue = source.getCredentialValue();
+        this.methodVerified = source.methodVerified;
+        this.enabled = source.enabled;
+        this.updated = source.getUpdated();
+        this.destination = source.getDestination();
+        this.priority = source.getPriority();
+        this.mfaIdentifier = source.getMfaIdentifier();
+    }
+
     public static MFAMethod authAppMfaMethod(
             String credentialValue,
             boolean methodVerified,
@@ -197,7 +209,6 @@ public class MFAMethod implements Comparable<MFAMethod> {
                 && Objects.equals(credentialValue, that.credentialValue)
                 && Objects.equals(methodVerified, that.methodVerified)
                 && Objects.equals(enabled, that.enabled)
-                && Objects.equals(updated, that.updated)
                 && Objects.equals(destination, that.destination)
                 && Objects.equals(priority, that.priority)
                 && Objects.equals(mfaIdentifier, that.mfaIdentifier);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaRetrieveFailureReason.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/mfa/MfaRetrieveFailureReason.java
@@ -2,5 +2,6 @@ package uk.gov.di.authentication.shared.services.mfa;
 
 public enum MfaRetrieveFailureReason {
     UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP,
-    USER_DOES_NOT_HAVE_ACCOUNT
+    USER_DOES_NOT_HAVE_ACCOUNT,
+    UNKNOWN_MFA_IDENTIFIER
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/MFAMethodsServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/MFAMethodsServiceTest.java
@@ -188,7 +188,7 @@ public class MFAMethodsServiceTest {
             when(persistentService.updateMfaMethods(any(), any()))
                     .thenReturn(Result.success(mockMfaMethods));
 
-            service.updateMfaMethod("some-email@email.com", identifier, request);
+            service.updateMfaMethod("some-email@email.com", mfaMethod, mockMfaMethods, request);
 
             verify(cloudwatchMetricsService)
                     .incrementMfaMethodCounter(
@@ -224,7 +224,8 @@ public class MFAMethodsServiceTest {
             when(persistentService.updateAllMfaMethodsForUser(any(), any()))
                     .thenReturn(Result.success(mockMfaMethods));
 
-            service.updateMfaMethod("some-email@email.com", backupIdentifier, request);
+            service.updateMfaMethod(
+                    "some-email@email.com", backupMfaMethod, mockMfaMethods, request);
 
             verify(cloudwatchMetricsService)
                     .incrementMfaMethodCounter(


### PR DESCRIPTION
## What

This introduces the `AUTH_CODE_VERIFIED` audit event to the `account-management-api` which is raised when a user successfully verifies an OTP via the `MFAMethodsCreateHandler` and `MFAMethodsPutHandler`.

- A new `getMfaMethod` function was created to fetch a specific MFA method's data before it is updated.
- The `updateMfaMethod` function was refactored to no longer fetch the MFA method itself. The method must now be provided.
- The audit context construction in the `MFAMethodsCreateHandler` and `MFAMethodsPutHandler` was refactored for clarity and consistency.

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [X] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
