### PR TITLE
ATO-1858: rename no session service

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -32,10 +32,10 @@ import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
@@ -74,7 +74,7 @@ public class DocAppCallbackHandler
     private final AuditService auditService;
     private final DynamoDocAppCriService dynamoDocAppCriService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
-    private final NoSessionOrchestrationService noSessionOrchestrationService;
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final OrchAuthCodeService orchAuthCodeService;
     private final AuthFrontend authFrontend;
     private final DocAppCriAPI docAppCriApi;
@@ -94,7 +94,7 @@ public class DocAppCallbackHandler
             DynamoDocAppCriService dynamoDocAppCriService,
             OrchAuthCodeService orchAuthCodeService,
             CloudwatchMetricsService cloudwatchMetricsService,
-            NoSessionOrchestrationService noSessionOrchestrationService,
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService,
             AuthFrontend authFrontend,
             DocAppCriAPI docAppCriApi,
             OrchSessionService orchSessionService) {
@@ -106,7 +106,7 @@ public class DocAppCallbackHandler
         this.dynamoDocAppCriService = dynamoDocAppCriService;
         this.orchAuthCodeService = orchAuthCodeService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
-        this.noSessionOrchestrationService = noSessionOrchestrationService;
+        this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.authFrontend = authFrontend;
         this.docAppCriApi = docAppCriApi;
         this.orchSessionService = orchSessionService;
@@ -129,8 +129,8 @@ public class DocAppCallbackHandler
         this.dynamoDocAppCriService = new DynamoDocAppCriService(configurationService);
         this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.noSessionOrchestrationService =
-                new NoSessionOrchestrationService(configurationService);
+        this.crossBrowserOrchestrationService =
+                new CrossBrowserOrchestrationService(configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
     }
@@ -153,8 +153,8 @@ public class DocAppCallbackHandler
         this.dynamoDocAppCriService = new DynamoDocAppCriService(configurationService);
         this.orchAuthCodeService = new OrchAuthCodeService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.noSessionOrchestrationService =
-                new NoSessionOrchestrationService(configurationService, redis);
+        this.crossBrowserOrchestrationService =
+                new CrossBrowserOrchestrationService(configurationService, redis);
         this.authFrontend = new AuthFrontend(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
     }
@@ -180,7 +180,7 @@ public class DocAppCallbackHandler
             if (Objects.isNull(sessionCookiesIds)) {
                 LOG.warn("No session cookie present. Attempt to find session using state");
                 var noSessionEntity =
-                        noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                        crossBrowserOrchestrationService.generateNoSessionOrchestrationEntity(
                                 input.getQueryStringParameters());
                 var authRequest =
                         AuthenticationRequest.parse(

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -41,8 +41,8 @@ import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseE
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
@@ -91,8 +91,8 @@ class DocAppCallbackHandlerTest {
     private final AuditService auditService = mock(AuditService.class);
     private final DynamoDocAppCriService dynamoDocAppCriService =
             mock(DynamoDocAppCriService.class);
-    private final NoSessionOrchestrationService noSessionOrchestrationService =
-            mock(NoSessionOrchestrationService.class);
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService =
+            mock(CrossBrowserOrchestrationService.class);
     private static final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
     private final DocAppCriAPI docAppCriApi = mock(DocAppCriAPI.class);
     private final AuthFrontend authFrontend = mock(AuthFrontend.class);
@@ -157,7 +157,7 @@ class DocAppCallbackHandlerTest {
                         dynamoDocAppCriService,
                         orchAuthCodeService,
                         cloudwatchMetricsService,
-                        noSessionOrchestrationService,
+                        crossBrowserOrchestrationService,
                         authFrontend,
                         docAppCriApi,
                         orchSessionService);
@@ -456,7 +456,7 @@ class DocAppCallbackHandlerTest {
         queryParameters.put("state", STATE.getValue());
         queryParameters.put("error", OAuth2Error.ACCESS_DENIED_CODE);
         queryParameters.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
-        when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
+        when(crossBrowserOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
                 .thenReturn(
                         new CrossBrowserEntity(
                                 CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, orchClientSession));
@@ -514,7 +514,7 @@ class DocAppCallbackHandlerTest {
         Mockito.doThrow(
                         new NoSessionException(
                                 "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: false"))
-                .when(noSessionOrchestrationService)
+                .when(crossBrowserOrchestrationService)
                 .generateNoSessionOrchestrationEntity(queryParameters);
 
         var response =

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -32,7 +32,7 @@ import uk.gov.di.authentication.app.services.DynamoDocAppCriService;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.api.DocAppCriAPI;
-import uk.gov.di.orchestration.shared.entity.NoSessionEntity;
+import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -458,7 +458,7 @@ class DocAppCallbackHandlerTest {
         queryParameters.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
         when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
                 .thenReturn(
-                        new NoSessionEntity(
+                        new CrossBrowserEntity(
                                 CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, orchClientSession));
 
         var response =

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -47,10 +47,10 @@ import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
@@ -91,7 +91,7 @@ public class IPVCallbackHandler
     private final LogoutService logoutService;
     private final AccountInterventionService accountInterventionService;
     private final IPVCallbackHelper ipvCallbackHelper;
-    private final NoSessionOrchestrationService noSessionOrchestrationService;
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final CommonFrontend frontend;
     protected final Json objectMapper = SerializationService.getInstance();
 
@@ -110,7 +110,7 @@ public class IPVCallbackHandler
             AuditService auditService,
             LogoutService logoutService,
             AccountInterventionService accountInterventionService,
-            NoSessionOrchestrationService noSessionOrchestrationService,
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService,
             IPVCallbackHelper ipvCallbackHelper,
             CommonFrontend frontend) {
         this.configurationService = configurationService;
@@ -123,7 +123,7 @@ public class IPVCallbackHandler
         this.auditService = auditService;
         this.logoutService = logoutService;
         this.accountInterventionService = accountInterventionService;
-        this.noSessionOrchestrationService = noSessionOrchestrationService;
+        this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.ipvCallbackHelper = ipvCallbackHelper;
         this.frontend = frontend;
     }
@@ -146,8 +146,8 @@ public class IPVCallbackHandler
                         configurationService,
                         new CloudwatchMetricsService(configurationService),
                         auditService);
-        this.noSessionOrchestrationService =
-                new NoSessionOrchestrationService(configurationService);
+        this.crossBrowserOrchestrationService =
+                new CrossBrowserOrchestrationService(configurationService);
         this.ipvCallbackHelper = new IPVCallbackHelper(configurationService);
         this.frontend = getFrontend(configurationService);
     }
@@ -171,8 +171,8 @@ public class IPVCallbackHandler
                         configurationService,
                         new CloudwatchMetricsService(configurationService),
                         auditService);
-        this.noSessionOrchestrationService =
-                new NoSessionOrchestrationService(configurationService, redis);
+        this.crossBrowserOrchestrationService =
+                new CrossBrowserOrchestrationService(configurationService, redis);
         this.ipvCallbackHelper = new IPVCallbackHelper(configurationService);
         this.frontend = getFrontend(configurationService);
     }
@@ -198,7 +198,7 @@ public class IPVCallbackHandler
                     CookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
             if (Objects.isNull(sessionCookiesIds)) {
                 var noSessionEntity =
-                        noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                        crossBrowserOrchestrationService.generateNoSessionOrchestrationEntity(
                                 input.getQueryStringParameters());
                 var authRequest =
                         AuthenticationRequest.parse(
@@ -237,7 +237,7 @@ public class IPVCallbackHandler
 
             if (configurationService.isEnhancedCrossBrowserHandlingEnabled()) {
                 var mismatchedEntity =
-                        noSessionOrchestrationService.generateEntityForMismatchInClientSessionId(
+                        crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
                                 input.getQueryStringParameters(), clientSessionId);
 
                 if (mismatchedEntity.isPresent()) {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -69,10 +69,10 @@ import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.AwsSqsClient;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
@@ -130,8 +130,8 @@ class IPVCallbackHandlerTest {
             mock(OrchClientSessionService.class);
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final DynamoIdentityService dynamoIdentityService = mock(DynamoIdentityService.class);
-    private final NoSessionOrchestrationService noSessionOrchestrationService =
-            mock(NoSessionOrchestrationService.class);
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService =
+            mock(CrossBrowserOrchestrationService.class);
     private final LogoutService logoutService = mock(LogoutService.class);
     private final AccountInterventionService accountInterventionService =
             mock(AccountInterventionService.class);
@@ -290,7 +290,7 @@ class IPVCallbackHandlerTest {
                         auditService,
                         logoutService,
                         accountInterventionService,
-                        noSessionOrchestrationService,
+                        crossBrowserOrchestrationService,
                         ipvCallbackHelper,
                         frontend);
         when(frontend.ipvCallbackURI()).thenReturn(FRONT_END_IPV_CALLBACK_URI);
@@ -1007,7 +1007,7 @@ class IPVCallbackHandlerTest {
         queryParameters.put("state", STATE.getValue());
         queryParameters.put("error", OAuth2Error.ACCESS_DENIED_CODE);
         queryParameters.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
-        when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
+        when(crossBrowserOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
                 .thenReturn(
                         new CrossBrowserEntity(
                                 CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, orchClientSession));
@@ -1050,7 +1050,7 @@ class IPVCallbackHandlerTest {
         doThrow(
                         new NoSessionException(
                                 "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: false"))
-                .when(noSessionOrchestrationService)
+                .when(crossBrowserOrchestrationService)
                 .generateNoSessionOrchestrationEntity(queryParameters);
 
         var response =
@@ -1202,7 +1202,7 @@ class IPVCallbackHandlerTest {
                         UnsuccessfulCredentialResponseException,
                         Json.JsonException {
 
-            when(noSessionOrchestrationService.generateEntityForMismatchInClientSessionId(
+            when(crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
                             anyMap(), anyString()))
                     .thenReturn(Optional.empty());
 
@@ -1263,7 +1263,7 @@ class IPVCallbackHandlerTest {
         void itReturnsToRpIfTheCrossBrowserServiceReturnsAMismatchEntity()
                 throws NoSessionException, Json.JsonException {
 
-            when(noSessionOrchestrationService.generateEntityForMismatchInClientSessionId(
+            when(crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
                             anyMap(), anyString()))
                     .thenReturn(
                             Optional.of(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -51,9 +51,9 @@ import uk.gov.di.orchestration.shared.entity.AccountIntervention;
 import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
+import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
 import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.IdentityClaims;
-import uk.gov.di.orchestration.shared.entity.NoSessionEntity;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -1009,7 +1009,7 @@ class IPVCallbackHandlerTest {
         queryParameters.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
         when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
                 .thenReturn(
-                        new NoSessionEntity(
+                        new CrossBrowserEntity(
                                 CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, orchClientSession));
 
         var response =
@@ -1267,7 +1267,7 @@ class IPVCallbackHandlerTest {
                             anyMap(), anyString()))
                     .thenReturn(
                             Optional.of(
-                                    new NoSessionEntity(
+                                    new CrossBrowserEntity(
                                             clientSessionIdFromState,
                                             errorObject,
                                             clientSessionFromState)));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -56,10 +56,10 @@ import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageServ
 import uk.gov.di.orchestration.shared.services.ClientService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
@@ -116,7 +116,7 @@ public class AuthenticationCallbackHandler
     private final AccountInterventionService accountInterventionService;
     private final LogoutService logoutService;
     private final AuthFrontend authFrontend;
-    private final NoSessionOrchestrationService noSessionOrchestrationService;
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
 
     public AuthenticationCallbackHandler() {
         this(ConfigurationService.getInstance());
@@ -146,7 +146,7 @@ public class AuthenticationCallbackHandler
                         auditService,
                         new IPVAuthorisationService(configurationService, kmsConnectionService),
                         cloudwatchMetricsService,
-                        new NoSessionOrchestrationService(configurationService),
+                        new CrossBrowserOrchestrationService(configurationService),
                         new TokenService(
                                 configurationService,
                                 redisConnectionService,
@@ -157,8 +157,8 @@ public class AuthenticationCallbackHandler
                         configurationService, cloudwatchMetricsService, auditService);
         this.logoutService = new LogoutService(configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
-        this.noSessionOrchestrationService =
-                new NoSessionOrchestrationService(configurationService);
+        this.crossBrowserOrchestrationService =
+                new CrossBrowserOrchestrationService(configurationService);
     }
 
     public AuthenticationCallbackHandler(
@@ -185,7 +185,7 @@ public class AuthenticationCallbackHandler
                         auditService,
                         new IPVAuthorisationService(configurationService, kmsConnectionService),
                         cloudwatchMetricsService,
-                        new NoSessionOrchestrationService(
+                        new CrossBrowserOrchestrationService(
                                 configurationService, redisConnectionService),
                         new TokenService(
                                 configurationService,
@@ -197,8 +197,8 @@ public class AuthenticationCallbackHandler
                         configurationService, cloudwatchMetricsService, auditService);
         this.logoutService = new LogoutService(configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
-        this.noSessionOrchestrationService =
-                new NoSessionOrchestrationService(configurationService, redisConnectionService);
+        this.crossBrowserOrchestrationService =
+                new CrossBrowserOrchestrationService(configurationService, redisConnectionService);
     }
 
     public AuthenticationCallbackHandler(
@@ -216,7 +216,7 @@ public class AuthenticationCallbackHandler
             AccountInterventionService accountInterventionService,
             LogoutService logoutService,
             AuthFrontend authFrontend,
-            NoSessionOrchestrationService noSessionOrchestrationService) {
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService) {
         this.configurationService = configurationService;
         this.authorisationService = responseService;
         this.tokenService = tokenService;
@@ -231,7 +231,7 @@ public class AuthenticationCallbackHandler
         this.accountInterventionService = accountInterventionService;
         this.logoutService = logoutService;
         this.authFrontend = authFrontend;
-        this.noSessionOrchestrationService = noSessionOrchestrationService;
+        this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
     }
 
     public APIGatewayProxyResponseEvent handleRequest(
@@ -602,7 +602,7 @@ public class AuthenticationCallbackHandler
     private APIGatewayProxyResponseEvent handleCrossBrowserError(APIGatewayProxyRequestEvent input)
             throws NoSessionException, ParseException {
         var noSessionEntity =
-                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                crossBrowserOrchestrationService.generateNoSessionOrchestrationEntity(
                         input.getQueryStringParameters());
         var authenticationRequest =
                 AuthenticationRequest.parse(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -70,11 +70,11 @@ import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ClientService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
@@ -135,7 +135,7 @@ public class AuthorisationHandler
     private final ClientService clientService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final DocAppAuthorisationService docAppAuthorisationService;
-    private final NoSessionOrchestrationService noSessionOrchestrationService;
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final TokenValidationService tokenValidationService;
     private final AuthFrontend authFrontend;
     private final AuthorisationService authorisationService;
@@ -152,7 +152,7 @@ public class AuthorisationHandler
             ClientService clientService,
             DocAppAuthorisationService docAppAuthorisationService,
             CloudwatchMetricsService cloudwatchMetricsService,
-            NoSessionOrchestrationService noSessionOrchestrationService,
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService,
             TokenValidationService tokenValidationService,
             AuthFrontend authFrontend,
             AuthorisationService authorisationService,
@@ -167,7 +167,7 @@ public class AuthorisationHandler
         this.clientService = clientService;
         this.docAppAuthorisationService = docAppAuthorisationService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
-        this.noSessionOrchestrationService = noSessionOrchestrationService;
+        this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.tokenValidationService = tokenValidationService;
         this.authFrontend = authFrontend;
         this.authorisationService = authorisationService;
@@ -180,14 +180,14 @@ public class AuthorisationHandler
         var jwksService = new JwksService(configurationService, kmsConnectionService);
         var stateStorageService = new StateStorageService(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
-        this.noSessionOrchestrationService =
-                new NoSessionOrchestrationService(configurationService);
+        this.crossBrowserOrchestrationService =
+                new CrossBrowserOrchestrationService(configurationService);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
         this.orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(
                         configurationService,
                         kmsConnectionService,
-                        noSessionOrchestrationService,
+                        crossBrowserOrchestrationService,
                         stateStorageService);
         this.auditService = new AuditService(configurationService);
         this.queryParamsAuthorizeValidator =
@@ -235,8 +235,8 @@ public class AuthorisationHandler
                         stateStorageService);
         var cloudwatchMetricService = new CloudwatchMetricsService(configurationService);
         this.cloudwatchMetricsService = cloudwatchMetricService;
-        this.noSessionOrchestrationService =
-                new NoSessionOrchestrationService(configurationService, redis);
+        this.crossBrowserOrchestrationService =
+                new CrossBrowserOrchestrationService(configurationService, redis);
         this.tokenValidationService = new TokenValidationService(jwksService, configurationService);
         this.authFrontend = new AuthFrontend(configurationService);
         this.authorisationService = new AuthorisationService(configurationService);
@@ -609,7 +609,7 @@ public class AuthorisationHandler
         var authorisationRequest = authRequestBuilder.build();
 
         docAppAuthorisationService.storeState(newSessionId, state);
-        noSessionOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
+        crossBrowserOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
 
         auditService.submitAuditEvent(
                 DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
@@ -23,7 +23,7 @@ import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.TokenService;
 
 import java.util.List;
@@ -43,7 +43,7 @@ public class InitiateIPVAuthorisationService {
     private final AuditService auditService;
     private final IPVAuthorisationService authorisationService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
-    private final NoSessionOrchestrationService noSessionOrchestrationService;
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final TokenService tokenService;
 
     public InitiateIPVAuthorisationService(
@@ -51,13 +51,13 @@ public class InitiateIPVAuthorisationService {
             AuditService auditService,
             IPVAuthorisationService authorisationService,
             CloudwatchMetricsService cloudwatchMetricsService,
-            NoSessionOrchestrationService noSessionOrchestrationService,
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService,
             TokenService tokenService) {
         this.configurationService = configurationService;
         this.auditService = auditService;
         this.authorisationService = authorisationService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
-        this.noSessionOrchestrationService = noSessionOrchestrationService;
+        this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.tokenService = tokenService;
     }
 
@@ -104,7 +104,7 @@ public class InitiateIPVAuthorisationService {
 
         var ipvAuthorisationRequest = authRequestBuilder.build();
         authorisationService.storeState(sessionId, state);
-        noSessionOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
+        crossBrowserOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
 
         var rpPairwiseId = userInfo.getClaim("rp_pairwise_id");
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
@@ -38,9 +38,9 @@ import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.StateStorageService;
 
 import java.net.URI;
@@ -60,7 +60,7 @@ public class OrchestrationAuthorizationService {
     private final ConfigurationService configurationService;
     private final DynamoClientService dynamoClientService;
     private final KmsConnectionService kmsConnectionService;
-    private final NoSessionOrchestrationService noSessionOrchestrationService;
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final StateStorageService stateStorageService;
     private static final Logger LOG = LogManager.getLogger(OrchestrationAuthorizationService.class);
 
@@ -68,12 +68,12 @@ public class OrchestrationAuthorizationService {
             ConfigurationService configurationService,
             DynamoClientService dynamoClientService,
             KmsConnectionService kmsConnectionService,
-            NoSessionOrchestrationService noSessionOrchestrationService,
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService,
             StateStorageService stateStorageService) {
         this.configurationService = configurationService;
         this.dynamoClientService = dynamoClientService;
         this.kmsConnectionService = kmsConnectionService;
-        this.noSessionOrchestrationService = noSessionOrchestrationService;
+        this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.stateStorageService = stateStorageService;
     }
 
@@ -82,20 +82,20 @@ public class OrchestrationAuthorizationService {
                 configurationService,
                 new DynamoClientService(configurationService),
                 new KmsConnectionService(configurationService),
-                new NoSessionOrchestrationService(configurationService),
+                new CrossBrowserOrchestrationService(configurationService),
                 new StateStorageService(configurationService));
     }
 
     public OrchestrationAuthorizationService(
             ConfigurationService configurationService,
             KmsConnectionService kmsConnectionService,
-            NoSessionOrchestrationService noSessionOrchestrationService,
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService,
             StateStorageService stateStorageService) {
         this(
                 configurationService,
                 new DynamoClientService(configurationService),
                 kmsConnectionService,
-                noSessionOrchestrationService,
+                crossBrowserOrchestrationService,
                 stateStorageService);
     }
 
@@ -251,7 +251,7 @@ public class OrchestrationAuthorizationService {
         LOG.info("Storing state");
         stateStorageService.storeState(
                 AUTHENTICATION_STATE_STORAGE_PREFIX + sessionId, state.getValue());
-        noSessionOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
+        crossBrowserOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
     }
 
     public boolean isJarValidationRequired(ClientRegistry client) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -50,10 +50,10 @@ import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.CredentialTrustLevel;
+import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
 import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.MFAMethodType;
-import uk.gov.di.orchestration.shared.entity.NoSessionEntity;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
@@ -385,7 +385,7 @@ class AuthenticationCallbackHandlerTest {
 
         when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
                 .thenReturn(
-                        new NoSessionEntity(
+                        new CrossBrowserEntity(
                                 CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, orchClientSession));
 
         var response = handler.handleRequest(event, CONTEXT);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -67,8 +67,8 @@ import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageServ
 import uk.gov.di.orchestration.shared.services.ClientService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.LogoutService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
@@ -135,8 +135,8 @@ class AuthenticationCallbackHandlerTest {
             mock(InitiateIPVAuthorisationService.class);
     private static final AccountInterventionService accountInterventionService =
             mock(AccountInterventionService.class);
-    private static final NoSessionOrchestrationService noSessionOrchestrationService =
-            mock(NoSessionOrchestrationService.class);
+    private static final CrossBrowserOrchestrationService CROSS_BROWSER_ORCHESTRATION_SERVICE =
+            mock(CrossBrowserOrchestrationService.class);
     private static final LogoutService logoutService = mock(LogoutService.class);
     private final ClientService clientService = mock(ClientService.class);
     private static final AuthFrontend authFrontend = mock(AuthFrontend.class);
@@ -220,7 +220,7 @@ class AuthenticationCallbackHandlerTest {
         reset(initiateIPVAuthorisationService);
         reset(logoutService);
         reset(authorizationService);
-        reset(noSessionOrchestrationService);
+        reset(CROSS_BROWSER_ORCHESTRATION_SERVICE);
 
         clearInvocations(orchAuthCodeService);
 
@@ -257,7 +257,7 @@ class AuthenticationCallbackHandlerTest {
                         accountInterventionService,
                         logoutService,
                         authFrontend,
-                        noSessionOrchestrationService);
+                        CROSS_BROWSER_ORCHESTRATION_SERVICE);
         orchSession.resetClientSessions();
     }
 
@@ -383,7 +383,8 @@ class AuthenticationCallbackHandlerTest {
         event.setQueryStringParameters(queryParameters);
         event.setHeaders(Collections.emptyMap());
 
-        when(noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParameters))
+        when(CROSS_BROWSER_ORCHESTRATION_SERVICE.generateNoSessionOrchestrationEntity(
+                        queryParameters))
                 .thenReturn(
                         new CrossBrowserEntity(
                                 CLIENT_SESSION_ID, OAuth2Error.ACCESS_DENIED, orchClientSession));
@@ -424,7 +425,7 @@ class AuthenticationCallbackHandlerTest {
         doThrow(
                         new NoSessionException(
                                 "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: false"))
-                .when(noSessionOrchestrationService)
+                .when(CROSS_BROWSER_ORCHESTRATION_SERVICE)
                 .generateNoSessionOrchestrationEntity(queryParameters);
 
         var response = handler.handleRequest(event, CONTEXT);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -84,8 +84,8 @@ import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ClientService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.TokenValidationService;
@@ -168,8 +168,8 @@ class AuthorisationHandlerTest {
     private final AuthorisationService authorisationService = mock(AuthorisationService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
 
-    private final NoSessionOrchestrationService noSessionOrchestrationService =
-            mock(NoSessionOrchestrationService.class);
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService =
+            mock(CrossBrowserOrchestrationService.class);
     private final TokenValidationService tokenValidationService =
             mock(TokenValidationService.class);
     private final RequestObjectAuthorizeValidator requestObjectAuthorizeValidator =
@@ -296,7 +296,7 @@ class AuthorisationHandlerTest {
                         clientService,
                         docAppAuthorisationService,
                         cloudwatchMetricsService,
-                        noSessionOrchestrationService,
+                        crossBrowserOrchestrationService,
                         tokenValidationService,
                         authFrontend,
                         authorisationService,
@@ -1897,7 +1897,7 @@ class AuthorisationHandlerTest {
         void shouldSaveStateAndStoreItToClientSession() throws JOSEException {
             makeDocAppHandlerRequest();
             verify(docAppAuthorisationService).storeState(eq(NEW_SESSION_ID), any());
-            verify(noSessionOrchestrationService)
+            verify(crossBrowserOrchestrationService)
                     .storeClientSessionIdAgainstState(eq(NEW_CLIENT_SESSION_ID), any());
         }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -41,7 +41,7 @@ import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.CloudwatchMetricsService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.TokenService;
 
 import java.net.URI;
@@ -96,8 +96,8 @@ public class InitiateIPVAuthorisationServiceTest {
             mock(IPVAuthorisationService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
-    private final NoSessionOrchestrationService noSessionOrchestrationService =
-            mock(NoSessionOrchestrationService.class);
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService =
+            mock(CrossBrowserOrchestrationService.class);
     private InitiateIPVAuthorisationService initiateAuthorisationService;
     private final TokenService tokenService = mock(TokenService.class);
     private APIGatewayProxyRequestEvent event;
@@ -131,7 +131,7 @@ public class InitiateIPVAuthorisationServiceTest {
                         auditService,
                         authorisationService,
                         cloudwatchMetricsService,
-                        noSessionOrchestrationService,
+                        crossBrowserOrchestrationService,
                         tokenService);
 
         event = new APIGatewayProxyRequestEvent();
@@ -206,7 +206,7 @@ public class InitiateIPVAuthorisationServiceTest {
 
         assertThat(splitQuery(redirectLocation).get("request"), equalTo(encryptedJWT.serialize()));
         verify(authorisationService).storeState(eq(SESSION_ID), any(State.class));
-        verify(noSessionOrchestrationService)
+        verify(crossBrowserOrchestrationService)
                 .storeClientSessionIdAgainstState(eq(CLIENT_SESSION_ID), any(State.class));
         verify(authorisationService)
                 .constructRequestJWT(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
@@ -40,9 +40,9 @@ import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
-import uk.gov.di.orchestration.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
@@ -90,8 +90,8 @@ class OrchestrationAuthorizationServiceTest {
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final IPVCapacityService ipvCapacityService = mock(IPVCapacityService.class);
     private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
-    private final NoSessionOrchestrationService noSessionOrchestrationService =
-            mock(NoSessionOrchestrationService.class);
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService =
+            mock(CrossBrowserOrchestrationService.class);
     private final StateStorageService stateStorageService = mock(StateStorageService.class);
     private PrivateKey privateKey;
 
@@ -106,7 +106,7 @@ class OrchestrationAuthorizationServiceTest {
                         configurationService,
                         dynamoClientService,
                         kmsConnectionService,
-                        noSessionOrchestrationService,
+                        crossBrowserOrchestrationService,
                         stateStorageService);
         var keyPair = generateRsaKeyPair();
         privateKey = keyPair.getPrivate();
@@ -311,7 +311,7 @@ class OrchestrationAuthorizationServiceTest {
 
         var prefixedSessionId = "auth-state:" + sessionId;
         verify(stateStorageService).storeState(prefixedSessionId, state.getValue());
-        verify(noSessionOrchestrationService)
+        verify(crossBrowserOrchestrationService)
                 .storeClientSessionIdAgainstState(clientSessionId, state);
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/CrossBrowserEntity.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/CrossBrowserEntity.java
@@ -2,13 +2,13 @@ package uk.gov.di.orchestration.shared.entity;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
 
-public class NoSessionEntity {
+public class CrossBrowserEntity {
 
     private final String clientSessionId;
     private final ErrorObject errorObject;
     private final OrchClientSessionItem orchClientSession;
 
-    public NoSessionEntity(
+    public CrossBrowserEntity(
             String clientSessionId,
             ErrorObject errorObject,
             OrchClientSessionItem orchClientSession) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationService.java
@@ -20,15 +20,15 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 
-public class NoSessionOrchestrationService {
+public class CrossBrowserOrchestrationService {
 
-    private static final Logger LOG = LogManager.getLogger(NoSessionOrchestrationService.class);
+    private static final Logger LOG = LogManager.getLogger(CrossBrowserOrchestrationService.class);
     private final RedisConnectionService redisConnectionService;
     private final OrchClientSessionService orchClientSessionService;
     private final ConfigurationService configurationService;
     public static final String STATE_STORAGE_PREFIX = "state:";
 
-    public NoSessionOrchestrationService(
+    public CrossBrowserOrchestrationService(
             RedisConnectionService redisConnectionService,
             OrchClientSessionService orchClientSessionService,
             ConfigurationService configurationService) {
@@ -37,14 +37,14 @@ public class NoSessionOrchestrationService {
         this.configurationService = configurationService;
     }
 
-    public NoSessionOrchestrationService(ConfigurationService configurationService) {
+    public CrossBrowserOrchestrationService(ConfigurationService configurationService) {
         this(
                 new RedisConnectionService(configurationService),
                 new OrchClientSessionService(configurationService),
                 configurationService);
     }
 
-    public NoSessionOrchestrationService(
+    public CrossBrowserOrchestrationService(
             ConfigurationService configurationService, RedisConnectionService redis) {
         this(redis, new OrchClientSessionService(configurationService), configurationService);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/NoSessionOrchestrationService.java
@@ -6,7 +6,7 @@ import com.nimbusds.oauth2.sdk.id.State;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
-import uk.gov.di.orchestration.shared.entity.NoSessionEntity;
+import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 
@@ -49,7 +49,7 @@ public class NoSessionOrchestrationService {
         this(redis, new OrchClientSessionService(configurationService), configurationService);
     }
 
-    public NoSessionEntity generateNoSessionOrchestrationEntity(
+    public CrossBrowserEntity generateNoSessionOrchestrationEntity(
             Map<String, String> queryStringParameters) throws NoSessionException {
         LOG.info("Attempting to generate error response using state");
         if (isAccessDeniedErrorAndStatePresent(queryStringParameters)) {
@@ -86,7 +86,7 @@ public class NoSessionOrchestrationService {
                             "Access denied for security reasons, a new authentication request may be successful");
             LOG.info(
                     "ErrorObject created for session cookie not present. Generating NoSessionEntity in preparation for response to RP");
-            return new NoSessionEntity(clientSessionId, errorObject, orchClientSession);
+            return new CrossBrowserEntity(clientSessionId, errorObject, orchClientSession);
         } else {
             LOG.warn(
                     "Session Cookie not present and access_denied or state param missing from error response");
@@ -95,7 +95,7 @@ public class NoSessionOrchestrationService {
         }
     }
 
-    public Optional<NoSessionEntity> generateEntityForMismatchInClientSessionId(
+    public Optional<CrossBrowserEntity> generateEntityForMismatchInClientSessionId(
             Map<String, String> queryStringParameters, String clientSessionIdFromCookie)
             throws NoSessionException {
         if (!isStatePresentInQueryParams(queryStringParameters)) {
@@ -144,7 +144,7 @@ public class NoSessionOrchestrationService {
                         "Access denied for security reasons, a new authentication request may be successful");
 
         return Optional.of(
-                new NoSessionEntity(clientSessionIdFromState, errorObject, orchClientSession));
+                new CrossBrowserEntity(clientSessionIdFromState, errorObject, orchClientSession));
     }
 
     @NotNull

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/CrossBrowserOrchestrationServiceTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class NoSessionOrchestrationServiceTest {
+class CrossBrowserOrchestrationServiceTest {
 
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
@@ -44,12 +44,12 @@ class NoSessionOrchestrationServiceTest {
     private static final State STATE = new State();
     private static final Nonce NONCE = new Nonce();
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
-    private NoSessionOrchestrationService noSessionOrchestrationService;
+    private CrossBrowserOrchestrationService crossBrowserOrchestrationService;
 
     @BeforeEach
     void setup() {
-        noSessionOrchestrationService =
-                new NoSessionOrchestrationService(
+        crossBrowserOrchestrationService =
+                new CrossBrowserOrchestrationService(
                         redisConnectionService, orchClientSessionService, configurationService);
     }
 
@@ -66,7 +66,7 @@ class NoSessionOrchestrationServiceTest {
         queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
         queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
         var noSessionEntity =
-                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(queryParams);
+                crossBrowserOrchestrationService.generateNoSessionOrchestrationEntity(queryParams);
 
         assertThat(
                 noSessionEntity.getErrorObject().getCode(),
@@ -99,8 +99,8 @@ class NoSessionOrchestrationServiceTest {
                 assertThrows(
                         NoSessionException.class,
                         () ->
-                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams));
+                                crossBrowserOrchestrationService
+                                        .generateNoSessionOrchestrationEntity(queryParams));
 
         assertThat(
                 noSessionException.getMessage(),
@@ -120,8 +120,8 @@ class NoSessionOrchestrationServiceTest {
                 assertThrows(
                         NoSessionException.class,
                         () ->
-                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams));
+                                crossBrowserOrchestrationService
+                                        .generateNoSessionOrchestrationEntity(queryParams));
 
         assertThat(
                 noSessionException.getMessage(),
@@ -139,8 +139,8 @@ class NoSessionOrchestrationServiceTest {
                 assertThrows(
                         NoSessionException.class,
                         () ->
-                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams));
+                                crossBrowserOrchestrationService
+                                        .generateNoSessionOrchestrationEntity(queryParams));
 
         assertThat(
                 noSessionException.getMessage(),
@@ -159,8 +159,8 @@ class NoSessionOrchestrationServiceTest {
                 assertThrows(
                         NoSessionException.class,
                         () ->
-                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams));
+                                crossBrowserOrchestrationService
+                                        .generateNoSessionOrchestrationEntity(queryParams));
 
         assertThat(
                 noSessionException.getMessage(),
@@ -182,8 +182,8 @@ class NoSessionOrchestrationServiceTest {
                 assertThrows(
                         NoSessionException.class,
                         () ->
-                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams));
+                                crossBrowserOrchestrationService
+                                        .generateNoSessionOrchestrationEntity(queryParams));
 
         assertThat(
                 noSessionException.getMessage(),
@@ -206,8 +206,8 @@ class NoSessionOrchestrationServiceTest {
                 assertThrows(
                         NoSessionException.class,
                         () ->
-                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
-                                        queryParams));
+                                crossBrowserOrchestrationService
+                                        .generateNoSessionOrchestrationEntity(queryParams));
 
         assertThat(
                 noSessionException.getMessage(),
@@ -217,7 +217,7 @@ class NoSessionOrchestrationServiceTest {
     @Test
     void shouldCallRedisAndSaveClientSessionIdAgainstState() {
         when(configurationService.getSessionExpiry()).thenReturn(7200L);
-        noSessionOrchestrationService.storeClientSessionIdAgainstState(CLIENT_SESSION_ID, STATE);
+        crossBrowserOrchestrationService.storeClientSessionIdAgainstState(CLIENT_SESSION_ID, STATE);
 
         verify(redisConnectionService)
                 .saveWithExpiry("state:" + STATE.getValue(), CLIENT_SESSION_ID, 7200);
@@ -240,7 +240,7 @@ class NoSessionOrchestrationServiceTest {
             assertThrows(
                     NoSessionException.class,
                     () ->
-                            noSessionOrchestrationService
+                            crossBrowserOrchestrationService
                                     .generateEntityForMismatchInClientSessionId(
                                             queryParams, CLIENT_SESSION_ID));
         }
@@ -258,7 +258,7 @@ class NoSessionOrchestrationServiceTest {
             queryParams.put("code", new AuthorizationCode().getValue());
 
             var noSessionEntity =
-                    noSessionOrchestrationService.generateEntityForMismatchInClientSessionId(
+                    crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
                             queryParams, IdGenerator.generate());
 
             assertTrue(noSessionEntity.isPresent());
@@ -292,7 +292,7 @@ class NoSessionOrchestrationServiceTest {
             queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
             queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
             var noSessionEntity =
-                    noSessionOrchestrationService.generateEntityForMismatchInClientSessionId(
+                    crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
                             queryParams, cookieClientSessionID);
 
             assertTrue(noSessionEntity.isPresent());
@@ -325,7 +325,7 @@ class NoSessionOrchestrationServiceTest {
             queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
             queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
             var noSessionEntity =
-                    noSessionOrchestrationService.generateEntityForMismatchInClientSessionId(
+                    crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
                             queryParams, CLIENT_SESSION_ID);
 
             assertTrue(noSessionEntity.isEmpty());
@@ -346,7 +346,7 @@ class NoSessionOrchestrationServiceTest {
             assertThrows(
                     NoSessionException.class,
                     () ->
-                            noSessionOrchestrationService
+                            crossBrowserOrchestrationService
                                     .generateEntityForMismatchInClientSessionId(
                                             queryParams, CLIENT_SESSION_ID));
         }
@@ -369,7 +369,7 @@ class NoSessionOrchestrationServiceTest {
             assertThrows(
                     NoSessionException.class,
                     () ->
-                            noSessionOrchestrationService
+                            crossBrowserOrchestrationService
                                     .generateEntityForMismatchInClientSessionId(
                                             queryParams, CLIENT_SESSION_ID));
         }


### PR DESCRIPTION
### Wider context of change:

We've added new functionality to the `NoSessionOrchestrationService` which means it no longer just represents the _no session_ handling.  This renames the service and entity.

### What’s changed:
- Renames NoSessionEntity to CrossBrowserEntity
- Renames NoSessionOrchestrationService to CrossBrowserOrchestrationService

### Manual testing:
- N/A just a straight rename of existing classes

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
