### PR TITLE
ATO-1842: Validate redirectUri before client isActive check

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -346,17 +346,6 @@ public class AuthorisationHandler
             }
         }
 
-        if (!client.isActive()) {
-            LOG.error("Client configured as not active in Client Registry");
-            return generateErrorResponse(
-                    authRequest.getRedirectionURI(),
-                    authRequest.getState(),
-                    authRequest.getResponseMode(),
-                    new ErrorObject(UNAUTHORIZED_CLIENT_CODE, "client deactivated"),
-                    authRequest.getClientID().getValue(),
-                    user);
-        }
-
         if (configurationService.isRpRateLimitingEnabled()) {
             var rateLimitDecision =
                     rateLimitService.getClientRateLimitDecision(
@@ -390,6 +379,17 @@ public class AuthorisationHandler
         } catch (JwksException e) {
             return generateApiGatewayProxyResponse(
                     SERVER_ERROR.getHTTPStatusCode(), SERVER_ERROR.getDescription());
+        }
+
+        if (!client.isActive()) {
+            LOG.error("Client configured as not active in Client Registry");
+            return generateErrorResponse(
+                    authRequest.getRedirectionURI(),
+                    authRequest.getState(),
+                    authRequest.getResponseMode(),
+                    new ErrorObject(UNAUTHORIZED_CLIENT_CODE, "client deactivated"),
+                    authRequest.getClientID().getValue(),
+                    user);
         }
 
         if (authRequestError.isPresent()) {


### PR DESCRIPTION
### Wider context of change

Previously, if a client was disabled, and sent us an auth request with an invalid redirect URI (one that was not configured for them in the client registry), the redirect would succeed.

### What’s changed

This PR moves the `client.isActive()` check to after the validation of the query parameters / request object. These validators check if the redirectUri is valid for a client, and exit early if the client has an invalid redirectUri. We can therefore be confident that the redirectUri is valid once the validators have exited without throwing an exception. 

### Manual testing

This is covered by an existing unit test (`shouldReturn400WhenAuthorisationRequestContainsInvalidRedirectUri`)

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
