### PR TITLE
ATO-1802: Remove ClientRateLimitData table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -6434,29 +6434,6 @@ Resources:
               ArnLike:
                 kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
 
-  ClientRateLimitTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      TableName: !Sub ${Environment}-Client-Rate-Limit
-      AttributeDefinitions:
-        - AttributeName: ClientId
-          AttributeType: S
-      KeySchema:
-        - AttributeName: ClientId
-          KeyType: HASH
-      BillingMode: PAY_PER_REQUEST
-      SSESpecification:
-        SSEEnabled: true
-        KMSMasterKeyId: !GetAtt ClientRateLimitTableEncryptionKey.Arn
-        SSEType: KMS
-      TimeToLiveSpecification:
-        AttributeName: ttl
-        Enabled: true
-      PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
-      Tags:
-        - Key: Name
-          Value: ClientRateLimitTable
   #endregion
   #region StateStorage policies
   StateStorageTableReadAccessPolicy:


### PR DESCRIPTION
### Wider context of change

We would like to use this table with a rate limiting algorithm. This involves adding a sort key to this table. However, we cannot do this without recreating the table. Fortunately, this table is unused at the moment so we can just recreate it.

### What’s changed

This PR removes the ClientRateLimitData table.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs
PR to add table back with a sort key: https://github.com/govuk-one-login/authentication-api/pull/6832
