### PR TITLE
ATO-1783: Redirect to RP if client is rate limited

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -382,7 +382,12 @@ public class AuthorisationHandler
             if (rateLimitDecision.hasExceededRateLimit()) {
                 switch (rateLimitDecision.getAction()) {
                     case RETURN_TO_RP -> {
-                        // ATO-1783: return an oAuth Error here to say unavailable
+                        authRequestError =
+                                Optional.of(
+                                        new AuthRequestError(
+                                                OAuth2Error.TEMPORARILY_UNAVAILABLE,
+                                                authRequest.getRedirectionURI(),
+                                                authRequest.getState()));
                     }
                     case NONE -> {
                         // continue

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -345,23 +345,6 @@ public class AuthorisationHandler
             }
         }
 
-        if (configurationService.isRpRateLimitingEnabled()) {
-            var rateLimitDecision =
-                    rateLimitService.getClientRateLimitDecision(
-                            ClientRateLimitConfig.fromClientRegistry(client));
-
-            if (rateLimitDecision.hasExceededRateLimit()) {
-                switch (rateLimitDecision.getAction()) {
-                    case RETURN_TO_RP -> {
-                        // ATO-1783: return an oAuth Error here to say unavailable
-                    }
-                    case NONE -> {
-                        // continue
-                    }
-                }
-            }
-        }
-
         try {
             if (authRequest.getRequestObject() == null) {
                 LOG.info("Validating request query params");
@@ -389,6 +372,23 @@ public class AuthorisationHandler
                     new ErrorObject(UNAUTHORIZED_CLIENT_CODE, "client deactivated"),
                     authRequest.getClientID().getValue(),
                     user);
+        }
+
+        if (configurationService.isRpRateLimitingEnabled()) {
+            var rateLimitDecision =
+                    rateLimitService.getClientRateLimitDecision(
+                            ClientRateLimitConfig.fromClientRegistry(client));
+
+            if (rateLimitDecision.hasExceededRateLimit()) {
+                switch (rateLimitDecision.getAction()) {
+                    case RETURN_TO_RP -> {
+                        // ATO-1783: return an oAuth Error here to say unavailable
+                    }
+                    case NONE -> {
+                        // continue
+                    }
+                }
+            }
         }
 
         if (authRequestError.isPresent()) {


### PR DESCRIPTION
### Wider context of change

We have a service that soon will determine if a client has exceeded their configured rate limit. At the moment if they have exceeded their rate limit nothing happens. We would like to redirect them back to the RP with the error `TEMPORARILY_UNAVAILABLE` if they are being rate limited.

The actual implementation of the algorithm is being handled in other tickets. However, since we've configured the service to use an algorithm interface, we can work on this ticket independently, and mock the result of the RateLimitService to check that the redirect works.

### What’s changed

When the `RateLimitService` returns an `OVER_LIMIT_RETURN_TO_RP` decision, the user will be redirected to the RP, using the redirectURI in the auth request. 

### Manual testing

Tested in authdev3 by setting a rate limit for the dev RP. Hit the authorize endpoint enough times to trigger the error redirect. I then waited a bit of time and tried hitting authorize again, and was allowed through to the login page.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
