### PR TITLE
ATO-1782 add metric for request blocked

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -200,12 +200,14 @@ public class AuthorisationHandler
                         kmsConnectionService,
                         jwksService,
                         stateStorageService);
-        this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
+        var cloudwatchMetricService = new CloudwatchMetricsService(configurationService);
+        this.cloudwatchMetricsService = cloudwatchMetricService;
         this.tokenValidationService = new TokenValidationService(jwksService, configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
         this.authorisationService = new AuthorisationService(configurationService);
         var slidingWindowAlgorithm = new SlidingWindowAlgorithm(configurationService);
-        this.rateLimitService = new RateLimitService(slidingWindowAlgorithm);
+        this.rateLimitService =
+                new RateLimitService(slidingWindowAlgorithm, cloudwatchMetricService);
     }
 
     public AuthorisationHandler(
@@ -230,14 +232,16 @@ public class AuthorisationHandler
                         kmsConnectionService,
                         jwksService,
                         stateStorageService);
-        this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
+        var cloudwatchMetricService = new CloudwatchMetricsService(configurationService);
+        this.cloudwatchMetricsService = cloudwatchMetricService;
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService, redis);
         this.tokenValidationService = new TokenValidationService(jwksService, configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
         this.authorisationService = new AuthorisationService(configurationService);
         this.rateLimitService =
-                new RateLimitService(new SlidingWindowAlgorithm(configurationService));
+                new RateLimitService(
+                        new SlidingWindowAlgorithm(configurationService), cloudwatchMetricService);
     }
 
     public AuthorisationHandler() {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RateLimitService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RateLimitService.java
@@ -1,15 +1,25 @@
 package uk.gov.di.authentication.oidc.services;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.ClientRateLimitConfig;
 import uk.gov.di.authentication.oidc.entity.RateLimitAlgorithm;
 import uk.gov.di.authentication.oidc.entity.RateLimitDecision;
+import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
+
+import java.util.Map;
 
 public class RateLimitService {
 
     private final RateLimitAlgorithm rateLimitAlgorithm;
+    private final CloudwatchMetricsService cloudwatchMetricsService;
+    private static final Logger LOG = LogManager.getLogger(RateLimitService.class);
 
-    public RateLimitService(RateLimitAlgorithm rateLimitAlgorithm) {
+    public RateLimitService(
+            RateLimitAlgorithm rateLimitAlgorithm,
+            CloudwatchMetricsService cloudwatchMetricsService) {
         this.rateLimitAlgorithm = rateLimitAlgorithm;
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
     }
 
     public RateLimitDecision getClientRateLimitDecision(
@@ -18,9 +28,28 @@ public class RateLimitService {
             return RateLimitDecision.NOT_CONFIGURED_NO_ACTION;
         }
 
-        if (rateLimitAlgorithm.hasRateLimitExceeded(clientRateLimitConfig)) {
-            return RateLimitDecision.OVER_LIMIT_RETURN_TO_RP;
+        var rateLimitExceeded = rateLimitAlgorithm.hasRateLimitExceeded(clientRateLimitConfig);
+
+        if (rateLimitExceeded) {
+            var decision = RateLimitDecision.OVER_LIMIT_RETURN_TO_RP;
+            emitRateLimitExceededMetric(decision, clientRateLimitConfig.clientID());
+
+            return decision;
         }
         return RateLimitDecision.UNDER_LIMIT_NO_ACTION;
+    }
+
+    private void emitRateLimitExceededMetric(RateLimitDecision rateLimitDecision, String clientId) {
+        try {
+            cloudwatchMetricsService.incrementCounter(
+                    "RpRateLimitExceeded",
+                    Map.of(
+                            "clientId",
+                            clientId,
+                            "action",
+                            rateLimitDecision.getAction().toString()));
+        } catch (Exception e) {
+            LOG.warn("Error incrementing RpRateLimitExceeded metric", e);
+        }
     }
 }


### PR DESCRIPTION
### Wider context of change: 
- We want to add a metric for when a rate limit has been exceeded

### What’s changed: 
- Adds a new metric RpRateLimitExceeded

### Manual testing: 
- N/A just emitting a metric

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
