### PR TITLE
INCIDEN-1031: Introduce DeprecationChecker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,3 +143,9 @@ repos:
           - windows_amd64
           - -r
           - ci/terraform
+      - id: deprecation-checker
+        name: Check deprecation policy
+        entry: ./gradlew :deprecation-checker:checkDeprecations
+        language: system
+        pass_filenames: false
+        files: '\.java$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
           checkov-policies.*|\
           .terraform-docs.yml|\
           package.json|\
+          deprecation-config.json|\
           http-client.env.json|\
           package-lock.json|\
           .*provider.json|\

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ ext {
         aws_lambda_events_version: "3.16.0",
         gson: "2.13.1",
         jetbrains_annotations: "26.0.2",
+        jgit: "6.10.1.202505221210-r",
         nimbusds_oauth_version: "10.13.2",
         nimbusds_jwt_version: "10.3.1",
         junit: "5.12.2",
@@ -103,6 +104,7 @@ subprojects {
         gson
         hamcrest
         jetbrains_annotations
+        jgit
         kms
         lambda
         lambda_tests
@@ -192,6 +194,8 @@ subprojects {
         hamcrest "org.hamcrest:hamcrest:3.0"
 
         jetbrains_annotations "org.jetbrains:annotations:${dependencyVersions.jetbrains_annotations}"
+
+        jgit "org.eclipse.jgit:org.eclipse.jgit:${dependencyVersions.jgit}"
 
         kms "software.amazon.awssdk:kms:${dependencyVersions.aws_sdk_v2_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ ext {
         aws_lambda_core_version: "1.3.0",
         aws_lambda_events_version: "3.16.0",
         gson: "2.13.1",
+        java_parser: "3.25.7",
         jetbrains_annotations: "26.0.2",
         jgit: "6.10.1.202505221210-r",
         nimbusds_oauth_version: "10.13.2",
@@ -103,6 +104,7 @@ subprojects {
         govuk_notify
         gson
         hamcrest
+        java_parser
         jetbrains_annotations
         jgit
         kms
@@ -192,6 +194,8 @@ subprojects {
         gson "com.google.code.gson:gson:${dependencyVersions.gson}"
 
         hamcrest "org.hamcrest:hamcrest:3.0"
+
+        java_parser "com.github.javaparser:javaparser-core:${dependencyVersions.java_parser}"
 
         jetbrains_annotations "org.jetbrains:annotations:${dependencyVersions.jetbrains_annotations}"
 

--- a/deprecation-checker/build.gradle
+++ b/deprecation-checker/build.gradle
@@ -5,6 +5,9 @@ plugins {
 }
 
 dependencies {
+    implementation configurations.gson
+    implementation configurations.logging_runtime
+
     testImplementation configurations.tests
     testRuntimeOnly configurations.test_runtime
 }

--- a/deprecation-checker/build.gradle
+++ b/deprecation-checker/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'java'
+    id 'application'
+    id "jacoco"
+}
+
+dependencies {
+    testImplementation configurations.tests
+    testRuntimeOnly configurations.test_runtime
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
+    }
+}
+
+application {
+    mainClass = 'DeprecationChecker'
+}
+
+task checkDeprecations(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'uk.gov.di.deprecationchecker.DeprecationChecker'
+    workingDir = project.rootDir
+    ignoreExitValue = false
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
+}

--- a/deprecation-checker/build.gradle
+++ b/deprecation-checker/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 dependencies {
+    implementation configurations.java_parser
     implementation configurations.jgit
     implementation configurations.gson
     implementation configurations.logging_runtime

--- a/deprecation-checker/build.gradle
+++ b/deprecation-checker/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 dependencies {
+    implementation configurations.jgit
     implementation configurations.gson
     implementation configurations.logging_runtime
 

--- a/deprecation-checker/src/main/java/uk/gov/di/deprecationchecker/DeprecationChecker.java
+++ b/deprecation-checker/src/main/java/uk/gov/di/deprecationchecker/DeprecationChecker.java
@@ -1,5 +1,57 @@
 package uk.gov.di.deprecationchecker;
 
+import com.google.gson.Gson;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+
 public class DeprecationChecker {
-    public static void main() {}
+
+    private static final Logger LOG = LogManager.getLogger(DeprecationChecker.class);
+
+    public static void main(String[] args) {
+        try {
+            loadConfig();
+        } catch (Exception e) {
+            LOG.error("Error during deprecation check", e);
+            System.exit(1);
+        }
+    }
+
+    static Config loadConfig() throws IOException {
+        var configPath = Paths.get(System.getProperty("user.dir"), "deprecation-config.json");
+
+        if (!Files.exists(configPath)) {
+            LOG.info("No config file found, using defaults");
+            return new Config("origin/main", Set.of());
+        }
+
+        String json = Files.readString(configPath);
+        com.google.gson.Gson gson = new Gson();
+        ConfigJson configJson = gson.fromJson(json, ConfigJson.class);
+
+        String baseBranch = configJson.baseBranch != null ? configJson.baseBranch : "origin/main";
+        Set<String> enums = configJson.enums != null ? Set.copyOf(configJson.enums) : Set.of();
+
+        return new Config(baseBranch, enums);
+    }
+
+    static class Config {
+        final String baseBranch;
+        final Set<String> enums;
+
+        Config(String baseBranch, Set<String> enums) {
+            this.baseBranch = baseBranch;
+            this.enums = enums;
+        }
+    }
+
+    private static class ConfigJson {
+        String baseBranch;
+        java.util.List<String> enums;
+    }
 }

--- a/deprecation-checker/src/main/java/uk/gov/di/deprecationchecker/DeprecationChecker.java
+++ b/deprecation-checker/src/main/java/uk/gov/di/deprecationchecker/DeprecationChecker.java
@@ -1,0 +1,5 @@
+package uk.gov.di.deprecationchecker;
+
+public class DeprecationChecker {
+    public static void main() {}
+}

--- a/deprecation-checker/src/main/java/uk/gov/di/deprecationchecker/DeprecationChecker.java
+++ b/deprecation-checker/src/main/java/uk/gov/di/deprecationchecker/DeprecationChecker.java
@@ -3,8 +3,13 @@ package uk.gov.di.deprecationchecker;
 import com.google.gson.Gson;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
@@ -38,6 +43,45 @@ public class DeprecationChecker {
         Set<String> enums = configJson.enums != null ? Set.copyOf(configJson.enums) : Set.of();
 
         return new Config(baseBranch, enums);
+    }
+
+    static List<String> getAllJavaFiles() throws IOException {
+        List<String> javaFiles = new ArrayList<>();
+        var workDir = Paths.get(System.getProperty("user.dir"));
+        try (var paths = Files.walk(workDir)) {
+            paths.filter(path -> path.toString().endsWith(".java"))
+                    .filter(path -> !path.toString().contains("/build/"))
+                    .filter(path -> !path.toString().contains("/target/"))
+                    .filter(path -> !path.toString().contains("/.gradle/"))
+                    .map(path -> workDir.relativize(path).toString())
+                    .forEach(javaFiles::add);
+        }
+        return javaFiles;
+    }
+
+    static String getWorkspaceFileContent(String path) throws IOException {
+        return Files.readString(Paths.get(path));
+    }
+
+    static String getCommitedFileContent(Repository repository, ObjectId commitId, String path) {
+        try (RevWalk walk = new RevWalk(repository)) {
+            RevCommit commit = walk.parseCommit(commitId);
+            try (org.eclipse.jgit.treewalk.TreeWalk treeWalk =
+                    new org.eclipse.jgit.treewalk.TreeWalk(repository)) {
+                treeWalk.addTree(commit.getTree());
+                treeWalk.setRecursive(true);
+                treeWalk.setFilter(org.eclipse.jgit.treewalk.filter.PathFilter.create(path));
+
+                if (treeWalk.next()) {
+                    ObjectId fileId = treeWalk.getObjectId(0);
+                    return new String(repository.open(fileId).getBytes(), StandardCharsets.UTF_8);
+                }
+                return "";
+            }
+        } catch (Exception e) {
+            LOG.error("Warning: Could not read file {} from commit: {}", path, e.getMessage());
+            return "";
+        }
     }
 
     static class Config {

--- a/deprecation-checker/src/test/java/uk/gov/di/deprecationchecker/DeprecationCheckerTest.java
+++ b/deprecation-checker/src/test/java/uk/gov/di/deprecationchecker/DeprecationCheckerTest.java
@@ -1,0 +1,12 @@
+package uk.gov.di.deprecationchecker;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DeprecationCheckerTest {
+    @Test
+    void initialTest() {
+        assertDoesNotThrow(DeprecationChecker::main);
+    }
+}

--- a/deprecation-checker/src/test/java/uk/gov/di/deprecationchecker/DeprecationCheckerTest.java
+++ b/deprecation-checker/src/test/java/uk/gov/di/deprecationchecker/DeprecationCheckerTest.java
@@ -1,12 +1,90 @@
 package uk.gov.di.deprecationchecker;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class DeprecationCheckerTest {
-    @Test
-    void initialTest() {
-        assertDoesNotThrow(DeprecationChecker::main);
+
+    @Nested
+    class LoadConfig {
+        @Test
+        void shouldLoadDefaultConfigWhenFileNotExists(@TempDir Path tempDir) throws IOException {
+            String originalDir = System.getProperty("user.dir");
+            try {
+                System.setProperty("user.dir", tempDir.toString());
+
+                var config = DeprecationChecker.loadConfig();
+
+                assertEquals("origin/main", config.baseBranch);
+                assertTrue(config.enums.isEmpty());
+            } finally {
+                System.setProperty("user.dir", originalDir);
+            }
+        }
+
+        @Test
+        void shouldLoadConfigFromFile(@TempDir Path tempDir) throws IOException {
+            String originalDir = System.getProperty("user.dir");
+            try {
+                Path configFile = tempDir.resolve("deprecation-config.json");
+                Files.writeString(
+                        configFile,
+                        """
+                    {
+                        "baseBranch": "origin/develop",
+                        "enums": ["com.example.TestEnum"]
+                    }
+                    """);
+
+                System.setProperty("user.dir", tempDir.toString());
+
+                var config = DeprecationChecker.loadConfig();
+
+                assertEquals("origin/develop", config.baseBranch);
+                assertEquals(Set.of("com.example.TestEnum"), config.enums);
+            } finally {
+                System.setProperty("user.dir", originalDir);
+            }
+        }
+
+        @Test
+        void shouldLoadConfigWithNullBaseBranch(@TempDir Path tempDir) throws IOException {
+            String originalDir = System.getProperty("user.dir");
+            try {
+                Path configFile = tempDir.resolve("deprecation-config.json");
+                Files.writeString(configFile, "{\"enums\": [\"test\"]}");
+                System.setProperty("user.dir", tempDir.toString());
+
+                var config = DeprecationChecker.loadConfig();
+
+                assertEquals("origin/main", config.baseBranch);
+            } finally {
+                System.setProperty("user.dir", originalDir);
+            }
+        }
+
+        @Test
+        void shouldLoadConfigWithNullEnums(@TempDir Path tempDir) throws IOException {
+            String originalDir = System.getProperty("user.dir");
+            try {
+                Path configFile = tempDir.resolve("deprecation-config.json");
+                Files.writeString(configFile, "{\"baseBranch\": \"test\"}");
+                System.setProperty("user.dir", tempDir.toString());
+
+                var config = DeprecationChecker.loadConfig();
+
+                assertTrue(config.enums.isEmpty());
+            } finally {
+                System.setProperty("user.dir", originalDir);
+            }
+        }
     }
 }

--- a/deprecation-config.json
+++ b/deprecation-config.json
@@ -1,0 +1,15 @@
+{
+  "baseBranch": "origin/main",
+  "enums": [
+    "uk.gov.di.authentication.shared.entity.CodeRequestType",
+    "uk.gov.di.authentication.shared.entity.CountType",
+    "uk.gov.di.authentication.shared.entity.CredentialTrustLevel",
+    "uk.gov.di.authentication.shared.entity.DeliveryReceiptsNotificationType",
+    "uk.gov.di.authentication.shared.entity.EmailCheckResultStatus",
+    "uk.gov.di.authentication.shared.entity.ErrorResponse",
+    "uk.gov.di.authentication.shared.entity.JourneyType",
+    "uk.gov.di.authentication.shared.entity.LevelOfConfidence",
+    "uk.gov.di.authentication.shared.entity.MFAMethodType",
+    "uk.gov.di.authentication.shared.entity.PriorityIdentifier"
+  ]
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ include 'auth-external-api'
 include 'interventions-api-stub'
 include 'ticf-cri-stub'
 include 'user-permissions'
+include 'deprecation-checker'
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
## What

Introduces a new automated tool to prevent the accidental removal of code without proper deprecation. In this iteration only enum value checks are supported.

Configured enums should have values marked as `@Deprecated` on the main branch before they can be removed, otherwise the precommit configuration will prevent a commit being made.

This exists to encourage safe two-stage deployment practices as described in https://github.com/govuk-one-login/authentication-api/pull/6785.

## How to review

1. Code Review
1. Checkout locally
1. Remove a value from one of the enums configured
1. Commit the change
  1. If you have precommit installed locally, see the commit fail 
  1. Otherwise you could push a new branch and make a PR and see the GitHub action checks fail

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [X] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.

## Related PRs

- https://github.com/govuk-one-login/authentication-api/pull/6785
