### PR TITLE
ATO-1860: Refactor JWKS caching code

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -47,7 +47,7 @@ import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.orchestration.sharedtest.extensions.DocAppJwksExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.JwksExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
@@ -122,8 +122,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String PERSISTENT_SESSION_ID =
             IdGenerator.generate() + "--" + ARBITRARY_UNIX_TIMESTAMP;
 
-    @RegisterExtension
-    public static final DocAppJwksExtension jwksExtension = new DocAppJwksExtension();
+    @RegisterExtension public static final JwksExtension jwksExtension = new JwksExtension();
 
     @RegisterExtension
     public static final KmsKeyExtension tokenSigningKey = new KmsKeyExtension("token-signing-key");

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/JwksUtilsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/JwksUtilsIntegrationTest.java
@@ -1,0 +1,73 @@
+package uk.gov.di.authentication.utils;
+
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.orchestration.shared.utils.JwksUtils;
+import uk.gov.di.orchestration.sharedtest.extensions.JwksExtension;
+
+import java.security.interfaces.RSAPublicKey;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
+
+class JwksUtilsIntegrationTest {
+    @RegisterExtension private static final JwksExtension jwksExtension = new JwksExtension();
+    private static final String TEST_JWK_ID_1 = "test-jwk-id-1";
+    private static final String TEST_JWK_ID_2 = "test-jwk-id-2";
+    private static final JWK TEST_JWK_1 = createPublicJwk(TEST_JWK_ID_1);
+    private static final JWK TEST_JWK_2 = createPublicJwk(TEST_JWK_ID_2);
+
+    @BeforeAll
+    static void setup() {
+        jwksExtension.init(new JWKSet(List.of(TEST_JWK_1, TEST_JWK_2)));
+    }
+
+    @Test
+    void shouldRetrieveSpecificKeyFromJwksEndpoint() throws Exception {
+        var actualKey =
+                JwksUtils.retrieveJwkFromURLWithKeyId(jwksExtension.getJwksUrl(), TEST_JWK_ID_1);
+
+        assertEquals(TEST_JWK_1, actualKey);
+    }
+
+    @Test
+    void shouldThrowIfSpecificKeyNotFoundOnJwksEndpoint() {
+        assertThrows(
+                KeySourceException.class,
+                () ->
+                        JwksUtils.retrieveJwkFromURLWithKeyId(
+                                jwksExtension.getJwksUrl(), "not-a-key-id"));
+    }
+
+    @Test
+    void shouldRetrieveListOfKeysFromJwksEndpoint() throws Exception {
+        var actualKeys = JwksUtils.retrieveJwksFromUrl(jwksExtension.getJwksUrl());
+
+        assertEquals(List.of(TEST_JWK_1, TEST_JWK_2), actualKeys);
+    }
+
+    @Test
+    void shouldGetFirstKeyOfTypeFromJwksEndpoint() throws Exception {
+        var actualKey = JwksUtils.getKey(jwksExtension.getJwksUrl(), KeyUse.ENCRYPTION);
+
+        assertEquals(TEST_JWK_1, actualKey);
+    }
+
+    public static JWK createPublicJwk(String keyId) {
+        var keyPair = generateRsaKeyPair();
+        return new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                .keyUse(KeyUse.ENCRYPTION)
+                .algorithm(JWEAlgorithm.RSA_OAEP_256)
+                .keyID(keyId)
+                .build();
+    }
+}

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/JwksExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/JwksExtension.java
@@ -5,22 +5,22 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.orchestration.sharedtest.httpstub.HttpStubExtension;
 
-public class DocAppJwksExtension extends HttpStubExtension implements BeforeAllCallback {
+public class JwksExtension extends HttpStubExtension implements BeforeAllCallback {
 
-    public DocAppJwksExtension(int port) {
+    public JwksExtension(int port) {
         super(port);
     }
 
-    public DocAppJwksExtension() {
+    public JwksExtension() {
         super();
     }
 
     public void init(JWKSet jwkSet) {
-        register(
-                "/.well-known/jwks.json",
-                200,
-                "application/json",
-                jwkSet.toPublicJWKSet().toString());
+        init("/.well-known/jwks.json", jwkSet);
+    }
+
+    public void init(String path, JWKSet jwkSet) {
+        register(path, 200, "application/json", jwkSet.toPublicJWKSet().toString());
     }
 
     @Override

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/JwksExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/JwksExtension.java
@@ -5,7 +5,11 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.orchestration.sharedtest.httpstub.HttpStubExtension;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 public class JwksExtension extends HttpStubExtension implements BeforeAllCallback {
+    private String endpoint = "/.well-known/jwks.json";
 
     public JwksExtension(int port) {
         super(port);
@@ -15,11 +19,16 @@ public class JwksExtension extends HttpStubExtension implements BeforeAllCallbac
         super();
     }
 
+    public URL getJwksUrl() throws MalformedURLException {
+        return uri(endpoint).toURL();
+    }
+
     public void init(JWKSet jwkSet) {
         init("/.well-known/jwks.json", jwkSet);
     }
 
     public void init(String path, JWKSet jwkSet) {
+        endpoint = path;
         register(path, 200, "application/json", jwkSet.toPublicJWKSet().toString());
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/JwkCacheEntry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/JwkCacheEntry.java
@@ -1,10 +1,6 @@
 package uk.gov.di.orchestration.shared.helpers;
 
-import com.nimbusds.jose.Algorithm;
-import com.nimbusds.jose.JWEAlgorithm;
-import com.nimbusds.jose.KeySourceException;
 import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.KeyType;
 import com.nimbusds.jose.jwk.KeyUse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,87 +9,37 @@ import uk.gov.di.orchestration.shared.utils.JwksUtils;
 import java.net.URL;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 public class JwkCacheEntry {
     private static final Logger LOG = LogManager.getLogger(JwkCacheEntry.class);
     private final URL jwksUrl;
     private final int expirationInSeconds;
     private final KeyUse keyUse;
-    private final KeyType kty;
-    private final Set<Algorithm> algs;
     private JWK latestKey;
     private Date expireTime;
 
-    private JwkCacheEntry(
-            URL jwksUrl, int expirationInSeconds, KeyUse keyUse, Set<Algorithm> algs, KeyType kty) {
+    private JwkCacheEntry(URL jwksUrl, int expirationInSeconds, KeyUse keyUse) {
         this.jwksUrl = jwksUrl;
         this.expirationInSeconds = expirationInSeconds;
         this.expireTime = NowHelper.nowPlus(this.expirationInSeconds, ChronoUnit.SECONDS);
         this.keyUse = keyUse;
-        this.algs = algs;
-        this.kty = kty;
-        this.latestKey = getKeyFromUrl();
+        this.latestKey = JwksUtils.getKey(jwksUrl, keyUse);
     }
 
     public static JwkCacheEntry forEncryptionKeys(URL url, int expirationInSeconds) {
-        return forKeyUse(
-                url,
-                expirationInSeconds,
-                KeyUse.ENCRYPTION,
-                Set.of(JWEAlgorithm.RSA_OAEP_256),
-                KeyType.RSA);
+        return forKeyUse(url, expirationInSeconds, KeyUse.ENCRYPTION);
     }
 
-    public static JwkCacheEntry forKeyUse(
-            URL url, int expirationInSeconds, KeyUse keyUse, Algorithm alg, KeyType kty) {
-        return new JwkCacheEntry(url, expirationInSeconds, keyUse, Set.of(alg), kty);
-    }
-
-    public static JwkCacheEntry forKeyUse(
-            URL url, int expirationInSeconds, KeyUse keyUse, Set<Algorithm> algs, KeyType kty) {
-        return new JwkCacheEntry(url, expirationInSeconds, keyUse, algs, kty);
+    public static JwkCacheEntry forKeyUse(URL url, int expirationInSeconds, KeyUse keyUse) {
+        return new JwkCacheEntry(url, expirationInSeconds, keyUse);
     }
 
     public JWK getKey() {
         if (NowHelper.now().after(expireTime)) {
             LOG.info("JWK Cache expired. Fetching latest key...");
-            latestKey = getKeyFromUrl();
+            latestKey = JwksUtils.getKey(jwksUrl, keyUse);
             expireTime = NowHelper.nowPlus(expirationInSeconds, ChronoUnit.SECONDS);
         }
         return latestKey;
-    }
-
-    private JWK getKeyFromUrl() {
-        try {
-            List<JWK> jwks = JwksUtils.retrieveJwksFromUrl(jwksUrl);
-            LOG.info("Found {} {} JWKs at {}", jwks.size(), keyUse, jwksUrl);
-            return getFirstKeyByAlg(jwks, keyUse, algs)
-                    .orElseGet(
-                            () -> {
-                                LOG.info(
-                                        "Cannot find key by alg. Falling back to finding key by kty");
-                                return getFirstKeyByKty(jwks, keyUse, kty).orElse(null);
-                            });
-        } catch (KeySourceException e) {
-            throw new RuntimeException("Key sourcing failed", e);
-        }
-    }
-
-    private static Optional<JWK> getFirstKeyByAlg(
-            List<JWK> jwks, KeyUse keyUse, Set<Algorithm> algs) {
-        return jwks.stream()
-                .filter(key -> keyUse.equals(key.getKeyUse()))
-                .filter(key -> key.getAlgorithm() != null && algs.contains(key.getAlgorithm()))
-                .findFirst();
-    }
-
-    private static Optional<JWK> getFirstKeyByKty(List<JWK> jwks, KeyUse keyUse, KeyType kty) {
-        return jwks.stream()
-                .filter(key -> keyUse.equals(key.getKeyUse()))
-                .filter(key -> kty.equals(key.getKeyType()))
-                .findFirst();
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/JwksUtils.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/JwksUtils.java
@@ -1,9 +1,13 @@
 package uk.gov.di.orchestration.shared.utils;
 
+import com.nimbusds.jose.Algorithm;
+import com.nimbusds.jose.JWEAlgorithm;
 import com.nimbusds.jose.KeySourceException;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKMatcher;
 import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
 import com.nimbusds.jose.proc.SecurityContext;
@@ -12,11 +16,18 @@ import org.apache.logging.log4j.Logger;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 public class JwksUtils {
 
     private static final Logger LOG = LogManager.getLogger(JwksUtils.class);
     private static final JWKMatcher ALL_KEYS = new JWKMatcher.Builder().build();
+    private static final Map<KeyUse, KeyType> KEY_TYPE_BY_KEY_USE =
+            Map.of(KeyUse.ENCRYPTION, KeyType.RSA);
+    private static final Map<KeyUse, Set<Algorithm>> ALGS_BY_KEY_USE =
+            Map.of(KeyUse.ENCRYPTION, Set.of(JWEAlgorithm.RSA_OAEP_256));
 
     private JwksUtils() {}
 
@@ -47,5 +58,41 @@ public class JwksUtils {
 
     private static JWKMatcher matcherForKeyId(String keyId) {
         return new JWKMatcher.Builder().keyID(keyId).build();
+    }
+
+    public static JWK getKey(URL jwksUrl, KeyUse keyUse) {
+        try {
+            return getKey(retrieveJwksFromUrl(jwksUrl), keyUse);
+        } catch (KeySourceException e) {
+            throw new RuntimeException("Failed to source keys");
+        }
+    }
+
+    public static JWK getKey(List<JWK> jwks, KeyUse keyUse) {
+        var algs = ALGS_BY_KEY_USE.get(keyUse);
+        var kty = KEY_TYPE_BY_KEY_USE.get(keyUse);
+
+        LOG.info("Found {} {} JWKs", jwks.size(), keyUse);
+        return getFirstKeyByAlg(jwks, keyUse, algs)
+                .orElseGet(
+                        () -> {
+                            LOG.info("Cannot find key by alg. Falling back to finding key by kty");
+                            return getFirstKeyByKty(jwks, keyUse, kty).orElse(null);
+                        });
+    }
+
+    private static Optional<JWK> getFirstKeyByAlg(
+            List<JWK> jwks, KeyUse keyUse, Set<Algorithm> algs) {
+        return jwks.stream()
+                .filter(key -> keyUse.equals(key.getKeyUse()))
+                .filter(key -> key.getAlgorithm() != null && algs.contains(key.getAlgorithm()))
+                .findFirst();
+    }
+
+    private static Optional<JWK> getFirstKeyByKty(List<JWK> jwks, KeyUse keyUse, KeyType kty) {
+        return jwks.stream()
+                .filter(key -> keyUse.equals(key.getKeyUse()))
+                .filter(key -> kty.equals(key.getKeyType()))
+                .findFirst();
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
@@ -15,7 +15,6 @@ import uk.gov.di.orchestration.shared.utils.JwksUtils;
 
 import java.net.URL;
 import java.util.Base64;
-import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -104,8 +103,8 @@ class JwksServiceTest {
             when(testKey1.getKeyUse()).thenReturn(KeyUse.ENCRYPTION);
             when(testKey1.getAlgorithm()).thenReturn(JWEAlgorithm.RSA_OAEP_256);
             mockJwksUtils
-                    .when(() -> JwksUtils.retrieveJwksFromUrl(testJwksUrl))
-                    .thenReturn(List.of(testKey1));
+                    .when(() -> JwksUtils.getKey(testJwksUrl, KeyUse.ENCRYPTION))
+                    .thenReturn(testKey1);
 
             assertEquals(testKey1, jwksService.getIpvJwk());
         }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/utils/JwksUtilsTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/utils/JwksUtilsTest.java
@@ -1,0 +1,63 @@
+package uk.gov.di.orchestration.shared.utils;
+
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.jose.jwk.KeyUse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JwksUtilsTest {
+    private static final JWK TEST_KEY_1 = mock(JWK.class);
+    private static final JWK TEST_KEY_2 = mock(JWK.class);
+
+    @BeforeEach
+    void setup() {
+        when(TEST_KEY_1.getKeyUse()).thenReturn(KeyUse.ENCRYPTION);
+        when(TEST_KEY_2.getKeyUse()).thenReturn(KeyUse.ENCRYPTION);
+        when(TEST_KEY_1.getAlgorithm()).thenReturn(JWEAlgorithm.RSA_OAEP_256);
+        when(TEST_KEY_2.getAlgorithm()).thenReturn(JWEAlgorithm.RSA_OAEP_256);
+    }
+
+    @Test
+    void shouldCacheFirstKeyIfMultipleKeysArePresent() {
+        var jwksKeys = List.of(TEST_KEY_1, TEST_KEY_2);
+        var validKey = JwksUtils.getKey(jwksKeys, KeyUse.ENCRYPTION);
+        assertEquals(TEST_KEY_1, validKey);
+    }
+
+    @Test
+    void shouldIgnoreFirstKeyIfKeyHasDifferentUse() {
+        when(TEST_KEY_1.getKeyUse()).thenReturn(KeyUse.SIGNATURE);
+        var jwksKeys = List.of(TEST_KEY_1, TEST_KEY_2);
+        var validKey = JwksUtils.getKey(jwksKeys, KeyUse.ENCRYPTION);
+        assertEquals(TEST_KEY_2, validKey);
+    }
+
+    @Test
+    void shouldIgnoreFirstKeyIfKeyHasDifferentAlg() {
+        when(TEST_KEY_1.getAlgorithm()).thenReturn(JWEAlgorithm.ECDH_1PU);
+
+        var jwksKeys = List.of(TEST_KEY_1, TEST_KEY_2);
+        var validKey = JwksUtils.getKey(jwksKeys, KeyUse.ENCRYPTION);
+        assertEquals(TEST_KEY_2, validKey);
+    }
+
+    @Test
+    void shouldGetEncryptionKeyByKeyTypeIfKeyAlgIsNotPresent() {
+        when(TEST_KEY_1.getAlgorithm()).thenReturn(null);
+        when(TEST_KEY_1.getKeyType()).thenReturn(KeyType.RSA);
+        when(TEST_KEY_2.getAlgorithm()).thenReturn(null);
+        when(TEST_KEY_2.getKeyType()).thenReturn(KeyType.RSA);
+        var jwksKeys = List.of(TEST_KEY_1, TEST_KEY_2);
+
+        var validKey = JwksUtils.getKey(jwksKeys, KeyUse.ENCRYPTION);
+        assertEquals(TEST_KEY_1, validKey);
+    }
+}


### PR DESCRIPTION
### Wider context of change

We have an in-memory cache for storing JWKs retrieved from a JWKS endpoint. At the moment, the logic to select the relevant key is in the implementation of the caching code. If we were to move away from using an in memory cache it would be a bit messy to untangle the logic.

### What’s changed

This PR moves the key selection logic out of `JwkCacheEntry` into `JwksUtils`, as well as creating a unit test class for `JwksUtils` and moving the relevant tests into it

I've also added test coverage for `JwksUtils.retrieveJwksFromUrl`, and created an extension which sets up a stubbed JWKS endpoint (`JwksExtension`)

### Manual testing

Covered by existing tests

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs
Stacked on this PR: https://github.com/govuk-one-login/authentication-api/pull/6901
