### PR TITLE
ATO-1856: Handle cross browser access_denied with concurrent client sessions

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -82,38 +82,38 @@ public class IPVAuthorisationService {
     }
 
     public Optional<IpvCallbackValidationError> validateResponse(
-            Map<String, String> headers, String sessionId) {
-        if (headers == null || headers.isEmpty()) {
+            Map<String, String> queryParams, String sessionId) {
+        if (queryParams == null || queryParams.isEmpty()) {
             LOG.warn("No Query parameters in IPV Authorisation response");
             return Optional.of(
                     new IpvCallbackValidationError(
                             OAuth2Error.INVALID_REQUEST_CODE, "No query parameters present"));
         }
-        if (headers.containsKey("error")) {
+        if (queryParams.containsKey("error")) {
 
-            if (SESSION_INVALIDATED_ERROR_CODE.equals(headers.get("error"))) {
+            if (SESSION_INVALIDATED_ERROR_CODE.equals(queryParams.get("error"))) {
                 LOG.warn("Session invalidated response from IPV");
                 return Optional.of(
-                        new IpvCallbackValidationError(headers.get("error"), null, true));
+                        new IpvCallbackValidationError(queryParams.get("error"), null, true));
             }
 
             LOG.warn("Error response found in IPV Authorisation response");
-            return Optional.of(new IpvCallbackValidationError(headers.get("error"), null));
+            return Optional.of(new IpvCallbackValidationError(queryParams.get("error"), null));
         }
-        if (!headers.containsKey("state") || headers.get("state").isEmpty()) {
+        if (!queryParams.containsKey("state") || queryParams.get("state").isEmpty()) {
             LOG.warn("No state param in IPV Authorisation response");
             return Optional.of(
                     new IpvCallbackValidationError(
                             OAuth2Error.INVALID_REQUEST_CODE,
                             "No state param present in Authorisation response"));
         }
-        if (!isStateValid(sessionId, headers.get("state"))) {
+        if (!isStateValid(sessionId, queryParams.get("state"))) {
             return Optional.of(
                     new IpvCallbackValidationError(
                             OAuth2Error.INVALID_REQUEST_CODE,
                             "Invalid state param present in Authorisation response"));
         }
-        if (!headers.containsKey("code") || headers.get("code").isEmpty()) {
+        if (!queryParams.containsKey("code") || queryParams.get("code").isEmpty()) {
             LOG.warn("No code param in IPV Authorisation response");
             return Optional.of(
                     new IpvCallbackValidationError(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -99,6 +99,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED");
     }
 
+    public boolean isEnhancedCrossBrowserHandlingEnabled() {
+        return getFlagOrFalse("USE_ENHANCED_CROSS_BROWSER_HANDLING");
+    }
+
     public boolean abortOnAccountInterventionsErrorResponse() {
         return getFlagOrFalse("ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR");
     }

--- a/template.yaml
+++ b/template.yaml
@@ -134,6 +134,12 @@ Conditions:
     ]
   IsRpRateLimitingEnabled: !Equals [dev, !Ref Environment]
   UseGlobalLogoutTxmaQueue: !Equals [staging, !Ref Environment]
+  IsEnhancedCrossBrowserHandlingEnabled:
+    !Or [
+      !Equals [dev, !Ref Environment],
+      !Equals [build, !Ref Environment],
+      !Equals [staging, !Ref Environment],
+    ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -4413,6 +4419,10 @@ Resources:
           IPV_JWK_CACHE_EXPIRATION_IN_SECONDS: 300
           USE_STRONGLY_CONSISTENT_READS: !If
             - UseStronglyConsistentReads
+            - true
+            - false
+          USE_ENHANCED_CROSS_BROWSER_HANDLING: !If
+            - IsEnhancedCrossBrowserHandlingEnabled
             - true
             - false
       Policies:


### PR DESCRIPTION
### Wider context of change: 

We have uncovered that our handling of concurrent client sessions is currently not the best. In the cross browser scenario  IPV may return the user back to us with an access_denied error code. This PR aims to resolve the concurrent client session issues in the case we get an access_denied from IPV and ensure we use the correct client session.

### What’s changed:
- Adds a new method to the `NoSessionOrchestrationService` which handles the mismatch behaviour - we will rename this service shortly in a future PR to make the code clearer
- Currently only handles this in the case we get an access denied error with state
- The usage of this method is feature flagged in the handler, I've turned the feature flag on in **dev**, **build**, and **staging**.

This is not the neatest implementation - and I think our callback validation needs refactoring more generally - but this is the _quick_ fix. 

### Manual testing:
Slightly convoluted - the RP stub we use for testing is not best setup to handle these multi client journeys but I've got around this by running one copy of the stub locally, configured to point at dev and the other using the deployed stub:

- Get two copies of the stub - this required some fiddling of the config for the stub to add a new localhost redirect uri in dev
- Open a browser window with each copy of the stub in separate tabs
- In one tab start an identity journey - get to IPV stub page
- In the other tab initiate another journey - I chose an auth-only - see this through to at least past /authorize to get new cookies
- Now on tab 1 - choose the Return an oAuth error box on the IPV stub and input `access_denied` in the error code field
- Put any description or omit it 
- Hit go on the IPV stub
- See you hit IPV callback and validate a couple of things:
    - You are on the correct domain for the original journey (either localhost or deployed domain)
    - You see the following error and error_description:
    - **Error: access_denied Error description: Access denied for security reasons, a new authentication request may be successful**

Also ran through a normal identity journey and all was as expected.
### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
