### PR TITLE
AUT-4565: mfa-reset-authorize lambda egress setup for accessing identity api

### DIFF
--- a/ci/cloudformation/auth/function/mfa-reset-authorize.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-authorize.yaml
@@ -120,11 +120,12 @@ Resources:
         - !Ref RedisParametersAccessPolicy
       VpcConfig:
         SecurityGroupIds:
+          - !Ref HttpsEgressSecurityGroup
           - !Ref LambdaSecurityGroup
         SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdC
 
   MfaResetAuthorizeFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
## What

mfa-reset-authorize lambda egress setup for accessing identity api

<!-- Describe what you have changed and why -->

## How to review

As devplatform VPC is used, it requires
1. the lambda to be deployed to protected subnets
2. to attach the egress security group