### PR TITLE
BAU: Pin minimum org.apache.commons:commons-lang3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,10 @@ subprojects {
                 classpath('commons-beanutils:commons-beanutils:[1.11.0,)') {
                     because 'CVE-2025-48734 is fixed in commons-beanutils:commons-beanutils:1.11.0 and higher'
                 }
+
+                classpath('org.apache.commons:commons-lang3:[3.18.0,)') {
+                    because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.18.0 and higher'
+                }
             }
         }
     }
@@ -158,6 +162,10 @@ subprojects {
                 add(conf.name, 'commons-beanutils:commons-beanutils:[1.11.0,)') {
                     because 'CVE-2025-48734 is fixed in commons-beanutils:commons-beanutils:1.11.0 and higher'
                 }
+
+                add(conf.name, 'org.apache.commons:commons-lang3:[3.18.0,)') {
+                    because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.18.0 and higher'
+                }
             }
         }
 
@@ -166,7 +174,7 @@ subprojects {
                 "org.apache.commons:commons-collections4:4.5.0",
                 "commons-net:commons-net:3.11.1",
                 "commons-io:commons-io:2.20.0",
-                "org.apache.commons:commons-lang3:3.17.0"
+                "org.apache.commons:commons-lang3:3.18.0"
 
         bouncycastle "org.bouncycastle:bcpkix-jdk18on:1.81"
 

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/pact/LambdaHandlerConfig.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/pact/LambdaHandlerConfig.java
@@ -3,7 +3,7 @@ package uk.gov.di.orchestration.sharedtest.pact;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -47,7 +47,7 @@ public class LambdaHandlerConfig {
         var pathRegexGroupNames = new LinkedList<String>();
         var pathPattern = new StringBuilder();
         pathPattern.append("^");
-        var pathElems = StringUtils.removeStart(path, "/").split("/");
+        var pathElems = Strings.CS.removeStart(path, "/").split("/");
         for (var pathElem : pathElems) {
             pathPattern.append("/");
             var paramMatch = PATH_PARAM_REGEX.matcher(pathElem);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/ConstructUriHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/ConstructUriHelper.java
@@ -1,6 +1,6 @@
 package uk.gov.di.orchestration.shared.helpers;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.hc.core5.net.URIBuilder;
 
 import java.net.URI;
@@ -44,7 +44,7 @@ public class ConstructUriHelper {
             var uriBuilder =
                     path.isEmpty()
                             ? new URIBuilder(baseUri)
-                            : new URIBuilder(StringUtils.removeEnd(baseUri, "/"));
+                            : new URIBuilder(Strings.CS.removeEnd(baseUri, "/"));
             path.ifPresent(uriBuilder::appendPath);
             queryParams.ifPresent(
                     qp -> {


### PR DESCRIPTION
## What

CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.18.0 and higher. Had to update our use of the strings library.

## How to review

1. Code review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [X] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.