### PR TITLE
AUT-4538: New auth integration env gaining access to old env resources

### DIFF
--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -321,20 +321,43 @@ Mappings:
       testClientsEnabled: true
       useStronglyConsistentReads: true
     integration:
+      accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/11fdf47e-ce54-4d47-a9cf-7544489a112a
+      accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/1e526227-051b-4078-ae10-46bda94e71c4
+      auditPayloadSigningKey: arn:aws:kms:eu-west-2:761723964695:key/c87c5099-d8b5-422b-bd85-fb4559168838
+      authCodeStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/f7ca754b-80bb-4f60-a3e5-3963d6827f47
+      authenticationAttemptTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/5917a6e9-13c3-4276-946b-487a0e6411f9
+      authSessionTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/9372359d-fb44-4182-8977-7254654dcd1a
+      clientRegistryTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/f8897cf9-760f-463e-bb27-a86cc9e629de
       cloudwatchLogRetentionInDays: 30
+      commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/85164499-9392-458c-8596-b5a810ca90f6
       customDocAppClaimEnabled: true
-      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       docAppDomain: https://api.review-b.integration.account.gov.uk
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      emailAcctCreationOtpCodeTtlDuration: 3600
+      emailCheckResultTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/be1b5ce0-3e55-4705-8437-8b68301ebcb1
       EnableSnapStart: "No"
+      eventsTopicEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/44a77768-8782-4d8c-8a18-3e2f7d160800
+      experianPhoneCheckQueueEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/5c3be595-77cd-444f-a69e-8d9a1e56a75d
       frontendApiFMSTagValue: "authfrontendint"
       frontendBaseUrl: https://signin.integration.account.gov.uk
+      idReverificationStateTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/0fd64c49-cd23-4e0b-9061-8c8cf65954d5
       IPVApiEnabled: true
       IsSplunkEnabled: "Yes"
       lambdaMinConcurrency: 0
+      lockoutCountTtl: 900
+      lockoutDuration: 7200
       orchApiVpcEndpointId: vpce-0704b783d794cea52
       orchToAuthSigningPublicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzzwKLypUL89WVaeTbfBZu0Fws8T7ppx89XLVfgXIoCs2P//N5qdghvzgNIgVehQ7CkzyorO/lnRlWPfjCG4Oxw==
+      otpCodeTtlDuration: 900
+      pendingEmailCheckQueueEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/ac2fa7d3-5c80-4a78-905b-e22b2bf525d8
+      reauthEnterEmailCountTtl: 3600
+      reducedLockoutDuration: 900
+      supportReauthSignoutEnabled: true
+      termsConditionsVersion: 1.13
       testClientsEnabled: false
       UseAlarmActions: "Yes"
+      userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/2f7fd1cc-c0e1-40f5-a747-2ed29e02427d
+      userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/7f17084d-14a7-4482-8a7b-e392d1f60d41
       useStronglyConsistentReads: false
     production:
       cloudwatchLogRetentionInDays: 30

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -8,6 +8,9 @@ shared_state_bucket                  = "digital-identity-dev-tfstate"
 # FMS
 frontend_api_fms_tag_value = "authfrontendint"
 
+# Auth new strategic account
+auth_new_account_id = "211125600642"
+
 # App-specific
 internal_sector_uri                     = "https://identity.integration.account.gov.uk"
 test_clients_enabled                    = false

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -609,7 +609,9 @@ resource "aws_dynamodb_table" "authentication_attempt_table" {
 }
 
 locals {
-  authorized_account_ids = local.allow_cross_account_access ? [var.auth_new_account_id, var.orchestration_account_id] : [var.orchestration_account_id]
+  restricted_environments    = ["production"]
+  allow_cross_account_access = !contains(local.restricted_environments, var.environment)
+  authorized_account_ids     = local.allow_cross_account_access ? [var.auth_new_account_id, var.orchestration_account_id] : [var.orchestration_account_id]
 }
 
 resource "aws_dynamodb_resource_policy" "client_registry_table_policy" {
@@ -773,13 +775,6 @@ resource "aws_dynamodb_resource_policy" "id_reverification_state" {
   resource_arn = aws_dynamodb_table.id_reverification_state.arn
   policy       = data.aws_iam_policy_document.auth_cross_account_table_resource_policy_document[0].json
 }
-
-
-locals {
-  allowed_env                = ["staging", "build", "dev", "authdev1", "authdev2", "authdev3", "sandpit"]
-  allow_cross_account_access = contains(local.allowed_env, var.environment)
-}
-
 
 data "aws_iam_policy_document" "auth_cross_account_table_resource_policy_document" {
   #checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -360,7 +360,7 @@ data "aws_iam_policy_document" "cross_account_doc_app_auth_signing_key_policy" {
   }
 
   dynamic "statement" {
-    for_each = var.environment != "production" && var.environment != "integration" ? ["1"] : []
+    for_each = var.environment != "production" ? ["1"] : []
     content {
       sid    = "AllowAuthAccessToKmsDocAppSigningKey-${var.environment}"
       effect = "Allow"
@@ -635,7 +635,7 @@ data "aws_iam_policy_document" "cross_account_table_encryption_key_access_policy
   }
 
   dynamic "statement" {
-    for_each = var.environment != "production" && var.environment != "integration" ? ["1"] : []
+    for_each = var.environment != "production" ? ["1"] : []
     content {
       sid    = "Allow Auth access to dynamo table encryption key"
       effect = "Allow"
@@ -734,7 +734,7 @@ data "aws_iam_policy_document" "pending_email_check_queue_encryption_key_access_
   }
 
   dynamic "statement" {
-    for_each = var.environment != "production" && var.environment != "integration" ? ["1"] : []
+    for_each = var.environment != "production" ? ["1"] : []
     content {
       sid    = "Allow Auth access to dynamo table encryption key"
       effect = "Allow"
@@ -826,7 +826,7 @@ data "aws_iam_policy_document" "auth_dynamo_table_encryption_key_access_policy" 
   }
 
   dynamic "statement" {
-    for_each = var.environment != "production" && var.environment != "integration" ? ["1"] : []
+    for_each = var.environment != "production" ? ["1"] : []
     content {
       sid    = "Allow Auth access to dynamo table encryption key"
       effect = "Allow"

--- a/ci/terraform/shared/sqs-policy.tf
+++ b/ci/terraform/shared/sqs-policy.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "pending_email_check_queue_subscription_policy_do
   }
 
   dynamic "statement" {
-    for_each = var.environment != "production" && var.environment != "integration" ? ["1"] : []
+    for_each = var.environment != "production" ? ["1"] : []
     content {
       sid    = "AllowSenderWriteAccessToPendingEmailCheckQueue"
       effect = "Allow"


### PR DESCRIPTION
## What

New auth integration env gaining access to old env resources
[AUT-4538]

## How to review

On the terraform side, several policy changes were not applied to integration before. Those will now be applied since the `var.environment != "integration"` condition has been removed. 

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

https://github.com/govuk-one-login/authentication-infrastructure/pull/87
https://github.com/govuk-one-login/authentication-contra-indicators/pull/367


[AUT-4538]: https://govukverify.atlassian.net/browse/AUT-4538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ