### PR TITLE
BAU OTel java http client for Orchestration

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -28,6 +28,7 @@ import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.ge
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.orchestration.shared.services.AuditService.UNKNOWN;
 
 public class ClientRegistrationHandler
@@ -68,6 +69,7 @@ public class ClientRegistrationHandler
 
     public APIGatewayProxyResponseEvent clientRegistrationRequestHandler(
             APIGatewayProxyRequestEvent input, Context context) {
+        attachTraceId();
         String ipAddress = IpAddressHelper.extractIpAddress(input);
 
         var user =

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -30,6 +30,7 @@ import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.ge
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.orchestration.shared.services.AuditService.UNKNOWN;
 
 public class UpdateClientConfigHandler
@@ -70,6 +71,7 @@ public class UpdateClientConfigHandler
 
     public APIGatewayProxyResponseEvent updateClientRequestHandler(
             APIGatewayProxyRequestEvent input, Context context) {
+        attachTraceId();
         String ipAddress = IpAddressHelper.extractIpAddress(input);
 
         var user = TxmaAuditUser.user().withIpAddress(ipAddress);

--- a/client-registry-api/src/main/resources/log4j2.xml
+++ b/client-registry-api/src/main/resources/log4j2.xml
@@ -3,6 +3,7 @@
         <Lambda name="Lambda">
             <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
                 <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+                <KeyValuePair key="trace-id" value="$${ctx:traceId:-}"/>
             </JsonLayout>
         </Lambda>
     </Appenders>

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -61,6 +61,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
 
 public class DocAppCallbackHandler
@@ -175,6 +176,7 @@ public class DocAppCallbackHandler
 
     public APIGatewayProxyResponseEvent docAppCallbackRequestHandler(
             APIGatewayProxyRequestEvent input, Context context) {
+        attachTraceId();
         LOG.info("Request received to DocAppCallbackHandler");
         attachTxmaAuditFieldFromHeaders(input.getHeaders());
         try {

--- a/doc-checking-app-api/src/main/resources/log4j2.xml
+++ b/doc-checking-app-api/src/main/resources/log4j2.xml
@@ -8,6 +8,7 @@
                 <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
                 <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
                 <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
+                <KeyValuePair key="trace-id" value="$${ctx:traceId:-}"/>
             </JsonLayout>
         </Lambda>
     </Appenders>

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -74,6 +74,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class IPVCallbackHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -186,6 +187,7 @@ public class IPVCallbackHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         LOG.info("Request received to IPVCallbackHandler");
         attachTxmaAuditFieldFromHeaders(input.getHeaders());
         try {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_CAPACITY_REQUESTED;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class IPVCapacityHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -38,7 +39,7 @@ public class IPVCapacityHandler
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-
+        attachTraceId();
         LOG.info("Request received to IPVCapacityHandler");
         auditService.submitAuditEvent(
                 IPV_CAPACITY_REQUESTED, AuditService.UNKNOWN, TxmaAuditUser.user());

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IpvJwksHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IpvJwksHandler.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class IpvJwksHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -48,6 +49,7 @@ public class IpvJwksHandler
 
     public APIGatewayProxyResponseEvent ipvJwksRequestHandler() {
         try {
+            attachTraceId();
             LOG.info("IpvJwks request received");
 
             List<JWK> signingKeys = new ArrayList<>();

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -27,6 +27,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
 
@@ -56,6 +57,7 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
         for (SQSMessage msg : event.getRecords()) {
             try {
                 ThreadContext.clearMap();
+                attachTraceId();
                 var spotResponse = objectMapper.readValue(msg.getBody(), SPOTResponse.class);
                 var logIds = spotResponse.getLogIds();
 

--- a/ipv-api/src/main/resources/log4j2.xml
+++ b/ipv-api/src/main/resources/log4j2.xml
@@ -8,6 +8,7 @@
                 <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
                 <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
                 <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
+                <KeyValuePair key="trace-id" value="$${ctx:traceId:-}"/>
             </JsonLayout>
         </Lambda>
     </Appenders>

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -60,6 +60,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachOrchSessionIdToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.orchestration.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
 
@@ -124,6 +125,7 @@ public class AuthCodeHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -94,6 +94,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.orchestration.shared.services.AuditService.UNKNOWN;
 
@@ -236,6 +237,7 @@ public class AuthenticationCallbackHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         LOG.info("Request received to AuthenticationCallbackHandler");
         attachTxmaAuditFieldFromHeaders(input.getHeaders());

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -115,6 +115,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachOrchSessionIdToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.updateAttachedLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.updateAttachedSessionIdToLogs;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
@@ -251,6 +252,7 @@ public class AuthorisationHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
@@ -36,6 +36,7 @@ import static java.util.Collections.emptyMap;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class BackChannelLogoutRequestHandler implements RequestHandler<SQSEvent, Object> {
 
@@ -72,6 +73,7 @@ public class BackChannelLogoutRequestHandler implements RequestHandler<SQSEvent,
     @Override
     public Object handleRequest(SQSEvent event, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/FetchJwksHandler.java
@@ -14,6 +14,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
+
 public class FetchJwksHandler implements RequestHandler<Map<String, String>, String> {
 
     private final JwksService jwksService;
@@ -35,6 +37,7 @@ public class FetchJwksHandler implements RequestHandler<Map<String, String>, Str
 
     @Override
     public String handleRequest(Map<String, String> event, Context context) {
+        attachTraceId();
         String url = event.get("url");
         String keyId = event.get("keyId");
         final String errorResponse = "error";

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandler.java
@@ -20,6 +20,7 @@ import static uk.gov.di.authentication.oidc.validators.GlobalLogoutValidator.val
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class GlobalLogoutHandler implements RequestHandler<SQSEvent, Object> {
     private static final Logger LOG = LogManager.getLogger(GlobalLogoutHandler.class);
@@ -40,6 +41,7 @@ public class GlobalLogoutHandler implements RequestHandler<SQSEvent, Object> {
     @Override
     public Object handleRequest(SQSEvent sqsEvent, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(), () -> processEvents(sqsEvent));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
@@ -21,6 +21,7 @@ import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.ge
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class JwksHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -49,6 +50,7 @@ public class JwksHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -26,6 +26,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class LogoutHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -69,6 +70,7 @@ public class LogoutHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(), () -> logoutRequestHandler(input));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/OrchFrontendAuthorizerHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/OrchFrontendAuthorizerHandler.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class OrchFrontendAuthorizerHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, Map<String, Object>> {
@@ -48,6 +49,7 @@ public class OrchFrontendAuthorizerHandler
     @Override
     public Map<String, Object> handleRequest(APIGatewayProxyRequestEvent event, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(),
                 () -> orchFrontendAuthorizerHandler(event, context));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/StorageTokenJwkHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/StorageTokenJwkHandler.java
@@ -21,6 +21,7 @@ import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.ge
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class StorageTokenJwkHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -46,6 +47,7 @@ public class StorageTokenJwkHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(), this::storageTokenJwkRequestHandler);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -70,6 +70,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.updateAttachedLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.RequestBodyHelper.parseRequestBody;
 
@@ -162,6 +163,7 @@ public class TokenHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(), () -> tokenRequestHandler(input));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
@@ -22,6 +22,7 @@ import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.ge
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class TrustMarkHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -41,6 +42,7 @@ public class TrustMarkHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -46,6 +46,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.orchestration.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
 import static uk.gov.di.orchestration.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
@@ -130,6 +131,7 @@ public class UserInfoHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -35,6 +35,7 @@ import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.ge
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class WellknownHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -64,6 +65,7 @@ public class WellknownHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
         return segmentedFunctionCall(
                 "oidc-api::" + getClass().getSimpleName(),

--- a/oidc-api/src/main/resources/log4j2.xml
+++ b/oidc-api/src/main/resources/log4j2.xml
@@ -8,6 +8,7 @@
                 <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
                 <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
                 <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
+                <KeyValuePair key="trace-id" value="$${ctx:traceId:-}"/>
             </JsonLayout>
         </Lambda>
     </Appenders>

--- a/orchestration-shared/build.gradle
+++ b/orchestration-shared/build.gradle
@@ -26,6 +26,7 @@ dependencies {
             configurations.cloudwatch,
             configurations.gson,
             configurations.apache,
+            configurations.open_telemetry,
             "org.apache.httpcomponents.core5:httpcore5:5.3.4"
 
     testImplementation configurations.tests,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/HttpClientHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/HttpClientHelper.java
@@ -1,0 +1,16 @@
+package uk.gov.di.orchestration.shared.helpers;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.javahttpclient.JavaHttpClientTelemetry;
+
+import java.net.http.HttpClient;
+
+public class HttpClientHelper {
+    private HttpClientHelper() {}
+
+    public static HttpClient newInstrumentedHttpClient() {
+        return JavaHttpClientTelemetry.builder(GlobalOpenTelemetry.get())
+                .build()
+                .newHttpClient(HttpClient.newHttpClient());
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/LogLineHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/LogLineHelper.java
@@ -1,10 +1,12 @@
 package uk.gov.di.orchestration.shared.helpers;
 
+import io.opentelemetry.api.trace.Span;
 import org.apache.logging.log4j.ThreadContext;
 
 import static uk.gov.di.orchestration.shared.helpers.InputSanitiser.sanitiseBase64;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.ORCH_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.SESSION_ID;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.TRACE_ID;
 
 public class LogLineHelper {
 
@@ -18,7 +20,8 @@ public class LogLineHelper {
         PERSISTENT_SESSION_ID("persistentSessionId", true),
         AWS_REQUEST_ID("awsRequestId", false),
         CLIENT_ID("clientId", true),
-        CLIENT_NAME("clientName", false);
+        CLIENT_NAME("clientName", false),
+        TRACE_ID("traceId", false);
 
         private final String logFieldName;
         private boolean isBase64;
@@ -61,5 +64,14 @@ public class LogLineHelper {
 
     public static void attachOrchSessionIdToLogs(String orchSessionId) {
         attachLogFieldToLogs(ORCH_SESSION_ID, orchSessionId);
+    }
+
+    public static void attachTraceId() {
+        // Adapted from
+        // https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-log-enrichment#retrieve-span-and-trace-ids
+        var spanContext = Span.current().getSpanContext();
+        if (spanContext.isValid()) {
+            attachLogFieldToLogs(TRACE_ID, spanContext.getTraceId());
+        }
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/lambda/BaseFrontendHandler.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/lambda/BaseFrontendHandler.java
@@ -37,6 +37,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.UNKNOWN;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.orchestration.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
 import static uk.gov.di.orchestration.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeadersOpt;
 
@@ -110,6 +111,7 @@ public abstract class BaseFrontendHandler<T>
     private APIGatewayProxyResponseEvent validateAndHandleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         String sessionId;
         var sessionIdOpt =
                 getHeaderValueFromHeadersOpt(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/lambda/BaseOrchestrationFrontendHandler.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/lambda/BaseOrchestrationFrontendHandler.java
@@ -24,6 +24,7 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.UNKNOWN;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.orchestration.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeadersOpt;
 
 public abstract class BaseOrchestrationFrontendHandler
@@ -65,6 +66,7 @@ public abstract class BaseOrchestrationFrontendHandler
     private APIGatewayProxyResponseEvent validateAndHandleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         ThreadContext.clearMap();
+        attachTraceId();
         var sessionIdOpt =
                 getHeaderValueFromHeadersOpt(
                         input.getHeaders(),

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/AccountInterventionService.java
@@ -7,6 +7,7 @@ import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionResponse;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.exceptions.AccountInterventionException;
+import uk.gov.di.orchestration.shared.helpers.HttpClientHelper;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AuditService.MetadataPair;
 
@@ -39,7 +40,7 @@ public class AccountInterventionService {
     public AccountInterventionService(ConfigurationService configService) {
         this(
                 configService,
-                HttpClient.newHttpClient(),
+                HttpClientHelper.newInstrumentedHttpClient(),
                 new CloudwatchMetricsService(),
                 new AuditService(configService));
     }
@@ -48,7 +49,11 @@ public class AccountInterventionService {
             ConfigurationService configService,
             CloudwatchMetricsService cloudwatchMetricsService,
             AuditService auditService) {
-        this(configService, HttpClient.newHttpClient(), cloudwatchMetricsService, auditService);
+        this(
+                configService,
+                HttpClientHelper.newInstrumentedHttpClient(),
+                cloudwatchMetricsService,
+                auditService);
     }
 
     public AccountInterventionService(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/LogLineHelperTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/helpers/LogLineHelperTest.java
@@ -1,16 +1,27 @@
 package uk.gov.di.orchestration.shared.helpers;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import org.apache.logging.log4j.ThreadContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.ORCH_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.SESSION_ID;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.TRACE_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachOrchSessionIdToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.updateAttachedSessionIdToLogs;
 
 class LogLineHelperTest {
@@ -66,5 +77,31 @@ class LogLineHelperTest {
 
         assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
         assertEquals("invalid-identifier", ThreadContext.get(SESSION_ID.getLogFieldName()));
+    }
+
+    @Test
+    void shouldNotLogSpanAndTraceIdIfUnavailable() {
+        attachTraceId();
+
+        assertFalse(ThreadContext.containsKey(TRACE_ID.getLogFieldName()));
+    }
+
+    @Test
+    void shouldLogSpanAndTraceIdIfAvailable() {
+        var spanContext =
+                SpanContext.create(
+                        TraceId.fromLongs(1, 2),
+                        SpanId.fromLong(3),
+                        TraceFlags.getDefault(),
+                        TraceState.getDefault());
+        var span = Span.wrap(spanContext);
+        var context = span.storeInContext(Context.root());
+
+        try (Scope ignored = context.makeCurrent()) {
+            attachTraceId();
+
+            assertTrue(ThreadContext.containsKey(TRACE_ID.getLogFieldName()));
+            assertEquals(spanContext.getTraceId(), ThreadContext.get(TRACE_ID.getLogFieldName()));
+        }
     }
 }


### PR DESCRIPTION
### Wider context of change

A couple of improvements to our Dynatrace tracing

### What’s changed

See https://github.com/govuk-one-login/authentication-api/pull/6840 for pictures

- Adds trace id to log messages, allowing correlation between log messages and distributed traces
- Adds tracing to the Java HTTP clients used for AIS calls

### Manual testing

TODO: deploy to orch dev and confirm that
- Nothing is broken
- Trace ids are logged and can be correlated with dynatrace as expected

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/6840