### PR TITLE
ATO-1658: Fix incorrect global logout field name

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/GlobalLogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/GlobalLogoutIntegrationTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -123,16 +124,17 @@ public class GlobalLogoutIntegrationTest extends IntegrationTest {
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(GLOBAL_LOG_OUT_SUCCESS));
     }
 
-    private static GlobalLogoutMessage createGlobalLogoutMessage(
+    private static Map<String, String> createGlobalLogoutMessage(
             String internalCommonSubjectId, String sessionId, String clientSessionId) {
-        return new GlobalLogoutMessage(
-                "test-client-id",
-                "test-event-id",
-                sessionId,
-                clientSessionId,
-                internalCommonSubjectId,
-                "psid",
-                "test-ip-address");
+        return Map.ofEntries(
+                Map.entry("event_name", "HOME_GLOBAL_LOGOUT_REQUESTED"),
+                Map.entry("client_id", "oidc-client-id"),
+                Map.entry("session_id", sessionId),
+                Map.entry("client_session_id", clientSessionId),
+                Map.entry("internal_common_subject_identifier", internalCommonSubjectId),
+                Map.entry("persistent_session_id", "42S9P4onAcnMnBho-aWW7SJnwEA--1701090539559"),
+                Map.entry("ip_address", "123.123.123.123"),
+                Map.entry("event_id", "test-event-id"));
     }
 
     private void withSessions(OrchSessionItem... orchSessionItems) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/GlobalLogoutMessage.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/GlobalLogoutMessage.java
@@ -1,6 +1,7 @@
 package uk.gov.di.orchestration.shared.entity;
 
 import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import uk.gov.di.orchestration.shared.validation.Required;
 
 public record GlobalLogoutMessage(
@@ -8,6 +9,7 @@ public record GlobalLogoutMessage(
         @Expose @Required String eventId,
         @Expose @Required String sessionId,
         @Expose @Required String clientSessionId,
-        @Expose @Required String internalCommonSubjectId,
+        @Expose @Required @SerializedName("internal_common_subject_identifier")
+                String internalCommonSubjectId,
         @Expose @Required String persistentSessionId,
         @Expose @Required String ipAddress) {}


### PR DESCRIPTION
### Wider context of change

We have previously configured a TxMA consumer to consume Global Logout events, and we are deserialising them using the class `GlobalLogoutMessage`. We have just received a message from TxMA and have noticed one of the field mappings is incorrect for our class. Its worth noting that there was no test coverage for this too.

### What’s changed

This PR modifies the existing GlobalLogoutIntegrationTest to not use `GlobalLogoutMessage` objects to populate the fake TxMA queue, but instead use a basic Map. This way we can copy the example from the TxMA consumer config and paste it into the tests. 

This PR also fixes a bug where the mapping for internalCommonSubjectId was wrong. TxMA were sending us `internal_common_subject_identifier`, and `GlobalLogoutMessage` was expecting `internal_common_subject_id`. I've added a `@SerializedName` annotation to override this, as the field name is shorter, which is easier to work with.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

